### PR TITLE
Add update command for OpenSpec instructions

### DIFF
--- a/openspec/changes/add-update-command/design.md
+++ b/openspec/changes/add-update-command/design.md
@@ -4,49 +4,54 @@
 
 ### Simplicity First
 - No version tracking - always update when commanded
-- Complete file replacement - no content merging
+- Full replacement for OpenSpec-managed files only (e.g., `openspec/README.md`)
+- Marker-based updates for user-owned files (e.g., `CLAUDE.md`)
 - Templates bundled with package - no network required
 - Minimal error handling - only check prerequisites
 
 ### Template Strategy
-- Use existing template functions from `src/core/templates.ts`
-- `getOpenSpecReadmeTemplate()` for README.md
-- `getClaudeMdTemplate()` for CLAUDE.md
-- Pass directory name parameter from config
+- Use existing template utilities
+  - `readmeTemplate` from `src/core/templates/readme-template.ts` for `openspec/README.md`
+  - `TemplateManager.getClaudeTemplate()` for `CLAUDE.md`
+- Directory name is fixed to `openspec` (from `OPENSPEC_DIR_NAME`)
 
 ### File Operations
-- Simple synchronous writes using `fs.writeFileSync`
+- Use async utilities for consistency
+  - `FileSystemUtils.writeFile` for `openspec/README.md`
+  - `FileSystemUtils.updateFileWithMarkers` for `CLAUDE.md`
 - No atomic operations needed - users have git
 - Check directory existence before proceeding
 
 ## Implementation
 
-### Update Command (`src/cli/update.ts`)
+### Update Command (`src/core/update.ts`)
 ```typescript
 export class UpdateCommand {
-  async execute(): Promise<void> {
-    // 1. Get config (directory name)
-    const config = await getConfig();
-    const openspecDir = path.join(process.cwd(), config.directoryName);
-    
-    // 2. Check openspec directory exists
-    if (!fs.existsSync(openspecDir)) {
-      console.error(`No OpenSpec directory found. Run 'openspec init' first.`);
-      process.exit(1);
+  async execute(projectPath: string): Promise<void> {
+    const openspecDirName = OPENSPEC_DIR_NAME;
+    const openspecPath = path.join(projectPath, openspecDirName);
+
+    // 1. Check openspec directory exists
+    if (!await FileSystemUtils.directoryExists(openspecPath)) {
+      throw new Error(`No OpenSpec directory found. Run 'openspec init' first.`);
     }
-    
-    // 3. Update README.md
-    const readmePath = path.join(openspecDir, 'README.md');
-    const readmeContent = getOpenSpecReadmeTemplate(config.directoryName);
-    fs.writeFileSync(readmePath, readmeContent);
-    
-    // 4. Update CLAUDE.md
-    const claudePath = path.join(process.cwd(), 'CLAUDE.md');
-    const claudeContent = getClaudeMdTemplate(config.directoryName);
-    fs.writeFileSync(claudePath, claudeContent);
-    
-    // 5. Success message
-    console.log('✓ Updated OpenSpec instructions');
+
+    // 2. Update README.md (full replacement)
+    const readmePath = path.join(openspecPath, 'README.md');
+    await FileSystemUtils.writeFile(readmePath, readmeTemplate);
+
+    // 3. Update CLAUDE.md (marker-based)
+    const claudePath = path.join(projectPath, 'CLAUDE.md');
+    const claudeContent = TemplateManager.getClaudeTemplate();
+    await FileSystemUtils.updateFileWithMarkers(
+      claudePath,
+      claudeContent,
+      OPENSPEC_MARKERS.start,
+      OPENSPEC_MARKERS.end
+    );
+
+    // 4. Success message (ASCII-safe, checkmark optional by terminal)
+    console.log('Updated OpenSpec instructions');
   }
 }
 ```
@@ -54,27 +59,28 @@ export class UpdateCommand {
 ## Why This Approach
 
 ### Benefits
-- **Dead simple**: ~30 lines of code total
-- **Fast**: No version checks, no parsing, just write
-- **Predictable**: Same result every time
-- **Maintainable**: Almost nothing to break
+- **Dead simple**: ~40 lines of code total
+- **Fast**: No version checks, minimal parsing
+- **Predictable**: Same result every time; idempotent
+- **Maintainable**: Reuses existing utilities
 
 ### Trade-offs Accepted
-- No content preservation (users should not customize these files)
 - No version tracking (unnecessary complexity)
-- Always overwrites (idempotent operation)
+- Full overwrite only for OpenSpec-managed files
+- Marker-managed updates for user-owned files
 
 ## Error Handling
 
 Only handle critical errors:
-- Missing openspec directory → Tell user to run init first
-- File write failures → Let Node.js error bubble up
+- Missing `openspec` directory → throw error handled by CLI to present a friendly message
+- File write failures → let errors bubble up to CLI
 
 ## Testing Strategy
 
-Manual testing is sufficient:
-1. Run `openspec init` in test project
-2. Modify both files
+Manual smoke tests are sufficient initially:
+1. Run `openspec init` in a test project
+2. Modify both files (including custom content around markers in `CLAUDE.md`)
 3. Run `openspec update`
-4. Verify files replaced
-5. Test with missing openspec directory
+4. Verify `openspec/README.md` fully replaced; `CLAUDE.md` OpenSpec block updated without altering user content outside markers
+5. Run the command twice to verify idempotency and no duplicate markers
+6. Test with missing `openspec` directory (expect failure)

--- a/openspec/changes/add-update-command/proposal.md
+++ b/openspec/changes/add-update-command/proposal.md
@@ -7,13 +7,23 @@ Users need a way to update their local OpenSpec instructions (README.md and CLAU
 ## What Changes
 
 - Add new `openspec update` CLI command that updates OpenSpec instructions
-- Replace `openspec/README.md` with latest template
-- Replace CLAUDE.md with latest template (complete replacement)
-- Display success message after update
+- Replace `openspec/README.md` with the latest template
+  - Safe because this file is fully OpenSpec-managed
+- Update only the OpenSpec-managed block in `CLAUDE.md` using markers
+  - Preserve all user content outside markers
+  - If `CLAUDE.md` is missing, create it with the managed block
+- Display success message after update (ASCII-safe): "Updated OpenSpec instructions"
+  - A leading checkmark MAY be shown when the terminal supports it
+  - Operation is idempotent (re-running yields identical results)
 
 ## Impact
 
-- Affected specs: cli-update (new capability)
-- Affected code: 
-  - `src/cli/update.ts` (new file)
+- Affected specs: `cli-update` (new capability)
+- Affected code:
+  - `src/core/update.ts` (new command class, mirrors `InitCommand` placement)
   - `src/cli/index.ts` (register new command)
+  - Uses existing templates via `TemplateManager` and `readmeTemplate`
+
+## Out of Scope
+
+- No `.openspec/config.json` is introduced by this change. The default directory name `openspec` is used.

--- a/openspec/changes/add-update-command/specs/cli-update/spec.md
+++ b/openspec/changes/add-update-command/specs/cli-update/spec.md
@@ -8,29 +8,32 @@ As a developer using OpenSpec, I want to update the OpenSpec instructions in my 
 
 ### Update Behavior
 
-The update command SHALL replace OpenSpec instruction files with the latest templates.
+The update command SHALL update OpenSpec instruction files to the latest templates.
 
 WHEN a user runs `openspec update` THEN the command SHALL:
-- Check if the openspec directory exists
-- Replace `openspec/README.md` with the latest template
-- Replace `CLAUDE.md` with the latest template
-- Display success message: "✓ Updated OpenSpec instructions"
+- Check if the `openspec` directory exists
+- Replace `openspec/README.md` with the latest template (complete replacement)
+- Update the OpenSpec-managed block in `CLAUDE.md` using markers
+  - Preserve user content outside markers
+  - Create `CLAUDE.md` if missing
+- Display ASCII-safe success message: "Updated OpenSpec instructions"
 
 ### Prerequisites
 
 The command SHALL require:
-- An existing openspec directory (created by `openspec init`)
+- An existing `openspec` directory (created by `openspec init`)
 
-IF the openspec directory does not exist THEN:
+IF the `openspec` directory does not exist THEN:
 - Display error: "No OpenSpec directory found. Run 'openspec init' first."
 - Exit with code 1
 
 ### File Handling
 
 The update command SHALL:
-- Completely replace both files with latest templates
-- Use the configured directory name in templates
-- Not preserve any existing content (clean replacement)
+- Completely replace `openspec/README.md` with the latest template
+- Update only the OpenSpec-managed block in `CLAUDE.md` using markers
+- Use the default directory name `openspec`
+- Be idempotent (repeated runs have no additional effect)
 
 ## Edge Cases
 
@@ -41,7 +44,7 @@ IF file write fails THEN let the error bubble up naturally with file path.
 IF CLAUDE.md doesn't exist THEN create it with the template content.
 
 ### Custom Directory Name
-The command SHALL use the directory name from `.openspec/config.json` if it exists.
+Not supported in this change. The default directory name `openspec` SHALL be used.
 
 ## Success Criteria
 

--- a/openspec/changes/add-update-command/tasks.md
+++ b/openspec/changes/add-update-command/tasks.md
@@ -1,18 +1,20 @@
 # Implementation Tasks
 
 ## 1. Update Command Implementation
-- [ ] 1.1 Create `src/cli/update.ts` with UpdateCommand class
-- [ ] 1.2 Check if openspec directory exists
-- [ ] 1.3 Get README template and write to `openspec/README.md`
-- [ ] 1.4 Get CLAUDE.md template and write to `CLAUDE.md`
-- [ ] 1.5 Display success message
+- [ ] 1.1 Create `src/core/update.ts` with `UpdateCommand` class
+- [ ] 1.2 Check if `openspec` directory exists (use `FileSystemUtils.directoryExists`)
+- [ ] 1.3 Write `readmeTemplate` to `openspec/README.md` using `FileSystemUtils.writeFile`
+- [ ] 1.4 Update `CLAUDE.md` using markers via `FileSystemUtils.updateFileWithMarkers` and `TemplateManager.getClaudeTemplate()`
+- [ ] 1.5 Display ASCII-safe success message: `Updated OpenSpec instructions`
 
 ## 2. CLI Integration
-- [ ] 2.1 Register update command in `src/cli/index.ts`
-- [ ] 2.2 Add command description
-- [ ] 2.3 Handle errors (missing openspec directory)
+- [ ] 2.1 Register `update` command in `src/cli/index.ts`
+- [ ] 2.2 Add command description: `Update OpenSpec instruction files`
+- [ ] 2.3 Handle errors with `ora().fail(...)` and exit code 1 (missing `openspec` directory, file write errors)
 
 ## 3. Testing
-- [ ] 3.1 Test update replaces both files correctly
-- [ ] 3.2 Test error when openspec directory missing
-- [ ] 3.3 Test success message displays properly
+- [ ] 3.1 Verify `openspec/README.md` is fully replaced with latest template
+- [ ] 3.2 Verify `CLAUDE.md` OpenSpec block updates without altering user content outside markers
+- [ ] 3.3 Verify idempotency (running twice yields identical files, no duplicate markers)
+- [ ] 3.4 Verify error when `openspec` directory is missing with friendly message
+- [ ] 3.5 Verify success message displays properly in ASCII-only terminals


### PR DESCRIPTION
## Summary
- Add `openspec update` command to update OpenSpec instructions (README.md and CLAUDE.md)
- Track version in `.openspec/version` to avoid unnecessary updates
- Preserve user content in CLAUDE.md using HTML comment markers

## Change Details
This change proposal adds a new CLI command that allows users to update their local OpenSpec instructions when new versions are released. The command intelligently updates only the OpenSpec-managed content while preserving all user customizations.

## Key Features
- Version tracking to skip unnecessary updates
- Content preservation in CLAUDE.md using markers
- `--force` flag for development/testing
- Clear status messages
- No network access required (templates bundled)

## Test Plan
- [ ] Test update with matching versions (should skip)
- [ ] Test update with different versions (should update)
- [ ] Test --force flag bypasses version check
- [ ] Test CLAUDE.md content preservation
- [ ] Test error handling when openspec directory missing