### PR TITLE
Fix: Add spec update functionality to archive command

### DIFF
--- a/openspec/changes/add-archive-command/proposal.md
+++ b/openspec/changes/add-archive-command/proposal.md
@@ -6,6 +6,9 @@ Need a command to archive completed changes to the archive folder with proper da
 - Check for incomplete tasks before archiving and warn user
 - Allow interactive selection of change to archive
 - Prevent archiving if target directory already exists
+- Update main specs from the change's future state specs (copy from `changes/[name]/specs/` to `openspec/specs/`)
+- Show confirmation prompt before updating specs, displaying which specs will be created/updated
+- Support `--yes` flag to skip confirmations for automation
 
 ## Impact
 - Affected specs: cli-archive (new)

--- a/openspec/changes/add-archive-command/specs/cli-archive/spec.md
+++ b/openspec/changes/add-archive-command/specs/cli-archive/spec.md
@@ -5,8 +5,11 @@ The archive command moves completed changes from the active changes directory to
 
 ## Command Syntax
 ```bash
-openspec archive [change-name]
+openspec archive [change-name] [--yes|-y]
 ```
+
+Options:
+- `--yes`, `-y`: Skip confirmation prompts (for automation)
 
 ## Behavior
 
@@ -35,14 +38,59 @@ The archive operation SHALL:
 1. Create archive/ directory if it doesn't exist
 2. Generate target name as `YYYY-MM-DD-[change-name]` using current date
 3. Check if target directory already exists
-4. Move the entire change directory to the archive location
+4. Update main specs from the change's future state specs (see Spec Update Process below)
+5. Move the entire change directory to the archive location
 
 WHEN target archive already exists
 THEN fail with error message
 AND do not overwrite existing archive
 
 WHEN move succeeds
-THEN display success message with archived name
+THEN display success message with archived name and list of updated specs
+
+### Spec Update Process
+Before moving the change to archive, the command SHALL update main specs to reflect the deployed reality:
+
+WHEN the change contains specs in `changes/[name]/specs/`
+THEN:
+1. Analyze which specs will be affected by comparing with existing specs
+2. Display a summary of spec updates to the user (see Confirmation Behavior below)
+3. Prompt for confirmation unless `--yes` flag is provided
+4. If confirmed, for each capability spec in the change directory:
+   - Copy the spec from `changes/[name]/specs/[capability]/spec.md` to `openspec/specs/[capability]/spec.md`
+   - Create the target directory structure if it doesn't exist
+   - Overwrite existing spec files (specs represent current reality, change specs are the new reality)
+   - Track which specs were updated for the success message
+
+WHEN no specs exist in the change
+THEN skip the spec update step
+AND proceed with archiving
+
+### Confirmation Behavior
+The spec update confirmation SHALL:
+- Display a clear summary showing:
+  - Which specs will be created (new capabilities)
+  - Which specs will be updated (existing capabilities)
+  - The source path for each spec
+- Format the confirmation prompt as:
+  ```
+  The following specs will be updated:
+  
+  NEW specs to be created:
+    - cli-archive (from changes/add-archive-command/specs/cli-archive/spec.md)
+  
+  EXISTING specs to be updated:
+    - cli-init (from changes/update-init-command/specs/cli-init/spec.md)
+  
+  Update 2 specs and archive 'add-archive-command'? [y/N]:
+  ```
+- Default to "No" for safety (require explicit "y" or "yes")
+- Skip confirmation when `--yes` or `-y` flag is provided
+
+WHEN user declines the confirmation
+THEN abort the entire archive operation
+AND display message: "Archive cancelled. No changes were made."
+AND exit with non-zero status code
 
 ## Error Handling
 
@@ -58,3 +106,6 @@ SHALL handle the following error conditions:
 **Task checking**: Prevents accidental archiving of incomplete work
 **Date prefixing**: Maintains chronological order and prevents naming conflicts
 **No overwrite**: Preserves historical archives and prevents data loss
+**Spec updates before archiving**: Specs in the main directory represent current reality; when a change is deployed and archived, its future state specs become the new reality and must replace the main specs
+**Confirmation for spec updates**: Provides visibility into what will change, prevents accidental overwrites, and ensures users understand the impact before specs are modified
+**--yes flag for automation**: Allows CI/CD pipelines to archive without interactive prompts while maintaining safety by default for manual use

--- a/openspec/changes/add-archive-command/tasks.md
+++ b/openspec/changes/add-archive-command/tasks.md
@@ -5,13 +5,21 @@
   - [ ] 1.1.1 Implement change selection (interactive if not provided)
   - [ ] 1.1.2 Implement incomplete task checking from tasks.md
   - [ ] 1.1.3 Implement confirmation prompt for incomplete tasks
-  - [ ] 1.1.4 Implement archive move with date prefixing
+  - [ ] 1.1.4 Implement spec update functionality
+    - [ ] 1.1.4.1 Detect specs in change directory
+    - [ ] 1.1.4.2 Compare with existing main specs
+    - [ ] 1.1.4.3 Display summary of new vs updated specs
+    - [ ] 1.1.4.4 Show confirmation prompt for spec updates
+    - [ ] 1.1.4.5 Copy specs to main spec directory
+  - [ ] 1.1.5 Implement archive move with date prefixing
+  - [ ] 1.1.6 Support --yes flag to skip confirmations
 
 ## 2. CLI Integration
 - [ ] 2.1 Add archive command to `src/cli/index.ts`
   - [ ] 2.1.1 Import ArchiveCommand
   - [ ] 2.1.2 Register command with commander
-  - [ ] 2.1.3 Add proper error handling
+  - [ ] 2.1.3 Add --yes/-y flag option
+  - [ ] 2.1.4 Add proper error handling
 
 ## 3. Error Handling
 - [ ] 3.1 Handle missing openspec/changes/ directory
@@ -24,6 +32,12 @@
 - [ ] 4.2 Test with incomplete tasks (warning shown)
 - [ ] 4.3 Test interactive selection mode
 - [ ] 4.4 Test duplicate archive prevention
+- [ ] 4.5 Test spec update functionality
+  - [ ] 4.5.1 Test creating new specs
+  - [ ] 4.5.2 Test updating existing specs
+  - [ ] 4.5.3 Test confirmation prompt display
+  - [ ] 4.5.4 Test declining confirmation (no changes made)
+  - [ ] 4.5.5 Test --yes flag skips confirmation
 
 ## 5. Build and Validation
 - [ ] 5.1 Ensure TypeScript compilation succeeds


### PR DESCRIPTION
## Summary
- Added missing spec update functionality to the archive command that updates main specs from change's future state specs
- Added confirmation prompt showing which specs will be created vs updated for transparency
- Added `--yes` flag support for automation scenarios

## Context
The archive command proposal was missing a critical piece: when archiving a change, the main specs need to be updated from the change's future state specs since specs represent current reality and the archived change represents deployed functionality.

## Changes Made
1. **Updated proposal.md**: Added spec update and confirmation features to the change list
2. **Updated spec.md**: 
   - Added detailed spec update process section
   - Added confirmation behavior section with clear formatting
   - Added `--yes` flag to command syntax for automation
   - Updated rationale section explaining why spec updates are needed
3. **Updated tasks.md**: Added implementation tasks for spec update functionality and testing

## Test Plan
- [ ] Archive a change with new specs - verify specs are created in main directory
- [ ] Archive a change with existing specs - verify specs are updated
- [ ] Test confirmation prompt shows correct new vs existing specs
- [ ] Test declining confirmation cancels entire operation
- [ ] Test `--yes` flag skips confirmations

🤖 Generated with [Claude Code](https://claude.ai/code)