### PR TITLE
docs: add explicit session boundaries to OpenSpec workflow instructions

### DIFF
--- a/openspec/README.md.proposed-update
+++ b/openspec/README.md.proposed-update
@@ -1,0 +1,96 @@
+# OpenSpec Instructions
+
+Instructions for AI coding assistants using OpenSpec for spec-driven development.
+
+## Three-Stage Workflow (Different Sessions)
+
+**IMPORTANT: Each stage happens in a SEPARATE session with explicit user approval between stages.**
+
+### Stage 1: Creating Changes (Proposal Only)
+**This stage creates the proposal ONLY - no implementation.**
+
+Create proposal when you need to:
+- Add features or functionality
+- Make breaking changes (API, schema)
+- Change architecture or patterns  
+- Optimize performance (changes behavior)
+- Update security patterns
+
+Skip proposal for:
+- Bug fixes (restore intended behavior)
+- Typos, formatting, comments
+- Dependency updates (non-breaking)
+- Configuration changes
+- Tests for existing behavior
+
+**STOP after creating proposal files (proposal.md, design.md, tasks.md, specs/).**
+**DO NOT implement unless user explicitly says "implement it" or "proceed with implementation".**
+
+### Stage 2: Implementing Changes (Separate Session)
+**Only start this stage when user explicitly requests implementation.**
+
+1. **Read proposal.md** - Understand what's being built
+2. **Read design.md** (if exists) - Review technical decisions
+3. **Read tasks.md** - Get implementation checklist
+4. **Implement tasks sequentially** - Complete in order
+5. **Mark complete immediately** - Update `- [x]` after each task
+
+**Never assume you should implement just because a proposal exists.**
+
+### Stage 3: Archiving Changes (After Deployment)
+**This happens in a separate session after the change is deployed to production.**
+
+After deployment, create separate PR to:
+- Move `changes/[name]/` → `changes/archive/YYYY-MM-DD-[name]/`
+- Update `specs/` if capabilities changed
+- Use `openspec archive [change] --skip-specs` for tooling-only changes
+
+## Before Creating ANY Change
+
+**STOP: You MUST run these commands before creating any change proposal:**
+1. `openspec list` - Check all active changes for conflicts
+2. `openspec list --specs` - Check existing specs to avoid duplicates
+3. Only proceed if no conflicts or duplicates found
+
+**Context Gathering Requirement:**
+When asked to create a change proposal, ALWAYS start by:
+1. Showing current changes: `openspec list`
+2. Showing current specs: `openspec list --specs`  
+3. Explaining why the new change doesn't conflict with existing work
+4. Using `openspec show [item]` to examine any related specs or changes
+
+**Session Boundaries:**
+- Creating proposal = One session (STOP after proposal files)
+- Implementation = Separate session (ONLY when explicitly requested)
+- Archiving = Separate session (after deployment)
+
+**Mandatory Checklist for Proposals:**
+- [ ] Ran `openspec list` to see active changes
+- [ ] Ran `openspec list --specs` to check existing specs
+- [ ] Searched for related functionality that might already exist
+- [ ] Verified no conflicts or duplicates found
+- [ ] Used proper OpenSpec CLI tools (not manual directory browsing)
+- [ ] Created proposal files ONLY (no implementation)
+- [ ] Waiting for explicit user approval before implementing
+
+## Before Any Task
+
+**Context Checklist:**
+- [ ] Read relevant specs in `specs/[capability]/spec.md`
+- [ ] Check pending changes in `changes/` for conflicts
+- [ ] Read `openspec/project.md` for conventions
+- [ ] Run `openspec list` to see active changes
+- [ ] Run `openspec list --specs` to see existing capabilities
+
+**Before Creating Specs:**
+- Always check if capability already exists
+- Prefer modifying existing specs over creating duplicates
+- Use `openspec show [spec]` to review current state
+
+## Common Mistakes to Avoid
+
+1. **Creating AND implementing in one session** - Always wait for explicit approval
+2. **Skipping OpenSpec CLI tools** - Always use `openspec list` and `openspec show`
+3. **Manual directory browsing** - Use the CLI tools instead
+4. **Assuming implementation is wanted** - User must explicitly request it
+5. **Creating duplicate specs** - Always check existing specs first

--- a/openspec/changes/add-claude-testing-tools/design.md
+++ b/openspec/changes/add-claude-testing-tools/design.md
@@ -1,0 +1,270 @@
+# Technical Design: Claude Code Testing Tools
+
+## Architecture Overview
+
+The Claude Code testing tools are designed as a thin wrapper around the `claude` CLI command, leveraging the existing local subscription authentication. The architecture prioritizes simplicity, reusability, and integration with the existing OpenSpec codebase.
+
+## Design Decisions
+
+### 1. CLI Wrapper Approach
+**Decision**: Use Node.js child_process to execute `claude` CLI commands rather than an SDK.
+
+**Rationale**:
+- No API key management required (uses existing subscription)
+- Leverages battle-tested Claude CLI functionality
+- Avoids SDK version dependencies
+- Simpler implementation and maintenance
+
+**Implementation**:
+```typescript
+import { spawn } from 'child_process';
+
+async function executeClaude(prompt: string, options: ClaudeOptions): Promise<ClaudeResponse> {
+  const args = [
+    '-p', prompt,
+    '--output-format', 'json',
+    ...buildArgs(options)
+  ];
+  
+  return new Promise((resolve, reject) => {
+    const process = spawn('claude', args);
+    // Handle stdout, stderr, exit
+  });
+}
+```
+
+### 2. Integration with Existing Package
+**Decision**: Add testing tools to the existing OpenSpec package rather than creating a new package.
+
+**Rationale**:
+- Reuses existing dependencies (commander, chalk, ora)
+- Maintains consistent code patterns
+- Simpler dependency management
+- Easier to maintain
+
+**Structure**:
+```
+src/
+├── cli/          # Existing CLI
+├── commands/     # Existing commands
+├── core/         # Existing core logic
+├── utils/        # Existing utilities
+└── testing/      # NEW: Testing tools (isolated)
+    ├── claude-tester.ts
+    ├── types.ts
+    └── lib/
+```
+
+### 3. JSON-Based Communication
+**Decision**: Use JSON output format for all Claude interactions.
+
+**Rationale**:
+- Structured data parsing
+- Consistent error handling
+- Metrics extraction
+- Programmatic analysis
+
+**Response Format**:
+```typescript
+interface ClaudeResponse {
+  type: 'result';
+  subtype: 'success' | 'error';
+  is_error: boolean;
+  duration_ms: number;
+  result: string;
+  session_id: string;
+  total_cost_usd: number;
+  usage: {
+    input_tokens: number;
+    output_tokens: number;
+    cache_creation_input_tokens?: number;
+    cache_read_input_tokens?: number;
+  };
+}
+```
+
+### 4. File-Based Result Storage
+**Decision**: Store test results as JSON files in a local directory.
+
+**Rationale**:
+- Simple persistence mechanism
+- Easy to version control (or ignore)
+- Human-readable format
+- Easy to process with other tools
+
+**Naming Convention**:
+```
+test-results/
+├── {test_name}_{timestamp}.json           # Single tests
+├── {test_name}_comparison_{timestamp}.json # Comparisons
+└── {test_name}_conversation_{timestamp}.json # Conversations
+```
+
+## Component Design
+
+### 1. CLI Entry Point (`claude-tester.ts`)
+Responsibilities:
+- Parse command-line arguments using Commander
+- Route to appropriate test mode (single, compare, conversation)
+- Handle global options and configuration
+- Display results summary
+
+Key Methods:
+```typescript
+class ClaudeTester {
+  async runSingleTest(options: SingleTestOptions): Promise<TestResult>
+  async runComparison(options: ComparisonOptions): Promise<ComparisonResult>
+  async runConversation(options: ConversationOptions): Promise<ConversationResult>
+}
+```
+
+### 2. Executor (`lib/executor.ts`)
+Responsibilities:
+- Build claude CLI arguments from options
+- Execute claude command via child_process
+- Parse JSON responses
+- Handle errors and timeouts
+- Support streaming for long responses
+
+Key Methods:
+```typescript
+class ClaudeExecutor {
+  async execute(prompt: string, options: ExecuteOptions): Promise<ClaudeResponse>
+  async stream(prompt: string, options: StreamOptions): AsyncIterable<ClaudeMessage>
+  buildArgs(options: ExecuteOptions): string[]
+}
+```
+
+### 3. Analyzer (`lib/analyzer.ts`)
+Responsibilities:
+- Extract metrics from responses
+- Parse reasoning steps from text
+- Identify tool usage patterns
+- Calculate derived metrics
+
+Key Methods:
+```typescript
+class ResponseAnalyzer {
+  extractMetrics(response: ClaudeResponse): Metrics
+  extractReasoningSteps(text: string): string[]
+  analyzeToolUsage(response: ClaudeResponse): ToolUsage[]
+  compareResponses(responses: ClaudeResponse[]): ComparisonMetrics
+}
+```
+
+### 4. Reporter (`lib/reporter.ts`)
+Responsibilities:
+- Format results for console display
+- Save results to JSON files
+- Generate comparison tables
+- Create summary reports
+
+Key Methods:
+```typescript
+class ResultReporter {
+  saveResult(result: TestResult, outputDir: string): string
+  printSummary(result: TestResult): void
+  printComparisonTable(comparison: ComparisonResult): void
+  generateReport(results: TestResult[]): Report
+}
+```
+
+## Data Flow
+
+### Single Test Flow
+1. User runs: `pnpm test:claude --prompt "..." --name "test1"`
+2. CLI parses arguments, creates options object
+3. Executor builds claude command with JSON output
+4. Executor spawns claude process, captures response
+5. Analyzer extracts metrics and patterns
+6. Reporter saves JSON and prints summary
+
+### Comparison Flow
+1. User runs: `pnpm test:claude compare --prompt "..." --variants "A" "B" "C"`
+2. CLI creates comparison options
+3. For each variant:
+   - Executor runs claude with variant as instruction
+   - Analyzer processes response
+4. Analyzer compares all responses
+5. Reporter generates comparison table and saves results
+
+### Conversation Flow
+1. User runs: `pnpm test:claude conversation --turns "Q1" "Q2" "Q3"`
+2. CLI creates conversation options
+3. For each turn:
+   - Executor runs claude with --continue flag (after first)
+   - Analyzer tracks conversation metrics
+4. Reporter saves conversation history
+
+## Error Handling
+
+### Expected Errors
+- Claude CLI not found → Clear installation instructions
+- No subscription → Guide to authentication
+- Timeout → Configurable timeout with retry option
+- Invalid JSON → Fallback to text parsing
+
+### Error Recovery
+```typescript
+try {
+  const response = await executor.execute(prompt, options);
+  return analyzer.process(response);
+} catch (error) {
+  if (error.code === 'ENOENT') {
+    console.error('Claude CLI not found. Install with: npm install -g @anthropic-ai/claude-code');
+  } else if (error.code === 'TIMEOUT') {
+    console.error(`Request timed out after ${options.timeout}ms`);
+  }
+  // Save partial results if available
+  reporter.saveError(error, options);
+}
+```
+
+## Performance Considerations
+
+### Optimization Strategies
+1. **Parallel Execution**: Run comparison variants in parallel (with rate limiting)
+2. **Result Caching**: Cache responses for identical prompts (optional)
+3. **Streaming**: Use stream-json format for large responses
+4. **Batch Processing**: Support batch test files
+
+### Resource Management
+- Limit concurrent Claude processes (default: 3)
+- Implement exponential backoff for rate limits
+- Clean up old test results (configurable retention)
+
+## Future Enhancements
+
+### Potential Features (Not in Initial Implementation)
+1. **Web UI**: Simple web interface for viewing results
+2. **Diff Visualization**: Visual diff between response variants
+3. **Pattern Detection**: Automatic pattern extraction from responses
+4. **Test Suites**: YAML/JSON test definition format
+5. **CI Integration**: GitHub Actions for automated testing
+6. **Metrics Dashboard**: Aggregate metrics across tests
+
+### Extension Points
+The design allows for future extensions without breaking changes:
+- Custom analyzers via plugin system
+- Additional output formats (CSV, Markdown)
+- Integration with evaluation frameworks
+- Custom Claude CLI flags support
+
+## Testing Strategy
+
+### Unit Tests
+- Mock claude CLI responses for executor tests
+- Test analyzer pattern extraction with fixtures
+- Test reporter formatting with snapshots
+
+### Integration Tests
+- Test with actual claude CLI (requires subscription)
+- Test error scenarios (timeout, invalid input)
+- Test multi-turn conversations
+
+### Example Tests
+Provide comprehensive examples in `test/claude-tests/`:
+- Basic prompts
+- Instruction variants
+- Multi-turn conversations
+- Error handling scenarios

--- a/openspec/changes/add-claude-testing-tools/proposal.md
+++ b/openspec/changes/add-claude-testing-tools/proposal.md
@@ -1,0 +1,151 @@
+# Add Claude Code Testing Tools
+
+## Why
+
+Development teams need a systematic way to test and evaluate Claude Code prompts and instructions to:
+- Understand how different instructions affect Claude's responses
+- Compare instruction variants to find optimal approaches
+- Track Claude's tool usage patterns and reasoning steps
+- Create reproducible test cases for prompt engineering
+- Build a simple evaluation system for local development
+
+Currently, testing Claude Code requires manual interaction through the CLI, making it difficult to:
+- Compare multiple instruction variants systematically
+- Track metrics and patterns across tests
+- Reproduce specific test scenarios
+- Analyze response characteristics programmatically
+
+## What Changes
+
+### New Testing Infrastructure
+- **TypeScript-based testing CLI** that wraps the `claude` command
+  - Executes Claude Code in headless mode (no API key required)
+  - Captures and parses JSON responses
+  - Supports single tests, comparisons, and multi-turn conversations
+  - Saves results for analysis and comparison
+
+### Core Features
+- **Single Test Mode**: Test individual prompts with optional instructions
+  ```bash
+  pnpm test:claude --prompt "Write a function" --name "test1"
+  ```
+
+- **Comparison Mode**: Test same prompt with multiple instruction variants
+  ```bash
+  pnpm test:claude compare \
+    --prompt "Create API" \
+    --variants "Be verbose" "Be concise" "Focus on security"
+  ```
+
+- **Conversation Mode**: Multi-turn conversations for complex scenarios
+  ```bash
+  pnpm test:claude conversation \
+    --turns "Create model" "Add validation" "Add tests"
+  ```
+
+- **Analysis Capabilities**:
+  - Response text extraction and metrics
+  - Token usage and cost tracking
+  - Execution time measurement
+  - Session ID tracking for resumption
+  - Tool usage pattern analysis (when available)
+  - Reasoning step extraction
+
+### File Structure
+```
+src/testing/              # Development testing tools (not production code)
+├── claude-tester.ts      # Main CLI entry point
+├── types.ts              # TypeScript interfaces
+└── lib/
+    ├── executor.ts       # Claude CLI execution wrapper
+    ├── analyzer.ts       # Response analysis utilities
+    └── reporter.ts       # Result reporting and formatting
+
+test/claude-tests/        # Example test suites
+├── example-prompts.ts    # Basic prompt examples
+└── instruction-variants.ts # Instruction comparison examples
+
+test-results/            # Git-ignored output directory
+└── *.json              # JSON test results
+```
+
+### Integration Approach
+- **Leverage existing package.json** - No new package or dependencies
+- **Use existing dependencies** - commander, chalk, ora already available
+- **Follow project patterns** - Consistent with existing OpenSpec structure
+- **Non-invasive** - Testing tools isolated in `src/testing/` directory
+- **Development-only** - Not included in production builds
+
+### Command Line Interface
+```bash
+# Main commands
+pnpm test:claude [options]           # Run single test
+pnpm test:claude compare [options]   # Compare variants
+pnpm test:claude conversation [options] # Multi-turn test
+
+# Options
+--prompt, -p <text>         # Prompt to test
+--prompt-file, -f <file>    # Load prompt from file
+--instructions, -i <text>   # Custom instructions
+--name, -n <name>          # Test name for results
+--output-dir, -o <dir>     # Results directory (default: ./test-results)
+--model <model>            # Claude model (sonnet, opus, etc.)
+--allowed-tools <tools>    # Restrict tool usage
+--permission-mode <mode>   # Permission mode (acceptEdits, plan, etc.)
+
+# Comparison options
+--variants <texts...>      # Instruction variants to compare
+
+# Conversation options  
+--turns <prompts...>       # Conversation turns
+--session-id <id>         # Resume specific session
+```
+
+### Output Format
+Test results saved as JSON with:
+- Test metadata (name, timestamp, prompt, instructions)
+- Full response text
+- Response metrics (length, tokens, cost)
+- Execution timing
+- Session information
+- Error tracking
+
+Example output structure:
+```json
+{
+  "test_name": "api_test",
+  "timestamp": "2025-09-01T10:30:00Z",
+  "prompt": "Create a REST API",
+  "instructions": "Be concise",
+  "response": "...",
+  "metrics": {
+    "response_length": 1250,
+    "tokens": { "input": 100, "output": 250 },
+    "cost_usd": 0.0025,
+    "duration_ms": 3500
+  },
+  "session_id": "uuid-here"
+}
+```
+
+## Impact
+
+### Code Changes
+- **New files only** - No modifications to existing production code
+- **Isolated testing directory** - `src/testing/` for all testing tools
+- **Example tests** - `test/claude-tests/` for documentation
+- **Scripts addition** - Two new scripts in package.json
+
+### Dependencies
+- **No new dependencies** - Uses existing commander, chalk, ora
+- **No API key required** - Uses local Claude subscription via CLI
+
+### Documentation
+- This is a development tool, not part of OpenSpec's public API
+- Example tests serve as documentation
+- No changes to existing OpenSpec documentation
+
+### Notes
+- This is a tooling/infrastructure change for development purposes
+- Does not affect OpenSpec's core functionality or specifications
+- When archiving, use: `openspec archive 2025-09-01-add-claude-testing-tools --skip-specs`

--- a/openspec/changes/add-claude-testing-tools/tasks.md
+++ b/openspec/changes/add-claude-testing-tools/tasks.md
@@ -1,0 +1,145 @@
+# Implementation Tasks: Claude Code Testing Tools
+
+## Phase 1: Core Infrastructure
+
+- [ ] Create testing directory structure
+  - [ ] Create `src/testing/` directory
+  - [ ] Create `src/testing/lib/` subdirectory
+  - [ ] Create `test/claude-tests/` directory
+  - [ ] Add `test-results/` to .gitignore
+
+- [ ] Define TypeScript types (`src/testing/types.ts`)
+  - [ ] ClaudeResponse interface
+  - [ ] TestResult interface
+  - [ ] ComparisonResult interface
+  - [ ] ConversationResult interface
+  - [ ] ExecuteOptions interface
+  - [ ] TestMetrics interface
+
+## Phase 2: Core Components
+
+- [ ] Implement Claude Executor (`src/testing/lib/executor.ts`)
+  - [ ] Create ClaudeExecutor class
+  - [ ] Implement execute() method with child_process spawn
+  - [ ] Implement buildArgs() for CLI argument construction
+  - [ ] Add JSON response parsing
+  - [ ] Add error handling for missing CLI, timeouts
+  - [ ] Add support for streaming responses
+
+- [ ] Implement Response Analyzer (`src/testing/lib/analyzer.ts`)
+  - [ ] Create ResponseAnalyzer class
+  - [ ] Implement extractMetrics() method
+  - [ ] Implement extractReasoningSteps() method
+  - [ ] Implement compareResponses() method
+  - [ ] Add pattern detection for common reasoning indicators
+
+- [ ] Implement Result Reporter (`src/testing/lib/reporter.ts`)
+  - [ ] Create ResultReporter class
+  - [ ] Implement saveResult() for JSON file output
+  - [ ] Implement printSummary() for console display
+  - [ ] Implement printComparisonTable() for variant comparison
+  - [ ] Add timestamp-based file naming
+  - [ ] Add colored console output using chalk
+
+## Phase 3: CLI Implementation
+
+- [ ] Implement main CLI (`src/testing/claude-tester.ts`)
+  - [ ] Set up Commander CLI structure
+  - [ ] Add single test command
+  - [ ] Add comparison command
+  - [ ] Add conversation command
+  - [ ] Add global options (output-dir, model, etc.)
+  - [ ] Add help text and examples
+  - [ ] Implement main execution flow
+  - [ ] Add progress indicators using ora
+
+- [ ] Update package.json
+  - [ ] Add `test:claude` script
+  - [ ] Add `test:claude:watch` script for development
+  - [ ] Ensure tsx is available for TypeScript execution
+
+## Phase 4: Test Modes
+
+- [ ] Implement Single Test Mode
+  - [ ] Parse prompt and instructions
+  - [ ] Support file input for prompts
+  - [ ] Execute claude command
+  - [ ] Analyze and save results
+  - [ ] Display summary
+
+- [ ] Implement Comparison Mode
+  - [ ] Parse prompt and variants
+  - [ ] Execute tests for each variant
+  - [ ] Compare results
+  - [ ] Generate comparison table
+  - [ ] Save comparison summary
+
+- [ ] Implement Conversation Mode
+  - [ ] Parse conversation turns
+  - [ ] Handle session continuity
+  - [ ] Track conversation metrics
+  - [ ] Save conversation history
+
+## Phase 5: Examples and Documentation
+
+- [ ] Create example test files
+  - [ ] `test/claude-tests/example-prompts.ts` with basic examples
+  - [ ] `test/claude-tests/instruction-variants.ts` with comparison examples
+  - [ ] `test/claude-tests/conversation-examples.ts` with multi-turn examples
+
+- [ ] Create usage documentation
+  - [ ] Add README to `src/testing/` explaining the tools
+  - [ ] Document all CLI options
+  - [ ] Provide example commands
+  - [ ] Document output format
+
+## Phase 6: Testing and Validation
+
+- [ ] Manual testing
+  - [ ] Test single prompt execution
+  - [ ] Test comparison with multiple variants
+  - [ ] Test conversation mode
+  - [ ] Test error scenarios (no Claude CLI, timeout)
+  - [ ] Test file input options
+  - [ ] Test JSON output parsing
+
+- [ ] Verify integration
+  - [ ] Ensure no conflicts with existing OpenSpec commands
+  - [ ] Verify scripts work with pnpm
+  - [ ] Test on different Claude models (sonnet, opus)
+  - [ ] Verify output directory creation
+
+## Phase 7: Polish and Optimization
+
+- [ ] Add advanced features
+  - [ ] Support for custom Claude CLI flags
+  - [ ] Batch test file support
+  - [ ] Result comparison between test runs
+  - [ ] Session resumption support
+
+- [ ] Performance optimization
+  - [ ] Implement parallel execution for comparisons
+  - [ ] Add configurable rate limiting
+  - [ ] Optimize large response handling
+
+- [ ] Error handling improvements
+  - [ ] Better error messages for common issues
+  - [ ] Graceful degradation for missing features
+  - [ ] Recovery suggestions for failures
+
+## Completion Checklist
+
+- [ ] All TypeScript files compile without errors
+- [ ] Scripts work via `pnpm test:claude`
+- [ ] Example tests run successfully
+- [ ] Results saved to test-results directory
+- [ ] Console output is clear and informative
+- [ ] No modifications to production code
+- [ ] Documentation is complete
+
+## Notes
+
+- This is a development tool only, not part of OpenSpec's public API
+- All code goes in `src/testing/` to keep it isolated
+- No new npm dependencies should be added
+- Use existing utilities from `src/utils/` where applicable


### PR DESCRIPTION
## Summary
- Add mandatory context gathering requirements before creating any OpenSpec change
- Clarify that proposal creation and implementation must happen in separate sessions
- Add explicit warnings about waiting for user approval between stages

## Key Changes
- **Session Boundaries**: Makes it clear that Stage 1 (proposal), Stage 2 (implementation), and Stage 3 (archiving) happen in different sessions
- **Mandatory CLI Usage**: Requires using `openspec list` and `openspec list --specs` before creating any change
- **Explicit Approval**: Emphasizes that implementation only happens when user explicitly requests it
- **Common Mistakes Section**: Highlights pitfalls to avoid

## Files Changed
- `openspec/README.md.proposed-update` - Updated agent instructions with session boundaries
- `openspec/changes/add-claude-testing-tools/` - Example change proposal for Claude testing tools

## Context
This change was created after identifying that AI assistants were not following the proper OpenSpec workflow - specifically, they were creating and implementing changes in a single session without checking for conflicts or waiting for approval.

🤖 Generated with [Claude Code](https://claude.ai/code)