### PR TITLE
feat: add active change sorting proposal

### DIFF
--- a/openspec/changes/sort-active-changes-by-progress/proposal.md
+++ b/openspec/changes/sort-active-changes-by-progress/proposal.md
@@ -1,0 +1,25 @@
+# Change: Sort Active Changes by Progress
+
+## Problem
+- The dashboard currently lists active changes in filesystem discovery order.
+- Users cannot quickly spot proposals that have not started or are nearly complete.
+- Inconsistent ordering between runs makes it harder to track progress when many changes exist.
+
+## Proposal
+1. Update the Active Changes list in the dashboard to sort by percentage of completion in ascending order so 0% items show first.
+2. When two changes share the same completion percentage, break ties deterministically by change identifier (alphabetical).
+
+## Benefits
+- Highlights work that has not started yet, enabling quicker prioritization.
+- Provides consistent ordering across machines and repeated runs.
+- Keeps the dashboard compact while communicating the most important status signal.
+
+## Risks & Mitigations
+- **Risk:** Sorting logic could regress rendering when progress data is missing.
+  - **Mitigation:** Treat missing progress as 0% so items still surface and document behavior in tests.
+- **Risk:** Additional sorting could impact performance for large change sets.
+  - **Mitigation:** The number of active changes is typically small; sorting a few entries is negligible.
+
+## Success Criteria
+- Dashboard output shows active changes ordered by ascending completion percentage with deterministic tie-breaking.
+- Unit coverage verifying the sort when percentages vary and when ties occur.

--- a/openspec/changes/sort-active-changes-by-progress/specs/cli-view/spec.md
+++ b/openspec/changes/sort-active-changes-by-progress/specs/cli-view/spec.md
@@ -1,0 +1,9 @@
+## MODIFIED Requirements
+### Requirement: Active Changes Display
+The dashboard SHALL show active changes with visual progress indicators.
+
+#### Scenario: Active changes ordered by completion percentage
+- **WHEN** multiple active changes are displayed with progress information
+- **THEN** list them sorted by completion percentage ascending so 0% items appear first
+- **AND** treat missing progress values as 0% for ordering
+- **AND** break ties by change identifier in ascending alphabetical order to keep output deterministic

--- a/openspec/changes/sort-active-changes-by-progress/tasks.md
+++ b/openspec/changes/sort-active-changes-by-progress/tasks.md
@@ -1,0 +1,8 @@
+# Implementation Tasks
+
+## 1. Dashboard Sorting Logic
+- [ ] 1.1 Update the Active Changes rendering to sort by completion percentage ascending.
+- [ ] 1.2 Treat missing progress as 0% and break ties alphabetically by change identifier.
+
+## 2. Verification
+- [ ] 2.1 Add tests that cover different completion percentages and tie cases to confirm deterministic ordering.


### PR DESCRIPTION
## Summary
- add a proposal to sort the dashboard's Active Changes by ascending completion percentage
- refine the implementation tasks to focus on sorting logic, deterministic behavior, and regression coverage

## Testing
- not run (spec-only change)

------
https://chatgpt.com/codex/tasks/task_e_68c8b523880c8322ac4ca5142db184a4