### PR TITLE
docs: correct claude code commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,14 @@
 
 # OpenSpec
 
-**Supported AI Tools:** ✅ Claude Code | 🔜 Cursor (coming soon) | ✅ AGENTS.md instructions
+**Supported AI Tools:** ✅ Claude Code | ✅ Cursor | ✅ AGENTS.md instructions
+
+**Custom Slash Commands:** Jump straight into any workflow step with the optional `/openspec` commands—no prompt engineering required:
+
+- In Claude Code, type `/openspec:proposal` to draft a change, `/openspec:apply` to implement tasks, and `/openspec:archive` once it's deployed.
+- In Cursor, use `/openspec-proposal`, `/openspec-apply`, and `/openspec-archive` for proposals, implementation, and archiving respectively.
+
+You can still trigger every OpenSpec workflow step by chatting with your agent—the slash commands simply provide more precise control for tools that support custom commands.
 
 Create **alignment** between humans and AI coding assistants through spec-driven development. **No API keys required.**
 
@@ -91,10 +98,12 @@ cd my-project
 # Initialize OpenSpec
 openspec init
 
-# Select your AI tool (more coming soon!):
+# Select your AI tool:
 # "Which AI tool do you use?"
 #   > Claude Code
-#     Cursor (coming soon)
+#       Use /openspec:proposal, /openspec:apply, and /openspec:archive in Claude Code to run proposals, apply tasks, and archive changes.
+#     Cursor
+#       Use /openspec-proposal, /openspec-apply, and /openspec-archive in Cursor for proposals, implementation, and archiving.
 
 # This creates:
 # openspec/


### PR DESCRIPTION
## Summary
- clarify the slash command section to spell out the `/openspec` commands people can run in Claude Code (with colon syntax) and Cursor
- update the initialization walkthrough to explain how to invoke the commands with the correct syntax instead of referencing where they live

## Testing
- not run (docs only)

------
https://chatgpt.com/codex/tasks/task_e_68c929df84508322a9963dc92094a585