### PR TITLE
docs: add --yes flag to archive command template

### DIFF
--- a/src/core/templates/slash-command-templates.ts
+++ b/src/core/templates/slash-command-templates.ts
@@ -32,7 +32,7 @@ const applyReferences = `**Reference**
 
 const archiveSteps = `**Steps**
 1. Identify the requested change ID (via the prompt or \`openspec list\`).
-2. Run \`openspec archive <id>\` to let the CLI move the change and apply spec updates (use \`--skip-specs\` only for tooling-only work).
+2. Run \`openspec archive <id> --yes\` to let the CLI move the change and apply spec updates without prompts (use \`--skip-specs\` only for tooling-only work).
 3. Review the command output to confirm the target specs were updated and the change landed in \`changes/archive/\`.
 4. Validate with \`openspec validate --strict\` and inspect with \`openspec show <id>\` if anything looks off.`;
 


### PR DESCRIPTION
## Summary
- Updates the archive slash command template to include the `--yes` flag in the command documentation
- This makes the archiving process non-interactive by default, which aligns with the expected CLI behavior

## Test plan
- [ ] Review the updated template in slash command documentation
- [ ] Verify the command suggestion now includes `--yes` flag

🤖 Generated with [Claude Code](https://claude.ai/code)