### PR TITLE
docs: document archive yes flag usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,13 +185,13 @@ You: Please archive the change
      (Shortcut for tools with slash commands: /openspec:archive add-profile-filters)
 
 AI:  I'll archive the add-profile-filters change.
-     *Runs: openspec archive add-profile-filters*
+    *Runs: openspec archive add-profile-filters --yes*
      ✓ Change archived successfully. Specs updated. Ready for the next feature!
 ```
 
 Or run the command yourself in terminal:
 ```bash
-$ openspec archive add-profile-filters  # Archive the completed change
+$ openspec archive add-profile-filters --yes  # Archive the completed change without prompts
 ```
 
 **Note:** Tools with native slash commands (Claude Code, Cursor) can use the shortcuts shown. All other tools work with natural language requests to "create an OpenSpec proposal", "apply the OpenSpec change", or "archive the change".
@@ -203,7 +203,7 @@ openspec list               # View active change folders
 openspec view               # Interactive dashboard of specs and changes
 openspec show <change>      # Display change details (proposal, tasks, spec updates)
 openspec validate <change>  # Check spec formatting and structure
-openspec archive <change>   # Move a completed change into archive/
+openspec archive <change> [--yes|-y]   # Move a completed change into archive/ (non-interactive with --yes)
 ```
 
 ## Example: How AI Creates OpenSpec Files

--- a/openspec/AGENTS.md
+++ b/openspec/AGENTS.md
@@ -58,7 +58,7 @@ Skip proposal for:
 After deployment, create separate PR to:
 - Move `changes/[name]/` → `changes/archive/YYYY-MM-DD-[name]/`
 - Update `specs/` if capabilities changed
-- Use `openspec archive [change] --skip-specs` for tooling-only changes
+- Use `openspec archive [change] --skip-specs --yes` for tooling-only changes
 - Run `openspec validate --strict` to confirm the archived change passes checks
 
 ## Before Any Task
@@ -95,7 +95,7 @@ openspec list --specs          # List specifications
 openspec show [item]           # Display change or spec
 openspec diff [change]         # Show spec differences
 openspec validate [item]       # Validate changes or specs
-openspec archive [change]      # Archive after deployment
+openspec archive [change] [--yes|-y]      # Archive after deployment (add --yes for non-interactive runs)
 
 # Project management
 openspec init [path]           # Initialize OpenSpec
@@ -117,6 +117,7 @@ openspec validate [change] --strict
 - `--strict` - Comprehensive validation
 - `--no-interactive` - Disable prompts
 - `--skip-specs` - Archive without spec updates
+- `--yes`/`-y` - Skip confirmation prompts (non-interactive archive)
 
 ## Directory Structure
 
@@ -447,7 +448,7 @@ openspec list              # What's in progress?
 openspec show [item]       # View details
 openspec diff [change]     # What's changing?
 openspec validate --strict # Is it correct?
-openspec archive [change]  # Mark complete
+openspec archive [change] [--yes|-y]  # Mark complete (add --yes for automation)
 ```
 
 Remember: Specs are truth. Changes are proposals. Keep them in sync.

--- a/src/core/templates/agents-template.ts
+++ b/src/core/templates/agents-template.ts
@@ -58,7 +58,7 @@ Skip proposal for:
 After deployment, create separate PR to:
 - Move \`changes/[name]/\` → \`changes/archive/YYYY-MM-DD-[name]/\`
 - Update \`specs/\` if capabilities changed
-- Use \`openspec archive [change] --skip-specs\` for tooling-only changes
+- Use \`openspec archive [change] --skip-specs --yes\` for tooling-only changes
 - Run \`openspec validate --strict\` to confirm the archived change passes checks
 
 ## Before Any Task
@@ -95,7 +95,7 @@ openspec list --specs          # List specifications
 openspec show [item]           # Display change or spec
 openspec diff [change]         # Show spec differences
 openspec validate [item]       # Validate changes or specs
-openspec archive [change]      # Archive after deployment
+openspec archive [change] [--yes|-y]      # Archive after deployment (add --yes for non-interactive runs)
 
 # Project management
 openspec init [path]           # Initialize OpenSpec
@@ -117,6 +117,7 @@ openspec validate [change] --strict
 - \`--strict\` - Comprehensive validation
 - \`--no-interactive\` - Disable prompts
 - \`--skip-specs\` - Archive without spec updates
+- \`--yes\`/\`-y\` - Skip confirmation prompts (non-interactive archive)
 
 ## Directory Structure
 
@@ -447,7 +448,7 @@ openspec list              # What's in progress?
 openspec show [item]       # View details
 openspec diff [change]     # What's changing?
 openspec validate --strict # Is it correct?
-openspec archive [change]  # Mark complete
+openspec archive [change] [--yes|-y]  # Mark complete (add --yes for automation)
 \`\`\`
 
 Remember: Specs are truth. Changes are proposals. Keep them in sync.


### PR DESCRIPTION
## Summary
- document the --yes/-y archive flag in the AGENTS template and generated instructions
- note the non-interactive archive flag in the README examples and command reference

## Testing
- not run (docs only)

------
https://chatgpt.com/codex/tasks/task_e_68d9eb172374832284b6dfb9d0419f1d