### PR TITLE
Align Kilo slash command proposal with init/update specs

### DIFF
--- a/openspec/changes/add-kilo-slash-commands/proposal.md
+++ b/openspec/changes/add-kilo-slash-commands/proposal.md
@@ -1,0 +1,12 @@
+## Why
+- Kilo Code supports customizable slash command "workflows" by loading Markdown files from `.kilocode/workflows/` and exposing each file as a `/filename.md` action inside chat. These workflows can drive CLI usage, MCP integrations, and scripted release or project tasks, making them a good fit for codifying OpenSpec routines.
+- Today OpenSpec contributors have to hand-build those Markdown files (and keep them updated) if they want Kilo to run project hygiene like `openspec list`, `openspec validate`, or spec scaffolding. That creates inconsistent setups and stale automation across teams.
+
+## What Changes
+- Extend the existing `openspec init` AI tool selection flow to list "Kilo Code" and scaffold recommended `.kilocode/workflows/*.md` slash commands when selected, mirroring how Claude Code and Cursor are handled.
+- Refresh `.kilocode/workflows/*.md` during `openspec update` runs whenever the managed Kilo files already exist so teams stay current without manual edits.
+- Ship curated workflow templates that walk Kilo through the OpenSpec research loop (gather context, list specs/changes), proposal authoring, and validation, including inline reminders about when to ask for missing parameters.
+
+## Impact
+- Affected specs: cli-init, cli-update
+- Affected code: CLI command wiring, workflow template assets, documentation

--- a/openspec/changes/add-kilo-slash-commands/specs/cli-init/spec.md
+++ b/openspec/changes/add-kilo-slash-commands/specs/cli-init/spec.md
@@ -1,0 +1,10 @@
+## MODIFIED Requirements
+### Requirement: Slash Command Configuration
+The init command SHALL generate slash command files for supported editors using shared templates.
+
+#### Scenario: Generating slash commands for Kilo Code
+- **WHEN** the user selects Kilo Code during initialization
+- **THEN** create `.kilocode/workflows/openspec-plan-change.md`, `.kilocode/workflows/openspec-author-proposal.md`, and `.kilocode/workflows/openspec-validate-change.md`
+- **AND** populate each Markdown file with the OpenSpec planning, proposal authoring, and validation workflows (including frontmatter descriptions and reminders to collect missing inputs)
+- **AND** wrap the managed content in OpenSpec markers so future updates can refresh the body safely
+- **AND** list the resulting `/openspec-plan-change.md`, `/openspec-author-proposal.md`, and `/openspec-validate-change.md` slash commands in the success summary

--- a/openspec/changes/add-kilo-slash-commands/specs/cli-update/spec.md
+++ b/openspec/changes/add-kilo-slash-commands/specs/cli-update/spec.md
@@ -1,0 +1,9 @@
+## MODIFIED Requirements
+### Requirement: Slash Command Updates
+The update command SHALL refresh existing slash command files for configured tools without creating new ones.
+
+#### Scenario: Updating slash commands for Kilo Code
+- **WHEN** `.kilocode/workflows/` already contains `openspec-plan-change.md`, `openspec-author-proposal.md`, and `openspec-validate-change.md`
+- **THEN** refresh each Markdown workflow from the shared templates while preserving any content outside the OpenSpec markers
+- **AND** ensure the regenerated workflows keep the frontmatter descriptions and reminders to gather missing context
+- **AND** report the updated `/openspec-plan-change.md`, `/openspec-author-proposal.md`, and `/openspec-validate-change.md` slash commands in the success summary

--- a/openspec/changes/add-kilo-slash-commands/tasks.md
+++ b/openspec/changes/add-kilo-slash-commands/tasks.md
@@ -1,0 +1,20 @@
+## 1. Slash command scaffolding
+- [ ] 1.1 Add Kilo Code to the slash command template registry with a configurator that maps `plan-change`, `author-proposal`, and `validate-change` to `.kilocode/workflows/*.md`.
+- [ ] 1.2 Author Markdown templates for each workflow that include frontmatter descriptions, reminders to gather missing context, and step-by-step OpenSpec guidance wrapped in OpenSpec markers.
+- [ ] 1.3 Ensure templates share common snippets where possible so future updates stay consistent across editors.
+
+## 2. CLI init integration
+- [ ] 2.1 Extend the AI tool selection menu to list "Kilo Code" alongside existing tools, including already-configured detection and success messaging.
+- [ ] 2.2 Ensure `openspec init` writes the Kilo `.kilocode/workflows/` files when the tool is selected, creating parent directories as needed and summarizing the resulting slash commands.
+
+## 3. CLI update integration
+- [ ] 3.1 Teach `openspec update` to refresh the Kilo workflow files only when they already exist, preserving content outside OpenSpec markers.
+- [ ] 3.2 Extend logging to report Kilo workflow refreshes alongside other tools.
+
+## 4. Documentation & guidance
+- [ ] 4.1 Add an integration guide explaining how to enable the Kilo "Run Slash Command" experiment, run `openspec init`, and trigger the generated commands.
+- [ ] 4.2 Update README or CLI help output to mention the new Kilo support and link to the guide.
+
+## 5. Tests
+- [ ] 5.1 Add Vitest coverage under `test/core/init.test.ts` verifying the `.kilocode/workflows/*.md` files are generated with the expected prompts and markers.
+- [ ] 5.2 Add Vitest coverage under `test/core/update.test.ts` confirming existing Kilo files get refreshed while preserving unmanaged sections.


### PR DESCRIPTION
## Summary
- update the Kilo integration proposal to extend the existing `openspec init` and `openspec update` flows instead of introducing a new command
- add spec deltas for `cli-init` and `cli-update` that cover generating and refreshing Kilo `.kilocode/workflows/*.md` slash commands
- refresh the implementation task list to match the init/update integration plan

## Testing
- node bin/openspec.js validate add-kilo-slash-commands --strict

------
https://chatgpt.com/codex/tasks/task_e_68da9243eef4832297372f50f649e36f