### PR TITLE
chore: release 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,11 @@
 # @fission-ai/openspec
 
-## Unreleased
-
-### Minor Changes
-
-- Always generate the root `AGENTS.md` stub during `openspec init`, regroup the tool prompt into native vs. other assistants, and refresh docs to reflect the universal hand-off.
-
 ## 0.7.0
 
 ### Minor Changes
 
-- Add Kilo Code workflow support so `openspec init` scaffolds `.kilocode/workflows/openspec-*.md` and `openspec update` refreshes them in place.
+- Add native Kilo Code workflow integration so `openspec init` and `openspec update` manage `.kilocode/workflows/openspec-*.md` files.
+- Always scaffold the managed root `AGENTS.md` hand-off stub and regroup the AI tool prompts during init/update to keep instructions consistent.
 
 ## 0.6.0
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fission-ai/openspec",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "AI-native system for spec-driven development",
   "keywords": [
     "openspec",


### PR DESCRIPTION
  Summary

  - bump @fission-ai/openspec to 0.7.0 for the latest CLI improvements
  - document the Kilo Code workflow integration and always-on AGENTS.md stub in the
  changelog

  Testing

  - Not run (release prep only)

  Next Steps

  1. Merge after CI green.
  2. Create tag v0.7.0 and publish the GitHub Release to trigger npm publish.