### PR TITLE
Add change proposals for scaffold command and validation UX

### DIFF
--- a/openspec/changes/add-scaffold-command/proposal.md
+++ b/openspec/changes/add-scaffold-command/proposal.md
@@ -1,0 +1,11 @@
+## Why
+Manual setup for new changes leads to formatting mistakes in spec deltas and slows agents who must recreate the same file skeletons for every proposal. A built-in scaffold command will generate compliant templates so assistants can focus on the change content instead of structure.
+
+## What Changes
+- Add an `openspec scaffold <change-id>` CLI command that creates a change directory with validated `proposal.md`, `tasks.md`, and spec delta templates.
+- Update CLI documentation and quick-reference guidance so agents discover the scaffold workflow before drafting files manually.
+- Add automated coverage (unit/integ tests) to ensure the command respects existing naming rules and generated Markdown passes validation.
+
+## Impact
+- Affected specs: `specs/cli-scaffold`
+- Affected code: `src/cli/index.ts`, `src/commands`, `docs/`

--- a/openspec/changes/add-scaffold-command/specs/cli-scaffold/spec.md
+++ b/openspec/changes/add-scaffold-command/specs/cli-scaffold/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+### Requirement: Scaffolding Command Registration
+The CLI SHALL expose an `openspec scaffold <change-id>` command that validates the change identifier before generating files.
+
+#### Scenario: Registering scaffold command
+- **WHEN** a user runs `openspec scaffold add-user-notifications`
+- **THEN** the CLI SHALL reject invalid identifiers (non kebab-case) before proceeding
+- **AND** display usage documentation via `openspec scaffold --help`
+- **AND** exit with code 0 after successful scaffolding
+
+### Requirement: Change Directory Structure
+The scaffold command SHALL create the standard change workspace with proposal, tasks, optional design, and delta directories laid out according to OpenSpec conventions.
+
+#### Scenario: Generating change workspace
+- **WHEN** scaffolding a new change with id `add-user-notifications`
+- **THEN** create `openspec/changes/add-user-notifications/`
+- **AND** generate `proposal.md`, `tasks.md`, and `design.md` (commented placeholder content) in that directory when missing
+- **AND** create `openspec/changes/add-user-notifications/specs/` ready for capability-specific deltas
+
+### Requirement: Template Content Guidance
+The scaffold command SHALL populate generated Markdown files with OpenSpec-compliant templates so authors can copy, edit, and pass validation without reformatting.
+
+#### Scenario: Populating proposal and tasks templates
+- **WHEN** the scaffold command writes `proposal.md`
+- **THEN** include the `## Why`, `## What Changes`, and `## Impact` headings with placeholder guidance text
+- **AND** ensure `tasks.md` starts with `## 1. Implementation` and numbered checklist items using `- [ ]` syntax
+- **AND** annotate optional sections (like `design.md`) with inline TODO comments so users understand when to keep or delete them
+
+### Requirement: Delta Spec Creation
+The scaffold command SHALL create at least one capability delta file with correctly formatted requirement and scenario placeholders that guide authors to enter the actual behavior.
+
+#### Scenario: Creating spec delta skeleton
+- **WHEN** scaffolding a change and the capability `cli-scaffold` is provided interactively or via flags
+- **THEN** generate `openspec/changes/add-user-notifications/specs/cli-scaffold/spec.md`
+- **AND** include `## ADDED Requirements` with at least one `### Requirement:` block and matching `#### Scenario:` entries that remind the author to replace placeholder text
+- **AND** ensure the generated delta passes `openspec validate add-user-notifications --strict` until the author edits it
+
+### Requirement: Idempotent Execution
+The scaffold command SHALL be safe to rerun, preserving user edits while filling in any missing managed sections.
+
+#### Scenario: Rerunning scaffold on existing change
+- **WHEN** the command is executed again for an existing change directory containing user-edited files
+- **THEN** leave existing content untouched except for managed placeholder regions or missing files that need creation
+- **AND** update the filesystem summary to highlight which files were skipped, created, or refreshed

--- a/openspec/changes/add-scaffold-command/tasks.md
+++ b/openspec/changes/add-scaffold-command/tasks.md
@@ -1,0 +1,11 @@
+## 1. CLI scaffolding command
+- [ ] 1.1 Register an `openspec scaffold` command in the CLI entrypoint with `change-id` argument validation.
+- [ ] 1.2 Implement generator logic that creates the change directory structure plus default `proposal.md`, `tasks.md`, and delta spec skeletons without overwriting existing populated files.
+
+## 2. Templates and documentation
+- [ ] 2.1 Surface copy/paste templates and scaffold usage in the top-level quick reference for `openspec/AGENTS.md`.
+- [ ] 2.2 Refresh other CLI docs (`docs/`, README) to mention the scaffold workflow and link to instructions.
+
+## 3. Test coverage
+- [ ] 3.1 Add unit tests covering name validation, file generation, and idempotent reruns.
+- [ ] 3.2 Add integration coverage ensuring generated files pass `openspec validate --strict` without manual edits.

--- a/openspec/changes/enhance-validation-error-messages/proposal.md
+++ b/openspec/changes/enhance-validation-error-messages/proposal.md
@@ -1,0 +1,12 @@
+## Why
+Validation errors like "no deltas found" or "missing requirement text" do not tell agents how to recover, leading to repeated failures. Making error output specific about headers, required text, and next actions will help assistants fix issues in a single pass.
+
+## What Changes
+- Extend `openspec validate` error reporting so each failure names the exact header, file, and expected structure, including concrete examples of compliant Markdown.
+- Tailor messages for the most common mistakes (missing delta sections, absent descriptive requirement text, missing scenarios) with actionable fixes and suggested debug commands.
+- Update docs/help output so the improved messaging is discoverable (e.g., `--help`, troubleshooting section).
+- Add regression coverage to lock in the richer messaging for the top validation paths.
+
+## Impact
+- Affected specs: `specs/cli-validate`
+- Affected code: `src/commands/validate.ts`, `src/core/validation`, `docs/`

--- a/openspec/changes/enhance-validation-error-messages/specs/cli-validate/spec.md
+++ b/openspec/changes/enhance-validation-error-messages/specs/cli-validate/spec.md
@@ -1,0 +1,39 @@
+## MODIFIED Requirements
+### Requirement: Validation SHALL provide actionable remediation steps
+Validation output SHALL include specific guidance to fix each error, including expected structure, example headers, and suggested commands to verify fixes.
+
+#### Scenario: No deltas found in change
+- **WHEN** validating a change with zero parsed deltas
+- **THEN** show error "No deltas found" with guidance:
+  - Explain that change specs must include `## ADDED Requirements`, `## MODIFIED Requirements`, `## REMOVED Requirements`, or `## RENAMED Requirements`
+  - Remind authors that files must live under `openspec/changes/{id}/specs/<capability>/spec.md`
+  - Include an explicit note: "Spec delta files cannot start with titles before the operation headers"
+  - Suggest running `openspec change show {id} --json --deltas-only` for debugging
+
+#### Scenario: Missing required sections
+- **WHEN** a required section is missing
+- **THEN** include expected header names and a minimal skeleton:
+  - For Spec: `## Purpose`, `## Requirements`
+  - For Change: `## Why`, `## What Changes`
+  - Provide an example snippet of the missing section with placeholder prose ready to copy
+  - Mention the quick-reference section in `openspec/AGENTS.md` as the authoritative template
+
+#### Scenario: Missing requirement descriptive text
+- **WHEN** a requirement header lacks descriptive text before scenarios
+- **THEN** emit an error explaining that `### Requirement:` lines must be followed by narrative text before any `#### Scenario:` headers
+  - Show compliant example: "### Requirement: Foo" followed by "The system SHALL ..."
+  - Suggest adding 1-2 sentences describing the normative behavior prior to listing scenarios
+  - Reference the pre-validation checklist in `openspec/AGENTS.md`
+
+### Requirement: Validator SHALL detect likely misformatted scenarios and warn with a fix
+The validator SHALL recognize bulleted lines that look like scenarios (e.g., lines beginning with WHEN/THEN/AND) and emit a targeted warning with a conversion example to `#### Scenario:`.
+
+#### Scenario: Bulleted WHEN/THEN under a Requirement
+- **WHEN** bullets that start with WHEN/THEN/AND are found under a requirement without any `#### Scenario:` headers
+- **THEN** emit warning: "Scenarios must use '#### Scenario:' headers", and show a conversion template:
+```
+#### Scenario: Short name
+- **WHEN** ...
+- **THEN** ...
+- **AND** ...
+```

--- a/openspec/changes/enhance-validation-error-messages/tasks.md
+++ b/openspec/changes/enhance-validation-error-messages/tasks.md
@@ -1,0 +1,12 @@
+## 1. Messaging enhancements
+- [ ] 1.1 Inventory current validation failures and map each to the desired message improvements.
+- [ ] 1.2 Implement structured error builders that include file paths, normalized header names, and example fixes.
+- [ ] 1.3 Ensure `openspec validate --help` and troubleshooting docs mention the richer messages and debug tips.
+
+## 2. Tests
+- [ ] 2.1 Add unit tests for representative errors (no deltas, missing requirement body, missing scenarios) asserting the new wording.
+- [ ] 2.2 Add integration coverage verifying the Next steps footer reflects contextual guidance.
+
+## 3. Documentation
+- [ ] 3.1 Update troubleshooting sections and CLI docs with sample output from the enhanced errors.
+- [ ] 3.2 Note the change in CHANGELOG or release notes if applicable.

--- a/openspec/changes/improve-agent-instruction-usability/proposal.md
+++ b/openspec/changes/improve-agent-instruction-usability/proposal.md
@@ -1,0 +1,12 @@
+## Why
+Agents fumble proposal formatting because the essential Markdown templates and formatting rules are buried mid-document. Reorganizing `openspec/AGENTS.md` with a prominent quick-reference and embedded examples will help assistants follow the process without guesswork.
+
+## What Changes
+- Restructure `openspec/AGENTS.md` so file formats and scaffold templates appear in a top-level quick-reference section before workflow prose.
+- Embed copy/paste templates for `proposal.md`, `tasks.md`, `design.md`, and spec deltas alongside inline examples within the workflow steps.
+- Add a pre-validation checklist that highlights the most common formatting pitfalls before running `openspec validate`.
+- Split content into beginner vs. advanced sections to progressively disclose complexity while keeping advanced guidance accessible.
+
+## Impact
+- Affected specs: `specs/docs-agent-instructions`
+- Affected code: `openspec/AGENTS.md`, `docs/`

--- a/openspec/changes/improve-agent-instruction-usability/specs/docs-agent-instructions/spec.md
+++ b/openspec/changes/improve-agent-instruction-usability/specs/docs-agent-instructions/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+### Requirement: Quick Reference Placement
+The AI instructions SHALL begin with a quick-reference section that surfaces required file structures, templates, and formatting rules before any narrative guidance.
+
+#### Scenario: Loading templates at the top
+- **WHEN** `openspec/AGENTS.md` is regenerated or updated
+- **THEN** the first substantive section after the title SHALL provide copy-ready headings for `proposal.md`, `tasks.md`, spec deltas, and scenario formatting
+- **AND** link each template to the corresponding workflow step for deeper reading
+
+### Requirement: Embedded Templates and Examples
+`openspec/AGENTS.md` SHALL include complete copy/paste templates and inline examples exactly where agents make corresponding edits.
+
+#### Scenario: Providing file templates
+- **WHEN** authors reach the workflow guidance for drafting proposals and deltas
+- **THEN** provide fenced Markdown templates that match the required structure (`## Why`, `## ADDED Requirements`, `#### Scenario:` etc.)
+- **AND** accompany each template with a brief example showing correct header usage and scenario bullets
+
+### Requirement: Pre-validation Checklist
+`openspec/AGENTS.md` SHALL offer a concise pre-validation checklist that highlights common formatting mistakes before running `openspec validate`.
+
+#### Scenario: Highlighting common validation failures
+- **WHEN** a reader reaches the validation guidance
+- **THEN** present a checklist reminding them to verify requirement headers, scenario formatting, and delta sections
+- **AND** include reminders about at least `#### Scenario:` usage and descriptive requirement text before scenarios
+
+### Requirement: Progressive Disclosure of Workflow Guidance
+The documentation SHALL separate beginner essentials from advanced topics so newcomers can focus on core steps without losing access to advanced workflows.
+
+#### Scenario: Organizing beginner and advanced sections
+- **WHEN** reorganizing `openspec/AGENTS.md`
+- **THEN** keep an introductory section limited to the minimum steps (scaffold, draft, validate, request review)
+- **AND** move advanced topics (multi-capability changes, archiving details, tooling deep dives) into clearly labeled later sections
+- **AND** provide anchor links from the quick-reference to those advanced sections

--- a/openspec/changes/improve-agent-instruction-usability/tasks.md
+++ b/openspec/changes/improve-agent-instruction-usability/tasks.md
@@ -1,0 +1,11 @@
+## 1. Instruction redesign
+- [ ] 1.1 Draft a quick-reference section that surfaces file templates and formatting rules at the top of `openspec/AGENTS.md`.
+- [ ] 1.2 Reorganize the workflow narrative with inline examples and progressive disclosure for advanced topics.
+
+## 2. Templates and checklists
+- [ ] 2.1 Add copy/paste templates for proposal, tasks, design, and spec delta files.
+- [ ] 2.2 Insert a pre-validation checklist capturing common lint failures before running `openspec validate`.
+
+## 3. Documentation updates
+- [ ] 3.1 Update supporting docs or README pointers so contributors find the redesigned instructions.
+- [ ] 3.2 Confirm examples and references stay in sync with the new scaffold command guidance.


### PR DESCRIPTION
## Summary
- add a proposal for an `openspec scaffold` CLI that generates compliant change skeletons
- reorganize agent instructions with a new quick-reference and templates proposal
- enhance validation error messaging via a dedicated change proposal

## Testing
- pnpm exec openspec validate add-scaffold-command --strict
- pnpm exec openspec validate improve-agent-instruction-usability --strict
- pnpm exec openspec validate enhance-validation-error-messages --strict
