### PR TITLE
fix: correct CLI version mismatch and add release guard (0.8.1)

### DIFF
--- a/.changeset/fix-cli-version-mismatch.md
+++ b/.changeset/fix-cli-version-mismatch.md
@@ -1,0 +1,6 @@
+---
+"@fission-ai/openspec": patch
+---
+
+Fix CLI version mismatch and add a release guard that validates the packed tarball prints the same version as package.json via `openspec --version`.
+

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -41,7 +41,9 @@ jobs:
         with:
           title: 'chore(release): version packages'
           createGithubReleases: true
-          publish: pnpm run release
+          # Use CI-specific release script: relies on version PR having been merged
+          # so package.json already contains the bumped version.
+          publish: pnpm run release:ci
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "test:coverage": "vitest --coverage",
     "prepare": "pnpm run build",
     "prepublishOnly": "pnpm run build",
-    "release": "pnpm run build && pnpm exec changeset publish",
+    "check:pack-version": "node scripts/pack-version-check.mjs",
+    "release": "pnpm exec changeset version && pnpm run build && pnpm run check:pack-version && pnpm exec changeset publish",
     "changeset": "changeset"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,9 @@
     "prepare": "pnpm run build",
     "prepublishOnly": "pnpm run build",
     "check:pack-version": "node scripts/pack-version-check.mjs",
-    "release": "pnpm run check:pack-version && pnpm exec changeset publish",
+    "release": "pnpm run release:ci",
+    "release:ci": "pnpm run check:pack-version && pnpm exec changeset publish",
+    "release:local": "pnpm exec changeset version && pnpm run check:pack-version && pnpm exec changeset publish",
     "changeset": "changeset"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "prepare": "pnpm run build",
     "prepublishOnly": "pnpm run build",
     "check:pack-version": "node scripts/pack-version-check.mjs",
-    "release": "pnpm exec changeset version && pnpm run build && pnpm run check:pack-version && pnpm exec changeset publish",
+    "release": "pnpm run check:pack-version && pnpm exec changeset publish",
     "changeset": "changeset"
   },
   "engines": {

--- a/scripts/pack-version-check.mjs
+++ b/scripts/pack-version-check.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+// Verifies that the packed tarball prints the same version as package.json
+// by installing the packed tgz into a temp project and running `openspec --version`.
+
+import { execFileSync } from 'child_process';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+
+function log(msg) {
+  if (process.env.CI) return; // keep CI logs quiet by default
+  console.log(msg);
+}
+
+function run(cmd, args, opts = {}) {
+  return execFileSync(cmd, args, { encoding: 'utf-8', stdio: ['ignore', 'pipe', 'pipe'], ...opts });
+}
+
+function npmPack() {
+  try {
+    const jsonOut = run('npm', ['pack', '--json', '--silent']);
+    const arr = JSON.parse(jsonOut);
+    const file = Array.isArray(arr) && arr.length > 0 ? arr[arr.length - 1].filename || arr[arr.length - 1] : null;
+    if (!file) throw new Error('npm pack returned unexpected JSON');
+    return file.trim();
+  } catch (e) {
+    // Fallback for older npm: last line of output is filename
+    const out = run('npm', ['pack', '--silent']).trim();
+    const lines = out.split(/\r?\n/);
+    return lines[lines.length - 1].trim();
+  }
+}
+
+function main() {
+  const pkg = JSON.parse(readFileSync(path.join(process.cwd(), 'package.json'), 'utf-8'));
+  const expected = pkg.version;
+
+  log(`Packing @fission-ai/openspec@${expected}...`);
+  const filename = npmPack();
+  const tgzPath = path.resolve(filename);
+  log(`Created: ${tgzPath}`);
+
+  const work = mkdtempSync(path.join(tmpdir(), 'openspec-pack-check-'));
+  log(`Temp dir: ${work}`);
+
+  // Make a tiny project
+  writeFileSync(path.join(work, 'package.json'), JSON.stringify({ name: 'pack-check', private: true }, null, 2));
+
+  // Try to avoid noisy output
+  const env = { ...process.env, npm_config_loglevel: 'silent' };
+
+  // Install the tarball
+  run('npm', ['install', tgzPath, '--silent'], { cwd: work, env });
+
+  // Run the installed CLI via Node to avoid bin resolution/platform issues
+  const binRel = path.join('node_modules', '@fission-ai', 'openspec', 'bin', 'openspec.js');
+  const actual = run(process.execPath, [binRel, '--version'], { cwd: work }).trim();
+
+  if (actual !== expected) {
+    throw new Error(`Packed CLI version mismatch: expected ${expected}, got ${actual}`);
+  }
+
+  log('Version check passed. Cleaning up...');
+  // Cleanup temp dir and local tgz
+  try { rmSync(work, { recursive: true, force: true }); } catch {}
+  try { rmSync(tgzPath, { force: true }); } catch {}
+}
+
+try {
+  main();
+  console.log('✅ pack-version-check: OK');
+} catch (err) {
+  console.error(`❌ pack-version-check: ${err.message}`);
+  process.exit(1);
+}
+


### PR DESCRIPTION

---

**Summary**
This PR fixes a packaging mistake where the `0.8.0` tarball printed `0.7.0` via `openspec --version` due to shipping the internal `0.7.0` `package.json`.

---

### 🧩 Changes

* Add patch changeset for `0.8.1` (fix CLI version mismatch)
* Add `scripts/pack-version-check.mjs` to:

  * Pack the tarball
  * Install it
  * Assert the CLI prints the tarball’s version
* Update `release` script to run `changeset version` + build + pack-version check before publish

---

### 🔜 Follow-ups

* Deprecate `0.8.0` on npm:

  npm deprecate @fission-ai/openspec@0.8.0 "Incorrect internal version. Upgrade to 0.8.1."

---

### ✅ After Merge

* Run:

  pnpm run release
  *(or let CI publish)*

* Verify:

  npx @fission-ai/openspec@0.8.1 --version
  → should print `0.8.1`

---
