### PR TITLE
fix: Fix Codex integration on Windows by using platform-specific path separators

### DIFF
--- a/src/core/configurators/slash/codex.ts
+++ b/src/core/configurators/slash/codex.ts
@@ -6,9 +6,9 @@ import { FileSystemUtils } from "../../../utils/file-system.js";
 import { OPENSPEC_MARKERS } from "../../config.js";
 
 const FILE_PATHS: Record<SlashCommandId, string> = {
-  proposal: ".codex/prompts/openspec-proposal.md",
-  apply: ".codex/prompts/openspec-apply.md",
-  archive: ".codex/prompts/openspec-archive.md",
+  proposal: path.join(".codex", "prompts", "openspec-proposal.md"),
+  apply: path.join(".codex", "prompts", "openspec-apply.md"),
+  archive: path.join(".codex", "prompts", "openspec-archive.md"),
 };
 
 export class CodexSlashCommandConfigurator extends SlashCommandConfigurator {


### PR DESCRIPTION
## Summary

Fixes #132 - Codex integration was not working on Windows during `init` and `update` commands.

## Problem

The `FILE_PATHS` constant in `codex.ts` was using hardcoded forward slashes (`/`), which caused `path.basename()` to fail on Windows. 

On Windows, `path.basename()` expects backslashes as path separators. When given a path with forward slashes like `.codex/prompts/openspec-proposal.md`, it would return the **entire string** instead of extracting just the filename `openspec-proposal.md`.

This broke:
- Codex detection during `openspec init` (would show Codex as not configured even when it was)
- Path construction in `resolveAbsolutePath()` which created incorrect file paths
- File existence checks in `isToolConfigured()`

## Solution

Changed `FILE_PATHS` to use `path.join()` which automatically uses the correct platform-specific path separators:
- **Windows**: `.codex\prompts\openspec-proposal.md` (backslashes)
- **macOS/Linux**: `.codex/prompts/openspec-proposal.md` (forward slashes)

## Test plan

- [ ] Test `openspec init` on Windows 11 and verify Codex is detected correctly
- [ ] Test `openspec update` on Windows 11 and verify prompts are updated
- [ ] Verify existing behavior on macOS/Linux remains unchanged
- [ ] Verify paths are correctly resolved in `C:\Users\<USERNAME>\.codex\prompts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)