### PR TITLE
fix: normalize paths for cross-platform consistency in logging

### DIFF
--- a/src/core/configurators/slash/codex.ts
+++ b/src/core/configurators/slash/codex.ts
@@ -5,10 +5,11 @@ import { SlashCommandId, TemplateManager } from "../../templates/index.js";
 import { FileSystemUtils } from "../../../utils/file-system.js";
 import { OPENSPEC_MARKERS } from "../../config.js";
 
+// Use POSIX-style paths for consistent logging across platforms.
 const FILE_PATHS: Record<SlashCommandId, string> = {
-  proposal: path.join(".codex", "prompts", "openspec-proposal.md"),
-  apply: path.join(".codex", "prompts", "openspec-apply.md"),
-  archive: path.join(".codex", "prompts", "openspec-archive.md"),
+  proposal: ".codex/prompts/openspec-proposal.md",
+  apply: ".codex/prompts/openspec-apply.md",
+  archive: ".codex/prompts/openspec-archive.md",
 };
 
 export class CodexSlashCommandConfigurator extends SlashCommandConfigurator {

--- a/src/core/update.ts
+++ b/src/core/update.ts
@@ -106,9 +106,9 @@ export class UpdateCommand {
     }
 
     if (updatedSlashFiles.length > 0) {
-      summaryParts.push(
-        `Updated slash commands: ${updatedSlashFiles.join(', ')}`
-      );
+      // Normalize to forward slashes for cross-platform log consistency
+      const normalized = updatedSlashFiles.map((p) => p.replace(/\\/g, '/'));
+      summaryParts.push(`Updated slash commands: ${normalized.join(', ')}`);
     }
 
     const failedItems = [


### PR DESCRIPTION
## Summary

- Reverts PR #134 use of `path.join()` in `FILE_PATHS` to use POSIX-style forward slashes instead for consistent logging
- Normalizes backslashes to forward slashes in update command output on Windows
- Improves cross-platform consistency in log messages while maintaining actual file path operations with `path.join()`

## Changes

1. **src/core/configurators/slash/codex.ts**: Changed `FILE_PATHS` to use literal forward slash paths instead of `path.join()` for logging purposes
2. **src/core/update.ts**: Added normalization of backslashes to forward slashes in the update summary output

## Test plan

- [ ] Verify slash commands work correctly on Windows
- [ ] Verify slash commands work correctly on Unix/macOS
- [ ] Check that log output shows consistent forward slashes on all platforms
- [ ] Verify actual file operations still work correctly with proper platform paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)