### PR TITLE
chore: add changeset for Windows OpenSpec fix

### DIFF
--- a/.changeset/windows-openspec-fix.md
+++ b/.changeset/windows-openspec-fix.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+Fix OpenSpec not working on Windows when Codex integration is selected. This release includes fixes for cross-platform path handling and normalization to ensure OpenSpec works correctly on Windows systems.


### PR DESCRIPTION
## Summary
- Adds changeset for patch release to fix OpenSpec not working on Windows when Codex integration is selected
- Includes fixes from PRs #134 and #135 for cross-platform path handling

## Changes
- Created changeset file for patch version bump
- Documents Windows compatibility fixes

## Test plan
- [ ] Verify changeset is properly formatted
- [ ] Confirm release workflow will process this changeset correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)