### PR TITLE
Fix joinPath to preserve POSIX separators

### DIFF
--- a/src/utils/file-system.ts
+++ b/src/utils/file-system.ts
@@ -56,14 +56,17 @@ export class FileSystemUtils {
     const normalizedSegments = this.normalizeSegments(segments);
 
     if (this.isWindowsBasePath(basePath)) {
+      const normalizedBasePath = path.win32.normalize(basePath);
       return normalizedSegments.length
-        ? path.win32.join(basePath, ...normalizedSegments)
-        : path.win32.normalize(basePath);
+        ? path.win32.join(normalizedBasePath, ...normalizedSegments)
+        : normalizedBasePath;
     }
 
+    const posixBasePath = basePath.replace(/\\/g, '/');
+
     return normalizedSegments.length
-      ? path.join(basePath, ...normalizedSegments)
-      : path.join(basePath);
+      ? path.posix.join(posixBasePath, ...normalizedSegments)
+      : path.posix.normalize(posixBasePath);
   }
 
   static async createDirectory(dirPath: string): Promise<void> {


### PR DESCRIPTION
## Summary
- normalize the Windows base path before joining segments
- ensure non-Windows base paths use POSIX joining so forward slashes are preserved

## Testing
- pnpm exec vitest run test/utils/file-system.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e90ee903088322aed2738965a8d414