### PR TITLE
chore: prepare openspec release

### DIFF
--- a/.changeset/prepare-openspec-release.md
+++ b/.changeset/prepare-openspec-release.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": minor
+---
+
+Prepare a release for the latest GitHub Copilot slash command support and prompt scaffolding improvements.


### PR DESCRIPTION
## Summary
- add a changeset to trigger the next @fission-ai/openspec release
- note the GitHub Copilot slash command support improvements in the release notes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e921da47b48322a9b66a950adcddd7