### PR TITLE
feat: improve init wizard Enter key behavior

### DIFF
--- a/openspec/changes/update-cli-init-enter-selection/proposal.md
+++ b/openspec/changes/update-cli-init-enter-selection/proposal.md
@@ -1,0 +1,14 @@
+## Why
+- Users frequently scroll to a tool and press Enter without toggling it, resulting in no configuration changes.
+- The current workflow deviates from common CLI expectations where Enter confirms the highlighted item.
+- Aligning behavior with user expectations reduces friction during onboarding.
+
+## What Changes
+- Update the init wizard so pressing Enter on a highlighted tool selects it before moving to the review step.
+- Adjust interactive instructions to clarify Enter selects the current tool and Space still toggles selections.
+- Refresh specs to capture the clarified behavior for the interactive menu.
+
+## Impact
+- Users who press Enter without toggling now configure the highlighted tool instead of exiting with no selections.
+- Spacebar multi-select support remains unchanged for power users.
+- Documentation better reflects how the wizard behaves.

--- a/openspec/changes/update-cli-init-enter-selection/specs/cli-init/spec.md
+++ b/openspec/changes/update-cli-init-enter-selection/specs/cli-init/spec.md
@@ -1,0 +1,10 @@
+## MODIFIED Requirements
+### Requirement: Interactive Mode
+The command SHALL provide an interactive menu for AI tool selection with clear navigation instructions.
+#### Scenario: Displaying interactive menu
+- **WHEN** run in fresh or extend mode
+- **THEN** present a looping select menu that lets users toggle tools with Space and review selections with Enter
+- **AND** when Enter is pressed on a highlighted selectable tool that is not already selected, automatically add it to the selection before moving to review so the highlighted tool is configured
+- **AND** label already configured tools with "(already configured)" while keeping disabled options marked "coming soon"
+- **AND** change the prompt copy in extend mode to "Which AI tools would you like to add or refresh?"
+- **AND** display inline instructions clarifying that Space toggles tools and Enter selects the highlighted tool before reviewing selections

--- a/openspec/changes/update-cli-init-enter-selection/tasks.md
+++ b/openspec/changes/update-cli-init-enter-selection/tasks.md
@@ -1,0 +1,8 @@
+## 1. Implementation
+- [x] Update the tool selection wizard to auto-select the highlighted tool when Enter is pressed without prior toggles.
+- [x] Refresh inline instructions copy so Enter behavior is clear.
+- [x] Adjust or add tests if needed to cover the new selection flow.
+
+## 2. Validation
+- [x] Run `pnpm run build`.
+- [x] Run `pnpm test` (or targeted suite) if applicable.

--- a/src/core/init.ts
+++ b/src/core/init.ts
@@ -220,6 +220,16 @@ const toolSelectionWizard = createPrompt<string[], ToolWizardConfig>(
         }
 
         if (isEnterKey(key)) {
+          const current = config.choices[cursor];
+          if (
+            current &&
+            current.selectable &&
+            !selectedSet.has(current.value)
+          ) {
+            const next = new Set(selected);
+            next.add(current.value);
+            updateSelected(next);
+          }
           setStep('review');
           setError(null);
           return;
@@ -298,7 +308,7 @@ const toolSelectionWizard = createPrompt<string[], ToolWizardConfig>(
       lines.push(PALETTE.white(config.baseMessage));
       lines.push(
         PALETTE.midGray(
-          'Use ↑/↓ to move · Space to toggle · Enter to review selections.'
+          'Use ↑/↓ to move · Space to toggle · Enter selects highlighted tool and reviews.'
         )
       );
       lines.push('');


### PR DESCRIPTION
## Summary
- Update the tool selection wizard so pressing Enter on a highlighted tool automatically selects it before proceeding to review
- Align Enter key behavior with common CLI expectations where Enter confirms the highlighted item
- Update help text to clarify that Enter selects the highlighted tool and reviews selections

## Changes
- Add logic to select the currently highlighted tool when Enter is pressed if it's not already selected
- Update instruction text: "Enter selects highlighted tool and reviews" instead of "Enter to review selections"
- Maintain Space key for toggling multiple selections

## Test plan
- [ ] Run `openspec init` in a test directory
- [ ] Navigate to a tool using arrow keys without pressing Space
- [ ] Press Enter and verify the tool is selected before moving to review
- [ ] Test Space key still toggles selections as expected
- [ ] Verify help text accurately describes the behavior

## Why
This reduces friction during onboarding by matching user expectations. Users who navigate to a tool and press Enter (without first toggling with Space) will now have their selection applied, instead of proceeding with no configuration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)