### PR TITLE
fix: use correct scoped package name in changeset

### DIFF
--- a/.changeset/amazon-q-integration.md
+++ b/.changeset/amazon-q-integration.md
@@ -1,5 +1,5 @@
 ---
-"openspec": minor
+"@fission-ai/openspec": minor
 ---
 
 Add Amazon Q Developer CLI integration. OpenSpec now supports Amazon Q Developer with automatic prompt generation in `.amazonq/prompts/` directory, allowing you to use OpenSpec slash commands with Amazon Q's @-syntax.


### PR DESCRIPTION
## Summary

Fixes the changeset to use the correct scoped package name `@fission-ai/openspec` instead of just `openspec`.

## Issue

The previous changeset (#165) was merged with the incorrect package name, causing the CI to fail with:
```
Error: Found changeset amazon-q-integration for package openspec which is not in the workspace
```

## Fix

Updated `.changeset/amazon-q-integration.md` to use `"@fission-ai/openspec"` which matches the package name in `package.json`.

This will allow the changesets action to properly process the changeset and create a release PR.