### PR TITLE
chore: add changeset for factory functions and init options

### DIFF
--- a/.changeset/factory-functions-and-init-options.md
+++ b/.changeset/factory-functions-and-init-options.md
@@ -1,0 +1,10 @@
+---
+"@fission-ai/openspec": minor
+---
+
+Add factory function support for slash commands and non-interactive init options
+
+This release includes two new features:
+
+- **Factory function support for slash commands**: Slash commands can now be defined as functions that return command objects, enabling dynamic command configuration
+- **Non-interactive init options**: Added `--tools`, `--all-tools`, and `--skip-tools` CLI flags to `openspec init` for automated initialization in CI/CD pipelines while maintaining backward compatibility with interactive mode


### PR DESCRIPTION
## Changes Being Released

This changeset includes the following merged changes since the last release:

### New Features

- **Factory function support for slash commands** (#178)
  - Slash commands can now be defined as functions that return command objects
  - Enables dynamic command configuration

- **Non-interactive init options** (#122)
  - Added `--tools`, `--all-tools`, and `--skip-tools` CLI flags to `openspec init`
  - Enables automated initialization for CI/CD pipelines
  - Maintains backward compatibility with interactive mode
  - Includes comprehensive validation and error handling

### Maintenance

- Multiple spec archival updates to keep documentation in sync

## Version Bump

**Minor** version bump - adds new features with backward compatibility

## Commits Included

- b81fa1e feat: add factory function support for slash commands (#178)
- cc9d540 feat: add non-interactive options to openspec init (#122)
- 4a86328 chore: archive 4 completed changes and update specs (#172)
- fe83be5 Add parallel merge plan (#171)
- 345f9db chore: archive 7 completed changes and update specs (#170)