### PR TITLE
docs: note restart requirement for slash commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ openspec init
 **After setup:**
 - Primary AI tools can trigger `/openspec` workflows without additional configuration
 - Run `openspec list` to verify the setup and view any active changes
+- If your coding assistant doesn't surface the new slash commands right away, restart it. Slash commands are loaded at startup,
+  so a fresh launch ensures they appear.
 
 ### Create Your First Change
 


### PR DESCRIPTION
## Summary
- document that coding assistants may need a restart after `openspec init` for slash commands to appear

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ef14b1f8bc832289386aeca05d3818