### PR TITLE
docs: sync AGENTS.md and agents-template with explicit change-id notation

### DIFF
--- a/openspec/AGENTS.md
+++ b/openspec/AGENTS.md
@@ -61,7 +61,6 @@ After deployment, create separate PR to:
 - Move `changes/[name]/` → `changes/archive/YYYY-MM-DD-[name]/`
 - Update `specs/` if capabilities changed
 - Use `openspec archive <change-id> --skip-specs --yes` for tooling-only changes (always pass the change ID explicitly)
-- OpenCode slash command: `/openspec:archive <change-id>` passes the change ID via arguments—fail fast if the ID is missing or invalid
 - Run `openspec validate --strict` to confirm the archived change passes checks
 
 ## Before Any Task
@@ -451,7 +450,7 @@ openspec list              # What's in progress?
 openspec show [item]       # View details
 openspec diff [change]     # What's changing?
 openspec validate --strict # Is it correct?
-openspec archive [change] [--yes|-y]  # Mark complete (add --yes for automation)
+openspec archive <change-id> [--yes|-y]  # Mark complete (add --yes for automation)
 ```
 
 Remember: Specs are truth. Changes are proposals. Keep them in sync.

--- a/src/core/templates/agents-template.ts
+++ b/src/core/templates/agents-template.ts
@@ -60,7 +60,7 @@ Track these steps as TODOs and complete them one by one.
 After deployment, create separate PR to:
 - Move \`changes/[name]/\` → \`changes/archive/YYYY-MM-DD-[name]/\`
 - Update \`specs/\` if capabilities changed
-- Use \`openspec archive [change] --skip-specs --yes\` for tooling-only changes
+- Use \`openspec archive <change-id> --skip-specs --yes\` for tooling-only changes (always pass the change ID explicitly)
 - Run \`openspec validate --strict\` to confirm the archived change passes checks
 
 ## Before Any Task
@@ -97,7 +97,7 @@ openspec list --specs          # List specifications
 openspec show [item]           # Display change or spec
 openspec diff [change]         # Show spec differences
 openspec validate [item]       # Validate changes or specs
-openspec archive [change] [--yes|-y]      # Archive after deployment (add --yes for non-interactive runs)
+openspec archive <change-id> [--yes|-y]   # Archive after deployment (add --yes for non-interactive runs)
 
 # Project management
 openspec init [path]           # Initialize OpenSpec
@@ -450,7 +450,7 @@ openspec list              # What's in progress?
 openspec show [item]       # View details
 openspec diff [change]     # What's changing?
 openspec validate --strict # Is it correct?
-openspec archive [change] [--yes|-y]  # Mark complete (add --yes for automation)
+openspec archive <change-id> [--yes|-y]  # Mark complete (add --yes for automation)
 \`\`\`
 
 Remember: Specs are truth. Changes are proposals. Keep them in sync.


### PR DESCRIPTION
## Summary
- Standardize `openspec archive` command documentation to use `<change-id>` instead of `[change]` across all references
- Add clarification that change ID must be explicitly passed in Stage 3 archiving instructions
- Remove OpenCode-specific slash command reference from AGENTS.md to keep instructions tool-agnostic
- Sync agents-template.ts with AGENTS.md to eliminate drift between the two files

## Test plan
- [x] Verify AGENTS.md and agents-template.ts now match (excluding the intentionally removed OpenCode line)
- [x] Confirm all `openspec archive` command references use `<change-id>` notation consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)