### PR TITLE
docs: add Crush to supported AI tools in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ These tools have built-in OpenSpec commands. Select the OpenSpec integration whe
 | **CodeBuddy Code (CLI)** | `/openspec:proposal`, `/openspec:apply`, `/openspec:archive` (`.codebuddy/commands/`) — see [docs](https://www.codebuddy.ai/cli) |
 | **Cursor** | `/openspec-proposal`, `/openspec-apply`, `/openspec-archive` |
 | **Cline** | Rules in `.clinerules/` directory (`.clinerules/openspec-*.md`) |
+| **Crush** | `/openspec-proposal`, `/openspec-apply`, `/openspec-archive` (`.crush/commands/openspec/`) |
 | **Factory Droid** | `/openspec-proposal`, `/openspec-apply`, `/openspec-archive` (`.factory/commands/`) |
 | **OpenCode** | `/openspec-proposal`, `/openspec-apply`, `/openspec-archive` |
 | **Kilo Code** | `/openspec-proposal.md`, `/openspec-apply.md`, `/openspec-archive.md` (`.kilocode/workflows/`) |


### PR DESCRIPTION
## Summary
Adds Crush to the Native Slash Commands table in the README.

## Context
Crush support was fully implemented in the codebase (including slash command configurator in `src/core/configurators/slash/crush.ts` and integration in the config), but was missing from the README documentation.

## Changes
- Added Crush entry to the "Native Slash Commands" table with its slash commands and command directory path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Crush to the list of supported AI tools in native slash commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->