### PR TITLE
feat: add Qoder CLI support to configuration and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ These tools have built-in OpenSpec commands. Select the OpenSpec integration whe
 | **Factory Droid** | `/openspec-proposal`, `/openspec-apply`, `/openspec-archive` (`.factory/commands/`) |
 | **OpenCode** | `/openspec-proposal`, `/openspec-apply`, `/openspec-archive` |
 | **Kilo Code** | `/openspec-proposal.md`, `/openspec-apply.md`, `/openspec-archive.md` (`.kilocode/workflows/`) |
+| **Qoder (CLI)** | `/openspec:proposal`, `/openspec:apply`, `/openspec:archive` (`.qoder/commands/openspec/`) — see [docs](https://qoder.com/cli) |
 | **Windsurf** | `/openspec-proposal`, `/openspec-apply`, `/openspec-archive` (`.windsurf/workflows/`) |
 | **Codex** | `/openspec-proposal`, `/openspec-apply`, `/openspec-archive` (global: `~/.codex/prompts`, auto-installed) |
 | **GitHub Copilot** | `/openspec-proposal`, `/openspec-apply`, `/openspec-archive` (`.github/prompts/`) |
@@ -144,7 +145,7 @@ openspec init
 ```
 
 **What happens during initialization:**
-- You'll be prompted to pick any natively supported AI tools (Claude Code, CodeBuddy, Cursor, OpenCode, etc.); other assistants always rely on the shared `AGENTS.md` stub
+- You'll be prompted to pick any natively supported AI tools (Claude Code, CodeBuddy, Cursor, OpenCode, Qoder,etc.); other assistants always rely on the shared `AGENTS.md` stub
 - OpenSpec automatically configures slash commands for the tools you choose and always writes a managed `AGENTS.md` hand-off at the project root
 - A new `openspec/` directory structure is created in your project
 
@@ -230,7 +231,7 @@ Or run the command yourself in terminal:
 $ openspec archive add-profile-filters --yes  # Archive the completed change without prompts
 ```
 
-**Note:** Tools with native slash commands (Claude Code, CodeBuddy, Cursor, Codex) can use the shortcuts shown. All other tools work with natural language requests to "create an OpenSpec proposal", "apply the OpenSpec change", or "archive the change".
+**Note:** Tools with native slash commands (Claude Code, CodeBuddy, Cursor, Codex, Qoder) can use the shortcuts shown. All other tools work with natural language requests to "create an OpenSpec proposal", "apply the OpenSpec change", or "archive the change".
 
 ## Command Reference
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -27,6 +27,7 @@ export const AI_TOOLS: AIToolOption[] = [
   { name: 'Factory Droid', value: 'factory', available: true, successLabel: 'Factory Droid' },
   { name: 'OpenCode', value: 'opencode', available: true, successLabel: 'OpenCode' },
   { name: 'Kilo Code', value: 'kilocode', available: true, successLabel: 'Kilo Code' },
+  { name: 'Qoder (CLI)', value: 'qoder', available: true, successLabel: 'Qoder' },
   { name: 'Windsurf', value: 'windsurf', available: true, successLabel: 'Windsurf' },
   { name: 'Codex', value: 'codex', available: true, successLabel: 'Codex' },
   { name: 'GitHub Copilot', value: 'github-copilot', available: true, successLabel: 'GitHub Copilot' },

--- a/src/core/configurators/qoder.ts
+++ b/src/core/configurators/qoder.ts
@@ -1,0 +1,53 @@
+import path from 'path';
+import { ToolConfigurator } from './base.js';
+import { FileSystemUtils } from '../../utils/file-system.js';
+import { TemplateManager } from '../templates/index.js';
+import { OPENSPEC_MARKERS } from '../config.js';
+
+/**
+ * Qoder AI Tool Configurator
+ * 
+ * Configures OpenSpec integration for Qoder AI coding assistant.
+ * Creates and manages QODER.md configuration file with OpenSpec instructions.
+ * 
+ * @implements {ToolConfigurator}
+ */
+export class QoderConfigurator implements ToolConfigurator {
+  /** Display name for the Qoder tool */
+  name = 'Qoder';
+  
+  /** Configuration file name at project root */
+  configFileName = 'QODER.md';
+  
+  /** Indicates tool is available for configuration */
+  isAvailable = true;
+
+  /**
+   * Configure Qoder integration for a project
+   * 
+   * Creates or updates QODER.md file with OpenSpec instructions.
+   * Uses Claude-compatible template for instruction content.
+   * Wrapped with OpenSpec markers for future updates.
+   * 
+   * @param {string} projectPath - Absolute path to project root directory
+   * @param {string} openspecDir - Path to openspec directory (unused but required by interface)
+   * @returns {Promise<void>} Resolves when configuration is complete
+   */
+  async configure(projectPath: string, openspecDir: string): Promise<void> {
+    // Construct full path to QODER.md at project root
+    const filePath = path.join(projectPath, this.configFileName);
+    
+    // Get Claude-compatible instruction template
+    // This ensures Qoder receives the same high-quality OpenSpec instructions
+    const content = TemplateManager.getClaudeTemplate();
+    
+    // Write or update file with managed content between markers
+    // This allows future updates to refresh instructions automatically
+    await FileSystemUtils.updateFileWithMarkers(
+      filePath,
+      content,
+      OPENSPEC_MARKERS.start,
+      OPENSPEC_MARKERS.end
+    );
+  }
+}

--- a/src/core/configurators/registry.ts
+++ b/src/core/configurators/registry.ts
@@ -3,6 +3,7 @@ import { ClaudeConfigurator } from './claude.js';
 import { ClineConfigurator } from './cline.js';
 import { CodeBuddyConfigurator } from './codebuddy.js';
 import { CostrictConfigurator } from './costrict.js';
+import { QoderConfigurator } from './qoder.js';
 import { AgentsStandardConfigurator } from './agents.js';
 
 export class ToolRegistry {
@@ -13,12 +14,14 @@ export class ToolRegistry {
     const clineConfigurator = new ClineConfigurator();
     const codeBuddyConfigurator = new CodeBuddyConfigurator();
     const costrictConfigurator = new CostrictConfigurator();
+    const qoderConfigurator = new QoderConfigurator();
     const agentsConfigurator = new AgentsStandardConfigurator();
     // Register with the ID that matches the checkbox value
     this.tools.set('claude', claudeConfigurator);
     this.tools.set('cline', clineConfigurator);
     this.tools.set('codebuddy', codeBuddyConfigurator);
     this.tools.set('costrict', costrictConfigurator);
+    this.tools.set('qoder', qoderConfigurator);
     this.tools.set('agents', agentsConfigurator);
   }
 

--- a/src/core/configurators/slash/qoder.ts
+++ b/src/core/configurators/slash/qoder.ts
@@ -1,0 +1,84 @@
+import { SlashCommandConfigurator } from './base.js';
+import { SlashCommandId } from '../../templates/index.js';
+
+/**
+ * File paths for Qoder slash commands
+ * Maps each OpenSpec workflow stage to its command file location
+ * Commands are stored in .qoder/commands/openspec/ directory
+ */
+const FILE_PATHS: Record<SlashCommandId, string> = {
+  // Create and validate new change proposals
+  proposal: '.qoder/commands/openspec/proposal.md',
+  
+  // Implement approved changes with task tracking
+  apply: '.qoder/commands/openspec/apply.md',
+  
+  // Archive completed changes and update specs
+  archive: '.qoder/commands/openspec/archive.md'
+};
+
+/**
+ * YAML frontmatter for Qoder slash commands
+ * Defines metadata displayed in Qoder's command palette
+ * Each command is categorized and tagged for easy discovery
+ */
+const FRONTMATTER: Record<SlashCommandId, string> = {
+  proposal: `---
+name: OpenSpec: Proposal
+description: Scaffold a new OpenSpec change and validate strictly.
+category: OpenSpec
+tags: [openspec, change]
+---`,
+  apply: `---
+name: OpenSpec: Apply
+description: Implement an approved OpenSpec change and keep tasks in sync.
+category: OpenSpec
+tags: [openspec, apply]
+---`,
+  archive: `---
+name: OpenSpec: Archive
+description: Archive a deployed OpenSpec change and update specs.
+category: OpenSpec
+tags: [openspec, archive]
+---`
+};
+
+/**
+ * Qoder Slash Command Configurator
+ * 
+ * Manages OpenSpec slash commands for Qoder AI assistant.
+ * Creates three workflow commands: proposal, apply, and archive.
+ * Uses colon-separated command format (/openspec:proposal).
+ * 
+ * @extends {SlashCommandConfigurator}
+ */
+export class QoderSlashCommandConfigurator extends SlashCommandConfigurator {
+  /** Unique identifier for Qoder tool */
+  readonly toolId = 'qoder';
+  
+  /** Indicates slash commands are available for this tool */
+  readonly isAvailable = true;
+
+  /**
+   * Get relative file path for a slash command
+   * 
+   * @param {SlashCommandId} id - Command identifier (proposal, apply, or archive)
+   * @returns {string} Relative path from project root to command file
+   */
+  protected getRelativePath(id: SlashCommandId): string {
+    return FILE_PATHS[id];
+  }
+
+  /**
+   * Get YAML frontmatter for a slash command
+   * 
+   * Frontmatter defines how the command appears in Qoder's UI,
+   * including display name, description, and categorization.
+   * 
+   * @param {SlashCommandId} id - Command identifier (proposal, apply, or archive)
+   * @returns {string} YAML frontmatter block with command metadata
+   */
+  protected getFrontmatter(id: SlashCommandId): string {
+    return FRONTMATTER[id];
+  }
+}

--- a/src/core/configurators/slash/registry.ts
+++ b/src/core/configurators/slash/registry.ts
@@ -1,6 +1,7 @@
 import { SlashCommandConfigurator } from './base.js';
 import { ClaudeSlashCommandConfigurator } from './claude.js';
 import { CodeBuddySlashCommandConfigurator } from './codebuddy.js';
+import { QoderSlashCommandConfigurator } from './qoder.js';
 import { CursorSlashCommandConfigurator } from './cursor.js';
 import { WindsurfSlashCommandConfigurator } from './windsurf.js';
 import { KiloCodeSlashCommandConfigurator } from './kilocode.js';
@@ -20,6 +21,7 @@ export class SlashCommandRegistry {
   static {
     const claude = new ClaudeSlashCommandConfigurator();
     const codeBuddy = new CodeBuddySlashCommandConfigurator();
+    const qoder = new QoderSlashCommandConfigurator();
     const cursor = new CursorSlashCommandConfigurator();
     const windsurf = new WindsurfSlashCommandConfigurator();
     const kilocode = new KiloCodeSlashCommandConfigurator();
@@ -35,6 +37,7 @@ export class SlashCommandRegistry {
 
     this.configurators.set(claude.toolId, claude);
     this.configurators.set(codeBuddy.toolId, codeBuddy);
+    this.configurators.set(qoder.toolId, qoder);
     this.configurators.set(cursor.toolId, cursor);
     this.configurators.set(windsurf.toolId, windsurf);
     this.configurators.set(kilocode.toolId, kilocode);


### PR DESCRIPTION
# PR: Add Qoder CLI Support

## Summary

This PR adds native support for Qoder CLI as an AI coding assistant tool in OpenSpec. Qoder users will now be able to leverage OpenSpec's specification-driven development workflow with dedicated slash commands and configuration files.

## Features Added

### 1. Qoder Slash Commands
- Added support for `/openspec:proposal`, `/openspec:apply`, and `/openspec:archive` commands
- Commands are stored in `.qoder/commands/openspec/` directory
- Each command includes proper YAML frontmatter for Qoder's command palette:
  - Name: "OpenSpec: Proposal/Apply/Archive"
  - Description: Clear purpose statement for each command
  - Category: "OpenSpec"
  - Tags: ["openspec", "change"/"apply"/"archive"]

### 2. Qoder Configuration File
- Created `QoderConfigurator` to manage QODER.md file at project root
- Uses the same high-quality OpenSpec instructions as Claude Code
- Automatically updates with OpenSpec markers to enable future updates

### 3. Integration Points
- Added Qoder to the list of supported AI tools in the initialization prompt
- Registered Qoder configurators in both tool and slash command registries
- Updated documentation to include Qoder in the supported tools list

## Changes Made

### Core Implementation
- `src/core/configurators/qoder.ts`: New configurator for QODER.md file management
- `src/core/configurators/slash/qoder.ts`: New configurator for slash command files
- `src/core/config.ts`: Added Qoder to the AI_TOOLS array
- `src/core/configurators/registry.ts`: Registered Qoder tool configurator
- `src/core/configurators/slash/registry.ts`: Registered Qoder slash command configurator

### Documentation Updates
- `README.md`: Added Qoder to the supported tools table and initialization description

### Test Coverage
- `test/core/init.test.ts`: Added comprehensive tests for Qoder configuration:
  - Slash command file creation
  - QODER.md file creation and updates
  - Extend mode configuration detection
- `test/core/update.test.ts`: Added tests for Qoder file updates:
  - Refreshing existing slash command files
  - Preserving content outside markers
  - Not creating missing files during update

## Usage

After initializing OpenSpec with Qoder selected:

1. Users can use `/openspec:proposal` to create new change proposals
2. `/openspec:apply` to implement approved changes
3. `/openspec:archive` to archive completed changes
4. A `QODER.md` file is created at the project root with OpenSpec instructions

## Testing

All new functionality is covered by unit tests that verify:
- Proper file creation and content
- Correct YAML frontmatter
- Marker-based content updates
- Integration with existing OpenSpec workflows

## Compatibility

This change is fully backward compatible and does not affect existing functionality. Users who don't select Qoder during initialization will not have any Qoder-specific files created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Qoder (CLI) as a supported AI tool.
  * Enabled native slash command support for Qoder (proposal, apply, archive).
  * Automatically generates and maintains a Qoder configuration file in project root.

* **Tests**
  * Added tests to validate Qoder slash command templates, configuration file creation, updates, and extend/update behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->