### PR TITLE
fix(opencode): remove hardcoded agent field from slash commands

### DIFF
--- a/src/core/configurators/slash/opencode.ts
+++ b/src/core/configurators/slash/opencode.ts
@@ -11,7 +11,6 @@ const FILE_PATHS: Record<SlashCommandId, string> = {
 
 const FRONTMATTER: Record<SlashCommandId, string> = {
   proposal: `---
-agent: build
 description: Scaffold a new OpenSpec change and validate strictly.
 ---
 The user has requested the following change proposal. Use the openspec instructions to create their change proposal.
@@ -20,7 +19,6 @@ The user has requested the following change proposal. Use the openspec instructi
 </UserRequest>
 `,
   apply: `---
-agent: build
 description: Implement an approved OpenSpec change and keep tasks in sync.
 ---
 The user has requested to implement the following change proposal. Find the change proposal and follow the instructions below. If you're not sure or if ambiguous, ask for clarification from the user.
@@ -29,7 +27,6 @@ The user has requested to implement the following change proposal. Find the chan
 </UserRequest>
 `,
   archive: `---
-agent: build
 description: Archive a deployed OpenSpec change and update specs.
 ---
 <ChangeId>

--- a/test/core/init.test.ts
+++ b/test/core/init.test.ts
@@ -492,21 +492,21 @@ describe('InitCommand', () => {
       expect(await fileExists(openCodeArchive)).toBe(true);
 
       const proposalContent = await fs.readFile(openCodeProposal, 'utf-8');
-      expect(proposalContent).toContain('agent: build');
+      expect(proposalContent).not.toContain('agent:');
       expect(proposalContent).toContain(
         'description: Scaffold a new OpenSpec change and validate strictly.'
       );
       expect(proposalContent).toContain('<!-- OPENSPEC:START -->');
 
       const applyContent = await fs.readFile(openCodeApply, 'utf-8');
-      expect(applyContent).toContain('agent: build');
+      expect(applyContent).not.toContain('agent:');
       expect(applyContent).toContain(
         'description: Implement an approved OpenSpec change and keep tasks in sync.'
       );
       expect(applyContent).toContain('Work through tasks sequentially');
 
       const archiveContent = await fs.readFile(openCodeArchive, 'utf-8');
-      expect(archiveContent).toContain('agent: build');
+      expect(archiveContent).not.toContain('agent:');
       expect(archiveContent).toContain(
         'description: Archive a deployed OpenSpec change and update specs.'
       );


### PR DESCRIPTION
## Summary
- Removes the `agent: build` field from OpenCode slash command templates
- When `agent` is not specified, OpenCode uses the current/custom agent instead of requiring the build agent

## Test plan
- [x] Unit tests updated and passing
- [x] Verified OpenCode slash command files no longer contain `agent:` field

Fixes #334

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated formatting in OpenCode workflow templates for improved consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->