### PR TITLE
feature(list): added option to output list as json

### DIFF
--- a/openspec/changes/archive/2025-11-25-add-list-json-output/proposal.md
+++ b/openspec/changes/archive/2025-11-25-add-list-json-output/proposal.md
@@ -1,0 +1,16 @@
+## Why
+Human-readable tables from `openspec list` force brittle parsing for CI, dashboards, and scripts needing change progress and spec requirement counts. A native JSON output flag provides structured data for automation without breaking existing usage.
+
+## What Changes
+- Extend `cli-list` spec: add Output Format requirement for machine-readable JSON.
+- Add `--json` flag to `openspec list` returning arrays of objects instead of table.
+- Changes mode JSON item: `{ name, completedTasks, totalTasks }`.
+- Specs mode JSON item: `{ id, requirementCount }`.
+- Empty results with `--json` produce `[]` (no error) to simplify scripting.
+- Document flag usage (README + agent guidance quick examples).
+- Add tests for both modes ensuring structure + counts.
+
+## Impact
+- Affected spec: `cli-list` (new requirement section + scenarios).
+- Affected code: `src/cli/index.ts`, `src/core/list.ts`, test additions.
+- Backwards compatible (default table unchanged).

--- a/openspec/changes/archive/2025-11-25-add-list-json-output/specs/cli-list/spec.md
+++ b/openspec/changes/archive/2025-11-25-add-list-json-output/specs/cli-list/spec.md
@@ -1,0 +1,35 @@
+## MODIFIED Requirements
+### Requirement: Output Format
+The command SHALL display items in a clear, readable table format with mode-appropriate progress or counts by default, and SHALL support machine-readable JSON output via the `--json` flag for automation.
+
+#### Scenario: Displaying change list (default)
+- **WHEN** `openspec list` is executed without flags
+- **THEN** show a table with columns:
+- Change name (directory name)
+- Task progress (e.g., "3/5 tasks" or "✓ Complete")
+
+#### Scenario: Displaying spec list (default)
+- **WHEN** `openspec list --specs` is executed
+- **THEN** show a table with columns:
+- Spec id (directory name)
+- Requirement count (e.g., "requirements 12")
+
+#### Scenario: Displaying JSON change list
+- **WHEN** `openspec list --json` is executed
+- **THEN** output a JSON array of objects each with fields `name`, `completedTasks`, `totalTasks`
+- **AND** preserve alphabetical sort order by change name
+- **AND** output only JSON (no leading human-readable header text)
+
+#### Scenario: Displaying JSON spec list
+- **WHEN** `openspec list --specs --json` is executed
+- **THEN** output a JSON array of objects each with fields `id`, `requirementCount`
+- **AND** preserve alphabetical sort order by spec id
+- **AND** output only JSON (no leading human-readable header text)
+
+#### Scenario: Empty JSON change list
+- **WHEN** `openspec list --json` is executed and there are no active changes
+- **THEN** output `[]` (an empty JSON array) with exit code 0
+
+#### Scenario: Empty JSON spec list
+- **WHEN** `openspec list --specs --json` is executed and there are no specs
+- **THEN** output `[]` (an empty JSON array) with exit code 0

--- a/openspec/changes/archive/2025-11-25-add-list-json-output/tasks.md
+++ b/openspec/changes/archive/2025-11-25-add-list-json-output/tasks.md
@@ -1,0 +1,22 @@
+## 1. Spec Update
+
+- [x] 1.1 Draft spec delta: add JSON output requirement & scenarios for changes/specs mode.
+
+## 2. CLI Implementation
+
+- [x] 2.1 Add `--json` flag option to top-level list command.
+- [x] 2.2 Pass flag through to ListCommand with boolean param.
+- [x] 2.3 Emit JSON arrays matching defined shape.
+
+## 3. Behavior & UX
+
+- [x] 3.1 Keep default table output unchanged when flag absent.
+- [x] 3.2 Return empty array `[]` rather than message when `--json` and no items.
+- [x] 3.3 Preserve existing empty state messages for non-JSON paths.
+
+## 4. Tests
+
+- [x] 4.1 Add test: changes mode JSON structure & counts.
+- [x] 4.2 Add test: specs mode JSON structure & requirement counts.
+- [x] 4.3 Add test: empty changes directory with `--json` returns [] (setup fixture).
+- [x] 4.4 Add test: empty specs with `--json` returns [].

--- a/openspec/specs/cli-list/spec.md
+++ b/openspec/specs/cli-list/spec.md
@@ -32,19 +32,39 @@ The command SHALL accurately count task completion status using standard markdow
 - **AND** calculate total tasks as the sum of completed and incomplete
 
 ### Requirement: Output Format
-The command SHALL display items in a clear, readable table format with mode-appropriate progress or counts.
+The command SHALL display items in a clear, readable table format with mode-appropriate progress or counts by default, and SHALL support machine-readable JSON output via the `--json` flag for automation.
 
 #### Scenario: Displaying change list (default)
-- **WHEN** displaying the list of changes
+- **WHEN** `openspec list` is executed without flags
 - **THEN** show a table with columns:
-  - Change name (directory name)
-  - Task progress (e.g., "3/5 tasks" or "✓ Complete")
+- Change name (directory name)
+- Task progress (e.g., "3/5 tasks" or "✓ Complete")
 
-#### Scenario: Displaying spec list
-- **WHEN** displaying the list of specs
+#### Scenario: Displaying spec list (default)
+- **WHEN** `openspec list --specs` is executed
 - **THEN** show a table with columns:
-  - Spec id (directory name)
-  - Requirement count (e.g., "requirements 12")
+- Spec id (directory name)
+- Requirement count (e.g., "requirements 12")
+
+#### Scenario: Displaying JSON change list
+- **WHEN** `openspec list --json` is executed
+- **THEN** output a JSON array of objects each with fields `name`, `completedTasks`, `totalTasks`
+- **AND** preserve alphabetical sort order by change name
+- **AND** output only JSON (no leading human-readable header text)
+
+#### Scenario: Displaying JSON spec list
+- **WHEN** `openspec list --specs --json` is executed
+- **THEN** output a JSON array of objects each with fields `id`, `requirementCount`
+- **AND** preserve alphabetical sort order by spec id
+- **AND** output only JSON (no leading human-readable header text)
+
+#### Scenario: Empty JSON change list
+- **WHEN** `openspec list --json` is executed and there are no active changes
+- **THEN** output `[]` (an empty JSON array) with exit code 0
+
+#### Scenario: Empty JSON spec list
+- **WHEN** `openspec list --specs --json` is executed and there are no specs
+- **THEN** output `[]` (an empty JSON array) with exit code 0
 
 ### Requirement: Flags
 The command SHALL accept flags to select the noun being listed.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,67 +1,75 @@
-import { Command } from 'commander';
-import { createRequire } from 'module';
-import ora from 'ora';
-import path from 'path';
-import { promises as fs } from 'fs';
-import { InitCommand } from '../core/init.js';
-import { AI_TOOLS } from '../core/config.js';
-import { UpdateCommand } from '../core/update.js';
-import { ListCommand } from '../core/list.js';
-import { ArchiveCommand } from '../core/archive.js';
-import { ViewCommand } from '../core/view.js';
-import { registerSpecCommand } from '../commands/spec.js';
-import { ChangeCommand } from '../commands/change.js';
-import { ValidateCommand } from '../commands/validate.js';
-import { ShowCommand } from '../commands/show.js';
+import { Command } from "commander";
+import { createRequire } from "module";
+import ora from "ora";
+import path from "path";
+import { promises as fs } from "fs";
+import { InitCommand } from "../core/init.js";
+import { AI_TOOLS } from "../core/config.js";
+import { UpdateCommand } from "../core/update.js";
+import { ListCommand } from "../core/list.js";
+import { ArchiveCommand } from "../core/archive.js";
+import { ViewCommand } from "../core/view.js";
+import { registerSpecCommand } from "../commands/spec.js";
+import { ChangeCommand } from "../commands/change.js";
+import { ValidateCommand } from "../commands/validate.js";
+import { ShowCommand } from "../commands/show.js";
 
 const program = new Command();
 const require = createRequire(import.meta.url);
-const { version } = require('../../package.json');
+const { version } = require("../../package.json");
 
 program
-  .name('openspec')
-  .description('AI-native system for spec-driven development')
+  .name("openspec")
+  .description("AI-native system for spec-driven development")
   .version(version);
 
 // Global options
-program.option('--no-color', 'Disable color output');
+program.option("--no-color", "Disable color output");
 
 // Apply global flags before any command runs
-program.hook('preAction', (thisCommand) => {
+program.hook("preAction", (thisCommand) => {
   const opts = thisCommand.opts();
   if (opts.noColor) {
-    process.env.NO_COLOR = '1';
+    process.env.NO_COLOR = "1";
   }
 });
 
-const availableToolIds = AI_TOOLS.filter((tool) => tool.available).map((tool) => tool.value);
-const toolsOptionDescription = `Configure AI tools non-interactively. Use "all", "none", or a comma-separated list of: ${availableToolIds.join(', ')}`;
+const availableToolIds = AI_TOOLS.filter((tool) => tool.available).map(
+  (tool) => tool.value
+);
+const toolsOptionDescription = `Configure AI tools non-interactively. Use "all", "none", or a comma-separated list of: ${availableToolIds.join(
+  ", "
+)}`;
 
 program
-  .command('init [path]')
-  .description('Initialize OpenSpec in your project')
-  .option('--tools <tools>', toolsOptionDescription)
-  .action(async (targetPath = '.', options?: { tools?: string }) => {
+  .command("init [path]")
+  .description("Initialize OpenSpec in your project")
+  .option("--tools <tools>", toolsOptionDescription)
+  .action(async (targetPath = ".", options?: { tools?: string }) => {
     try {
       // Validate that the path is a valid directory
       const resolvedPath = path.resolve(targetPath);
-      
+
       try {
         const stats = await fs.stat(resolvedPath);
         if (!stats.isDirectory()) {
           throw new Error(`Path "${targetPath}" is not a directory`);
         }
       } catch (error: any) {
-        if (error.code === 'ENOENT') {
+        if (error.code === "ENOENT") {
           // Directory doesn't exist, but we can create it
-          console.log(`Directory "${targetPath}" doesn't exist, it will be created.`);
-        } else if (error.message && error.message.includes('not a directory')) {
+          console.log(
+            `Directory "${targetPath}" doesn't exist, it will be created.`
+          );
+        } else if (error.message && error.message.includes("not a directory")) {
           throw error;
         } else {
-          throw new Error(`Cannot access path "${targetPath}": ${error.message}`);
+          throw new Error(
+            `Cannot access path "${targetPath}": ${error.message}`
+          );
         }
       }
-      
+
       const initCommand = new InitCommand({
         tools: options?.tools,
       });
@@ -74,9 +82,9 @@ program
   });
 
 program
-  .command('update [path]')
-  .description('Update OpenSpec instruction files')
-  .action(async (targetPath = '.') => {
+  .command("update [path]")
+  .description("Update OpenSpec instruction files")
+  .action(async (targetPath = ".") => {
     try {
       const resolvedPath = path.resolve(targetPath);
       const updateCommand = new UpdateCommand();
@@ -89,29 +97,36 @@ program
   });
 
 program
-  .command('list')
-  .description('List items (changes by default). Use --specs to list specs.')
-  .option('--specs', 'List specs instead of changes')
-  .option('--changes', 'List changes explicitly (default)')
-  .action(async (options?: { specs?: boolean; changes?: boolean }) => {
-    try {
-      const listCommand = new ListCommand();
-      const mode: 'changes' | 'specs' = options?.specs ? 'specs' : 'changes';
-      await listCommand.execute('.', mode);
-    } catch (error) {
-      console.log(); // Empty line for spacing
-      ora().fail(`Error: ${(error as Error).message}`);
-      process.exit(1);
+  .command("list")
+  .description("List items (changes by default). Use --specs to list specs.")
+  .option("--specs", "List specs instead of changes")
+  .option("--changes", "List changes explicitly (default)")
+  .option("--json", "Change output format to JSON")
+  .action(
+    async (options?: {
+      specs?: boolean;
+      changes?: boolean;
+      json?: boolean;
+    }) => {
+      try {
+        const listCommand = new ListCommand();
+        const mode: "changes" | "specs" = options?.specs ? "specs" : "changes";
+        await listCommand.execute(".", mode, options?.json);
+      } catch (error) {
+        console.log(); // Empty line for spacing
+        ora().fail(`Error: ${(error as Error).message}`);
+        process.exit(1);
+      }
     }
-  });
+  );
 
 program
-  .command('view')
-  .description('Display an interactive dashboard of specs and changes')
+  .command("view")
+  .description("Display an interactive dashboard of specs and changes")
   .action(async () => {
     try {
       const viewCommand = new ViewCommand();
-      await viewCommand.execute('.');
+      await viewCommand.execute(".");
     } catch (error) {
       console.log(); // Empty line for spacing
       ora().fail(`Error: ${(error as Error).message}`);
@@ -121,39 +136,55 @@ program
 
 // Change command with subcommands
 const changeCmd = program
-  .command('change')
-  .description('Manage OpenSpec change proposals');
+  .command("change")
+  .description("Manage OpenSpec change proposals");
 
 // Deprecation notice for noun-based commands
-changeCmd.hook('preAction', () => {
-  console.error('Warning: The "openspec change ..." commands are deprecated. Prefer verb-first commands (e.g., "openspec list", "openspec validate --changes").');
+changeCmd.hook("preAction", () => {
+  console.error(
+    'Warning: The "openspec change ..." commands are deprecated. Prefer verb-first commands (e.g., "openspec list", "openspec validate --changes").'
+  );
 });
 
 changeCmd
-  .command('show [change-name]')
-  .description('Show a change proposal in JSON or markdown format')
-  .option('--json', 'Output as JSON')
-  .option('--deltas-only', 'Show only deltas (JSON only)')
-  .option('--requirements-only', 'Alias for --deltas-only (deprecated)')
-  .option('--no-interactive', 'Disable interactive prompts')
-  .action(async (changeName?: string, options?: { json?: boolean; requirementsOnly?: boolean; deltasOnly?: boolean; noInteractive?: boolean }) => {
-    try {
-      const changeCommand = new ChangeCommand();
-      await changeCommand.show(changeName, options);
-    } catch (error) {
-      console.error(`Error: ${(error as Error).message}`);
-      process.exitCode = 1;
+  .command("show [change-name]")
+  .description("Show a change proposal in JSON or markdown format")
+  .option("--json", "Output as JSON")
+  .option("--deltas-only", "Show only deltas (JSON only)")
+  .option("--requirements-only", "Alias for --deltas-only (deprecated)")
+  .option("--no-interactive", "Disable interactive prompts")
+  .action(
+    async (
+      changeName?: string,
+      options?: {
+        json?: boolean;
+        requirementsOnly?: boolean;
+        deltasOnly?: boolean;
+        noInteractive?: boolean;
+      }
+    ) => {
+      try {
+        const changeCommand = new ChangeCommand();
+        await changeCommand.show(changeName, options);
+      } catch (error) {
+        console.error(`Error: ${(error as Error).message}`);
+        process.exitCode = 1;
+      }
     }
-  });
+  );
 
 changeCmd
-  .command('list')
-  .description('List all active changes (DEPRECATED: use "openspec list" instead)')
-  .option('--json', 'Output as JSON')
-  .option('--long', 'Show id and title with counts')
+  .command("list")
+  .description(
+    'List all active changes (DEPRECATED: use "openspec list" instead)'
+  )
+  .option("--json", "Output as JSON")
+  .option("--long", "Show id and title with counts")
   .action(async (options?: { json?: boolean; long?: boolean }) => {
     try {
-      console.error('Warning: "openspec change list" is deprecated. Use "openspec list".');
+      console.error(
+        'Warning: "openspec change list" is deprecated. Use "openspec list".'
+      );
       const changeCommand = new ChangeCommand();
       await changeCommand.list(options);
     } catch (error) {
@@ -163,91 +194,145 @@ changeCmd
   });
 
 changeCmd
-  .command('validate [change-name]')
-  .description('Validate a change proposal')
-  .option('--strict', 'Enable strict validation mode')
-  .option('--json', 'Output validation report as JSON')
-  .option('--no-interactive', 'Disable interactive prompts')
-  .action(async (changeName?: string, options?: { strict?: boolean; json?: boolean; noInteractive?: boolean }) => {
-    try {
-      const changeCommand = new ChangeCommand();
-      await changeCommand.validate(changeName, options);
-      if (typeof process.exitCode === 'number' && process.exitCode !== 0) {
-        process.exit(process.exitCode);
+  .command("validate [change-name]")
+  .description("Validate a change proposal")
+  .option("--strict", "Enable strict validation mode")
+  .option("--json", "Output validation report as JSON")
+  .option("--no-interactive", "Disable interactive prompts")
+  .action(
+    async (
+      changeName?: string,
+      options?: { strict?: boolean; json?: boolean; noInteractive?: boolean }
+    ) => {
+      try {
+        const changeCommand = new ChangeCommand();
+        await changeCommand.validate(changeName, options);
+        if (typeof process.exitCode === "number" && process.exitCode !== 0) {
+          process.exit(process.exitCode);
+        }
+      } catch (error) {
+        console.error(`Error: ${(error as Error).message}`);
+        process.exitCode = 1;
       }
-    } catch (error) {
-      console.error(`Error: ${(error as Error).message}`);
-      process.exitCode = 1;
     }
-  });
+  );
 
 program
-  .command('archive [change-name]')
-  .description('Archive a completed change and update main specs')
-  .option('-y, --yes', 'Skip confirmation prompts')
-  .option('--skip-specs', 'Skip spec update operations (useful for infrastructure, tooling, or doc-only changes)')
-  .option('--no-validate', 'Skip validation (not recommended, requires confirmation)')
-  .action(async (changeName?: string, options?: { yes?: boolean; skipSpecs?: boolean; noValidate?: boolean; validate?: boolean }) => {
-    try {
-      const archiveCommand = new ArchiveCommand();
-      await archiveCommand.execute(changeName, options);
-    } catch (error) {
-      console.log(); // Empty line for spacing
-      ora().fail(`Error: ${(error as Error).message}`);
-      process.exit(1);
+  .command("archive [change-name]")
+  .description("Archive a completed change and update main specs")
+  .option("-y, --yes", "Skip confirmation prompts")
+  .option(
+    "--skip-specs",
+    "Skip spec update operations (useful for infrastructure, tooling, or doc-only changes)"
+  )
+  .option(
+    "--no-validate",
+    "Skip validation (not recommended, requires confirmation)"
+  )
+  .action(
+    async (
+      changeName?: string,
+      options?: {
+        yes?: boolean;
+        skipSpecs?: boolean;
+        noValidate?: boolean;
+        validate?: boolean;
+      }
+    ) => {
+      try {
+        const archiveCommand = new ArchiveCommand();
+        await archiveCommand.execute(changeName, options);
+      } catch (error) {
+        console.log(); // Empty line for spacing
+        ora().fail(`Error: ${(error as Error).message}`);
+        process.exit(1);
+      }
     }
-  });
+  );
 
 registerSpecCommand(program);
 
 // Top-level validate command
 program
-  .command('validate [item-name]')
-  .description('Validate changes and specs')
-  .option('--all', 'Validate all changes and specs')
-  .option('--changes', 'Validate all changes')
-  .option('--specs', 'Validate all specs')
-  .option('--type <type>', 'Specify item type when ambiguous: change|spec')
-  .option('--strict', 'Enable strict validation mode')
-  .option('--json', 'Output validation results as JSON')
-  .option('--concurrency <n>', 'Max concurrent validations (defaults to env OPENSPEC_CONCURRENCY or 6)')
-  .option('--no-interactive', 'Disable interactive prompts')
-  .action(async (itemName?: string, options?: { all?: boolean; changes?: boolean; specs?: boolean; type?: string; strict?: boolean; json?: boolean; noInteractive?: boolean; concurrency?: string }) => {
-    try {
-      const validateCommand = new ValidateCommand();
-      await validateCommand.execute(itemName, options);
-    } catch (error) {
-      console.log();
-      ora().fail(`Error: ${(error as Error).message}`);
-      process.exit(1);
+  .command("validate [item-name]")
+  .description("Validate changes and specs")
+  .option("--all", "Validate all changes and specs")
+  .option("--changes", "Validate all changes")
+  .option("--specs", "Validate all specs")
+  .option("--type <type>", "Specify item type when ambiguous: change|spec")
+  .option("--strict", "Enable strict validation mode")
+  .option("--json", "Output validation results as JSON")
+  .option(
+    "--concurrency <n>",
+    "Max concurrent validations (defaults to env OPENSPEC_CONCURRENCY or 6)"
+  )
+  .option("--no-interactive", "Disable interactive prompts")
+  .action(
+    async (
+      itemName?: string,
+      options?: {
+        all?: boolean;
+        changes?: boolean;
+        specs?: boolean;
+        type?: string;
+        strict?: boolean;
+        json?: boolean;
+        noInteractive?: boolean;
+        concurrency?: string;
+      }
+    ) => {
+      try {
+        const validateCommand = new ValidateCommand();
+        await validateCommand.execute(itemName, options);
+      } catch (error) {
+        console.log();
+        ora().fail(`Error: ${(error as Error).message}`);
+        process.exit(1);
+      }
     }
-  });
+  );
 
 // Top-level show command
 program
-  .command('show [item-name]')
-  .description('Show a change or spec')
-  .option('--json', 'Output as JSON')
-  .option('--type <type>', 'Specify item type when ambiguous: change|spec')
-  .option('--no-interactive', 'Disable interactive prompts')
+  .command("show [item-name]")
+  .description("Show a change or spec")
+  .option("--json", "Output as JSON")
+  .option("--type <type>", "Specify item type when ambiguous: change|spec")
+  .option("--no-interactive", "Disable interactive prompts")
   // change-only flags
-  .option('--deltas-only', 'Show only deltas (JSON only, change)')
-  .option('--requirements-only', 'Alias for --deltas-only (deprecated, change)')
+  .option("--deltas-only", "Show only deltas (JSON only, change)")
+  .option("--requirements-only", "Alias for --deltas-only (deprecated, change)")
   // spec-only flags
-  .option('--requirements', 'JSON only: Show only requirements (exclude scenarios)')
-  .option('--no-scenarios', 'JSON only: Exclude scenario content')
-  .option('-r, --requirement <id>', 'JSON only: Show specific requirement by ID (1-based)')
+  .option(
+    "--requirements",
+    "JSON only: Show only requirements (exclude scenarios)"
+  )
+  .option("--no-scenarios", "JSON only: Exclude scenario content")
+  .option(
+    "-r, --requirement <id>",
+    "JSON only: Show specific requirement by ID (1-based)"
+  )
   // allow unknown options to pass-through to underlying command implementation
   .allowUnknownOption(true)
-  .action(async (itemName?: string, options?: { json?: boolean; type?: string; noInteractive?: boolean; [k: string]: any }) => {
-    try {
-      const showCommand = new ShowCommand();
-      await showCommand.execute(itemName, options ?? {});
-    } catch (error) {
-      console.log();
-      ora().fail(`Error: ${(error as Error).message}`);
-      process.exit(1);
+  .action(
+    async (
+      itemName?: string,
+      options?: {
+        json?: boolean;
+        type?: string;
+        noInteractive?: boolean;
+        [k: string]: any;
+      }
+    ) => {
+      try {
+        const showCommand = new ShowCommand();
+        await showCommand.execute(itemName, options ?? {});
+      } catch (error) {
+        console.log();
+        ora().fail(`Error: ${(error as Error).message}`);
+        process.exit(1);
+      }
     }
-  });
+  );
 
 program.parse();

--- a/src/core/list.ts
+++ b/src/core/list.ts
@@ -1,9 +1,12 @@
-import { promises as fs } from 'fs';
-import path from 'path';
-import { getTaskProgressForChange, formatTaskStatus } from '../utils/task-progress.js';
-import { readFileSync } from 'fs';
-import { join } from 'path';
-import { MarkdownParser } from './parsers/markdown-parser.js';
+import { promises as fs } from "fs";
+import path from "path";
+import {
+  getTaskProgressForChange,
+  formatTaskStatus,
+} from "../utils/task-progress.js";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { MarkdownParser } from "./parsers/markdown-parser.js";
 
 interface ChangeInfo {
   name: string;
@@ -12,77 +15,104 @@ interface ChangeInfo {
 }
 
 export class ListCommand {
-  async execute(targetPath: string = '.', mode: 'changes' | 'specs' = 'changes'): Promise<void> {
-    if (mode === 'changes') {
-      const changesDir = path.join(targetPath, 'openspec', 'changes');
-      
+  async execute(
+    targetPath: string = ".",
+    mode: "changes" | "specs" = "changes",
+    jsonOutput: boolean = false
+  ): Promise<void> {
+    if (mode === "changes") {
+      const changesDir = path.join(targetPath, "openspec", "changes");
+
       // Check if changes directory exists
       try {
         await fs.access(changesDir);
       } catch {
-        throw new Error("No OpenSpec changes directory found. Run 'openspec init' first.");
+        throw new Error(
+          "No OpenSpec changes directory found. Run 'openspec init' first."
+        );
       }
 
       // Get all directories in changes (excluding archive)
       const entries = await fs.readdir(changesDir, { withFileTypes: true });
       const changeDirs = entries
-        .filter(entry => entry.isDirectory() && entry.name !== 'archive')
-        .map(entry => entry.name);
+        .filter((entry) => entry.isDirectory() && entry.name !== "archive")
+        .map((entry) => entry.name);
 
       if (changeDirs.length === 0) {
-        console.log('No active changes found.');
+        if (jsonOutput) {
+          console.log(JSON.stringify([]));
+        } else {
+          console.log("No active changes found.");
+        }
         return;
       }
 
       // Collect information about each change
       const changes: ChangeInfo[] = [];
-      
+
       for (const changeDir of changeDirs) {
         const progress = await getTaskProgressForChange(changesDir, changeDir);
         changes.push({
           name: changeDir,
           completedTasks: progress.completed,
-          totalTasks: progress.total
+          totalTasks: progress.total,
         });
       }
 
       // Sort alphabetically by name
       changes.sort((a, b) => a.name.localeCompare(b.name));
 
+      // Display as JSON
+      if (jsonOutput) {
+        console.log(JSON.stringify(changes));
+        return;
+      }
+
       // Display results
-      console.log('Changes:');
-      const padding = '  ';
-      const nameWidth = Math.max(...changes.map(c => c.name.length));
+      console.log("Changes:");
+      const padding = "  ";
+      const nameWidth = Math.max(...changes.map((c) => c.name.length));
       for (const change of changes) {
         const paddedName = change.name.padEnd(nameWidth);
-        const status = formatTaskStatus({ total: change.totalTasks, completed: change.completedTasks });
+        const status = formatTaskStatus({
+          total: change.totalTasks,
+          completed: change.completedTasks,
+        });
         console.log(`${padding}${paddedName}     ${status}`);
       }
       return;
     }
 
     // specs mode
-    const specsDir = path.join(targetPath, 'openspec', 'specs');
+    const specsDir = path.join(targetPath, "openspec", "specs");
     try {
       await fs.access(specsDir);
     } catch {
-      console.log('No specs found.');
+      if (jsonOutput) {
+        console.log(JSON.stringify([]));
+      } else {
+        console.log("No specs found.");
+      }
       return;
     }
 
     const entries = await fs.readdir(specsDir, { withFileTypes: true });
-    const specDirs = entries.filter(e => e.isDirectory()).map(e => e.name);
+    const specDirs = entries.filter((e) => e.isDirectory()).map((e) => e.name);
     if (specDirs.length === 0) {
-      console.log('No specs found.');
+      if (jsonOutput) {
+        console.log(JSON.stringify([]));
+      } else {
+        console.log("No specs found.");
+      }
       return;
     }
 
     type SpecInfo = { id: string; requirementCount: number };
     const specs: SpecInfo[] = [];
     for (const id of specDirs) {
-      const specPath = join(specsDir, id, 'spec.md');
+      const specPath = join(specsDir, id, "spec.md");
       try {
-        const content = readFileSync(specPath, 'utf-8');
+        const content = readFileSync(specPath, "utf-8");
         const parser = new MarkdownParser(content);
         const spec = parser.parseSpec(id);
         specs.push({ id, requirementCount: spec.requirements.length });
@@ -93,12 +123,21 @@ export class ListCommand {
     }
 
     specs.sort((a, b) => a.id.localeCompare(b.id));
-    console.log('Specs:');
-    const padding = '  ';
-    const nameWidth = Math.max(...specs.map(s => s.id.length));
+
+    // Display as JSON
+    if (jsonOutput) {
+      console.log(JSON.stringify(specs));
+      return;
+    }
+
+    console.log("Specs:");
+    const padding = "  ";
+    const nameWidth = Math.max(...specs.map((s) => s.id.length));
     for (const spec of specs) {
       const padded = spec.id.padEnd(nameWidth);
-      console.log(`${padding}${padded}     requirements ${spec.requirementCount}`);
+      console.log(
+        `${padding}${padded}     requirements ${spec.requirementCount}`
+      );
     }
   }
 }


### PR DESCRIPTION
## Summary  

- Adds `--json` flag to openspec list for machine‑readable output of changes or specs.  
- Enables automation and scripting without parsing table output.

## Changes  

- Adds `--json` option to CLI list command.  
- Extends ListCommand.execute with jsonOutput parameter.  
- Outputs structured arrays for changes (name, completedTasks, totalTasks) src/core/list.ts:61 and specs (id, requirementCount).

## Why  

Provides direct integration surface for tooling (dashboards, CI checks) needing progress/status data. Current spec (cli-list) defines human-readable table only; JSON enhances interoperability while keeping existing format default.

## Behavior  

- Default (no flag): unchanged table output.  
- `--json`: prints raw arrays (no color) suitable for jq/scripts.  
- Works for both `--specs` and default changes mode.  
- Backward compatible; no breaking flags removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a --json flag to the openspec list command that outputs machine-readable JSON instead of human-readable tables
  * JSON output includes alphabetically sorted arrays with appropriate fields for changes and specs modes
  * Empty results correctly return valid empty JSON arrays with exit code 0

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->