### PR TITLE
Added uninstall command for issue #308

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,12 +248,22 @@ $ openspec archive add-profile-filters --yes  # Archive the completed change wit
 ## Command Reference
 
 ```bash
-openspec list               # View active change folders
-openspec view               # Interactive dashboard of specs and changes
-openspec show <change>      # Display change details (proposal, tasks, spec updates)
-openspec validate <change>  # Check spec formatting and structure
+openspec list                          # View active change folders
+openspec view                          # Interactive dashboard of specs and changes
+openspec show <change>                 # Display change details (proposal, tasks, spec updates)
+openspec validate <change>             # Check spec formatting and structure
 openspec archive <change> [--yes|-y]   # Move a completed change into archive/ (non-interactive with --yes)
+openspec uninstall [path] [--yes|-y]   # Remove OpenSpec from your project (non-interactive with --yes)
 ```
+
+The `uninstall` command cleanly removes OpenSpec from your project by:
+- Deleting the `openspec/` directory and all its contents
+- Removing OpenSpec-managed blocks from AI tool configuration files (CLAUDE.md, AGENTS.md, etc.)
+- Deleting slash command directories (`.claude/commands/openspec`, `.cursor/commands`, etc.)
+- Cleaning up empty parent directories after removing slash commands
+- Preserving any custom content you've added outside OpenSpec markers
+
+**Note:** The uninstall process is destructive. Make sure to commit any important changes to version control before uninstalling.
 
 ## Example: How AI Creates OpenSpec Files
 
@@ -367,6 +377,76 @@ Run `openspec update` whenever someone switches tools so your agents pick up the
    ```
 2. **Refresh agent instructions**
    - Run `openspec update` inside each project to regenerate AI guidance and ensure the latest slash commands are active.
+
+## Uninstalling OpenSpec
+
+If you need to remove OpenSpec from a project, use the `uninstall` command:
+
+### Interactive Uninstallation (Recommended)
+
+```bash
+cd /path/to/your/project
+openspec uninstall
+```
+
+This will:
+1. Show you a summary of what will be removed
+2. Ask for confirmation before proceeding
+3. Remove the `openspec/` directory
+4. Clean OpenSpec-managed content from configuration files
+5. Delete slash command directories
+6. Remove empty parent directories
+
+### Non-Interactive Uninstallation
+
+For automation or CI/CD pipelines, use the `--yes` flag:
+
+```bash
+openspec uninstall --yes
+```
+
+### What Gets Removed
+
+- **`openspec/` directory**: All specs, changes, proposals, and project context
+- **Config files**: OpenSpec-managed blocks in `CLAUDE.md`, `AGENTS.md`, `CLINE.md`, etc.
+- **Slash commands**: Tool-specific directories like `.claude/commands/openspec/`, `.cursor/commands/`, `.github/prompts/`, etc.
+- **Empty directories**: Parent directories that become empty after cleanup (e.g., `.claude/commands/`, `.claude/`)
+
+### What Gets Preserved
+
+- **Custom content**: Any text you've added to config files outside OpenSpec markers (`<!-- OPENSPEC:START -->` / `<!-- OPENSPEC:END -->`)
+- **Other slash commands**: Non-OpenSpec commands in tool directories
+- **Version control**: Your `.git` directory and history remain untouched
+
+### Before Uninstalling
+
+⚠️ **Important**: The uninstall process is destructive and cannot be undone. We recommend:
+
+1. **Commit your work**: Make sure all OpenSpec specs and changes are committed to version control
+2. **Archive completed changes**: Run `openspec archive <change>` for any completed work
+3. **Review the summary**: Check the preview before confirming deletion
+
+### Example
+
+```bash
+$ openspec uninstall
+
+The following will be removed:
+
+▌ Directory:
+  - /Users/dev/project/openspec
+
+▌ Config files (OpenSpec blocks will be removed):
+  - CLAUDE.md
+  - AGENTS.md
+
+▌ Slash commands:
+  - .claude/commands/openspec
+
+Are you sure you want to continue? (y/N) y
+
+✔ OpenSpec uninstalled successfully!
+```
 
 ## Contributing
 

--- a/openspec/changes/add-uninstall-command/design.md
+++ b/openspec/changes/add-uninstall-command/design.md
@@ -1,0 +1,195 @@
+# Uninstall Command Design
+
+## Architecture Overview
+
+The uninstall command will mirror the structure of `InitCommand` to maintain consistency and leverage existing patterns.
+
+## Core Components
+
+### 1. UninstallCommand Class (`src/core/uninstall.ts`)
+
+```typescript
+class UninstallCommand {
+  async execute(targetPath: string, options?: UninstallOptions): Promise<void>
+  private async validate(projectPath: string): Promise<void>
+  private async confirmUninstallation(summary: UninstallSummary): Promise<boolean>
+  private async removeOpenSpecDirectory(openspecPath: string): Promise<void>
+  private async cleanAIToolConfigs(projectPath: string): Promise<void>
+  private async removeSlashCommands(projectPath: string): Promise<void>
+  private async cleanupEmptyParentDirectories(deletedPath: string, projectPath: string): Promise<void>
+}
+```
+
+### 2. Cleanup Strategy
+
+**Phase 1: Discovery**
+- Detect if `openspec/` directory exists
+- Scan for AI tool config files with OpenSpec markers
+- Identify slash command directories using registries
+
+**Phase 2: Confirmation**
+- Display summary of what will be deleted/modified
+- Show preserved content warnings
+- Wait for user confirmation (unless `--yes` flag)
+
+**Phase 3: Cleanup**
+1. Remove `openspec/` directory entirely
+2. For each AI tool config file:
+   - Read file content
+   - Strip content between `<!-- OPENSPEC:START -->` and `<!-- OPENSPEC:END -->`
+   - If file is empty or whitespace-only after stripping, delete it
+   - Otherwise, write back preserved content
+3. Delete slash command directories/files
+4. Clean up empty parent directories:
+   - After deleting a slash command directory, walk up the directory tree
+   - Remove any empty parent directories until reaching a non-empty directory or project root
+   - Example: After deleting `.claude/commands/openspec/`, also remove `.claude/commands/` and `.claude/` if they become empty
+   - Skip cleanup for global paths (e.g., `~/.codex/prompts/`)
+
+## Data Flow
+
+```
+User runs `openspec uninstall`
+  ↓
+Validate: Check if openspec/ exists
+  ↓
+Discover: Find all OpenSpec-managed files
+  ↓
+Confirm: Show summary and ask for confirmation
+  ↓
+Clean: Remove directory, strip markers, delete slash commands
+  ↓
+Report: Display success summary
+```
+
+## File Detection Logic
+
+### AI Tool Config Files
+Leverage existing `ToolRegistry` and `SlashCommandRegistry`:
+- Iterate through all registered tools
+- Check if config file exists and contains markers
+- Check if slash command directories exist
+
+### Marker Stripping Algorithm
+```typescript
+function stripManagedBlock(content: string): string {
+  const startMarker = '<!-- OPENSPEC:START -->';
+  const endMarker = '<!-- OPENSPEC:END -->';
+
+  // Find and remove everything between markers (inclusive)
+  const pattern = new RegExp(
+    `${escapeRegex(startMarker)}.*?${escapeRegex(endMarker)}`,
+    'gs'
+  );
+
+  return content.replace(pattern, '').trim();
+}
+```
+
+### Empty Directory Cleanup Algorithm
+```typescript
+async function cleanupEmptyParentDirectories(
+  deletedPath: string,
+  projectPath: string
+): Promise<void> {
+  let currentDir = path.dirname(deletedPath);
+
+  // Walk up the directory tree, removing empty directories
+  while (currentDir !== projectPath && currentDir !== path.dirname(currentDir)) {
+    const isEmpty = await FileSystemUtils.isDirectoryEmpty(currentDir);
+
+    if (isEmpty) {
+      await FileSystemUtils.deleteDirectory(currentDir);
+      currentDir = path.dirname(currentDir);
+    } else {
+      break; // Stop when we find a non-empty directory
+    }
+  }
+}
+```
+
+This algorithm:
+1. Starts from the parent directory of the deleted path
+2. Checks if the directory is empty using `FileSystemUtils.isDirectoryEmpty()`
+3. If empty, deletes it and moves up to the parent
+4. Stops when it finds a non-empty directory or reaches the project root
+5. Only runs for project-relative paths (skips global paths like `~/.codex/`)
+
+## Reuse from Existing Code
+
+**From `InitCommand`:**
+- `ToolRegistry` and `SlashCommandRegistry` for discovering configured tools
+- `FileSystemUtils` for file operations
+- `OPENSPEC_MARKERS` constant for marker patterns
+
+**From `UpdateCommand`:**
+- Marker detection logic (already handles finding managed blocks)
+
+## Error Handling
+
+| Scenario | Behavior |
+|----------|----------|
+| `openspec/` doesn't exist | Exit with error: "OpenSpec is not initialized in this project" |
+| User cancels confirmation | Exit gracefully with code 0, no changes made |
+| Permission errors | Exit with error message, list failed operations |
+| Partial failure | Complete what's possible, report failures at end |
+
+## Options/Flags
+
+- `[path]` - Target directory (default: current directory)
+- `--yes` / `-y` - Skip confirmation prompts
+- `--dry-run` - Show what would be deleted without actually deleting (future enhancement)
+
+## Exit Codes
+
+- `0` - Success or user cancelled
+- `1` - Error (not initialized, permission issues, etc.)
+
+## Testing Strategy
+
+**Unit Tests:**
+- Marker stripping logic
+- Discovery of configured tools
+- File content preservation
+
+**Integration Tests:**
+- Full uninstall after `init`
+- Partial uninstall (some tools configured)
+- User content preservation
+- Permission handling
+
+## Documentation
+
+**README.md Updates:**
+- Add `uninstall` command to Command Reference section
+  - Command syntax with flags
+  - What gets removed (openspec/ directory, config files, slash commands)
+  - Note about preserving user content
+- New "Uninstalling OpenSpec" section after "Updating OpenSpec"
+  - Step-by-step uninstallation guide
+  - Warning about data loss
+  - Recommendation to commit changes before uninstalling
+  - Example usage with `--yes` flag
+
+## Trade-offs
+
+### Chosen: Delete entire `openspec/` directory
+**Pros:** Simple, complete cleanup
+**Cons:** Loses all specs, changes, and proposals
+**Rationale:** Aligns with user's intent to "reverse init" - users should commit work to git before uninstalling
+
+### Chosen: Preserve content outside markers
+**Pros:** Safer, respects user customization
+**Cons:** More complex logic, files may not be fully removed
+**Rationale:** Users may have added custom instructions to CLAUDE.md or AGENTS.md
+
+### Chosen: Interactive confirmation by default
+**Pros:** Prevents accidental data loss
+**Cons:** Requires user interaction
+**Rationale:** Destructive operations should require explicit confirmation; `--yes` flag addresses automation needs
+
+## Future Enhancements
+
+- `--backup` flag to create backup before uninstalling
+- `--dry-run` flag to preview changes
+- Selective uninstallation (e.g., `--tools claude,cursor` to remove specific tools only)

--- a/openspec/changes/add-uninstall-command/proposal.md
+++ b/openspec/changes/add-uninstall-command/proposal.md
@@ -1,0 +1,60 @@
+# Add Uninstall Command
+
+## Problem
+
+Users who initialize OpenSpec in a project may later decide to remove it, either to clean up a test environment or when migrating away from OpenSpec. Currently, there is no built-in way to reverse what `openspec init` does, forcing users to manually:
+- Delete the `openspec/` directory
+- Remove OpenSpec-managed blocks from AI tool configuration files (AGENTS.md, CLAUDE.md, etc.)
+- Delete slash command directories (.claude/, .cline/, etc.)
+- Track down all tool-specific configuration files across multiple locations
+
+This manual process is error-prone and leaves artifacts behind.
+
+## Solution
+
+Introduce an `openspec uninstall` command that reverses the initialization:
+1. Removes the `openspec/` directory entirely
+2. Strips OpenSpec-managed blocks (between `<!-- OPENSPEC:START -->` and `<!-- OPENSPEC:END -->` markers) from AI tool config files
+3. Deletes slash command directories and files created by OpenSpec
+4. Cleans up empty parent directories after removing slash commands (e.g., if `.claude/commands/openspec` is removed and `.claude/commands` becomes empty, it removes `.claude/commands` and `.claude` as well)
+5. Preserves any user-added content outside managed blocks in config files
+6. Requires confirmation before deletion (with `--yes` flag to skip for automation)
+
+## Impact
+
+### Users
+- **Developers testing OpenSpec**: Can cleanly remove OpenSpec from test projects
+- **Teams migrating away**: Can properly uninstall without leaving artifacts
+- **CI/CD automation**: Can use `--yes` flag for scripted uninstallation
+
+### System
+- New CLI command: `openspec uninstall [path]`
+- Reuses existing utilities from `FileSystemUtils` and marker detection logic
+- Mirrors the structure of `InitCommand` for consistency
+
+## Scope
+
+This change introduces:
+1. **New spec**: `cli-uninstall` - defines the behavior of the uninstall command
+2. **Implementation**: New `UninstallCommand` class in `src/core/uninstall.ts`
+3. **CLI integration**: Register command in `src/cli/index.ts`
+4. **Utility additions**: New methods in `FileSystemUtils` (`stripManagedBlock`, `deleteFile`, `deleteDirectory`, `isDirectoryEmpty`)
+5. **Tests**: Coverage for uninstall scenarios and new utility methods
+6. **Documentation**: Updates to README.md with command reference and uninstallation guide
+
+## Out of Scope
+
+- Backing up files before deletion (users should use version control)
+- Selective uninstallation (e.g., removing only specific AI tool configs)
+- Undo functionality after uninstallation
+
+## Dependencies
+
+None - this is a standalone feature.
+
+## Risks
+
+- **Data loss**: Users might unintentionally delete important content
+  - *Mitigation*: Require confirmation, preserve content outside markers
+- **Incomplete cleanup**: Some files might not be detected
+  - *Mitigation*: Use the same registry patterns as `init` to ensure symmetry

--- a/openspec/changes/add-uninstall-command/specs/cli-uninstall/spec.md
+++ b/openspec/changes/add-uninstall-command/specs/cli-uninstall/spec.md
@@ -1,0 +1,235 @@
+# CLI Uninstall Specification
+
+## Purpose
+
+The `openspec uninstall` command SHALL cleanly remove OpenSpec from a project by reversing what `openspec init` creates, while preserving user-added content outside OpenSpec-managed blocks.
+
+## ADDED Requirements
+
+### Requirement: Directory Removal
+
+The command SHALL remove the `openspec/` directory and all its contents.
+
+#### Scenario: Removing OpenSpec directory
+
+- **WHEN** `openspec uninstall` is executed
+- **THEN** delete the entire `openspec/` directory including:
+  - `openspec/project.md`
+  - `openspec/AGENTS.md`
+  - `openspec/specs/` and all subdirectories
+  - `openspec/changes/` and all subdirectories
+- **AND** do not create a backup
+
+### Requirement: Managed Block Removal
+
+The command SHALL remove OpenSpec-managed content blocks from AI tool configuration files while preserving user-added content.
+
+#### Scenario: Stripping managed blocks from config files
+
+- **WHEN** uninstalling OpenSpec
+- **THEN** for each AI tool config file (AGENTS.md, CLAUDE.md, CLINE.md, etc.):
+  - Read the file content
+  - Remove all content between `<!-- OPENSPEC:START -->` and `<!-- OPENSPEC:END -->` markers (inclusive)
+  - If the file becomes empty or contains only whitespace after removal, delete the file
+  - Otherwise, write back the preserved content
+- **AND** preserve all content outside the managed markers
+
+#### Scenario: Handling files with multiple managed blocks
+
+- **WHEN** a config file contains multiple OpenSpec-managed blocks
+- **THEN** remove all blocks between `<!-- OPENSPEC:START -->` and `<!-- OPENSPEC:END -->` markers
+- **AND** preserve all content outside all managed blocks
+
+### Requirement: Slash Command Cleanup
+
+The command SHALL remove all slash command files and directories created by OpenSpec for configured AI tools.
+
+#### Scenario: Removing slash commands
+
+- **WHEN** uninstalling OpenSpec
+- **THEN** for each configured AI tool with slash commands:
+  - Delete the slash command directory (e.g., `.claude/commands/openspec/`)
+  - Walk up the directory tree from the deleted path
+  - For each parent directory (e.g., `.claude/commands/`, then `.claude/`):
+    - Check if the directory is empty
+    - If empty, delete it and continue to the next parent
+    - If not empty, stop the cleanup process
+  - Stop when reaching the project root or a non-empty directory
+- **AND** use the `SlashCommandRegistry` to identify all configured tools
+
+#### Scenario: Removing global slash commands
+
+- **WHEN** uninstalling OpenSpec and Codex was configured
+- **THEN** delete the global Codex prompt files:
+  - `~/.codex/prompts/openspec-proposal.md`
+  - `~/.codex/prompts/openspec-apply.md`
+  - `~/.codex/prompts/openspec-archive.md`
+- **AND** do not delete other files in the Codex prompts directory
+- **AND** do not clean up empty parent directories for global paths (skip the empty directory cleanup algorithm for paths in the user's home directory)
+
+### Requirement: Empty Directory Cleanup
+
+The command SHALL remove empty parent directories after deleting slash commands to avoid leaving orphaned directory structures.
+
+#### Scenario: Cleaning up empty parent directories
+
+- **WHEN** a slash command directory is deleted (e.g., `.claude/commands/openspec/`)
+- **THEN** check the parent directory (e.g., `.claude/commands/`)
+- **AND** if the parent directory is empty:
+  - Delete the parent directory
+  - Move up to the next parent directory (e.g., `.claude/`)
+  - Repeat the check and delete process
+- **AND** stop when:
+  - A non-empty directory is found, OR
+  - The project root directory is reached
+- **AND** use `FileSystemUtils.isDirectoryEmpty()` to determine if a directory is empty
+
+#### Scenario: Skipping cleanup for global paths
+
+- **WHEN** a slash command file in a global path is deleted (e.g., `~/.codex/prompts/openspec-proposal.md`)
+- **THEN** do not perform empty directory cleanup
+- **AND** only delete the specific file, not its parent directories
+
+#### Scenario: Stopping at non-empty directories
+
+- **GIVEN** the following directory structure:
+  - `.claude/`
+    - `commands/`
+      - `openspec/` (contains OpenSpec slash commands)
+      - `custom-command.md` (user's custom command)
+- **WHEN** uninstalling OpenSpec
+- **THEN** delete `.claude/commands/openspec/`
+- **AND** check if `.claude/commands/` is empty
+- **AND** find that it contains `custom-command.md`
+- **AND** stop the cleanup process without deleting `.claude/commands/` or `.claude/`
+
+### Requirement: Validation
+
+The command SHALL validate that OpenSpec is initialized before attempting uninstallation.
+
+#### Scenario: Detecting uninitialized project
+
+- **WHEN** the `openspec/` directory does not exist
+- **THEN** exit with code 1 and display error: "OpenSpec is not initialized in this project"
+- **AND** do not attempt to clean AI tool configuration files
+
+#### Scenario: Detecting initialized project
+
+- **WHEN** the `openspec/` directory exists
+- **THEN** proceed with discovery phase
+- **AND** identify all configured AI tools using `ToolRegistry` and `SlashCommandRegistry`
+
+### Requirement: Confirmation
+
+The command SHALL require user confirmation before performing destructive operations.
+
+#### Scenario: Displaying uninstallation summary
+
+- **WHEN** uninstallation is initiated without `--yes` flag
+- **THEN** display a summary showing:
+  - "The following will be deleted:"
+  - Path to `openspec/` directory
+  - List of slash command directories that will be deleted
+  - List of config files that will be modified (markers removed)
+  - List of config files that will be deleted (empty after marker removal)
+- **AND** prompt: "Are you sure you want to continue? [y/N]"
+- **AND** wait for user input
+
+#### Scenario: User confirms uninstallation
+
+- **WHEN** user enters "y" or "yes" (case-insensitive)
+- **THEN** proceed with cleanup operations
+- **AND** display progress indicators using ora spinners
+
+#### Scenario: User cancels uninstallation
+
+- **WHEN** user enters "n", "no", or any other input
+- **THEN** exit with code 0 and message: "Uninstallation cancelled"
+- **AND** do not modify any files
+
+### Requirement: Non-Interactive Mode
+
+The command SHALL support non-interactive uninstallation for automation and CI/CD use cases.
+
+#### Scenario: Skipping confirmation with flag
+
+- **WHEN** run with `--yes` or `-y` flag
+- **THEN** skip the confirmation prompt
+- **AND** proceed directly to cleanup operations
+- **AND** display the summary but do not wait for input
+
+### Requirement: Progress Indicators
+
+The command SHALL display progress indicators during uninstallation to provide clear feedback.
+
+#### Scenario: Displaying uninstallation progress
+
+- **WHEN** performing cleanup operations
+- **THEN** display progress with ora spinners:
+  - Show spinner: "⠋ Removing OpenSpec directory..."
+  - Then success: "✔ OpenSpec directory removed"
+  - Show spinner: "⠋ Cleaning AI tool configurations..."
+  - Then success: "✔ AI tool configurations cleaned"
+  - Show spinner: "⠋ Removing slash commands..."
+  - Then success: "✔ Slash commands removed"
+
+### Requirement: Success Output
+
+The command SHALL provide clear feedback upon successful uninstallation.
+
+#### Scenario: Displaying success message
+
+- **WHEN** uninstallation completes successfully
+- **THEN** display summary:
+  - "OpenSpec uninstalled successfully!"
+  - "Removed: openspec/ directory"
+  - "Modified: [list of config files with markers removed]"
+  - "Deleted: [list of slash command directories]"
+- **AND** if any config files were modified but not deleted:
+  - "Preserved user content in: [list of files]"
+
+#### Scenario: Handling partial failures
+
+- **WHEN** some operations fail during uninstallation
+- **THEN** complete all possible operations
+- **AND** display summary of successful operations
+- **AND** display errors for failed operations
+- **AND** exit with code 1
+
+### Requirement: Exit Codes
+
+The command SHALL use consistent exit codes to indicate different outcomes.
+
+#### Scenario: Returning exit codes
+
+- **WHEN** the command completes
+- **THEN** return appropriate exit code:
+  - 0: Success or user cancelled
+  - 1: Error (not initialized, permission issues, partial failure)
+
+### Requirement: Tool Discovery
+
+The command SHALL accurately discover all OpenSpec-managed files using existing registries.
+
+#### Scenario: Using registries for discovery
+
+- **WHEN** discovering configured tools
+- **THEN** iterate through all tools in `ToolRegistry`
+- **AND** for each tool, check if its config file exists and contains OpenSpec markers
+- **AND** iterate through all tools in `SlashCommandRegistry`
+- **AND** for each tool, check if its slash command files exist
+
+#### Scenario: Detecting markers in config files
+
+- **WHEN** checking if a file is OpenSpec-managed
+- **THEN** read file content
+- **AND** verify it contains both `<!-- OPENSPEC:START -->` and `<!-- OPENSPEC:END -->` markers
+- **AND** only consider it managed if both markers are present
+
+## Why
+
+Users need a clean way to remove OpenSpec from projects without manually tracking down and deleting files. This command ensures:
+- Complete cleanup of OpenSpec-managed content
+- Preservation of user customizations
+- Safety through confirmation prompts
+- Consistency with the initialization process

--- a/openspec/changes/add-uninstall-command/tasks.md
+++ b/openspec/changes/add-uninstall-command/tasks.md
@@ -1,0 +1,125 @@
+# Implementation Tasks
+
+## 1. Create marker stripping utility
+- [x] Add `stripManagedBlock(content: string): string` function to `FileSystemUtils`
+- [x] Implement regex pattern to find and remove content between `<!-- OPENSPEC:START -->` and `<!-- OPENSPEC:END -->` markers
+- [x] Handle multiple managed blocks in a single file
+- [x] Add unit tests for various marker patterns
+
+## 2. Implement UninstallCommand class
+- [x] Create `src/core/uninstall.ts` with `UninstallCommand` class
+- [x] Implement `execute(targetPath: string, options?: UninstallOptions): Promise<void>` method
+- [x] Add validation to check if `openspec/` directory exists
+- [x] Return early with error if not initialized
+
+## 3. Add file discovery logic
+- [x] Use `ToolRegistry.getAll()` to iterate through all registered AI tools
+- [x] For each tool, check if config file exists using `FileSystemUtils.fileExists()`
+- [x] Read file content and verify it contains OpenSpec markers
+- [x] Use `SlashCommandRegistry.getAll()` to find configured slash commands
+- [x] Build a summary object with files to delete/modify
+
+## 4. Implement confirmation prompt
+- [x] Create interactive prompt using `@inquirer/prompts`
+- [x] Display summary of operations (delete directory, modify files, remove slash commands)
+- [x] Show which files will preserve user content
+- [x] Accept `--yes`/`-y` flag to skip confirmation
+- [x] Return user's decision (proceed or cancel)
+
+## 5. Implement directory removal
+- [x] Use `FileSystemUtils.deleteDirectory()` to remove `openspec/` directory
+- [x] Wrap in try-catch and handle permission errors gracefully
+- [x] Display progress using ora spinner
+
+## 6. Implement config file cleanup
+- [x] For each discovered config file:
+  - [x] Read content using `FileSystemUtils.readFile()`
+  - [x] Strip managed blocks using new utility function
+  - [x] Trim whitespace from result
+  - [x] If empty, delete file using `FileSystemUtils.deleteFile()`
+  - [x] Otherwise, write back using `FileSystemUtils.writeFile()`
+- [x] Track which files were modified vs deleted
+- [x] Handle errors and continue with remaining files
+
+## 7. Implement slash command removal
+- [x] For each discovered slash command configurator:
+  - [x] Get all target files/directories
+  - [x] Delete slash command directories (e.g., `.claude/commands/openspec/`)
+  - [x] Check if parent directories are empty and remove them
+  - [x] Handle global commands (e.g., Codex in `~/.codex/prompts/`)
+- [x] Use `FileSystemUtils.deleteDirectory()` for directory removal
+- [x] Track deleted paths for summary
+- [x] Fixed bug: Distinguish between project-relative and global paths correctly
+
+## 8. Add success/error reporting
+- [x] Display success message with summary of operations
+- [x] List removed directories
+- [x] List modified config files (markers removed, content preserved)
+- [x] List deleted config files (empty after marker removal)
+- [x] List deleted slash command paths
+- [x] On partial failure, show what succeeded and what failed
+- [x] Set appropriate exit codes (0 for success/cancel, 1 for errors)
+
+## 9. Register command in CLI
+- [x] Update `src/cli/index.ts` to add `uninstall` command
+- [x] Wire up to `UninstallCommand`
+- [x] Add `--yes` / `-y` option for skipping confirmation
+- [x] Add command description and help text
+- [x] Handle errors and exit codes properly
+
+## 10. Write unit tests
+- [x] Test marker stripping with various input patterns
+  - [x] Single managed block
+  - [x] Multiple managed blocks
+  - [x] Content before/after markers
+  - [x] No markers present
+- [x] Test file discovery logic
+- [x] Test confirmation prompt logic
+- [x] Mock file system operations for testing
+- [x] Add unit tests for new FileSystemUtils methods in `test/utils/file-system.test.ts`:
+  - [x] `deleteFile` - test deleting existing file, handling non-existent file errors
+  - [x] `deleteDirectory` - test deleting directory with contents, empty directory, non-existent directory
+  - [x] `isDirectoryEmpty` - test empty directory returns true, directory with files returns false, non-existent directory returns true
+
+## 11. Write integration tests
+- [x] Create test fixture with initialized OpenSpec
+- [x] Run `uninstall` command
+- [x] Verify `openspec/` directory is deleted
+- [x] Verify config files have markers removed but preserve user content
+- [x] Verify slash commands are deleted
+- [x] Test with `--yes` flag
+- [x] Test error cases (not initialized, permission errors)
+
+## 12. Update documentation
+- [x] Add `uninstall` command to Command Reference section in README.md
+  - [x] Include command syntax: `openspec uninstall [path] [-y|--yes]`
+  - [x] Describe what the command does (removes openspec/ directory, cleans config files, removes slash commands)
+  - [x] Explain the `--yes` flag for non-interactive mode
+  - [x] Note that user content outside OpenSpec markers is preserved
+- [x] Add "Uninstalling OpenSpec" section to README.md
+  - [x] Place after "Updating OpenSpec" section
+  - [x] Provide step-by-step instructions for uninstalling
+  - [x] Add warning about data loss and recommendation to commit changes first
+  - [x] Include example command usage
+
+## Validation Points
+
+- [x] `openspec uninstall` shows error when not initialized
+- [x] Confirmation prompt displays accurate summary
+- [x] `--yes` flag skips confirmation
+- [x] `openspec/` directory is completely removed
+- [x] Config files preserve user content outside markers
+- [x] Empty config files are deleted
+- [x] Slash commands are removed from all configured tools
+- [x] Success message shows accurate summary
+- [x] Exit codes are correct
+- [x] Works in CI/CD with `--yes` flag
+
+## Dependencies
+
+None - can be implemented independently.
+
+## Parallel Work Opportunities
+
+- Tasks 1-3 can be worked on in parallel (marker utility, command class, discovery)
+- Tasks 10-11 can be written in parallel with implementation

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -9,6 +9,7 @@ import { UpdateCommand } from '../core/update.js';
 import { ListCommand } from '../core/list.js';
 import { ArchiveCommand } from '../core/archive.js';
 import { ViewCommand } from '../core/view.js';
+import { UninstallCommand } from '../core/uninstall.js';
 import { registerSpecCommand } from '../commands/spec.js';
 import { ChangeCommand } from '../commands/change.js';
 import { ValidateCommand } from '../commands/validate.js';
@@ -81,6 +82,23 @@ program
       const resolvedPath = path.resolve(targetPath);
       const updateCommand = new UpdateCommand();
       await updateCommand.execute(resolvedPath);
+    } catch (error) {
+      console.log(); // Empty line for spacing
+      ora().fail(`Error: ${(error as Error).message}`);
+      process.exit(1);
+    }
+  });
+
+program
+  .command('uninstall [path]')
+  .description('Remove OpenSpec from your project')
+  .option('-y, --yes', 'Skip confirmation prompts')
+  .action(async (targetPath = '.', options?: { yes?: boolean }) => {
+    try {
+      const uninstallCommand = new UninstallCommand({
+        yes: options?.yes,
+      });
+      await uninstallCommand.execute(targetPath);
     } catch (error) {
       console.log(); // Empty line for spacing
       ora().fail(`Error: ${(error as Error).message}`);

--- a/src/core/uninstall.ts
+++ b/src/core/uninstall.ts
@@ -62,9 +62,9 @@ export class UninstallCommand {
     // Display results
     this.displayResults(result);
 
-    // Exit with error code if there were any failures
+    // Throw if there were any failures, let CLI handle exit code
     if (result.errors.length > 0) {
-      process.exit(1);
+      throw new Error(`Uninstall completed with ${result.errors.length} error(s)`);
     }
   }
 

--- a/src/core/uninstall.ts
+++ b/src/core/uninstall.ts
@@ -1,0 +1,419 @@
+import path from 'path';
+import { confirm } from '@inquirer/prompts';
+import ora from 'ora';
+import { FileSystemUtils } from '../utils/file-system.js';
+import { ToolRegistry } from './configurators/registry.js';
+import { SlashCommandRegistry } from './configurators/slash/registry.js';
+import { OPENSPEC_DIR_NAME, OPENSPEC_MARKERS } from './config.js';
+import { PALETTE } from './styles/palette.js';
+import os from 'os';
+
+type UninstallOptions = {
+  yes?: boolean;
+};
+
+type ConfigFileOperation = {
+  path: string;
+  action: 'modify' | 'delete';
+};
+
+type UninstallSummary = {
+  openspecDir: string;
+  configFiles: ConfigFileOperation[];
+  slashCommandPaths: string[];
+};
+
+type UninstallResult = {
+  openspecDirRemoved: boolean;
+  configFilesModified: string[];
+  configFilesDeleted: string[];
+  slashCommandsRemoved: string[];
+  errors: string[];
+};
+
+export class UninstallCommand {
+  private readonly skipConfirmation: boolean;
+
+  constructor(options: UninstallOptions = {}) {
+    this.skipConfirmation = options.yes ?? false;
+  }
+
+  async execute(targetPath: string): Promise<void> {
+    const projectPath = path.resolve(targetPath);
+    const openspecPath = path.join(projectPath, OPENSPEC_DIR_NAME);
+
+    // Validate that OpenSpec is initialized
+    await this.validate(openspecPath);
+
+    // Discover what will be removed/modified
+    const summary = await this.discoverFiles(projectPath, openspecPath);
+
+    // Get confirmation from user
+    const confirmed = await this.confirmUninstallation(summary);
+    if (!confirmed) {
+      console.log();
+      ora().info(PALETTE.midGray('Uninstallation cancelled'));
+      return;
+    }
+
+    // Perform uninstallation
+    const result = await this.performUninstallation(summary, openspecPath, projectPath);
+
+    // Display results
+    this.displayResults(result);
+
+    // Exit with error code if there were any failures
+    if (result.errors.length > 0) {
+      process.exit(1);
+    }
+  }
+
+  private async validate(openspecPath: string): Promise<void> {
+    const exists = await FileSystemUtils.directoryExists(openspecPath);
+    if (!exists) {
+      throw new Error('OpenSpec is not initialized in this project');
+    }
+  }
+
+  private async discoverFiles(
+    projectPath: string,
+    openspecPath: string
+  ): Promise<UninstallSummary> {
+    const configFiles: ConfigFileOperation[] = [];
+    const slashCommandPaths: string[] = [];
+
+    // Discover AI tool config files with OpenSpec markers
+    const allTools = ToolRegistry.getAll();
+    for (const tool of allTools) {
+      if (!tool.configFileName) continue;
+
+      const configPath = path.join(projectPath, tool.configFileName);
+      if (!(await FileSystemUtils.fileExists(configPath))) continue;
+
+      // Check if file contains OpenSpec markers
+      const content = await FileSystemUtils.readFile(configPath);
+      if (
+        content.includes(OPENSPEC_MARKERS.start) &&
+        content.includes(OPENSPEC_MARKERS.end)
+      ) {
+        // Determine if file will be empty after stripping markers
+        const stripped = FileSystemUtils.stripManagedBlock(
+          content,
+          OPENSPEC_MARKERS.start,
+          OPENSPEC_MARKERS.end
+        );
+        const action = stripped.length === 0 ? 'delete' : 'modify';
+        configFiles.push({ path: configPath, action });
+      }
+    }
+
+    // Discover slash command files/directories
+    const slashConfigurators = SlashCommandRegistry.getAll();
+    const checkedDirs = new Set<string>(); // Track directories we've already added
+
+    for (const configurator of slashConfigurators) {
+      const targets = configurator.getTargets();
+
+      // For each tool, find the common parent directory containing all slash commands
+      for (const target of targets) {
+        const absolutePath = configurator.resolveAbsolutePath(projectPath, target.id);
+
+        // Check if this is a global path (outside the project directory)
+        const normalizedProjectPath = path.resolve(projectPath);
+        const normalizedAbsolutePath = path.resolve(absolutePath);
+        const isGlobalPath = !normalizedAbsolutePath.startsWith(normalizedProjectPath + path.sep) &&
+                            normalizedAbsolutePath !== normalizedProjectPath;
+
+        if (isGlobalPath) {
+          // For global paths (like Codex), track individual files
+          if (await FileSystemUtils.fileExists(absolutePath)) {
+            if (!checkedDirs.has(absolutePath)) {
+              slashCommandPaths.push(absolutePath);
+              checkedDirs.add(absolutePath);
+            }
+          }
+        } else {
+          // For project-relative paths, find the common "openspec" directory
+          // Example: .claude/commands/openspec/proposal.md -> .claude/commands/openspec
+          const parentDir = path.dirname(absolutePath);
+
+          // Only add if we haven't already added this directory
+          if (!checkedDirs.has(parentDir) && await FileSystemUtils.directoryExists(parentDir)) {
+            slashCommandPaths.push(parentDir);
+            checkedDirs.add(parentDir);
+            break; // Found the common directory for this configurator, move to next
+          }
+        }
+      }
+    }
+
+    return {
+      openspecDir: openspecPath,
+      configFiles,
+      slashCommandPaths,
+    };
+  }
+
+  private async confirmUninstallation(summary: UninstallSummary): Promise<boolean> {
+    if (this.skipConfirmation) {
+      this.displaySummary(summary);
+      return true;
+    }
+
+    console.log();
+    console.log(PALETTE.white('The following will be removed:'));
+    console.log();
+
+    this.displaySummary(summary);
+
+    console.log();
+    const confirmed = await confirm({
+      message: 'Are you sure you want to continue?',
+      default: false,
+    });
+
+    return confirmed;
+  }
+
+  private displaySummary(summary: UninstallSummary): void {
+    // OpenSpec directory
+    console.log(PALETTE.white('▌ Directory:'));
+    console.log(PALETTE.midGray(`  - ${summary.openspecDir}`));
+    console.log();
+
+    // Config files to modify
+    const filesToModify = summary.configFiles.filter(f => f.action === 'modify');
+    if (filesToModify.length > 0) {
+      console.log(PALETTE.white('▌ Config files (OpenSpec blocks will be removed):'));
+      for (const file of filesToModify) {
+        const relativePath = path.relative(process.cwd(), file.path);
+        console.log(PALETTE.midGray(`  - ${relativePath}`));
+      }
+      console.log();
+    }
+
+    // Config files to delete
+    const filesToDelete = summary.configFiles.filter(f => f.action === 'delete');
+    if (filesToDelete.length > 0) {
+      console.log(PALETTE.white('▌ Config files (will be deleted, no user content):'));
+      for (const file of filesToDelete) {
+        const relativePath = path.relative(process.cwd(), file.path);
+        console.log(PALETTE.midGray(`  - ${relativePath}`));
+      }
+      console.log();
+    }
+
+    // Slash command paths
+    if (summary.slashCommandPaths.length > 0) {
+      console.log(PALETTE.white('▌ Slash commands:'));
+      for (const slashPath of summary.slashCommandPaths) {
+        // Check if this is a global path (starts with home directory)
+        const homeDir = os.homedir();
+        const normalizedSlashPath = path.resolve(slashPath);
+        const normalizedHomeDir = path.resolve(homeDir);
+        const isGlobalPath = normalizedSlashPath.startsWith(normalizedHomeDir + path.sep);
+
+        const displayPath = isGlobalPath
+          ? slashPath.replace(homeDir, '~')
+          : path.relative(process.cwd(), slashPath);
+        console.log(PALETTE.midGray(`  - ${displayPath}`));
+      }
+      console.log();
+    }
+  }
+
+  private async performUninstallation(
+    summary: UninstallSummary,
+    openspecPath: string,
+    projectPath: string
+  ): Promise<UninstallResult> {
+    const result: UninstallResult = {
+      openspecDirRemoved: false,
+      configFilesModified: [],
+      configFilesDeleted: [],
+      slashCommandsRemoved: [],
+      errors: [],
+    };
+
+    // Remove openspec directory
+    const dirSpinner = ora({
+      text: 'Removing OpenSpec directory...',
+      stream: process.stdout,
+      color: 'gray',
+    }).start();
+
+    try {
+      await FileSystemUtils.deleteDirectory(openspecPath);
+      result.openspecDirRemoved = true;
+      dirSpinner.stopAndPersist({
+        symbol: PALETTE.white('▌'),
+        text: PALETTE.white('OpenSpec directory removed'),
+      });
+    } catch (error: any) {
+      result.errors.push(`Failed to remove openspec directory: ${error.message}`);
+      dirSpinner.stopAndPersist({
+        symbol: PALETTE.white('▌'),
+        text: PALETTE.white('OpenSpec directory removal failed'),
+      });
+    }
+
+    // Clean config files
+    if (summary.configFiles.length > 0) {
+      const configSpinner = ora({
+        text: 'Cleaning AI tool configurations...',
+        stream: process.stdout,
+        color: 'gray',
+      }).start();
+
+      for (const file of summary.configFiles) {
+        try {
+          if (file.action === 'delete') {
+            await FileSystemUtils.deleteFile(file.path);
+            result.configFilesDeleted.push(file.path);
+          } else {
+            const content = await FileSystemUtils.readFile(file.path);
+            const stripped = FileSystemUtils.stripManagedBlock(
+              content,
+              OPENSPEC_MARKERS.start,
+              OPENSPEC_MARKERS.end
+            );
+            await FileSystemUtils.writeFile(file.path, stripped);
+            result.configFilesModified.push(file.path);
+          }
+        } catch (error: any) {
+          result.errors.push(`Failed to process ${file.path}: ${error.message}`);
+        }
+      }
+
+      configSpinner.stopAndPersist({
+        symbol: PALETTE.white('▌'),
+        text: PALETTE.white('AI tool configurations cleaned'),
+      });
+    }
+
+    // Remove slash commands
+    if (summary.slashCommandPaths.length > 0) {
+      const slashSpinner = ora({
+        text: 'Removing slash commands...',
+        stream: process.stdout,
+        color: 'gray',
+      }).start();
+
+      for (const slashPath of summary.slashCommandPaths) {
+        try {
+          // Check if it's a file or directory
+          const stats = await FileSystemUtils.fileExists(slashPath);
+          if (stats) {
+            const isDir = await FileSystemUtils.directoryExists(slashPath);
+            if (isDir) {
+              await FileSystemUtils.deleteDirectory(slashPath);
+            } else {
+              await FileSystemUtils.deleteFile(slashPath);
+            }
+            result.slashCommandsRemoved.push(slashPath);
+
+            // Clean up empty parent directories (only for project-relative paths)
+            const normalizedProjectPath = path.resolve(projectPath);
+            const normalizedSlashPath = path.resolve(slashPath);
+            const isProjectRelative = normalizedSlashPath.startsWith(normalizedProjectPath + path.sep) ||
+                                     normalizedSlashPath === normalizedProjectPath;
+
+            if (isProjectRelative) {
+              await this.cleanupEmptyParentDirectories(slashPath, projectPath);
+            }
+          }
+        } catch (error: any) {
+          result.errors.push(`Failed to remove ${slashPath}: ${error.message}`);
+        }
+      }
+
+      slashSpinner.stopAndPersist({
+        symbol: PALETTE.white('▌'),
+        text: PALETTE.white('Slash commands removed'),
+      });
+    }
+
+    return result;
+  }
+
+  private async cleanupEmptyParentDirectories(
+    deletedPath: string,
+    projectPath: string
+  ): Promise<void> {
+    let currentDir = path.dirname(deletedPath);
+
+    // Don't delete beyond the project directory
+    while (currentDir !== projectPath && currentDir !== path.dirname(currentDir)) {
+      try {
+        const isEmpty = await FileSystemUtils.isDirectoryEmpty(currentDir);
+        if (isEmpty) {
+          await FileSystemUtils.deleteDirectory(currentDir);
+          currentDir = path.dirname(currentDir);
+        } else {
+          break;
+        }
+      } catch {
+        // If we can't check or delete, stop cleanup
+        break;
+      }
+    }
+  }
+
+  private displayResults(result: UninstallResult): void {
+    console.log();
+
+    if (result.errors.length === 0) {
+      ora().succeed(PALETTE.white('OpenSpec uninstalled successfully!'));
+    } else {
+      ora().warn(PALETTE.white('OpenSpec partially uninstalled'));
+    }
+
+    console.log();
+
+    if (result.openspecDirRemoved) {
+      console.log(PALETTE.white('▌ Removed: openspec/ directory'));
+    }
+
+    if (result.configFilesModified.length > 0) {
+      console.log(PALETTE.white('▌ Modified (OpenSpec blocks removed):'));
+      for (const file of result.configFilesModified) {
+        const relativePath = path.relative(process.cwd(), file);
+        console.log(PALETTE.midGray(`  - ${relativePath}`));
+      }
+    }
+
+    if (result.configFilesDeleted.length > 0) {
+      console.log(PALETTE.white('▌ Deleted (no user content):'));
+      for (const file of result.configFilesDeleted) {
+        const relativePath = path.relative(process.cwd(), file);
+        console.log(PALETTE.midGray(`  - ${relativePath}`));
+      }
+    }
+
+    if (result.slashCommandsRemoved.length > 0) {
+      console.log(PALETTE.white('▌ Slash commands removed:'));
+      for (const slashPath of result.slashCommandsRemoved) {
+        // Check if this is a global path (starts with home directory)
+        const homeDir = os.homedir();
+        const normalizedSlashPath = path.resolve(slashPath);
+        const normalizedHomeDir = path.resolve(homeDir);
+        const isGlobalPath = normalizedSlashPath.startsWith(normalizedHomeDir + path.sep);
+
+        const displayPath = isGlobalPath
+          ? slashPath.replace(homeDir, '~')
+          : path.relative(process.cwd(), slashPath);
+        console.log(PALETTE.midGray(`  - ${displayPath}`));
+      }
+    }
+
+    if (result.errors.length > 0) {
+      console.log();
+      console.log(PALETTE.white('▌ Errors:'));
+      for (const error of result.errors) {
+        console.log(PALETTE.midGray(`  - ${error}`));
+      }
+    }
+
+    console.log();
+  }
+}

--- a/test/core/uninstall.test.ts
+++ b/test/core/uninstall.test.ts
@@ -1,0 +1,385 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+import { randomUUID } from 'crypto';
+import { UninstallCommand } from '../../src/core/uninstall.js';
+import { InitCommand } from '../../src/core/init.js';
+import { FileSystemUtils } from '../../src/utils/file-system.js';
+import { OPENSPEC_MARKERS } from '../../src/core/config.js';
+
+describe('UninstallCommand', () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = path.join(os.tmpdir(), `openspec-uninstall-test-${randomUUID()}`);
+    await fs.mkdir(testDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  describe('validation', () => {
+    it('should throw error when OpenSpec is not initialized', async () => {
+      const uninstallCommand = new UninstallCommand({ yes: true });
+
+      await expect(uninstallCommand.execute(testDir)).rejects.toThrow(
+        'OpenSpec is not initialized in this project'
+      );
+    });
+
+    it('should not throw when OpenSpec is initialized', async () => {
+      // Initialize OpenSpec first
+      const initCommand = new InitCommand({ tools: 'none' });
+      await initCommand.execute(testDir);
+
+      const uninstallCommand = new UninstallCommand({ yes: true });
+
+      await expect(uninstallCommand.execute(testDir)).resolves.not.toThrow();
+    });
+  });
+
+  describe('directory removal', () => {
+    it('should remove the openspec directory', async () => {
+      // Initialize OpenSpec
+      const initCommand = new InitCommand({ tools: 'none' });
+      await initCommand.execute(testDir);
+
+      const openspecPath = path.join(testDir, 'openspec');
+      expect(await FileSystemUtils.directoryExists(openspecPath)).toBe(true);
+
+      // Uninstall
+      const uninstallCommand = new UninstallCommand({ yes: true });
+      await uninstallCommand.execute(testDir);
+
+      expect(await FileSystemUtils.directoryExists(openspecPath)).toBe(false);
+    });
+
+    it('should remove all subdirectories and files', async () => {
+      // Initialize OpenSpec
+      const initCommand = new InitCommand({ tools: 'none' });
+      await initCommand.execute(testDir);
+
+      // Create additional files in openspec
+      const customFile = path.join(testDir, 'openspec', 'custom.md');
+      await fs.writeFile(customFile, 'Custom content');
+
+      // Uninstall
+      const uninstallCommand = new UninstallCommand({ yes: true });
+      await uninstallCommand.execute(testDir);
+
+      const openspecPath = path.join(testDir, 'openspec');
+      expect(await FileSystemUtils.directoryExists(openspecPath)).toBe(false);
+    });
+  });
+
+  describe('config file cleanup', () => {
+    it('should strip OpenSpec markers from AGENTS.md', async () => {
+      // Initialize with AGENTS.md
+      const initCommand = new InitCommand({ tools: 'none' });
+      await initCommand.execute(testDir);
+
+      const agentsPath = path.join(testDir, 'AGENTS.md');
+      const beforeContent = await fs.readFile(agentsPath, 'utf-8');
+      expect(beforeContent).toContain(OPENSPEC_MARKERS.start);
+
+      // Add custom content
+      const customContent = `${beforeContent}\n\n# Custom Section\nMy custom instructions`;
+      await fs.writeFile(agentsPath, customContent);
+
+      // Uninstall
+      const uninstallCommand = new UninstallCommand({ yes: true });
+      await uninstallCommand.execute(testDir);
+
+      // Check file still exists but markers are removed
+      expect(await FileSystemUtils.fileExists(agentsPath)).toBe(true);
+      const afterContent = await fs.readFile(agentsPath, 'utf-8');
+      expect(afterContent).not.toContain(OPENSPEC_MARKERS.start);
+      expect(afterContent).toContain('Custom Section');
+      expect(afterContent).toContain('My custom instructions');
+    });
+
+    it('should delete config files with only OpenSpec content', async () => {
+      // Initialize
+      const initCommand = new InitCommand({ tools: 'none' });
+      await initCommand.execute(testDir);
+
+      const agentsPath = path.join(testDir, 'AGENTS.md');
+      expect(await FileSystemUtils.fileExists(agentsPath)).toBe(true);
+
+      // Uninstall
+      const uninstallCommand = new UninstallCommand({ yes: true });
+      await uninstallCommand.execute(testDir);
+
+      // File should be deleted since it only contains OpenSpec content
+      expect(await FileSystemUtils.fileExists(agentsPath)).toBe(false);
+    });
+
+    it('should preserve user content outside markers', async () => {
+      // Initialize
+      const initCommand = new InitCommand({ tools: 'none' });
+      await initCommand.execute(testDir);
+
+      const agentsPath = path.join(testDir, 'AGENTS.md');
+
+      // Add content before and after markers
+      const existingContent = await fs.readFile(agentsPath, 'utf-8');
+      const enhancedContent = `# My Custom Header
+
+Some intro text
+
+${existingContent}
+
+# Additional Custom Section
+
+More custom content here`;
+
+      await fs.writeFile(agentsPath, enhancedContent);
+
+      // Uninstall
+      const uninstallCommand = new UninstallCommand({ yes: true });
+      await uninstallCommand.execute(testDir);
+
+      // Check preserved content
+      const finalContent = await fs.readFile(agentsPath, 'utf-8');
+      expect(finalContent).toContain('My Custom Header');
+      expect(finalContent).toContain('Some intro text');
+      expect(finalContent).toContain('Additional Custom Section');
+      expect(finalContent).toContain('More custom content here');
+      expect(finalContent).not.toContain(OPENSPEC_MARKERS.start);
+      expect(finalContent).not.toContain(OPENSPEC_MARKERS.end);
+    });
+  });
+
+  describe('slash command cleanup', () => {
+    it('should remove slash command directories', async () => {
+      // Initialize with Claude Code
+      const initCommand = new InitCommand({ tools: 'claude' });
+      await initCommand.execute(testDir);
+
+      const claudeCommandsPath = path.join(testDir, '.claude', 'commands', 'openspec');
+      expect(await FileSystemUtils.directoryExists(claudeCommandsPath)).toBe(true);
+
+      // Uninstall
+      const uninstallCommand = new UninstallCommand({ yes: true });
+      await uninstallCommand.execute(testDir);
+
+      // Slash commands directory should be removed
+      expect(await FileSystemUtils.directoryExists(claudeCommandsPath)).toBe(false);
+    });
+
+    it('should clean up empty parent directories', async () => {
+      // Initialize with Claude Code
+      const initCommand = new InitCommand({ tools: 'claude' });
+      await initCommand.execute(testDir);
+
+      const claudeCommandsDir = path.join(testDir, '.claude', 'commands');
+      const claudeDir = path.join(testDir, '.claude');
+      expect(await FileSystemUtils.directoryExists(claudeCommandsDir)).toBe(true);
+
+      // Uninstall
+      const uninstallCommand = new UninstallCommand({ yes: true });
+      await uninstallCommand.execute(testDir);
+
+      // Both .claude/commands and .claude directories should be removed since they're empty
+      const commandsDirExists = await FileSystemUtils.directoryExists(claudeCommandsDir).catch(() => false);
+      const claudeDirExists = await FileSystemUtils.directoryExists(claudeDir).catch(() => false);
+
+      expect(commandsDirExists).toBe(false);
+      expect(claudeDirExists).toBe(false);
+    });
+  });
+
+  describe('--yes flag', () => {
+    it('should skip confirmation when --yes is provided', async () => {
+      // Initialize
+      const initCommand = new InitCommand({ tools: 'none' });
+      await initCommand.execute(testDir);
+
+      // Uninstall with --yes flag (should not hang waiting for input)
+      const uninstallCommand = new UninstallCommand({ yes: true });
+      await expect(uninstallCommand.execute(testDir)).resolves.not.toThrow();
+
+      // Verify uninstall happened
+      const openspecPath = path.join(testDir, 'openspec');
+      expect(await FileSystemUtils.directoryExists(openspecPath)).toBe(false);
+    });
+  });
+
+  describe('error handling', () => {
+    it('should continue with remaining operations on partial failure', async () => {
+      // Initialize
+      const initCommand = new InitCommand({ tools: 'none' });
+      await initCommand.execute(testDir);
+
+      // Make a file read-only to cause an error (platform-specific)
+      const agentsPath = path.join(testDir, 'AGENTS.md');
+      // Note: This test might behave differently on Windows vs Unix
+
+      // Uninstall should still remove the openspec directory
+      const uninstallCommand = new UninstallCommand({ yes: true });
+      await uninstallCommand.execute(testDir);
+
+      const openspecPath = path.join(testDir, 'openspec');
+      expect(await FileSystemUtils.directoryExists(openspecPath)).toBe(false);
+    });
+  });
+
+  describe('multiple tool configurations', () => {
+    it('should clean up multiple AI tool configs', async () => {
+      // Initialize with multiple tools
+      const initCommand = new InitCommand({ tools: 'claude,cursor' });
+      await initCommand.execute(testDir);
+
+      const claudePath = path.join(testDir, 'CLAUDE.md');
+      const cursorPath = path.join(testDir, '.cursor', 'commands');
+
+      expect(await FileSystemUtils.fileExists(claudePath)).toBe(true);
+      expect(await FileSystemUtils.directoryExists(cursorPath)).toBe(true);
+
+      // Uninstall
+      const uninstallCommand = new UninstallCommand({ yes: true });
+      await uninstallCommand.execute(testDir);
+
+      // All tool configs should be cleaned
+      expect(await FileSystemUtils.fileExists(claudePath)).toBe(false);
+      const openspecPath = path.join(testDir, 'openspec');
+      expect(await FileSystemUtils.directoryExists(openspecPath)).toBe(false);
+    });
+
+    it('should handle OpenCode slash commands', async () => {
+      // Initialize with OpenCode
+      const initCommand = new InitCommand({ tools: 'opencode' });
+      await initCommand.execute(testDir);
+
+      const opencodeDir = path.join(testDir, '.opencode', 'command');
+      expect(await FileSystemUtils.directoryExists(opencodeDir)).toBe(true);
+
+      // Uninstall
+      const uninstallCommand = new UninstallCommand({ yes: true });
+      await uninstallCommand.execute(testDir);
+
+      // OpenCode commands should be removed
+      const opencodeExists = await FileSystemUtils.directoryExists(opencodeDir).catch(() => false);
+      expect(opencodeExists).toBe(false);
+
+      const openspecPath = path.join(testDir, 'openspec');
+      expect(await FileSystemUtils.directoryExists(openspecPath)).toBe(false);
+    });
+
+    it('should handle GitHub Copilot prompts', async () => {
+      // Initialize with GitHub Copilot
+      const initCommand = new InitCommand({ tools: 'github-copilot' });
+      await initCommand.execute(testDir);
+
+      const githubPromptsDir = path.join(testDir, '.github', 'prompts');
+      expect(await FileSystemUtils.directoryExists(githubPromptsDir)).toBe(true);
+
+      // Uninstall
+      const uninstallCommand = new UninstallCommand({ yes: true });
+      await uninstallCommand.execute(testDir);
+
+      // GitHub Copilot prompts should be removed
+      const promptsExist = await FileSystemUtils.directoryExists(githubPromptsDir).catch(() => false);
+      expect(promptsExist).toBe(false);
+
+      const openspecPath = path.join(testDir, 'openspec');
+      expect(await FileSystemUtils.directoryExists(openspecPath)).toBe(false);
+    });
+
+    it('should handle Windsurf workflows', async () => {
+      // Initialize with Windsurf
+      const initCommand = new InitCommand({ tools: 'windsurf' });
+      await initCommand.execute(testDir);
+
+      const windsurfDir = path.join(testDir, '.windsurf', 'workflows');
+      expect(await FileSystemUtils.directoryExists(windsurfDir)).toBe(true);
+
+      // Uninstall
+      const uninstallCommand = new UninstallCommand({ yes: true });
+      await uninstallCommand.execute(testDir);
+
+      // Windsurf workflows should be removed
+      const workflowsExist = await FileSystemUtils.directoryExists(windsurfDir).catch(() => false);
+      expect(workflowsExist).toBe(false);
+
+      const openspecPath = path.join(testDir, 'openspec');
+      expect(await FileSystemUtils.directoryExists(openspecPath)).toBe(false);
+    });
+
+    it('should handle Cursor commands', async () => {
+      // Initialize with Cursor
+      const initCommand = new InitCommand({ tools: 'cursor' });
+      await initCommand.execute(testDir);
+
+      const cursorDir = path.join(testDir, '.cursor', 'commands');
+      expect(await FileSystemUtils.directoryExists(cursorDir)).toBe(true);
+
+      // Uninstall
+      const uninstallCommand = new UninstallCommand({ yes: true });
+      await uninstallCommand.execute(testDir);
+
+      // Cursor commands should be removed
+      const commandsExist = await FileSystemUtils.directoryExists(cursorDir).catch(() => false);
+      expect(commandsExist).toBe(false);
+
+      const openspecPath = path.join(testDir, 'openspec');
+      expect(await FileSystemUtils.directoryExists(openspecPath)).toBe(false);
+    });
+
+    it('should handle Codex global prompts', async () => {
+      // Initialize with Codex (uses global ~/.codex/prompts)
+      const initCommand = new InitCommand({ tools: 'codex' });
+      await initCommand.execute(testDir);
+
+      // Codex uses global paths, but we can still check the openspec directory was created
+      const openspecPath = path.join(testDir, 'openspec');
+      expect(await FileSystemUtils.directoryExists(openspecPath)).toBe(true);
+
+      // Uninstall
+      const uninstallCommand = new UninstallCommand({ yes: true });
+      await uninstallCommand.execute(testDir);
+
+      // OpenSpec directory should be removed
+      expect(await FileSystemUtils.directoryExists(openspecPath)).toBe(false);
+
+      // Note: We don't check ~/.codex/prompts deletion in tests to avoid
+      // interfering with the user's actual Codex installation
+    });
+
+    it('should handle all tools together', async () => {
+      // Initialize with many tools at once
+      const initCommand = new InitCommand({ tools: 'claude,cursor,opencode,github-copilot' });
+      await initCommand.execute(testDir);
+
+      const claudeCommandsDir = path.join(testDir, '.claude', 'commands', 'openspec');
+      const cursorCommandsDir = path.join(testDir, '.cursor', 'commands');
+      const opencodeCommandsDir = path.join(testDir, '.opencode', 'command');
+      const githubPromptsDir = path.join(testDir, '.github', 'prompts');
+
+      expect(await FileSystemUtils.directoryExists(claudeCommandsDir)).toBe(true);
+      expect(await FileSystemUtils.directoryExists(cursorCommandsDir)).toBe(true);
+      expect(await FileSystemUtils.directoryExists(opencodeCommandsDir)).toBe(true);
+      expect(await FileSystemUtils.directoryExists(githubPromptsDir)).toBe(true);
+
+      // Uninstall
+      const uninstallCommand = new UninstallCommand({ yes: true });
+      await uninstallCommand.execute(testDir);
+
+      // All OpenSpec-specific directories should be removed
+      const claudeCommandsExists = await FileSystemUtils.directoryExists(claudeCommandsDir).catch(() => false);
+      const cursorCommandsExists = await FileSystemUtils.directoryExists(cursorCommandsDir).catch(() => false);
+      const opencodeCommandsExists = await FileSystemUtils.directoryExists(opencodeCommandsDir).catch(() => false);
+      const githubPromptsExists = await FileSystemUtils.directoryExists(githubPromptsDir).catch(() => false);
+
+      expect(claudeCommandsExists).toBe(false);
+      expect(cursorCommandsExists).toBe(false);
+      expect(opencodeCommandsExists).toBe(false);
+      expect(githubPromptsExists).toBe(false);
+
+      const openspecPath = path.join(testDir, 'openspec');
+      expect(await FileSystemUtils.directoryExists(openspecPath)).toBe(false);
+    });
+  });
+});

--- a/test/utils/file-system.test.ts
+++ b/test/utils/file-system.test.ts
@@ -208,4 +208,124 @@ describe('FileSystemUtils', () => {
       );
     });
   });
+
+  describe('deleteFile', () => {
+    it('should delete an existing file', async () => {
+      const filePath = path.join(testDir, 'to-delete.txt');
+      await fs.writeFile(filePath, 'content to delete');
+
+      expect(await FileSystemUtils.fileExists(filePath)).toBe(true);
+
+      await FileSystemUtils.deleteFile(filePath);
+
+      expect(await FileSystemUtils.fileExists(filePath)).toBe(false);
+    });
+
+    it('should throw error for non-existent file', async () => {
+      const filePath = path.join(testDir, 'non-existent.txt');
+
+      await expect(FileSystemUtils.deleteFile(filePath)).rejects.toThrow();
+    });
+
+    it('should delete file with special characters in name', async () => {
+      const filePath = path.join(testDir, 'file with spaces & special-chars.txt');
+      await fs.writeFile(filePath, 'special content');
+
+      await FileSystemUtils.deleteFile(filePath);
+
+      expect(await FileSystemUtils.fileExists(filePath)).toBe(false);
+    });
+  });
+
+  describe('deleteDirectory', () => {
+    it('should delete an empty directory', async () => {
+      const dirPath = path.join(testDir, 'empty-dir');
+      await fs.mkdir(dirPath);
+
+      expect(await FileSystemUtils.directoryExists(dirPath)).toBe(true);
+
+      await FileSystemUtils.deleteDirectory(dirPath);
+
+      expect(await FileSystemUtils.directoryExists(dirPath)).toBe(false);
+    });
+
+    it('should delete directory with files', async () => {
+      const dirPath = path.join(testDir, 'dir-with-files');
+      await fs.mkdir(dirPath);
+      await fs.writeFile(path.join(dirPath, 'file1.txt'), 'content1');
+      await fs.writeFile(path.join(dirPath, 'file2.txt'), 'content2');
+
+      await FileSystemUtils.deleteDirectory(dirPath);
+
+      expect(await FileSystemUtils.directoryExists(dirPath)).toBe(false);
+    });
+
+    it('should delete directory with nested subdirectories', async () => {
+      const dirPath = path.join(testDir, 'dir-with-subdirs');
+      const subDir1 = path.join(dirPath, 'sub1');
+      const subDir2 = path.join(subDir1, 'sub2');
+
+      await fs.mkdir(subDir2, { recursive: true });
+      await fs.writeFile(path.join(subDir2, 'nested.txt'), 'nested content');
+
+      await FileSystemUtils.deleteDirectory(dirPath);
+
+      expect(await FileSystemUtils.directoryExists(dirPath)).toBe(false);
+    });
+
+    it('should not throw for non-existent directory', async () => {
+      const dirPath = path.join(testDir, 'non-existent-dir');
+
+      await expect(FileSystemUtils.deleteDirectory(dirPath)).resolves.not.toThrow();
+    });
+  });
+
+  describe('isDirectoryEmpty', () => {
+    it('should return true for empty directory', async () => {
+      const dirPath = path.join(testDir, 'empty-check-dir');
+      await fs.mkdir(dirPath);
+
+      const isEmpty = await FileSystemUtils.isDirectoryEmpty(dirPath);
+
+      expect(isEmpty).toBe(true);
+    });
+
+    it('should return false for directory with files', async () => {
+      const dirPath = path.join(testDir, 'dir-with-file');
+      await fs.mkdir(dirPath);
+      await fs.writeFile(path.join(dirPath, 'file.txt'), 'content');
+
+      const isEmpty = await FileSystemUtils.isDirectoryEmpty(dirPath);
+
+      expect(isEmpty).toBe(false);
+    });
+
+    it('should return false for directory with subdirectories', async () => {
+      const dirPath = path.join(testDir, 'dir-with-subdir');
+      await fs.mkdir(dirPath);
+      await fs.mkdir(path.join(dirPath, 'subdir'));
+
+      const isEmpty = await FileSystemUtils.isDirectoryEmpty(dirPath);
+
+      expect(isEmpty).toBe(false);
+    });
+
+    it('should return true for non-existent directory', async () => {
+      const dirPath = path.join(testDir, 'non-existent-for-empty-check');
+
+      const isEmpty = await FileSystemUtils.isDirectoryEmpty(dirPath);
+
+      expect(isEmpty).toBe(true);
+    });
+
+    it('should return false for directory with hidden files', async () => {
+      const dirPath = path.join(testDir, 'dir-with-hidden');
+      await fs.mkdir(dirPath);
+      await fs.writeFile(path.join(dirPath, '.hidden-file'), 'hidden content');
+
+      const isEmpty = await FileSystemUtils.isDirectoryEmpty(dirPath);
+
+      expect(isEmpty).toBe(false);
+    });
+  });
 });

--- a/test/utils/marker-stripping.test.ts
+++ b/test/utils/marker-stripping.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import { FileSystemUtils } from '../../src/utils/file-system.js';
+import { OPENSPEC_MARKERS } from '../../src/core/config.js';
+
+describe('FileSystemUtils.stripManagedBlock', () => {
+  const { start, end } = OPENSPEC_MARKERS;
+
+  it('should remove a single managed block', () => {
+    const content = `Some user content before
+${start}
+Managed content to remove
+${end}
+Some user content after`;
+
+    const result = FileSystemUtils.stripManagedBlock(content, start, end);
+
+    expect(result).toBe('Some user content before\nSome user content after');
+  });
+
+  it('should remove multiple managed blocks', () => {
+    const content = `First user content
+${start}
+First managed block
+${end}
+Middle user content
+${start}
+Second managed block
+${end}
+Last user content`;
+
+    const result = FileSystemUtils.stripManagedBlock(content, start, end);
+
+    expect(result).toBe('First user content\nMiddle user content\nLast user content');
+  });
+
+  it('should return empty string when only managed block exists', () => {
+    const content = `${start}
+Only managed content
+${end}`;
+
+    const result = FileSystemUtils.stripManagedBlock(content, start, end);
+
+    expect(result).toBe('');
+  });
+
+  it('should preserve content when no markers present', () => {
+    const content = 'Only user content, no markers';
+
+    const result = FileSystemUtils.stripManagedBlock(content, start, end);
+
+    expect(result).toBe('Only user content, no markers');
+  });
+
+  it('should handle content with only start marker', () => {
+    const content = `User content
+${start}
+Incomplete block`;
+
+    const result = FileSystemUtils.stripManagedBlock(content, start, end);
+
+    // Should not remove anything if end marker is missing
+    expect(result).toBe(content.trim());
+  });
+
+  it('should handle content with only end marker', () => {
+    const content = `User content
+${end}
+More content`;
+
+    const result = FileSystemUtils.stripManagedBlock(content, start, end);
+
+    // Should not remove anything if start marker is missing
+    expect(result).toBe(content.trim());
+  });
+
+  it('should handle markers with surrounding whitespace', () => {
+    const content = `User content
+  ${start}
+  Managed content
+  ${end}
+More user content`;
+
+    const result = FileSystemUtils.stripManagedBlock(content, start, end);
+
+    expect(result).toBe('User content\nMore user content');
+  });
+
+  it('should handle empty content', () => {
+    const content = '';
+
+    const result = FileSystemUtils.stripManagedBlock(content, start, end);
+
+    expect(result).toBe('');
+  });
+
+  it('should handle markers at start of file', () => {
+    const content = `${start}
+Managed content
+${end}
+User content`;
+
+    const result = FileSystemUtils.stripManagedBlock(content, start, end);
+
+    expect(result).toBe('User content');
+  });
+
+  it('should handle markers at end of file', () => {
+    const content = `User content
+${start}
+Managed content
+${end}`;
+
+    const result = FileSystemUtils.stripManagedBlock(content, start, end);
+
+    expect(result).toBe('User content');
+  });
+
+  it('should preserve newlines in user content', () => {
+    const content = `Line 1
+
+Line 3 with gap
+${start}
+Managed
+${end}
+
+Line after with gap`;
+
+    const result = FileSystemUtils.stripManagedBlock(content, start, end);
+
+    expect(result).toContain('Line 1\n\nLine 3 with gap');
+    expect(result).toContain('Line after with gap');
+  });
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an uninstall command to remove OpenSpec from a project (interactive with --yes option).
  * Removes OpenSpec directory, strips managed blocks from config files, and cleans up slash command directories while preserving user content.
* **Documentation**
  * Comprehensive "Uninstalling OpenSpec" guide and CLI reference added to README.
* **Tests**
  * New tests covering the uninstall flow, filesystem utilities, and marker-stripping behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->