### PR TITLE
feat(workflow): add workflow engine PoC

### DIFF
--- a/POC_IMPLEMENTATION.md
+++ b/POC_IMPLEMENTATION.md
@@ -1,0 +1,260 @@
+# Workflow Engine PoC (Implementation)
+
+This document defines a minimal proof-of-concept (PoC) workflow engine for OpenSpec.
+It is intentionally **standalone**: an agent or engineer should be able to implement and verify the PoC using only the information in this file.
+
+**Status:** Draft  
+**Last Updated:** 2025-12-13
+
+## Overview
+
+We want a tiny system that helps AI agents (and humans) follow a structured workflow reliably across sessions.
+The PoC focuses on the core fundamentals:
+
+- A **file-backed state machine** (persisted on disk)
+- A small set of **phases** with clear transition rules
+- A minimal **task loop** with acceptance criteria
+- A **status** command that rebuilds context at any time
+
+This PoC intentionally trades completeness for speed of iteration.
+
+## Definitions (PoC)
+
+- **Change**: a unit of work being tracked (e.g., a feature or fix).
+- **Phase**: the current stage of a Change.
+- **Task**: a discrete unit of implementation work with acceptance criteria and a status.
+- **State store**: the on-disk files under `.openspec/` used to persist Changes and Tasks.
+
+## Goals (PoC)
+
+- Validate that agents can follow a structured, phase-based workflow without skipping steps.
+- Validate that output quality does not degrade under explicit structure (phases + tasks + acceptance criteria).
+- Prove that workflow state can be persisted and reliably re-loaded across sessions.
+- Keep iteration loops fast: start with 1 command and add more only if needed.
+
+## Non-Goals (PoC)
+
+- Multi-repo support and any external/global config store (e.g., `~/.config/openspec`).
+- Git hooks, auto-completion heuristics, or session tracking.
+- Rich artifact templating, schemas beyond minimal validation, or approval gates beyond phase/task checks.
+- Multiple workflow definitions, workflow pinning/snapshots, or registries.
+
+## General Requirements
+
+### Requirement: Minimal change FSM
+
+The PoC SHALL model a **Change** as a finite state machine with exactly these phases:
+
+- `plan` → `implement` → `done`
+
+Phase transitions SHALL be explicit (represented in persisted state) and, when performed via `openspec phase advance`, SHALL be blocked when preconditions are not met.
+
+#### Scenario: Create starts in `plan`
+
+- **WHEN** `openspec change create <title>` is executed
+- **THEN** the change SHALL be created with `currentPhaseId = "plan"`
+- **AND** the created change SHALL become the active change
+
+#### Scenario: Advance requires preconditions
+
+- **WHEN** `openspec phase advance` is executed
+- **THEN** the command SHALL validate the current phase preconditions
+- **AND** if blocked, SHALL print actionable blocking reasons and exit non-zero
+
+### Requirement: In-repo, file-based persistence
+
+The PoC SHALL persist workflow state on disk in a human-readable, git-friendly format.
+
+- State SHALL live under an in-repo `.openspec/` directory (PoC-only choice).
+- State SHALL be sufficient to resume work after a new agent/session starts.
+
+#### Expected state layout (PoC)
+
+```
+.openspec/
+├── current                          # active change id (plain text)
+└── changes/
+    └── <change-id>/
+        ├── meta.yaml                # change metadata + current phase
+        └── tasks.yaml               # task list + statuses
+```
+
+`meta.yaml` SHOULD be minimal but sufficient to support `status`:
+
+```yaml
+schemaVersion: "poc-1"
+id: add-rate-limiter
+title: Add rate limiter
+currentPhaseId: plan # plan | implement | done
+createdAt: 2025-12-13T00:00:00Z
+updatedAt: 2025-12-13T00:00:00Z
+```
+
+`tasks.yaml` SHOULD use the minimal task model defined below:
+
+```yaml
+schemaVersion: "poc-1"
+tasks:
+  - id: task-1
+    title: Add rate limiter middleware
+    acceptance_criteria:
+      - Middleware file exists
+      - Returns 429 on limit exceeded
+    status: pending # pending | in_progress | complete | blocked
+```
+
+#### Scenario: Status restores context after restart
+
+- **GIVEN** a change exists on disk
+- **WHEN** `openspec status` is executed in a new session
+- **THEN** it SHALL reconstruct the active change state from `.openspec/`
+- **AND** it SHALL report the current phase, task progress, and the next recommended action
+
+### Requirement: Minimal command surface for agents
+
+The PoC SHALL prioritize iteration speed by starting with a **single-command** interface and only adding commands when needed to reduce friction or enforce correctness.
+
+**Minimum interface (required for PoC)**
+- `openspec status [--json]`
+
+**Optional interface (add only if needed)**
+- `openspec phase advance [--change <id>] [--to <phase>]` (enforce gating + explicit transitions)
+- `openspec change create <title>` (scaffold state quickly)
+- `openspec task complete <task-id> [--notes <text>]` (avoid manual edits to `tasks.yaml`)
+- `openspec task next [--json]` (only if a dedicated task fetch is helpful; otherwise `status` can surface next task)
+
+The PoC MAY provide ergonomic aliases (`openspec create`, `openspec advance`, `openspec complete`) but the canonical shape SHOULD remain aligned with RFC terminology (change/phase/task).
+
+#### Scenario: One-command task loop
+
+- **GIVEN** a change in `implement` with pending tasks
+- **WHEN** an agent runs `openspec status`
+- **THEN** the output SHALL include the next pending task (with acceptance criteria) and a single “Next action” line
+- **AND** tasks MAY be marked complete either via `openspec task complete` (if implemented) or by editing the persisted task state directly
+
+### Requirement: Explicit phase gating rules
+
+The PoC SHALL enforce minimal gating rules:
+
+- `plan` → `implement` requires a tasks artifact to exist and be valid enough for execution.
+- `implement` → `done` requires all tasks to be complete.
+- The system SHALL NOT auto-advance phases implicitly when the last task is completed; advancing remains an explicit action (`openspec phase advance`) so agent behavior is observable.
+
+### Requirement: Minimal task model
+
+The PoC SHALL use a minimal task representation suitable for task execution:
+
+- Each task SHALL have: `id`, `title`, `acceptance_criteria`, `status`.
+- `status` SHALL be one of: `pending | in_progress | complete | blocked`.
+
+The PoC SHOULD avoid introducing additional required fields (e.g., `codeReferences`, `dependencies`) until after the PoC validates the approach.
+
+#### Scenario: Plan validation blocks empty task sets
+
+- **WHEN** attempting to advance from `plan` to `implement`
+- **AND** there are zero tasks or any task is missing `acceptance_criteria`
+- **THEN** `openspec phase advance` SHALL fail with a clear reason (e.g., “No executable tasks found”)
+
+### Requirement: Deterministic, agent-friendly outputs
+
+The PoC SHALL prioritize deterministic outputs that are easy for agents/tools to consume.
+
+- `openspec status --json` SHALL output a machine-readable summary of current state and blockers.
+- If `openspec task next` is implemented, `openspec task next --json` SHOULD output machine-readable task details.
+- Human-readable output SHOULD include a single “Next action” line.
+
+### Requirement: Offline operation
+
+The PoC SHALL not require network access and SHALL not depend on external services.
+
+### Requirement: Future-proofing without overbuilding
+
+The PoC SHOULD keep naming and conceptual alignment with the RFC terminology (change/phase/task),
+to minimize later migration cost to the full workflow engine architecture.
+
+## Task Breakdown (Graduated Milestones)
+
+These milestones are optimized for iteration speed. Start at Milestone 1, then only proceed to Milestone 2/3 if you observe concrete friction or correctness issues.
+
+### Milestone 1 (Minimum): 1-command PoC (`openspec status`)
+
+**Deliverable**
+- Implement `openspec status` that:
+  - Loads `.openspec/` state (or reports a clear empty state)
+  - Reports: active change id, current phase, task progress, next pending task, and phase blockers
+  - Prints a single “Next action” line
+  - Optionally supports `--json` for deterministic consumption
+- No other commands are required at this stage; state can be seeded/edited manually.
+
+**Verify**
+- `openspec status` (no state) prints a clear empty state and a recommended next action.
+- Seed a minimal `.openspec/` change on disk and confirm `openspec status`:
+  - Reconstructs phase/task state after restarting the process
+  - Updates correctly when tasks are marked complete or phase changes are edited in files
+
+**When to proceed**
+- Proceed to Milestone 2 only if agents routinely “skip gates” or lose phase discipline (you need enforcement), or if you want to measure command-driven behavior explicitly.
+
+### Milestone 2 (Optional): Add enforcement (`openspec phase advance`)
+
+**Deliverable**
+- Add `openspec phase advance` that:
+  - Validates phase preconditions and prints clear blocking reasons
+  - Updates `meta.yaml` to move `plan → implement → done`
+  - Does not auto-advance phases when the last task completes (explicit `advance` required)
+
+**Verify**
+- Attempt `plan → implement` with missing/invalid tasks and confirm it is blocked with specific reasons.
+- Mark all tasks complete (by editing files) and confirm `implement → done` is blocked until all are complete, then succeeds.
+
+**When to proceed**
+- Proceed to Milestone 3 only if manual seeding/editing of `.openspec/` state is slowing iteration or causing frequent mistakes.
+
+### Milestone 3 (Optional): Add scaffolding (`openspec change create`) — “3 command” PoC
+
+**Deliverable**
+- Add `openspec change create <title>` that:
+  - Creates a change id (slug) and seeds `.openspec/changes/<id>/meta.yaml` + `tasks.yaml`
+  - Sets the active change (`.openspec/current`)
+  - Starts in `plan`
+
+**Verify**
+- Run: `openspec change create "Test change"` then `openspec status` and confirm phase/task state is visible.
+- Confirm `openspec phase advance` continues to work for the created change.
+
+### Milestone 4 (Optional): Reduce manual edits (`openspec task complete`) (+ optional `task next`)
+
+**Deliverable**
+- Add `openspec task complete <task-id>` to update task state safely (avoid YAML footguns).
+- Only add `openspec task next` if it materially improves agent behavior vs surfacing the next task in `status`.
+
+**Verify**
+- In `implement`, run: `openspec status` → implement → `openspec task complete <id>` and confirm progress updates.
+
+### Milestone 5 (Hardening): Deterministic JSON + smoke tests
+
+**Deliverable**
+- Stabilize `openspec status --json` output shape and add a small, fast end-to-end test suite for:
+  - empty state
+  - plan gating blocked/unblocked (if `phase advance` exists)
+  - implement → done gating (if `phase advance` exists)
+- If `task next` exists, add a shape test for `openspec task next --json`.
+
+**Verify**
+- Run tests locally and confirm the PoC scenarios pass consistently.
+
+### Optional Milestone: Manifest-first resumption
+
+Only add this if you need to validate IDE-agent integration early.
+
+**Deliverable**
+- Generate/update `.openspec-context.json` (or equivalent) on `status` so an IDE agent can resume with minimal CLI usage.
+
+**Verify**
+- Delete chat context / restart agent session; confirm reading the manifest + running `openspec status` is sufficient to resume.
+
+## Optional References (not required to implement this PoC)
+
+- `rfcs/WORKFLOW_ENGINE.md` (full workflow engine vision: artifacts, tasks, gates, sync)
+- `rfcs/0002-implementation-breakdown.md` (domain/component breakdown)
+- `rfcs/0003-implementation-roadmap.md` (phased rollout plan)

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.7",
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^24.2.0",
     "@vitest/ui": "^3.2.4",
     "typescript": "^5.9.3",
@@ -70,6 +71,7 @@
     "@inquirer/prompts": "^7.8.0",
     "chalk": "^5.5.0",
     "commander": "^14.0.0",
+    "js-yaml": "^4.1.1",
     "ora": "^8.2.0",
     "zod": "^4.0.17"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       commander:
         specifier: ^14.0.0
         version: 14.0.0
+      js-yaml:
+        specifier: ^4.1.1
+        version: 4.1.1
       ora:
         specifier: ^8.2.0
         version: 8.2.0
@@ -30,6 +33,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.27.7
         version: 2.29.6(@types/node@24.2.0)
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
       '@types/node':
         specifier: ^24.2.0
         version: 24.2.0
@@ -527,6 +533,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
+
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
@@ -589,6 +598,9 @@ packages:
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
@@ -834,6 +846,10 @@ packages:
 
   js-yaml@3.14.1:
     resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
+    hasBin: true
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
   jsonfile@4.0.0:
@@ -1672,6 +1688,8 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/js-yaml@4.0.9': {}
+
   '@types/node@12.20.55': {}
 
   '@types/node@24.2.0':
@@ -1748,6 +1766,8 @@ snapshots:
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
+
+  argparse@2.0.1: {}
 
   array-union@2.1.0: {}
 
@@ -1974,6 +1994,10 @@ snapshots:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
 
   jsonfile@4.0.0:
     optionalDependencies:

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -14,6 +14,17 @@ import { ChangeCommand } from '../commands/change.js';
 import { ValidateCommand } from '../commands/validate.js';
 import { ShowCommand } from '../commands/show.js';
 import { CompletionCommand } from '../commands/completion.js';
+import {
+  runStatus,
+  runPhaseAdvance,
+  runChangeCreate,
+  runChangeList,
+  runChangeSwitch,
+  runTaskComplete,
+  runTaskStart,
+  runTaskNext,
+  runTaskAdd,
+} from '../commands/workflow/index.js';
 
 const program = new Command();
 const require = createRequire(import.meta.url);
@@ -311,6 +322,152 @@ program
     } catch (error) {
       // Silently fail for graceful shell completion experience
       process.exitCode = 1;
+    }
+  });
+
+// =============================================================================
+// Workflow Engine PoC Commands (openspec wf ...)
+// =============================================================================
+
+const wfCmd = program
+  .command('wf')
+  .description('[PoC] Workflow engine commands');
+
+// openspec wf status
+wfCmd
+  .command('status')
+  .description('Show current workflow state')
+  .option('--json', 'Output as JSON')
+  .action(async (options?: { json?: boolean }) => {
+    try {
+      await runStatus(options);
+    } catch (error) {
+      console.log();
+      ora().fail(`Error: ${(error as Error).message}`);
+      process.exit(1);
+    }
+  });
+
+// openspec wf phase advance
+const wfPhaseCmd = wfCmd
+  .command('phase')
+  .description('Manage workflow phases');
+
+wfPhaseCmd
+  .command('advance')
+  .description('Advance to the next phase')
+  .option('--to <phase>', 'Target phase (plan|implement|done)')
+  .action(async (options?: { to?: string }) => {
+    try {
+      await runPhaseAdvance(options);
+    } catch (error) {
+      console.log();
+      ora().fail(`Error: ${(error as Error).message}`);
+      process.exit(1);
+    }
+  });
+
+// openspec wf change create/list/switch
+const wfChangeCmd = wfCmd
+  .command('change')
+  .description('Manage workflow changes');
+
+wfChangeCmd
+  .command('create <title>')
+  .description('Create a new workflow change')
+  .action(async (title: string) => {
+    try {
+      await runChangeCreate(title);
+    } catch (error) {
+      console.log();
+      ora().fail(`Error: ${(error as Error).message}`);
+      process.exit(1);
+    }
+  });
+
+wfChangeCmd
+  .command('list')
+  .description('List workflow changes')
+  .option('--json', 'Output as JSON')
+  .action(async (options?: { json?: boolean }) => {
+    try {
+      await runChangeList(options);
+    } catch (error) {
+      console.log();
+      ora().fail(`Error: ${(error as Error).message}`);
+      process.exit(1);
+    }
+  });
+
+wfChangeCmd
+  .command('switch <change-id>')
+  .description('Switch active change')
+  .action(async (changeId: string) => {
+    try {
+      await runChangeSwitch(changeId);
+    } catch (error) {
+      console.log();
+      ora().fail(`Error: ${(error as Error).message}`);
+      process.exit(1);
+    }
+  });
+
+// openspec wf task complete/start/next/add
+const wfTaskCmd = wfCmd
+  .command('task')
+  .description('Manage workflow tasks');
+
+wfTaskCmd
+  .command('complete <task-id>')
+  .description('Mark a task as complete')
+  .action(async (taskId: string) => {
+    try {
+      await runTaskComplete(taskId);
+    } catch (error) {
+      console.log();
+      ora().fail(`Error: ${(error as Error).message}`);
+      process.exit(1);
+    }
+  });
+
+wfTaskCmd
+  .command('start <task-id>')
+  .description('Mark a task as in_progress')
+  .action(async (taskId: string) => {
+    try {
+      await runTaskStart(taskId);
+    } catch (error) {
+      console.log();
+      ora().fail(`Error: ${(error as Error).message}`);
+      process.exit(1);
+    }
+  });
+
+wfTaskCmd
+  .command('next')
+  .description('Show the next task to work on')
+  .option('--json', 'Output as JSON')
+  .action(async (options?: { json?: boolean }) => {
+    try {
+      await runTaskNext(options);
+    } catch (error) {
+      console.log();
+      ora().fail(`Error: ${(error as Error).message}`);
+      process.exit(1);
+    }
+  });
+
+wfTaskCmd
+  .command('add <task-id> <title>')
+  .description('Add a new task')
+  .option('-a, --ac <criteria...>', 'Acceptance criteria')
+  .action(async (taskId: string, title: string, options?: { ac?: string[] }) => {
+    try {
+      await runTaskAdd(taskId, title, options?.ac || []);
+    } catch (error) {
+      console.log();
+      ora().fail(`Error: ${(error as Error).message}`);
+      process.exit(1);
     }
   });
 

--- a/src/commands/workflow/change.ts
+++ b/src/commands/workflow/change.ts
@@ -1,0 +1,62 @@
+/**
+ * Workflow Engine PoC - Change Command
+ *
+ * `openspec wf change create <title>` - Create a new workflow change
+ */
+
+import chalk from 'chalk';
+import ora from 'ora';
+import { createChange, listChanges, saveActiveChangeId } from './state.js';
+
+export async function runChangeCreate(title: string): Promise<void> {
+  if (!title || title.trim().length === 0) {
+    console.log(chalk.red('Title is required. Usage: openspec wf change create "<title>"'));
+    process.exit(1);
+  }
+
+  const spinner = ora(`Creating change "${title}"...`).start();
+  try {
+    const id = await createChange('.', title.trim());
+    spinner.succeed(`Created change: ${chalk.bold(id)}`);
+    console.log();
+    console.log(chalk.dim('State directory: .openspec/changes/' + id));
+    console.log(chalk.dim('Phase: plan'));
+    console.log();
+    console.log(chalk.cyan('Next:'), 'Add tasks to .openspec/changes/' + id + '/tasks.yaml');
+    console.log(chalk.cyan('Then:'), 'Run `openspec wf phase advance` to move to implement');
+  } catch (error) {
+    spinner.fail(`Failed to create change: ${(error as Error).message}`);
+    process.exit(1);
+  }
+}
+
+export async function runChangeList(options: { json?: boolean } = {}): Promise<void> {
+  const changes = await listChanges('.');
+
+  if (options.json) {
+    console.log(JSON.stringify({ changes }, null, 2));
+    return;
+  }
+
+  if (changes.length === 0) {
+    console.log(chalk.dim('No workflow changes found.'));
+    return;
+  }
+
+  console.log(chalk.bold('Workflow Changes:'));
+  for (const change of changes) {
+    console.log(`  • ${change}`);
+  }
+}
+
+export async function runChangeSwitch(changeId: string): Promise<void> {
+  const changes = await listChanges('.');
+  if (!changes.includes(changeId)) {
+    console.log(chalk.red(`Change "${changeId}" not found.`));
+    console.log(chalk.dim('Available changes: ' + (changes.join(', ') || 'none')));
+    process.exit(1);
+  }
+
+  await saveActiveChangeId('.', changeId);
+  console.log(chalk.green(`Switched to change: ${chalk.bold(changeId)}`));
+}

--- a/src/commands/workflow/index.ts
+++ b/src/commands/workflow/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Workflow Engine PoC - Command Index
+ *
+ * Exports all workflow commands for registration in CLI.
+ */
+
+export { runStatus } from './status.js';
+export { runPhaseAdvance } from './phase.js';
+export { runChangeCreate, runChangeList, runChangeSwitch } from './change.js';
+export { runTaskComplete, runTaskStart, runTaskNext, runTaskAdd } from './task.js';
+export * from './types.js';

--- a/src/commands/workflow/phase.ts
+++ b/src/commands/workflow/phase.ts
@@ -1,0 +1,134 @@
+/**
+ * Workflow Engine PoC - Phase Command
+ *
+ * `openspec wf phase advance` - Advance to the next phase
+ */
+
+import chalk from 'chalk';
+import ora from 'ora';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { loadWorkflowState, updatePhase, getChangePath } from './state.js';
+import { PhaseId, Task } from './types.js';
+
+const PHASE_ORDER: PhaseId[] = ['draft', 'plan', 'implement', 'done'];
+
+function getNextPhase(current: PhaseId): PhaseId | null {
+  const index = PHASE_ORDER.indexOf(current);
+  if (index === -1 || index === PHASE_ORDER.length - 1) {
+    return null;
+  }
+  return PHASE_ORDER[index + 1];
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function validateTransition(
+  from: PhaseId,
+  to: PhaseId,
+  tasks: Task[],
+  changeId: string
+): Promise<string[]> {
+  const blockers: string[] = [];
+
+  if (from === 'draft' && to === 'plan') {
+    // Requires plan.md to exist
+    const planPath = path.join(getChangePath('.', changeId), 'plan.md');
+    if (!(await fileExists(planPath))) {
+      blockers.push('No plan.md found. Create a plan before advancing.');
+    }
+  } else if (from === 'plan' && to === 'implement') {
+    // Requires valid tasks
+    if (tasks.length === 0) {
+      blockers.push('No tasks defined. Add tasks to tasks.yaml before advancing.');
+    } else {
+      const missingAC = tasks.filter(
+        (t) => !t.acceptance_criteria || t.acceptance_criteria.length === 0
+      );
+      if (missingAC.length > 0) {
+        blockers.push(
+          `Tasks missing acceptance criteria: ${missingAC.map((t) => t.id).join(', ')}`
+        );
+      }
+    }
+  } else if (from === 'implement' && to === 'done') {
+    // Requires all tasks complete
+    const incomplete = tasks.filter((t) => t.status !== 'complete');
+    if (incomplete.length > 0) {
+      blockers.push(
+        `${incomplete.length} task(s) not complete: ${incomplete.map((t) => t.id).join(', ')}`
+      );
+    }
+  }
+
+  return blockers;
+}
+
+export async function runPhaseAdvance(options: { to?: string } = {}): Promise<void> {
+  const state = await loadWorkflowState('.');
+
+  if (!state.activeChangeId || !state.activeChange) {
+    console.log(chalk.red('No active change. Create one first with `openspec wf change create`.'));
+    process.exit(1);
+  }
+
+  const currentPhase = state.activeChange.meta.currentPhaseId;
+  const tasks = state.activeChange.tasks;
+
+  // Determine target phase
+  let targetPhase: PhaseId;
+  if (options.to) {
+    if (!PHASE_ORDER.includes(options.to as PhaseId)) {
+      console.log(chalk.red(`Invalid phase: ${options.to}. Valid phases: ${PHASE_ORDER.join(', ')}`));
+      process.exit(1);
+    }
+    targetPhase = options.to as PhaseId;
+  } else {
+    const next = getNextPhase(currentPhase);
+    if (!next) {
+      console.log(chalk.green('Already at final phase (done). Nothing to advance.'));
+      return;
+    }
+    targetPhase = next;
+  }
+
+  // Cannot go backwards
+  const currentIndex = PHASE_ORDER.indexOf(currentPhase);
+  const targetIndex = PHASE_ORDER.indexOf(targetPhase);
+  if (targetIndex <= currentIndex) {
+    console.log(chalk.red(`Cannot transition from "${currentPhase}" to "${targetPhase}". Phases only move forward.`));
+    process.exit(1);
+  }
+
+  // Validate all intermediate transitions
+  let phase = currentPhase;
+  while (phase !== targetPhase) {
+    const next = getNextPhase(phase)!;
+    const blockers = await validateTransition(phase, next, tasks, state.activeChangeId);
+    if (blockers.length > 0) {
+      console.log(chalk.red.bold(`Cannot advance from "${phase}" to "${next}":`));
+      for (const b of blockers) {
+        console.log(chalk.red(`  • ${b}`));
+      }
+      process.exit(1);
+    }
+    phase = next;
+  }
+
+  // Perform the transition
+  const spinner = ora(`Advancing from ${currentPhase} to ${targetPhase}...`).start();
+  try {
+    await updatePhase('.', state.activeChangeId, targetPhase);
+    spinner.succeed(`Advanced to ${chalk.bold(targetPhase)}`);
+  } catch (error) {
+    spinner.fail(`Failed to advance: ${(error as Error).message}`);
+    process.exit(1);
+  }
+}

--- a/src/commands/workflow/state.ts
+++ b/src/commands/workflow/state.ts
@@ -1,0 +1,194 @@
+/**
+ * Workflow Engine PoC - State Management
+ *
+ * File-backed state loading and saving for the workflow engine.
+ */
+
+import { promises as fs } from 'fs';
+import path from 'path';
+import yaml from 'js-yaml';
+import {
+  SCHEMA_VERSION,
+  MetaFile,
+  TasksFile,
+  Task,
+  WorkflowState,
+  WorkflowChange,
+  PhaseId,
+} from './types.js';
+
+const STATE_DIR = '.openspec';
+const CURRENT_FILE = 'current';
+const CHANGES_DIR = 'changes';
+const META_FILE = 'meta.yaml';
+const TASKS_FILE = 'tasks.yaml';
+
+export function getStatePath(root: string = '.'): string {
+  return path.join(root, STATE_DIR);
+}
+
+export function getChangePath(root: string, changeId: string): string {
+  return path.join(getStatePath(root), CHANGES_DIR, changeId);
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function loadActiveChangeId(root: string = '.'): Promise<string | null> {
+  const currentPath = path.join(getStatePath(root), CURRENT_FILE);
+  if (!(await fileExists(currentPath))) {
+    return null;
+  }
+  const content = await fs.readFile(currentPath, 'utf-8');
+  return content.trim() || null;
+}
+
+export async function saveActiveChangeId(root: string, changeId: string): Promise<void> {
+  const statePath = getStatePath(root);
+  await fs.mkdir(statePath, { recursive: true });
+  const currentPath = path.join(statePath, CURRENT_FILE);
+  await fs.writeFile(currentPath, changeId + '\n', 'utf-8');
+}
+
+export async function loadMeta(root: string, changeId: string): Promise<MetaFile | null> {
+  const metaPath = path.join(getChangePath(root, changeId), META_FILE);
+  if (!(await fileExists(metaPath))) {
+    return null;
+  }
+  const content = await fs.readFile(metaPath, 'utf-8');
+  return yaml.load(content) as MetaFile;
+}
+
+export async function saveMeta(root: string, changeId: string, meta: MetaFile): Promise<void> {
+  const changePath = getChangePath(root, changeId);
+  await fs.mkdir(changePath, { recursive: true });
+  const metaPath = path.join(changePath, META_FILE);
+  await fs.writeFile(metaPath, yaml.dump(meta), 'utf-8');
+}
+
+export async function loadTasks(root: string, changeId: string): Promise<Task[]> {
+  const tasksPath = path.join(getChangePath(root, changeId), TASKS_FILE);
+  if (!(await fileExists(tasksPath))) {
+    return [];
+  }
+  const content = await fs.readFile(tasksPath, 'utf-8');
+  const tasksFile = yaml.load(content) as TasksFile;
+  return tasksFile?.tasks || [];
+}
+
+export async function saveTasks(root: string, changeId: string, tasks: Task[]): Promise<void> {
+  const changePath = getChangePath(root, changeId);
+  await fs.mkdir(changePath, { recursive: true });
+  const tasksPath = path.join(changePath, TASKS_FILE);
+  const tasksFile: TasksFile = {
+    schemaVersion: SCHEMA_VERSION,
+    tasks,
+  };
+  await fs.writeFile(tasksPath, yaml.dump(tasksFile), 'utf-8');
+}
+
+export async function loadWorkflowState(root: string = '.'): Promise<WorkflowState> {
+  const activeChangeId = await loadActiveChangeId(root);
+
+  if (!activeChangeId) {
+    return {
+      activeChangeId: null,
+      activeChange: null,
+    };
+  }
+
+  const meta = await loadMeta(root, activeChangeId);
+  if (!meta) {
+    // Active change id exists but meta file is missing
+    return {
+      activeChangeId,
+      activeChange: null,
+    };
+  }
+
+  const tasks = await loadTasks(root, activeChangeId);
+
+  return {
+    activeChangeId,
+    activeChange: {
+      meta,
+      tasks,
+    },
+  };
+}
+
+export async function updatePhase(root: string, changeId: string, phase: PhaseId): Promise<void> {
+  const meta = await loadMeta(root, changeId);
+  if (!meta) {
+    throw new Error(`Change "${changeId}" not found`);
+  }
+  meta.currentPhaseId = phase;
+  meta.updatedAt = new Date().toISOString();
+  await saveMeta(root, changeId, meta);
+}
+
+export async function updateTaskStatus(
+  root: string,
+  changeId: string,
+  taskId: string,
+  status: Task['status'],
+  notes?: string
+): Promise<void> {
+  const tasks = await loadTasks(root, changeId);
+  const task = tasks.find((t) => t.id === taskId);
+  if (!task) {
+    throw new Error(`Task "${taskId}" not found in change "${changeId}"`);
+  }
+  task.status = status;
+  await saveTasks(root, changeId, tasks);
+
+  // Update meta timestamp
+  const meta = await loadMeta(root, changeId);
+  if (meta) {
+    meta.updatedAt = new Date().toISOString();
+    await saveMeta(root, changeId, meta);
+  }
+}
+
+export function slugify(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .substring(0, 50);
+}
+
+export async function createChange(root: string, title: string): Promise<string> {
+  const id = slugify(title);
+  const now = new Date().toISOString();
+
+  const meta: MetaFile = {
+    schemaVersion: SCHEMA_VERSION,
+    id,
+    title,
+    currentPhaseId: 'draft',
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  await saveMeta(root, id, meta);
+  await saveTasks(root, id, []);
+  await saveActiveChangeId(root, id);
+
+  return id;
+}
+
+export async function listChanges(root: string = '.'): Promise<string[]> {
+  const changesPath = path.join(getStatePath(root), CHANGES_DIR);
+  if (!(await fileExists(changesPath))) {
+    return [];
+  }
+  const entries = await fs.readdir(changesPath, { withFileTypes: true });
+  return entries.filter((e) => e.isDirectory()).map((e) => e.name);
+}

--- a/src/commands/workflow/status.ts
+++ b/src/commands/workflow/status.ts
@@ -1,0 +1,214 @@
+/**
+ * Workflow Engine PoC - Status Command
+ *
+ * `openspec status` - Reports current workflow state
+ */
+
+import chalk from 'chalk';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { loadWorkflowState, getChangePath } from './state.js';
+import { StatusOutput, Task, PhaseId } from './types.js';
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function getPhaseBlockers(phase: PhaseId, tasks: Task[], changeId: string): Promise<string[]> {
+  const blockers: string[] = [];
+
+  if (phase === 'draft') {
+    // draft -> plan requires plan.md
+    const planPath = path.join(getChangePath('.', changeId), 'plan.md');
+    if (!(await fileExists(planPath))) {
+      blockers.push('No plan.md found. Create a plan before advancing.');
+    }
+  } else if (phase === 'plan') {
+    // plan -> implement requires valid tasks
+    if (tasks.length === 0) {
+      blockers.push('No tasks defined. Add tasks to tasks.yaml before advancing.');
+    } else {
+      const missingAC = tasks.filter((t) => !t.acceptance_criteria || t.acceptance_criteria.length === 0);
+      if (missingAC.length > 0) {
+        blockers.push(
+          `Tasks missing acceptance criteria: ${missingAC.map((t) => t.id).join(', ')}`
+        );
+      }
+    }
+  } else if (phase === 'implement') {
+    // implement -> done requires all tasks complete
+    const incomplete = tasks.filter((t) => t.status !== 'complete');
+    if (incomplete.length > 0) {
+      blockers.push(
+        `${incomplete.length} task(s) not complete: ${incomplete.map((t) => t.id).join(', ')}`
+      );
+    }
+  }
+
+  return blockers;
+}
+
+function getNextAction(phase: PhaseId | null, tasks: Task[], blockers: string[]): string {
+  if (!phase) {
+    return 'Run `openspec wf change create "<title>"` to start a new change.';
+  }
+
+  if (phase === 'done') {
+    return 'Change is complete. Archive or start a new change.';
+  }
+
+  if (phase === 'draft') {
+    if (blockers.length > 0) {
+      return 'Create plan.md with your proposal, then run `openspec wf phase advance`.';
+    }
+    return 'Run `openspec wf phase advance` to move to plan phase.';
+  }
+
+  if (phase === 'plan') {
+    if (blockers.length > 0) {
+      return 'Add tasks with acceptance criteria, then run `openspec wf phase advance`.';
+    }
+    return 'Run `openspec wf phase advance` to move to implement phase.';
+  }
+
+  if (phase === 'implement') {
+    const nextTask = tasks.find((t) => t.status === 'pending' || t.status === 'in_progress');
+    if (nextTask) {
+      if (nextTask.status === 'pending') {
+        return `Start task "${nextTask.id}": ${nextTask.title}`;
+      }
+      return `Continue task "${nextTask.id}": ${nextTask.title}`;
+    }
+    if (blockers.length === 0) {
+      return 'All tasks complete! Run `openspec wf phase advance` to finish.';
+    }
+    return 'Fix blockers above to advance to done.';
+  }
+
+  return 'Unknown state.';
+}
+
+function getNextTask(tasks: Task[]): Task | null {
+  // Priority: in_progress > pending
+  const inProgress = tasks.find((t) => t.status === 'in_progress');
+  if (inProgress) return inProgress;
+
+  const pending = tasks.find((t) => t.status === 'pending');
+  return pending || null;
+}
+
+function getTaskProgress(tasks: Task[]) {
+  return {
+    total: tasks.length,
+    pending: tasks.filter((t) => t.status === 'pending').length,
+    in_progress: tasks.filter((t) => t.status === 'in_progress').length,
+    complete: tasks.filter((t) => t.status === 'complete').length,
+    blocked: tasks.filter((t) => t.status === 'blocked').length,
+  };
+}
+
+export async function runStatus(options: { json?: boolean } = {}): Promise<void> {
+  const state = await loadWorkflowState('.');
+
+  const tasks = state.activeChange?.tasks || [];
+  const phase = state.activeChange?.meta.currentPhaseId || null;
+  const changeId = state.activeChangeId || '';
+  const blockers = phase && changeId ? await getPhaseBlockers(phase, tasks, changeId) : [];
+  const nextTask = phase === 'implement' ? getNextTask(tasks) : null;
+  const nextAction = getNextAction(phase, tasks, blockers);
+
+  const output: StatusOutput = {
+    activeChangeId: state.activeChangeId,
+    phase,
+    taskProgress: tasks.length > 0 ? getTaskProgress(tasks) : null,
+    nextTask,
+    blockers,
+    nextAction,
+  };
+
+  if (options.json) {
+    console.log(JSON.stringify(output, null, 2));
+    return;
+  }
+
+  // Human-readable output
+  console.log();
+  console.log(chalk.bold('Workflow Status'));
+  console.log('═'.repeat(40));
+
+  if (!state.activeChangeId) {
+    console.log(chalk.dim('No active change.'));
+    console.log();
+    console.log(chalk.cyan('Next action:'), nextAction);
+    return;
+  }
+
+  console.log(chalk.bold('Change:'), state.activeChangeId);
+  if (state.activeChange) {
+    console.log(chalk.bold('Title:'), state.activeChange.meta.title);
+    console.log(chalk.bold('Phase:'), formatPhase(phase!));
+  } else {
+    console.log(chalk.yellow('Warning: Active change files not found.'));
+  }
+
+  if (output.taskProgress) {
+    console.log();
+    console.log(chalk.bold('Tasks:'));
+    const p = output.taskProgress;
+    console.log(
+      `  ${chalk.green(p.complete + ' complete')} / ${p.total} total` +
+      (p.in_progress > 0 ? ` (${chalk.yellow(p.in_progress + ' in progress')})` : '') +
+      (p.blocked > 0 ? ` (${chalk.red(p.blocked + ' blocked')})` : '')
+    );
+  }
+
+  if (blockers.length > 0) {
+    console.log();
+    console.log(chalk.red.bold('Blockers:'));
+    for (const blocker of blockers) {
+      console.log(chalk.red(`  • ${blocker}`));
+    }
+  }
+
+  if (nextTask) {
+    console.log();
+    console.log(chalk.bold('Next Task:'));
+    console.log(`  ID: ${nextTask.id}`);
+    console.log(`  Title: ${nextTask.title}`);
+    console.log(`  Status: ${formatTaskStatus(nextTask.status)}`);
+    if (nextTask.acceptance_criteria.length > 0) {
+      console.log('  Acceptance Criteria:');
+      for (const ac of nextTask.acceptance_criteria) {
+        console.log(`    • ${ac}`);
+      }
+    }
+  }
+
+  console.log();
+  console.log(chalk.cyan.bold('Next action:'), nextAction);
+}
+
+function formatPhase(phase: PhaseId): string {
+  const colors: Record<PhaseId, (s: string) => string> = {
+    draft: chalk.magenta,
+    plan: chalk.yellow,
+    implement: chalk.blue,
+    done: chalk.green,
+  };
+  return colors[phase](phase);
+}
+
+function formatTaskStatus(status: Task['status']): string {
+  const colors: Record<Task['status'], (s: string) => string> = {
+    pending: chalk.dim,
+    in_progress: chalk.yellow,
+    complete: chalk.green,
+    blocked: chalk.red,
+  };
+  return colors[status](status);
+}

--- a/src/commands/workflow/task.ts
+++ b/src/commands/workflow/task.ts
@@ -1,0 +1,153 @@
+/**
+ * Workflow Engine PoC - Task Command
+ *
+ * `openspec wf task complete <task-id>` - Mark a task as complete
+ * `openspec wf task start <task-id>` - Mark a task as in_progress
+ * `openspec wf task next` - Show the next task to work on
+ */
+
+import chalk from 'chalk';
+import ora from 'ora';
+import { loadWorkflowState, updateTaskStatus, loadTasks, saveTasks } from './state.js';
+import { Task, TaskStatus, SCHEMA_VERSION } from './types.js';
+
+export async function runTaskComplete(taskId: string): Promise<void> {
+  const state = await loadWorkflowState('.');
+
+  if (!state.activeChangeId || !state.activeChange) {
+    console.log(chalk.red('No active change.'));
+    process.exit(1);
+  }
+
+  const task = state.activeChange.tasks.find((t) => t.id === taskId);
+  if (!task) {
+    console.log(chalk.red(`Task "${taskId}" not found.`));
+    console.log(chalk.dim('Available tasks: ' + state.activeChange.tasks.map((t) => t.id).join(', ')));
+    process.exit(1);
+  }
+
+  if (task.status === 'complete') {
+    console.log(chalk.yellow(`Task "${taskId}" is already complete.`));
+    return;
+  }
+
+  const spinner = ora(`Marking task "${taskId}" as complete...`).start();
+  try {
+    await updateTaskStatus('.', state.activeChangeId, taskId, 'complete');
+    spinner.succeed(`Task "${taskId}" marked as ${chalk.green('complete')}`);
+  } catch (error) {
+    spinner.fail(`Failed: ${(error as Error).message}`);
+    process.exit(1);
+  }
+}
+
+export async function runTaskStart(taskId: string): Promise<void> {
+  const state = await loadWorkflowState('.');
+
+  if (!state.activeChangeId || !state.activeChange) {
+    console.log(chalk.red('No active change.'));
+    process.exit(1);
+  }
+
+  const task = state.activeChange.tasks.find((t) => t.id === taskId);
+  if (!task) {
+    console.log(chalk.red(`Task "${taskId}" not found.`));
+    process.exit(1);
+  }
+
+  if (task.status === 'in_progress') {
+    console.log(chalk.yellow(`Task "${taskId}" is already in progress.`));
+    return;
+  }
+
+  const spinner = ora(`Marking task "${taskId}" as in_progress...`).start();
+  try {
+    await updateTaskStatus('.', state.activeChangeId, taskId, 'in_progress');
+    spinner.succeed(`Task "${taskId}" marked as ${chalk.yellow('in_progress')}`);
+  } catch (error) {
+    spinner.fail(`Failed: ${(error as Error).message}`);
+    process.exit(1);
+  }
+}
+
+export async function runTaskNext(options: { json?: boolean } = {}): Promise<void> {
+  const state = await loadWorkflowState('.');
+
+  if (!state.activeChangeId || !state.activeChange) {
+    if (options.json) {
+      console.log(JSON.stringify({ task: null, reason: 'No active change' }, null, 2));
+    } else {
+      console.log(chalk.red('No active change.'));
+    }
+    return;
+  }
+
+  const tasks = state.activeChange.tasks;
+
+  // Priority: in_progress > pending
+  const inProgress = tasks.find((t) => t.status === 'in_progress');
+  const next = inProgress || tasks.find((t) => t.status === 'pending');
+
+  if (options.json) {
+    console.log(JSON.stringify({ task: next || null }, null, 2));
+    return;
+  }
+
+  if (!next) {
+    console.log(chalk.green('No pending or in-progress tasks.'));
+    return;
+  }
+
+  console.log(chalk.bold('Next Task:'));
+  console.log(`  ID: ${next.id}`);
+  console.log(`  Title: ${next.title}`);
+  console.log(`  Status: ${formatStatus(next.status)}`);
+  if (next.acceptance_criteria.length > 0) {
+    console.log('  Acceptance Criteria:');
+    for (const ac of next.acceptance_criteria) {
+      console.log(`    • ${ac}`);
+    }
+  }
+}
+
+export async function runTaskAdd(
+  taskId: string,
+  title: string,
+  acceptanceCriteria: string[]
+): Promise<void> {
+  const state = await loadWorkflowState('.');
+
+  if (!state.activeChangeId) {
+    console.log(chalk.red('No active change.'));
+    process.exit(1);
+  }
+
+  const tasks = await loadTasks('.', state.activeChangeId);
+
+  if (tasks.find((t) => t.id === taskId)) {
+    console.log(chalk.red(`Task "${taskId}" already exists.`));
+    process.exit(1);
+  }
+
+  const newTask: Task = {
+    id: taskId,
+    title,
+    acceptance_criteria: acceptanceCriteria,
+    status: 'pending',
+  };
+
+  tasks.push(newTask);
+  await saveTasks('.', state.activeChangeId, tasks);
+
+  console.log(chalk.green(`Added task: ${chalk.bold(taskId)}`));
+}
+
+function formatStatus(status: TaskStatus): string {
+  const colors: Record<TaskStatus, (s: string) => string> = {
+    pending: chalk.dim,
+    in_progress: chalk.yellow,
+    complete: chalk.green,
+    blocked: chalk.red,
+  };
+  return colors[status](status);
+}

--- a/src/commands/workflow/types.ts
+++ b/src/commands/workflow/types.ts
@@ -1,0 +1,58 @@
+/**
+ * Workflow Engine PoC - Types
+ *
+ * Minimal types for the file-backed state machine.
+ * Schema version: poc-1
+ */
+
+export const SCHEMA_VERSION = 'poc-1';
+
+export type PhaseId = 'draft' | 'plan' | 'implement' | 'done';
+
+export type TaskStatus = 'pending' | 'in_progress' | 'complete' | 'blocked';
+
+export interface Task {
+  id: string;
+  title: string;
+  acceptance_criteria: string[];
+  status: TaskStatus;
+}
+
+export interface TasksFile {
+  schemaVersion: string;
+  tasks: Task[];
+}
+
+export interface MetaFile {
+  schemaVersion: string;
+  id: string;
+  title: string;
+  currentPhaseId: PhaseId;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface WorkflowChange {
+  meta: MetaFile;
+  tasks: Task[];
+}
+
+export interface WorkflowState {
+  activeChangeId: string | null;
+  activeChange: WorkflowChange | null;
+}
+
+export interface StatusOutput {
+  activeChangeId: string | null;
+  phase: PhaseId | null;
+  taskProgress: {
+    total: number;
+    pending: number;
+    in_progress: number;
+    complete: number;
+    blocked: number;
+  } | null;
+  nextTask: Task | null;
+  blockers: string[];
+  nextAction: string;
+}


### PR DESCRIPTION
## Summary

Adds a lightweight file-backed workflow engine to help AI agents follow structured, multi-phase changes reliably across sessions.

- **4 flat phases**: `draft` → `plan` → `implement` → `done`
- **File-backed state** in `.openspec/` (YAML, git-friendly)
- **Gated transitions** prevent skipping steps
- **JSON output** for agent consumption (`--json` flag)

## Commands

| Command | Description |
|---------|-------------|
| `openspec wf status` | Show current workflow state |
| `openspec wf change create <title>` | Create new change (starts in draft) |
| `openspec wf phase advance` | Move to next phase (with gating) |
| `openspec wf task add/start/complete` | Manage tasks |

## Workflow

```
draft ──► plan ──► implement ──► done
  │         │          │          │
  ▼         ▼          ▼          ▼
plan.md   tasks     do work    finish
```

| Phase | Artifact | Gate |
|-------|----------|------|
| draft | plan.md | plan.md exists |
| plan | tasks.yaml | tasks with acceptance criteria |
| implement | code | all tasks complete |
| done | — | — |

## State Structure

```
.openspec/
├── current                 # active change id
└── changes/<id>/
    ├── meta.yaml           # phase + metadata
    ├── plan.md             # proposal (draft phase)
    └── tasks.yaml          # tasks (plan phase)
```

## Slash Commands (not committed, in `.claude/`)

- `/wf:start <title>` - Create change, generate plan.md, stop for approval
- `/wf:continue` - Check state, act based on phase, stop at boundaries

## Test plan

- [x] Build passes
- [x] All 400 existing tests pass
- [x] Manual testing of full workflow cycle
- [ ] Test with agent via slash commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a file-backed workflow engine with comprehensive change and task management capabilities
  * Added `wf status` command to view workflow state and progress
  * Added `wf change` commands to create, list, and switch between changes
  * Added `wf phase advance` to progress through workflow phases with validation
  * Added `wf task` commands to manage task lifecycle (create, start, complete, track progress)
  * Implemented JSON output support for programmatic integration

* **Chores**
  * Added js-yaml library for configuration serialization

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->