### PR TITLE
fix(completions): resolve Windows compatibility issues in zsh-installer tests

### DIFF
--- a/test/core/completions/installers/zsh-installer.test.ts
+++ b/test/core/completions/installers/zsh-installer.test.ts
@@ -195,7 +195,11 @@ describe('ZshInstaller', () => {
 
     it('should handle installation errors gracefully', async () => {
       // Create installer with non-existent/invalid home directory
-      const invalidInstaller = new ZshInstaller('/root/invalid/nonexistent/path');
+      // Use a path that will fail on both Unix and Windows
+      const invalidPath = process.platform === 'win32'
+        ? 'Z:\\nonexistent\\invalid\\path'  // Non-existent drive letter on Windows
+        : '/root/invalid/nonexistent/path';  // Permission-denied path on Unix
+      const invalidInstaller = new ZshInstaller(invalidPath);
 
       const result = await invalidInstaller.install(testScript);
 
@@ -503,7 +507,11 @@ describe('ZshInstaller', () => {
 
     it('should handle write permission errors gracefully', async () => {
       // Create installer with path that can't be written
-      const invalidInstaller = new ZshInstaller('/root/invalid/path');
+      // Use a path that will fail on both Unix and Windows
+      const invalidPath = process.platform === 'win32'
+        ? 'Z:\\nonexistent\\invalid\\path'  // Non-existent drive letter on Windows
+        : '/root/invalid/path';  // Permission-denied path on Unix
+      const invalidInstaller = new ZshInstaller(invalidPath);
 
       const result = await invalidInstaller.configureZshrc(completionsDir);
 
@@ -641,7 +649,8 @@ describe('ZshInstaller', () => {
       if (exists) {
         const content = await fs.readFile(zshrcPath, 'utf-8');
         expect(content).toContain('fpath=');
-        expect(content).toContain('custom/completions');
+        // Check for custom/completions or custom\completions (Windows path separator)
+        expect(content).toMatch(/custom[/\\]completions/);
       }
     });
 


### PR DESCRIPTION
## Summary

- Fix `canWriteFile` to use `fs.access` with `W_OK` flag instead of Unix-style permission bits (`stats.mode & 0o222`) which don't work reliably on Windows
- Update test paths to use platform-specific invalid paths that fail on both Unix and Windows (non-existent drive letter on Windows, permission-denied path on Unix)
- Use regex for path separator matching in test assertions to handle both forward and backslashes

## Test plan

- [x] All 400 tests pass locally
- [x] The three previously failing Windows tests now use platform-aware paths and assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved file write permission detection for cross-platform compatibility
  * Enhanced file permission checking on Windows environments
  * Refined handling of write permissions when targeting non-existent files

* **Tests**
  * Expanded test coverage for platform-specific file system scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->