### PR TITLE
feat(cli): add plx command alias and rebrand as OpenSplx

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,51 @@
 <p align="center">
-  <a href="https://github.com/Fission-AI/OpenSpec">
+  <a href="https://github.com/appyboypov/OpenSplx">
     <picture>
-      <source srcset="assets/openspec_pixel_dark.svg" media="(prefers-color-scheme: dark)">
-      <source srcset="assets/openspec_pixel_light.svg" media="(prefers-color-scheme: light)">
-      <img src="assets/openspec_pixel_light.svg" alt="OpenSpec logo" height="64">
+      <source srcset="assets/opensplx_pixel_dark.svg" media="(prefers-color-scheme: dark)">
+      <source srcset="assets/opensplx_pixel_light.svg" media="(prefers-color-scheme: light)">
+      <img src="assets/opensplx_pixel_light.svg" alt="OpenSplx logo" height="64">
     </picture>
   </a>
-  
+
 </p>
 <p align="center">Spec-driven development for AI coding assistants.</p>
 <p align="center">
-  <a href="https://github.com/Fission-AI/OpenSpec/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/Fission-AI/OpenSpec/actions/workflows/ci.yml/badge.svg" /></a>
-  <a href="https://www.npmjs.com/package/@fission-ai/openspec"><img alt="npm version" src="https://img.shields.io/npm/v/@fission-ai/openspec?style=flat-square" /></a>
+  <a href="https://github.com/Fission-AI/OpenSpec"><img alt="Fork of OpenSpec" src="https://img.shields.io/badge/Fork%20of-OpenSpec-blue?style=flat-square" /></a>
   <a href="https://nodejs.org/"><img alt="node version" src="https://img.shields.io/node/v/@fission-ai/openspec?style=flat-square" /></a>
   <a href="./LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square" /></a>
-  <a href="https://conventionalcommits.org"><img alt="Conventional Commits" src="https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg?style=flat-square" /></a>
-  <a href="https://discord.gg/YctCnvvshC"><img alt="Discord" src="https://img.shields.io/badge/Discord-Join%20the%20community-5865F2?logo=discord&logoColor=white&style=flat-square" /></a>
 </p>
 
 <p align="center">
-  <img src="assets/openspec_dashboard.png" alt="OpenSpec dashboard preview" width="90%">
+  <img src="assets/openspec_dashboard.png" alt="OpenSplx dashboard preview" width="90%">
 </p>
+
+# OpenSplx
+
+> **Fork Notice:** OpenSplx is a community fork of [OpenSpec](https://github.com/Fission-AI/OpenSpec).
+> It adds the `plx` command alias and extended features while maintaining full compatibility
+> with the original OpenSpec workflow.
+
+## What's Different in OpenSplx
+
+| Feature | OpenSpec | OpenSplx |
+|---------|----------|----------|
+| Command | `openspec` | `openspec` + `plx` alias |
+| Install | `npm i -g @fission-ai/openspec` | Clone & `npm link` (local) |
+
+### Quick Start (OpenSplx)
+
+```bash
+git clone https://github.com/appyboypov/OpenSplx.git
+cd OpenSplx
+pnpm install && pnpm build
+npm link
+plx --version  # or openspec --version
+```
+
+---
+
+<details>
+<summary><strong>Original OpenSpec Documentation</strong> (click to expand)</summary>
 
 <p align="center">
   Follow <a href="https://x.com/0xTab">@0xTab on X</a> for updates · Join the <a href="https://discord.gg/YctCnvvshC">OpenSpec Discord</a> for help and questions.
@@ -379,3 +404,5 @@ Run `openspec update` whenever someone switches tools so your agents pick up the
 ## License
 
 MIT
+
+</details>

--- a/assets/opensplx_pixel_dark.svg
+++ b/assets/opensplx_pixel_dark.svg
@@ -1,0 +1,94 @@
+<svg width="640" height="80" viewBox="0 0 640 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+<!-- O -->
+<path d="M32 0H16V16H32V0Z" fill="white"/>
+<path d="M48 0H32V16H48V0Z" fill="white"/>
+<path d="M16 16H0V32H16V16Z" fill="white"/>
+<path d="M64 16H48V32H64V16Z" fill="white"/>
+<path d="M16 32H0V48H16V32Z" fill="white"/>
+<path d="M64 32H48V48H64V32Z" fill="white"/>
+<path d="M16 48H0V64H16V48Z" fill="white"/>
+<path d="M64 48H48V64H64V48Z" fill="white"/>
+<path d="M32 64H16V80H32V64Z" fill="white"/>
+<path d="M48 64H32V80H48V64Z" fill="white"/>
+<!-- P -->
+<path d="M96 0H80V16H96V0Z" fill="white"/>
+<path d="M112 0H96V16H112V0Z" fill="white"/>
+<path d="M128 0H112V16H128V0Z" fill="white"/>
+<path d="M96 16H80V32H96V16Z" fill="white"/>
+<path d="M144 16H128V32H144V16Z" fill="white"/>
+<path d="M96 32H80V48H96V32Z" fill="white"/>
+<path d="M112 32H96V48H112V32Z" fill="white"/>
+<path d="M128 32H112V48H128V32Z" fill="white"/>
+<path d="M144 32H128V48H144V32Z" fill="white"/>
+<path d="M96 48H80V64H96V48Z" fill="white"/>
+<path d="M96 64H80V80H96V64Z" fill="white"/>
+<!-- E -->
+<path d="M176 0H160V16H176V0Z" fill="white"/>
+<path d="M192 0H176V16H192V0Z" fill="white"/>
+<path d="M208 0H192V16H208V0Z" fill="white"/>
+<path d="M224 0H208V16H224V0Z" fill="white"/>
+<path d="M176 16H160V32H176V16Z" fill="white"/>
+<path d="M176 32H160V48H176V32Z" fill="white"/>
+<path d="M192 32H176V48H192V32Z" fill="white"/>
+<path d="M208 32H192V48H208V32Z" fill="white"/>
+<path d="M176 48H160V64H176V48Z" fill="white"/>
+<path d="M176 64H160V80H176V64Z" fill="white"/>
+<path d="M192 64H176V80H192V64Z" fill="white"/>
+<path d="M208 64H192V80H208V64Z" fill="white"/>
+<path d="M224 64H208V80H224V64Z" fill="white"/>
+<!-- N -->
+<path d="M256 0H240V16H256V0Z" fill="white"/>
+<path d="M304 0H288V16H304V0Z" fill="white"/>
+<path d="M256 16H240V32H256V16Z" fill="white"/>
+<path d="M272 16H256V32H272V16Z" fill="white"/>
+<path d="M304 16H288V32H304V16Z" fill="white"/>
+<path d="M256 32H240V48H256V32Z" fill="white"/>
+<path d="M288 32H272V48H288V32Z" fill="white"/>
+<path d="M304 32H288V48H304V32Z" fill="white"/>
+<path d="M256 48H240V64H256V48Z" fill="white"/>
+<path d="M304 48H288V64H304V48Z" fill="white"/>
+<path d="M256 64H240V80H256V64Z" fill="white"/>
+<path d="M304 64H288V80H304V64Z" fill="white"/>
+<!-- S -->
+<path d="M352 0H336V16H352V0Z" fill="white"/>
+<path d="M368 0H352V16H368V0Z" fill="white"/>
+<path d="M384 0H368V16H384V0Z" fill="white"/>
+<path d="M336 16H320V32H336V16Z" fill="white"/>
+<path d="M352 32H336V48H352V32Z" fill="white"/>
+<path d="M368 32H352V48H368V32Z" fill="white"/>
+<path d="M384 48H368V64H384V48Z" fill="white"/>
+<path d="M336 64H320V80H336V64Z" fill="white"/>
+<path d="M352 64H336V80H352V64Z" fill="white"/>
+<path d="M368 64H352V80H368V64Z" fill="white"/>
+<!-- P -->
+<path d="M416 0H400V16H416V0Z" fill="white"/>
+<path d="M432 0H416V16H432V0Z" fill="white"/>
+<path d="M448 0H432V16H448V0Z" fill="white"/>
+<path d="M416 16H400V32H416V16Z" fill="white"/>
+<path d="M464 16H448V32H464V16Z" fill="white"/>
+<path d="M416 32H400V48H416V32Z" fill="white"/>
+<path d="M432 32H416V48H432V32Z" fill="white"/>
+<path d="M448 32H432V48H448V32Z" fill="white"/>
+<path d="M464 32H448V48H464V32Z" fill="white"/>
+<path d="M416 48H400V64H416V48Z" fill="white"/>
+<path d="M416 64H400V80H416V64Z" fill="white"/>
+<!-- L -->
+<path d="M496 0H480V16H496V0Z" fill="white"/>
+<path d="M496 16H480V32H496V16Z" fill="white"/>
+<path d="M496 32H480V48H496V32Z" fill="white"/>
+<path d="M496 48H480V64H496V48Z" fill="white"/>
+<path d="M496 64H480V80H496V64Z" fill="white"/>
+<path d="M512 64H496V80H512V64Z" fill="white"/>
+<path d="M528 64H512V80H528V64Z" fill="white"/>
+<path d="M544 64H528V80H544V64Z" fill="white"/>
+<!-- X -->
+<path d="M576 0H560V16H576V0Z" fill="white"/>
+<path d="M640 0H624V16H640V0Z" fill="white"/>
+<path d="M592 16H576V32H592V16Z" fill="white"/>
+<path d="M624 16H608V32H624V16Z" fill="white"/>
+<path d="M608 32H592V48H608V32Z" fill="white"/>
+<path d="M592 48H576V64H592V48Z" fill="white"/>
+<path d="M624 48H608V64H624V48Z" fill="white"/>
+<path d="M576 64H560V80H576V64Z" fill="white"/>
+<path d="M640 64H624V80H640V64Z" fill="white"/>
+</svg>

--- a/assets/opensplx_pixel_light.svg
+++ b/assets/opensplx_pixel_light.svg
@@ -1,0 +1,94 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="80" viewBox="0 0 640 80">
+<!-- O -->
+<rect x="16" y="0" width="16" height="16" fill="black" />
+<rect x="32" y="0" width="16" height="16" fill="black" />
+<rect x="0" y="16" width="16" height="16" fill="black" />
+<rect x="48" y="16" width="16" height="16" fill="black" />
+<rect x="0" y="32" width="16" height="16" fill="black" />
+<rect x="48" y="32" width="16" height="16" fill="black" />
+<rect x="0" y="48" width="16" height="16" fill="black" />
+<rect x="48" y="48" width="16" height="16" fill="black" />
+<rect x="16" y="64" width="16" height="16" fill="black" />
+<rect x="32" y="64" width="16" height="16" fill="black" />
+<!-- P -->
+<rect x="80" y="0" width="16" height="16" fill="black" />
+<rect x="96" y="0" width="16" height="16" fill="black" />
+<rect x="112" y="0" width="16" height="16" fill="black" />
+<rect x="80" y="16" width="16" height="16" fill="black" />
+<rect x="128" y="16" width="16" height="16" fill="black" />
+<rect x="80" y="32" width="16" height="16" fill="black" />
+<rect x="96" y="32" width="16" height="16" fill="black" />
+<rect x="112" y="32" width="16" height="16" fill="black" />
+<rect x="128" y="32" width="16" height="16" fill="black" />
+<rect x="80" y="48" width="16" height="16" fill="black" />
+<rect x="80" y="64" width="16" height="16" fill="black" />
+<!-- E -->
+<rect x="160" y="0" width="16" height="16" fill="black" />
+<rect x="176" y="0" width="16" height="16" fill="black" />
+<rect x="192" y="0" width="16" height="16" fill="black" />
+<rect x="208" y="0" width="16" height="16" fill="black" />
+<rect x="160" y="16" width="16" height="16" fill="black" />
+<rect x="160" y="32" width="16" height="16" fill="black" />
+<rect x="176" y="32" width="16" height="16" fill="black" />
+<rect x="192" y="32" width="16" height="16" fill="black" />
+<rect x="160" y="48" width="16" height="16" fill="black" />
+<rect x="160" y="64" width="16" height="16" fill="black" />
+<rect x="176" y="64" width="16" height="16" fill="black" />
+<rect x="192" y="64" width="16" height="16" fill="black" />
+<rect x="208" y="64" width="16" height="16" fill="black" />
+<!-- N -->
+<rect x="240" y="0" width="16" height="16" fill="black" />
+<rect x="288" y="0" width="16" height="16" fill="black" />
+<rect x="240" y="16" width="16" height="16" fill="black" />
+<rect x="256" y="16" width="16" height="16" fill="black" />
+<rect x="288" y="16" width="16" height="16" fill="black" />
+<rect x="240" y="32" width="16" height="16" fill="black" />
+<rect x="272" y="32" width="16" height="16" fill="black" />
+<rect x="288" y="32" width="16" height="16" fill="black" />
+<rect x="240" y="48" width="16" height="16" fill="black" />
+<rect x="288" y="48" width="16" height="16" fill="black" />
+<rect x="240" y="64" width="16" height="16" fill="black" />
+<rect x="288" y="64" width="16" height="16" fill="black" />
+<!-- S -->
+<rect x="336" y="0" width="16" height="16" fill="black" />
+<rect x="352" y="0" width="16" height="16" fill="black" />
+<rect x="368" y="0" width="16" height="16" fill="black" />
+<rect x="320" y="16" width="16" height="16" fill="black" />
+<rect x="336" y="32" width="16" height="16" fill="black" />
+<rect x="352" y="32" width="16" height="16" fill="black" />
+<rect x="368" y="48" width="16" height="16" fill="black" />
+<rect x="320" y="64" width="16" height="16" fill="black" />
+<rect x="336" y="64" width="16" height="16" fill="black" />
+<rect x="352" y="64" width="16" height="16" fill="black" />
+<!-- P -->
+<rect x="400" y="0" width="16" height="16" fill="black" />
+<rect x="416" y="0" width="16" height="16" fill="black" />
+<rect x="432" y="0" width="16" height="16" fill="black" />
+<rect x="400" y="16" width="16" height="16" fill="black" />
+<rect x="448" y="16" width="16" height="16" fill="black" />
+<rect x="400" y="32" width="16" height="16" fill="black" />
+<rect x="416" y="32" width="16" height="16" fill="black" />
+<rect x="432" y="32" width="16" height="16" fill="black" />
+<rect x="448" y="32" width="16" height="16" fill="black" />
+<rect x="400" y="48" width="16" height="16" fill="black" />
+<rect x="400" y="64" width="16" height="16" fill="black" />
+<!-- L -->
+<rect x="480" y="0" width="16" height="16" fill="black" />
+<rect x="480" y="16" width="16" height="16" fill="black" />
+<rect x="480" y="32" width="16" height="16" fill="black" />
+<rect x="480" y="48" width="16" height="16" fill="black" />
+<rect x="480" y="64" width="16" height="16" fill="black" />
+<rect x="496" y="64" width="16" height="16" fill="black" />
+<rect x="512" y="64" width="16" height="16" fill="black" />
+<rect x="528" y="64" width="16" height="16" fill="black" />
+<!-- X -->
+<rect x="560" y="0" width="16" height="16" fill="black" />
+<rect x="624" y="0" width="16" height="16" fill="black" />
+<rect x="576" y="16" width="16" height="16" fill="black" />
+<rect x="608" y="16" width="16" height="16" fill="black" />
+<rect x="592" y="32" width="16" height="16" fill="black" />
+<rect x="576" y="48" width="16" height="16" fill="black" />
+<rect x="608" y="48" width="16" height="16" fill="black" />
+<rect x="560" y="64" width="16" height="16" fill="black" />
+<rect x="624" y="64" width="16" height="16" fill="black" />
+</svg>

--- a/bin/plx.js
+++ b/bin/plx.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+import '../dist/cli/index.js';

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     }
   },
   "bin": {
-    "openspec": "./bin/openspec.js"
+    "openspec": "./bin/openspec.js",
+    "plx": "./bin/plx.js"
   },
   "files": [
     "dist",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -19,6 +19,16 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 /**
+ * Detect the command name from the invocation path
+ */
+function getCommandName() {
+  const scriptPath = process.argv[1] || '';
+  const scriptName = path.basename(scriptPath).replace(/\.js$/, '');
+  // Default to 'openspec' for postinstall context
+  return scriptName === 'plx' ? 'plx' : 'openspec';
+}
+
+/**
  * Check if we should skip installation
  */
 function shouldSkipInstallation() {
@@ -72,7 +82,7 @@ async function installCompletions(shell) {
 
     // Check if shell is supported
     if (!CompletionFactory.isSupported(shell)) {
-      console.log(`\nTip: Run 'openspec completion install' for shell completions`);
+      console.log(`\nTip: Run 'openspec completion install' or 'plx completion install' for shell completions`);
       return;
     }
 
@@ -99,11 +109,11 @@ async function installCompletions(shell) {
       }
     } else {
       // Installation failed, show tip for manual install
-      console.log(`\nTip: Run 'openspec completion install' for shell completions`);
+      console.log(`\nTip: Run 'openspec completion install' or 'plx completion install' for shell completions`);
     }
   } catch (error) {
     // Fail gracefully - show tip for manual install
-    console.log(`\nTip: Run 'openspec completion install' for shell completions`);
+    console.log(`\nTip: Run 'openspec completion install' or 'plx completion install' for shell completions`);
   }
 }
 
@@ -127,7 +137,7 @@ async function main() {
     // Detect shell
     const shell = await detectShell();
     if (!shell) {
-      console.log(`\nTip: Run 'openspec completion install' for shell completions`);
+      console.log(`\nTip: Run 'openspec completion install' or 'plx completion install' for shell completions`);
       return;
     }
 
@@ -136,7 +146,7 @@ async function main() {
   } catch (error) {
     // Fail gracefully - never break npm install
     // Show tip for manual install
-    console.log(`\nTip: Run 'openspec completion install' for shell completions`);
+    console.log(`\nTip: Run 'openspec completion install' or 'plx completion install' for shell completions`);
   }
 }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -15,12 +15,15 @@ import { ValidateCommand } from '../commands/validate.js';
 import { ShowCommand } from '../commands/show.js';
 import { CompletionCommand } from '../commands/completion.js';
 
+// Import command name detection utility
+import { commandName } from '../utils/command-name.js';
+
 const program = new Command();
 const require = createRequire(import.meta.url);
 const { version } = require('../../package.json');
 
 program
-  .name('openspec')
+  .name(commandName)
   .description('AI-native system for spec-driven development')
   .version(version);
 

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -5,6 +5,7 @@ import { COMMAND_REGISTRY } from '../core/completions/command-registry.js';
 import { detectShell, SupportedShell } from '../utils/shell-detection.js';
 import { CompletionProvider } from '../core/completions/completion-provider.js';
 import { getArchivedChangeIds } from '../utils/item-discovery.js';
+import { commandName } from '../utils/command-name.js';
 
 interface GenerateOptions {
   shell?: string;
@@ -59,7 +60,7 @@ export class CompletionCommand {
 
       // No shell specified and cannot auto-detect
       console.error('Error: Could not auto-detect shell. Please specify shell explicitly.');
-      console.error(`Usage: openspec completion ${operationName} [shell]`);
+      console.error(`Usage: ${commandName} completion ${operationName} [shell]`);
       console.error(`Currently supported: ${CompletionFactory.getSupportedShells().join(', ')}`);
       process.exitCode = 1;
       return null;
@@ -115,7 +116,7 @@ export class CompletionCommand {
    */
   private async generateForShell(shell: SupportedShell): Promise<void> {
     const generator = CompletionFactory.createGenerator(shell);
-    const script = generator.generate(COMMAND_REGISTRY);
+    const script = generator.generate(COMMAND_REGISTRY, commandName);
     console.log(script);
   }
 
@@ -126,11 +127,11 @@ export class CompletionCommand {
     const generator = CompletionFactory.createGenerator(shell);
     const installer = CompletionFactory.createInstaller(shell);
 
-    const spinner = ora(`Installing ${shell} completion script...`).start();
+    const spinner = ora(`Installing ${shell} completion script for ${commandName}...`).start();
 
     try {
       // Generate the completion script
-      const script = generator.generate(COMMAND_REGISTRY);
+      const script = generator.generate(COMMAND_REGISTRY, commandName);
 
       // Install it
       const result = await installer.install(script);
@@ -180,7 +181,7 @@ export class CompletionCommand {
     // Prompt for confirmation unless --yes flag is provided
     if (!skipConfirmation) {
       const confirmed = await confirm({
-        message: 'Remove OpenSpec configuration from ~/.zshrc?',
+        message: `Remove ${commandName} configuration from ~/.zshrc?`,
         default: false,
       });
 

--- a/src/core/completions/types.ts
+++ b/src/core/completions/types.ts
@@ -84,7 +84,8 @@ export interface CompletionGenerator {
    * Generate the completion script content
    *
    * @param commands - Command definitions to generate completions for
+   * @param commandName - The CLI command name (e.g., 'openspec' or 'plx')
    * @returns The shell-specific completion script as a string
    */
-  generate(commands: CommandDefinition[]): string;
+  generate(commands: CommandDefinition[], commandName?: string): string;
 }

--- a/src/utils/command-name.ts
+++ b/src/utils/command-name.ts
@@ -1,0 +1,16 @@
+import path from 'path';
+
+/**
+ * Detect the CLI command name from the invocation path.
+ * Returns 'plx' if invoked via plx, otherwise defaults to 'openspec'.
+ */
+export function getCommandName(): string {
+  const scriptPath = process.argv[1] || '';
+  const scriptName = path.basename(scriptPath).replace(/\.js$/, '');
+  return scriptName === 'plx' ? 'plx' : 'openspec';
+}
+
+/**
+ * The detected command name for the current invocation.
+ */
+export const commandName = getCommandName();

--- a/test/core/completions/generators/zsh-generator.test.ts
+++ b/test/core/completions/generators/zsh-generator.test.ts
@@ -32,7 +32,7 @@ describe('ZshGenerator', () => {
       const script = generator.generate(commands);
 
       expect(script).toContain('#compdef openspec');
-      expect(script).toContain('# Zsh completion script for OpenSpec CLI');
+      expect(script).toContain('# Zsh completion script for openspec CLI');
       expect(script).toContain('_openspec() {');
     });
 


### PR DESCRIPTION
## Summary
- Adds `plx` as an alias command for all OpenSpec commands
- Rebrands the fork as OpenSplx with new logo assets
- Both `plx` and `openspec` commands work identically

## Changes
- New pixel art logos: `assets/opensplx_pixel_light.svg`, `assets/opensplx_pixel_dark.svg`
- Updated README with fork notice and Quick Start section
- Added `plx` bin entry to `package.json`
- Created `bin/plx.js` entry point
- Added `src/utils/command-name.ts` for dynamic command detection
- Updated CLI and completion system to support both command names

## Test plan
- [x] `plx --version` outputs version
- [x] `plx --help` shows "plx" as command name
- [x] `openspec --version` still works
- [x] `plx completion generate zsh` generates correct completions
- [x] Unit tests pass (399/400 - one unrelated environment failure)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "plx" command as an alternative CLI entry point alongside "openspec"
  * Shell completion now supports both command variants with context-aware messaging

* **Documentation**
  * Updated README with OpenSplx branding, feature comparison table, and quick-start installation guide

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->