### PR TITLE
fix(global-config): respect XDG_CONFIG_HOME on all platforms

### DIFF
--- a/src/core/global-config.ts
+++ b/src/core/global-config.ts
@@ -18,10 +18,17 @@ const DEFAULT_CONFIG: GlobalConfig = {
 /**
  * Gets the global configuration directory path following XDG Base Directory Specification.
  *
- * - Unix/macOS: $XDG_CONFIG_HOME/openspec/ or ~/.config/openspec/
- * - Windows: %APPDATA%/openspec/
+ * - All platforms: $XDG_CONFIG_HOME/openspec/ if XDG_CONFIG_HOME is set
+ * - Unix/macOS fallback: ~/.config/openspec/
+ * - Windows fallback: %APPDATA%/openspec/
  */
 export function getGlobalConfigDir(): string {
+  // XDG_CONFIG_HOME takes precedence on all platforms when explicitly set
+  const xdgConfigHome = process.env.XDG_CONFIG_HOME;
+  if (xdgConfigHome) {
+    return path.join(xdgConfigHome, GLOBAL_CONFIG_DIR_NAME);
+  }
+
   const platform = os.platform();
 
   if (platform === 'win32') {
@@ -34,12 +41,7 @@ export function getGlobalConfigDir(): string {
     return path.join(os.homedir(), 'AppData', 'Roaming', GLOBAL_CONFIG_DIR_NAME);
   }
 
-  // Unix/macOS: use XDG_CONFIG_HOME or fallback to ~/.config
-  const xdgConfigHome = process.env.XDG_CONFIG_HOME;
-  if (xdgConfigHome) {
-    return path.join(xdgConfigHome, GLOBAL_CONFIG_DIR_NAME);
-  }
-
+  // Unix/macOS fallback: ~/.config
   return path.join(os.homedir(), '.config', GLOBAL_CONFIG_DIR_NAME);
 }
 

--- a/test/core/global-config.test.ts
+++ b/test/core/global-config.test.ts
@@ -70,10 +70,11 @@ describe('global-config', () => {
       }
     });
 
-    it('should use APPDATA on Windows', () => {
+    it('should use APPDATA on Windows when XDG_CONFIG_HOME is not set', () => {
       // This test only makes sense conceptually - we can't change os.platform()
       // But we can verify the APPDATA logic by checking the code path
       if (os.platform() === 'win32') {
+        delete process.env.XDG_CONFIG_HOME;
         const appData = process.env.APPDATA;
         if (appData) {
           const result = getGlobalConfigDir();


### PR DESCRIPTION
Prioritize XDG_CONFIG_HOME on Windows to fix test environment overrides. Previously, Windows would always use APPDATA regardless of XDG_CONFIG_HOME, causing tests to fail. Now XDG_CONFIG_HOME is checked first on all platforms before falling back to platform-specific defaults. The Windows APPDATA test is updated to explicitly clear XDG_CONFIG_HOME when testing the fallback behavior.

Fixes failing Windows tests in test/core/global-config.test.ts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed configuration directory resolution to consistently prioritize `XDG_CONFIG_HOME` environment variable across all platforms with appropriate platform-specific fallbacks.

* **Documentation**
  * Updated documentation to clarify cross-platform configuration directory precedence and fallback behavior.

* **Tests**
  * Updated tests to validate configuration directory behavior when environment variables are unset.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->