### PR TITLE
chore: add changeset for config command dynamic import fix

### DIFF
--- a/.changeset/config-dynamic-import.md
+++ b/.changeset/config-dynamic-import.md
@@ -1,0 +1,9 @@
+---
+"@fission-ai/openspec": patch
+---
+
+Fix pre-commit hook hang issue in config command by using dynamic import for @inquirer/prompts
+
+The config command was causing pre-commit hooks to hang indefinitely due to stdin event listeners being registered at module load time. This fix converts the static import to a dynamic import that only loads inquirer when the `config reset` command is actually used interactively.
+
+Also adds ESLint with a rule to prevent static @inquirer imports, avoiding future regressions.


### PR DESCRIPTION
## Summary

Adds a changeset for the changes since the last release (v0.0.32).

### Changes included in this release:

- **fix(cli)**: Use dynamic import for @inquirer/prompts in config command (#392)
  - Fixes pre-commit hook hang issue caused by stdin event listeners being registered at module load time
  - Adds ESLint configuration to prevent static @inquirer imports and avoid future regressions

- **feat(ci)**: Migrate to npm OIDC trusted publishing (#390) *(CI-only, not affecting package)*

### Version bump

This is a **patch** release (0.0.1 bump) as it contains a bug fix.