### PR TITLE
chore: add changeset for --no-interactive flag fix

### DIFF
--- a/.changeset/fix-no-interactive.md
+++ b/.changeset/fix-no-interactive.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+Fix `--no-interactive` flag in validate command to properly disable spinner, preventing hangs in pre-commit hooks and CI environments


### PR DESCRIPTION
## Summary

Adds a changeset for the changes merged since the last release.

### Changes included:
- **fix(cli)**: respect `--no-interactive` flag in validate command (#395)
  - Prevents spinner from starting when `--no-interactive` is set
  - Fixes hangs in pre-commit hooks and CI environments
  - Adds CI environment variable check to `isInteractive()`

This is a **patch** release as it contains only bug fixes.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the --no-interactive flag in the validate command to properly disable the spinner, preventing hangs in pre-commit hooks and CI environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->