### PR TITLE
feat: add agent schema selection to experimental artifact workflow

### DIFF
--- a/openspec/changes/add-agent-schema-selection/tasks.md
+++ b/openspec/changes/add-agent-schema-selection/tasks.md
@@ -1,32 +1,32 @@
 ## Prerequisites
 
-- [ ] 0.1 Implement `add-per-change-schema-metadata` change first
+- [x] 0.1 Implement `add-per-change-schema-metadata` change first
 
 ## 1. Schema Discovery
 
-- [ ] 1.1 Add CLI command or helper to list schemas with descriptions (for agent use)
-- [ ] 1.2 Ensure `openspec templates --schema <name>` returns artifact list for any schema
+- [x] 1.1 Add CLI command or helper to list schemas with descriptions (for agent use)
+- [x] 1.2 Ensure `openspec templates --schema <name>` returns artifact list for any schema
 
 ## 2. Update New Change Skill
 
-- [ ] 2.1 Add schema selection prompt using AskUserQuestion tool
-- [ ] 2.2 Present available schemas with descriptions (spec-driven, tdd, etc.)
-- [ ] 2.3 Pass selected schema to `openspec new change --schema <name>`
-- [ ] 2.4 Update output to show which schema/workflow was selected
+- [x] 2.1 Add schema selection prompt using AskUserQuestion tool
+- [x] 2.2 Present available schemas with descriptions (spec-driven, tdd, etc.)
+- [x] 2.3 Pass selected schema to `openspec new change --schema <name>`
+- [x] 2.4 Update output to show which schema/workflow was selected
 
 ## 3. Update Continue Change Skill
 
-- [ ] 3.1 Remove hardcoded artifact references (proposal, specs, design, tasks)
-- [ ] 3.2 Read artifact list dynamically from `openspec status --json`
-- [ ] 3.3 Adjust artifact creation guidelines to be schema-agnostic
-- [ ] 3.4 Handle schema-specific artifact types (e.g., TDD's `tests` artifact)
+- [x] 3.1 Remove hardcoded artifact references (proposal, specs, design, tasks)
+- [x] 3.2 Read artifact list dynamically from `openspec status --json`
+- [x] 3.3 Adjust artifact creation guidelines to be schema-agnostic
+- [x] 3.4 Handle schema-specific artifact types (e.g., TDD's `tests` artifact)
 
 ## 4. Update Apply Change Skill
 
-- [ ] 4.1 Make task detection work with different schema structures
-- [ ] 4.2 Adjust context file reading for schema-specific artifacts
+- [x] 4.1 Make task detection work with different schema structures
+- [x] 4.2 Adjust context file reading for schema-specific artifacts
 
 ## 5. Documentation
 
-- [ ] 5.1 Add schema descriptions to help text or skill instructions
-- [ ] 5.2 Document when to use each schema (TDD for bug fixes, spec-driven for features, etc.)
+- [x] 5.1 Add schema descriptions to help text or skill instructions
+- [x] 5.2 Document when to use each schema (TDD for bug fixes, spec-driven for features, etc.)

--- a/src/core/artifact-graph/index.ts
+++ b/src/core/artifact-graph/index.ts
@@ -21,10 +21,12 @@ export { detectCompleted } from './state.js';
 export {
   resolveSchema,
   listSchemas,
+  listSchemasWithInfo,
   getSchemaDir,
   getPackageSchemasDir,
   getUserSchemasDir,
   SchemaLoadError,
+  type SchemaInfo,
 } from './resolver.js';
 
 // Instruction loading


### PR DESCRIPTION
## Summary

- Adds `openspec schemas` CLI command with `--json` option for agents to list available workflow schemas
- Updates `openspec-new-change` skill to prompt users for schema selection (spec-driven, tdd, etc.)
- Makes all skill templates schema-agnostic by reading artifact lists dynamically from `openspec status --json`
- Updates slash commands (`/opsx:new`, `/opsx:continue`, `/opsx:apply`) to work with any schema

## Changes

### CLI
- New `openspec schemas` command lists schemas with descriptions and artifact sequences
- New `listSchemasWithInfo()` helper function for programmatic access

### Skill Templates
- `openspec-new-change`: Now prompts for schema selection before creating a change
- `openspec-continue-change`: Reads schema from status output, provides schema-specific guidance
- `openspec-apply-change`: Uses dynamic context files based on schema

### Slash Commands
- All `/opsx:*` commands updated to support schema selection and dynamic artifact handling

## Test plan

- [ ] Run `openspec schemas` and verify it lists spec-driven and tdd schemas
- [ ] Run `openspec schemas --json` and verify JSON output includes name, description, artifacts
- [ ] Run `openspec artifact-experimental-setup` and verify updated skills are generated
- [ ] Verify skill templates include schema selection step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added workflow schema selection during change creation—users can now choose between different schema types (e.g., spec-driven, TDD) for their workflow.
  * New `schemas` command displays available workflow schemas with descriptions and metadata.
  * System now provides schema-aware guidance throughout the change workflow with contextual artifact sequences.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->