### PR TITLE
fix: set USERPROFILE for Windows compatibility in telemetry tests

### DIFF
--- a/test/telemetry/config.test.ts
+++ b/test/telemetry/config.test.ts
@@ -14,20 +14,25 @@ import {
 describe('telemetry/config', () => {
   let tempDir: string;
   let originalHome: string | undefined;
+  let originalUserProfile: string | undefined;
 
   beforeEach(() => {
     // Create temp directory for tests
     tempDir = path.join(os.tmpdir(), `openspec-telemetry-test-${Date.now()}`);
     fs.mkdirSync(tempDir, { recursive: true });
 
-    // Mock HOME to point to temp dir
+    // Mock HOME/USERPROFILE to point to temp dir
+    // On POSIX, os.homedir() uses HOME; on Windows it uses USERPROFILE
     originalHome = process.env.HOME;
+    originalUserProfile = process.env.USERPROFILE;
     process.env.HOME = tempDir;
+    process.env.USERPROFILE = tempDir;
   });
 
   afterEach(() => {
-    // Restore HOME
+    // Restore HOME/USERPROFILE
     process.env.HOME = originalHome;
+    process.env.USERPROFILE = originalUserProfile;
 
     // Clean up temp directory
     fs.rmSync(tempDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- Fix telemetry config tests failing on Windows CI
- Set both `HOME` and `USERPROFILE` environment variables when mocking the home directory
- On Windows, `os.homedir()` uses `USERPROFILE` instead of `HOME`

## Test plan
- [x] All 12 telemetry config tests pass locally
- [ ] Windows CI should now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test environment isolation by properly managing HOME and USERPROFILE environment variables during setup and cleanup, ensuring reliable and consistent test execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->