### PR TITLE
chore: add changeset for explore command, telemetry, and shell completions

### DIFF
--- a/.changeset/explore-telemetry-completions.md
+++ b/.changeset/explore-telemetry-completions.md
@@ -1,0 +1,15 @@
+---
+"@fission-ai/openspec": minor
+---
+
+### New Features
+
+- Add `/opsx:explore` command for exploratory thinking mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements before committing to a change
+- Add optional anonymous usage statistics with privacy-first design - tracks only command names and version, opt-out via `OPENSPEC_TELEMETRY=0` or `DO_NOT_TRACK=1`, auto-disabled in CI
+- Add shell completions for Bash, Fish, and PowerShell (in addition to existing Zsh support)
+
+### Fixes
+
+- Fix parent flags not being offered in Bash and PowerShell completions when subcommands exist
+- Fix Windows compatibility issues in tests
+- Update Codebuddy slash command frontmatter


### PR DESCRIPTION
## Summary

Adds a changeset for the following changes since v0.0.55:

### New Features
- `/opsx:explore` command for exploratory thinking mode (#467)
- Optional anonymous usage statistics with privacy-first design (#468)
- Shell completions for Bash, Fish, and PowerShell (#401)

### Fixes
- Parent flags in Bash/PowerShell completions when subcommands exist (#466)
- Windows compatibility issues in tests (#464, #465, #469)
- Codebuddy slash command frontmatter (#462)

## Commits included
- `4715138` fix: set USERPROFILE for Windows compatibility in telemetry tests (#469)
- `940898c` Add optional anonymous usage statistics (#468)
- `d49a88c` feat: add /opsx:explore command for exploratory thinking (#467)
- `bb9f6ce` docs: add OPSX experimental workflow visibility to README (#460)
- `ae85a72` fix: offer parent flags in Bash and PowerShell completions when subcommands exist (#466)
- `504c93b` fix: skip additional Windows-specific tests (#465)
- `c4a54a8` fix: skip Windows-specific permission tests that rely on chmod() (#464)
- `38d2356` feature/bash_fish_power_shells_completions (#401)
- `3f67deb` feat: change the frontmatter of the Codebuddy Slash Commands (#462)

🤖 Generated with [Claude Code](https://claude.com/claude-code)