### PR TITLE
fix: use actionCommand for telemetry command tracking

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -50,7 +50,10 @@ program
 program.option('--no-color', 'Disable color output');
 
 // Apply global flags and telemetry before any command runs
-program.hook('preAction', async (thisCommand) => {
+// Note: preAction receives (thisCommand, actionCommand) where:
+// - thisCommand: the command where hook was added (root program)
+// - actionCommand: the command actually being executed (subcommand)
+program.hook('preAction', async (thisCommand, actionCommand) => {
   const opts = thisCommand.opts();
   if (opts.color === false) {
     process.env.NO_COLOR = '1';
@@ -59,8 +62,8 @@ program.hook('preAction', async (thisCommand) => {
   // Show first-run telemetry notice (if not seen)
   await maybeShowTelemetryNotice();
 
-  // Track command execution
-  const commandPath = getCommandPath(thisCommand);
+  // Track command execution (use actionCommand to get the actual subcommand)
+  const commandPath = getCommandPath(actionCommand);
   await trackCommand(commandPath, version);
 });
 


### PR DESCRIPTION
## Summary
- Fix telemetry command tracking to use the correct command parameter
- The `preAction` hook receives `(thisCommand, actionCommand)` where `thisCommand` is the root program and `actionCommand` is the actual subcommand being executed
- Previously, using `thisCommand` would incorrectly track the root command instead of the actual subcommand run by the user

## Test plan
- [ ] Run `openspec init` and verify telemetry tracks "init" not the root command
- [ ] Run other subcommands and verify correct tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI command tracking to correctly identify and track subcommands instead of parent commands.

* **Refactor**
  * Updated internal command handling logic to ensure more accurate command path resolution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->