### PR TITLE
chore: add changeset for Continue support, shell completions, and explore command

### DIFF
--- a/.changeset/continue-shells-telemetry.md
+++ b/.changeset/continue-shells-telemetry.md
@@ -1,0 +1,19 @@
+---
+"@fission-ai/openspec": minor
+---
+
+### New Features
+
+- **Continue IDE support** – OpenSpec now generates slash commands for [Continue](https://continue.dev/), expanding editor integration options alongside Cursor, Windsurf, Claude Code, and others
+- **Shell completions for Bash, Fish, and PowerShell** – Run `openspec completion install` to set up tab completion in your preferred shell
+- **`/opsx:explore` command** – A new thinking partner mode for exploring ideas and investigating problems before committing to changes
+- **Codebuddy slash command improvements** – Updated frontmatter format for better compatibility
+
+### Bug Fixes
+
+- Shell completions now correctly offer parent-level flags (like `--help`) when a command has subcommands
+- Fixed Windows compatibility issues in tests
+
+### Other
+
+- Added optional anonymous usage statistics to help understand how OpenSpec is used. This is **opt-out** by default – set `OPENSPEC_TELEMETRY=0` or `DO_NOT_TRACK=1` to disable. Only command names and version are collected; no arguments, file paths, or content. Automatically disabled in CI environments.


### PR DESCRIPTION
## Summary

Adds a changeset for the next release covering changes since v0.5.0 (#458).

### New Features
- **Continue IDE support** – Slash commands for Continue editor
- **Shell completions** – Bash, Fish, and PowerShell support via `openspec completion install`
- **`/opsx:explore` command** – Thinking partner mode for exploratory work
- **Codebuddy improvements** – Updated slash command frontmatter

### Bug Fixes
- Parent flags now offered in shell completions for commands with subcommands
- Windows test compatibility fixes

### Other
- Optional anonymous telemetry (opt-out via `OPENSPEC_TELEMETRY=0` or `DO_NOT_TRACK=1`)

---

**Commits included:**
- e987a5a Add Continue support (#402)
- 38d2356 Bash/Fish/PowerShell completions (#401)
- d49a88c /opsx:explore command (#467)
- 940898c Optional anonymous usage statistics (#468)
- 3f67deb Codebuddy frontmatter update (#462)
- ae85a72 Fix parent flags in completions (#466)
- Various test/Windows fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Continue IDE support with slash command generation.
  * Introduced shell completions for Bash, Fish, and PowerShell with an install command.
  * Added /opsx:explore command for brainstorming and investigation.
  * Enhanced Codebuddy slash command functionality.

* **Bug Fixes**
  * Fixed shell completions to properly respect parent-level flags.
  * Improved Windows compatibility.

* **Other**
  * Added optional anonymous telemetry with easy opt-out capability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->