### PR TITLE
ci: use GitHub App token to trigger CI on version PR

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -38,7 +38,7 @@ jobs:
       # (GITHUB_TOKEN cannot trigger workflows by design)
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

- Uses GitHub App token instead of `GITHUB_TOKEN` for the changesets action
- This allows the version PR to trigger CI workflows (required for auto-merge to work)
- `GITHUB_TOKEN` cannot trigger workflows by design (prevents infinite loops)

## Changes

- Added `actions/create-github-app-token@v1` step to generate token
- Updated `changesets/action` to use the app token
- Updated auto-merge step to use the app token

## Prerequisites

Already configured:
- [x] GitHub App created (`openspec-release-bot`)
- [x] App installed on OpenSpec repository
- [x] `APP_ID` variable added
- [x] `APP_PRIVATE_KEY` secret added

## Expected Flow After Merge

```
Feature PR merged → Release workflow runs → Version PR created
    → CI triggers on Version PR → CI passes → Auto-merges → Publishes to npm
```

## Test plan

- [ ] Merge this PR
- [ ] Merge a feature PR with a changeset
- [ ] Verify CI runs on the version PR (not just created, but CI actually triggers)
- [ ] Verify auto-merge completes after CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release workflow authentication updated to use a generated GitHub App token for publishing and auto-merge, improving reliability and security.
  * Token generation now occurs earlier in the workflow so subsequent release and publish steps use the app-generated credential.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->