### PR TITLE
ci: add commitMode github-api to trigger CI on version PR

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -50,6 +50,8 @@ jobs:
         with:
           title: 'chore(release): version packages'
           createGithubReleases: true
+          # Use github-api to attribute commits to the GitHub App, enabling CI triggers
+          commitMode: github-api
           # Use CI-specific release script: relies on version PR having been merged
           # so package.json already contains the bumped version.
           publish: pnpm run release:ci


### PR DESCRIPTION
## Summary

Adds `commitMode: github-api` to the changesets/action configuration.

## Why

The GitHub App token alone wasn't enough - commits were still being attributed to `github-actions[bot]` because the default `commitMode` is `git-cli`. 

With `commitMode: github-api`:
- Commits are pushed via the GitHub API
- Commits are attributed to the GitHub App (not `github-actions[bot]`)
- This allows the commits to trigger CI workflows

## References

- [changesets/action docs](https://github.com/changesets/action#with-the-github-api-commit-mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow's authentication and commit attribution process to improve CI integration reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->