### PR TITLE
ci: remove auto-merge to fix release triggering

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -47,7 +47,6 @@ jobs:
 
       # Opens/updates the Version Packages PR; publishes when the Version PR merges
       - name: Create/Update Version PR
-        id: changesets
         uses: changesets/action@v1
         with:
           title: 'chore(release): version packages'
@@ -58,10 +57,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           # npm authentication handled via OIDC trusted publishing (no token needed)
-
-      # Auto-merge the version PR when CI passes (reduces release to effectively 1 PR)
-      - name: Enable auto-merge for Version PR
-        if: steps.changesets.outputs.pullRequestNumber
-        run: gh pr merge ${{ steps.changesets.outputs.pullRequestNumber }} --auto --squash
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

Removes the auto-merge step from the release workflow.

## Why

GitHub's auto-merge feature uses an internal token that **cannot trigger workflows**. Even with manual approval, when auto-merge performs the actual merge, no workflows run.

This is why v0.19.0 didn't publish - the version PR merged but the release workflow never triggered.

## New Flow

```
Feature PR merged
    ↓
Release workflow creates Version PR
    ↓
CI runs on Version PR ✓
    ↓
User manually clicks "Merge" ← Human action triggers workflows
    ↓
Release workflow runs → publishes to npm
```

## Industry Standard

This is the common practice for changesets - manual merge of the version PR provides a checkpoint before publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions release workflow configuration by removing internal automation steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->