### PR TITLE
fix(vitest): cap worker parallelism to prevent process storms

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,12 +1,33 @@
 import { defineConfig } from 'vitest/config';
+import os from 'node:os';
+
+function resolveMaxWorkers(): number | undefined {
+  // Allow callers (CI/agents) to override without editing config.
+  const raw = process.env.VITEST_MAX_WORKERS;
+  if (raw) {
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed) && parsed > 0) {
+      return parsed;
+    }
+  }
+
+  // Vitest v3 defaults to `pool: "forks"` and scales worker processes with CPU.
+  // This repo's tests can spawn many Node processes (CLI invocations, temp FS),
+  // so cap parallelism to avoid runaway CPU/memory usage in automation.
+  const cpuCount = typeof os.availableParallelism === 'function'
+    ? os.availableParallelism()
+    : os.cpus().length;
+  return Math.min(4, Math.max(1, cpuCount));
+}
 
 export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
     globalSetup: './vitest.setup.ts',
-    // Keep default pool settings; some tests rely on process.chdir,
-    // which is not supported in worker threads
+    // Tests rely on per-file process isolation (e.g., `process.cwd()` assumptions).
+    pool: 'forks',
+    maxWorkers: resolveMaxWorkers(),
     include: ['test/**/*.test.ts'],
     coverage: {
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary
- Cap Vitest worker parallelism to prevent runaway CPU/memory usage when running tests
- Explicitly set `pool: 'forks'` since tests rely on process isolation (`process.cwd()` assumptions)
- Add `resolveMaxWorkers()` function that caps workers at `min(4, availableCPUs)`
- Allow `VITEST_MAX_WORKERS` env override for CI/automation tuning

## Test plan
- [ ] Run `npm test` locally to verify tests still pass with the new config
- [ ] Verify resource usage is more controlled during test runs
- [ ] Test with `VITEST_MAX_WORKERS=2` to confirm env override works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized test execution configuration with OS-aware worker allocation. Tests now intelligently scale worker count based on available system resources, with environment variable override support for custom configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->