### PR TITLE
fix: update polish-release-notes workflow to use correct Claude Code action parameters

### DIFF
--- a/.github/workflows/polish-release-notes.yml
+++ b/.github/workflows/polish-release-notes.yml
@@ -1,9 +1,14 @@
 name: Polish Release Notes
 
-# Triggers when changesets creates a release
+# Manual trigger after a release is published
+# The Claude Code action doesn't support 'release' event triggers directly
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Release tag to polish (e.g., v0.18.0)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -22,8 +27,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release view "${{ github.event.release.tag_name }}" --json body -q '.body' > current-notes.md
-          echo "Fetched release notes for ${{ github.event.release.tag_name }}"
+          gh release view "${{ inputs.tag_name }}" --json body -q '.body' > current-notes.md
+          echo "Fetched release notes for ${{ inputs.tag_name }}"
 
       - name: Transform release notes with Claude
         uses: anthropics/claude-code-action@v1
@@ -31,8 +36,8 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          direct_prompt: |
-            Transform the changelog in `current-notes.md` into release notes for OpenSpec ${{ github.event.release.tag_name }}.
+          prompt: |
+            Transform the changelog in `current-notes.md` into release notes for OpenSpec ${{ inputs.tag_name }}.
 
             ## Voice
 
@@ -49,7 +54,7 @@ jobs:
 
             A short title in this format:
             ```
-            ${{ github.event.release.tag_name }} - [1-4 words describing the release]
+            ${{ inputs.tag_name }} - [1-4 words describing the release]
             ```
 
             Examples:
@@ -66,7 +71,7 @@ jobs:
             ### 2. `polished-notes.md`
 
             ```markdown
-            ## What's New in ${{ github.event.release.tag_name }}
+            ## What's New in ${{ inputs.tag_name }}
 
             [One sentence: what's the theme of this release?]
 
@@ -123,7 +128,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG="${{ github.event.release.tag_name }}"
+          TAG="${{ inputs.tag_name }}"
 
           if [ -f "polished-notes.md" ] && [ -f "release-title.txt" ]; then
             TITLE=$(cat release-title.txt)


### PR DESCRIPTION
## Problem

The polish-release-notes workflow was failing with two errors:
1. **Unsupported event type**: `release` events are not supported by the Claude Code action
2. **Invalid parameter**: `direct_prompt` was deprecated in v1.0, replaced with `prompt`

See failed run: https://github.com/Fission-AI/OpenSpec/actions/runs/20985214300

## Solution

- Changed trigger from `release` event to `workflow_dispatch` (manual trigger)
- Replaced `direct_prompt` with `prompt` parameter
- Updated all tag references from `github.event.release.tag_name` to `inputs.tag_name`

## How to Use After Merge

After publishing a release, manually trigger the workflow:

1. Go to **Actions** → **Polish Release Notes**
2. Click **Run workflow**
3. Select `main` branch
4. Enter the release tag (e.g., `v0.18.0`)
5. Click **Run workflow**

The workflow will:
- Fetch the current release notes
- Polish them with Claude
- Update the release with improved notes and title

## Testing

The workflow syntax is valid and addresses both error messages from the failed run.