### PR TITLE
fix: add auto-approval for file writes in polish-release-notes workflow

### DIFF
--- a/.github/workflows/polish-release-notes.yml
+++ b/.github/workflows/polish-release-notes.yml
@@ -36,6 +36,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: "--allowedTools Write,Read"
           prompt: |
             Transform the changelog in `current-notes.md` into release notes for OpenSpec ${{ inputs.tag_name }}.
 


### PR DESCRIPTION
## Problem

The polish-release-notes workflow is failing when Claude tries to write the output files:

```
❌ Error: Claude requested permissions to write to /home/runner/work/OpenSpec/OpenSpec/release-title.txt, but you haven't granted it yet.
```

In GitHub Actions automation mode, there's no interactive user to approve file operations.

## Solution

Added `claude_args: "--allowedTools Write,Read"` to pre-approve file write and read operations.

This tells Claude Code it can use the Write and Read tools without requesting permission, which is necessary for automation contexts.

## Testing

After merging, re-run the workflow for v0.20.0 to verify it can now write the polished notes files successfully.

Related to: https://github.com/Fission-AI/OpenSpec/actions/runs/20985495417

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow configuration to enhance tool permissions and workflow reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->