### PR TITLE
feat: support project-level schemas

### DIFF
--- a/docs/experimental-workflow.md
+++ b/docs/experimental-workflow.md
@@ -473,7 +473,7 @@ Artifacts form a directed acyclic graph (DAG). Dependencies are **enablers**, no
 
 ### Custom Schemas
 
-Create your own workflow by adding a schema to `~/.local/share/openspec/schemas/`:
+Create your own workflow by adding a schema to `~/.local/share/openspec/schemas/` (or `<project>/openspec/schemas/` for project-level schemas):
 
 ```
 ~/.local/share/openspec/schemas/research-first/


### PR DESCRIPTION
## Summary

Adds support for project-level custom schemas stored in `<project>/openspec/schemas/`. This allows teams to define workflow schemas that are specific to their project without needing to install them globally.

## Changes

**Modified files:**

- `src/core/artifact-graph/resolver.ts` - Add `getProjectSchemasDir()` function; update schema resolution order to prioritize project-local schemas (project → user → package); extend `listSchemas()` and `listSchemasWithInfo()` to include project-local schemas; add `'project'` as a new source type in `SchemaInfo`
- `test/core/artifact-graph/resolver.test.ts` - Add comprehensive tests for project-local schema resolution, precedence ordering, and `listSchemasWithInfo()` functionality
- `docs/experimental-workflow.md` - Document the new project-level schemas location

## Resolution Order

Schema resolution now follows this precedence (highest to lowest):
1. **Project-local**: `<cwd>/openspec/schemas/<name>/schema.yaml`
2. **User override**: `${XDG_DATA_HOME}/openspec/schemas/<name>/schema.yaml`
3. **Package built-in**: `<package>/schemas/<name>/schema.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for project-local schemas with highest precedence and enhanced source attribution (project/user/package) in schema listings.

* **Bug Fixes / Behavior**
  * Schema resolution now deduplicates across sources and skips invalid project schemas silently.

* **Tests**
  * Added tests verifying project-local precedence, deduplication, source labeling, metadata, and error-handling.

* **Documentation**
  * Updated docs to note project-level schema location and behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->