### PR TITLE
Refine opsx archive sync assessment

### DIFF
--- a/src/core/templates/skill-templates.ts
+++ b/src/core/templates/skill-templates.ts
@@ -1565,10 +1565,10 @@ export function getArchiveChangeSkillTemplate(): SkillTemplate {
 
 4. **Assess delta spec sync state**
 
-   If no \`specs/\` directory exists in the change, proceed without sync prompt.
+   Check for delta specs at \`openspec/changes/<name>/specs/\`. If none exist, proceed without sync prompt.
 
    **If delta specs exist:**
-   - Compare each delta spec with its corresponding main spec
+   - Compare each delta spec with its corresponding main spec at \`openspec/specs/<capability>/spec.md\`
    - Determine what changes would be applied (adds, modifications, removals, renames)
    - Show a combined summary before prompting
 
@@ -1987,10 +1987,10 @@ export function getOpsxArchiveCommandTemplate(): CommandTemplate {
 
 4. **Assess delta spec sync state**
 
-   If no \`specs/\` directory exists in the change, proceed without sync prompt.
+   Check for delta specs at \`openspec/changes/<name>/specs/\`. If none exist, proceed without sync prompt.
 
    **If delta specs exist:**
-   - Compare each delta spec with its corresponding main spec
+   - Compare each delta spec with its corresponding main spec at \`openspec/specs/<capability>/spec.md\`
    - Determine what changes would be applied (adds, modifications, removals, renames)
    - Show a combined summary before prompting
 


### PR DESCRIPTION
Updates opsx archive instructions to assess delta spec sync state agentically and report a combined summary before prompting. Adds clearer prompt options and sync status wording.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized sync-assessment flow: added an explicit "Assess delta spec sync state" step with per-delta-spec evaluation and a combined summary before prompting.
  * Updated sync status wording across skill prompts (e.g., "Sync skipped" replaces prior labels) and simplified multi-step reporting into single assessment-and-prompt flows.
* **New Features**
  * When delta specs exist, users now get clear sync/ archive options based on a detailed comparison; when none exist, prompts are skipped.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->