### PR TITLE
feat(resolver): add project-local schema support

### DIFF
--- a/openspec/changes/project-local-schemas/design.md
+++ b/openspec/changes/project-local-schemas/design.md
@@ -1,0 +1,117 @@
+## Context
+
+OpenSpec currently resolves schemas from two locations:
+1. User override: `~/.local/share/openspec/schemas/<name>/`
+2. Package built-in: `<npm-package>/schemas/<name>/`
+
+This change adds a third, highest-priority level: project-local schemas at `./openspec/schemas/<name>/`.
+
+The resolver functions in `src/core/artifact-graph/resolver.ts` currently don't take a `projectRoot` parameter because user and package paths are absolute. To support project-local schemas, we need to pass project root context into the resolver.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Enable version-controlled custom workflow schemas
+- Allow teams to share schemas via git without per-machine setup
+- Maintain backward compatibility with existing resolver API
+- Integrate with `config.yaml`'s `schema` field (from project-config change)
+
+**Non-Goals:**
+- Schema inheritance or `extends` keyword
+- Template-level overrides (partial forks)
+- Schema management CLI commands (`openspec schema copy/which/diff/reset`)
+- Validation that project-local schema names don't conflict with built-ins (shadowing is intentional)
+
+## Decisions
+
+### Decision 1: Add optional `projectRoot` parameter to resolver functions
+
+**Choice:** Add optional `projectRoot?: string` parameter to resolver functions rather than using `process.cwd()` internally.
+
+**Alternatives considered:**
+- Use `process.cwd()` internally: Simpler API but implicit, harder to test, doesn't match existing codebase patterns
+- Create separate project-aware functions: No breaking changes but awkward API, callers must compose
+
+**Rationale:** The codebase already follows a pattern where CLI commands get project root via `process.cwd()` and pass it down to functions that need it. Adding an optional parameter maintains backward compatibility while enabling explicit, testable behavior.
+
+**Affected functions:**
+```typescript
+getSchemaDir(name: string, projectRoot?: string): string | null
+listSchemas(projectRoot?: string): string[]
+listSchemasWithInfo(projectRoot?: string): SchemaInfo[]
+resolveSchema(name: string, projectRoot?: string): SchemaYaml
+```
+
+### Decision 2: Resolution order is project → user → package
+
+**Choice:** Project-local schemas have highest priority, then user overrides, then package built-ins.
+
+**Rationale:**
+- Project-local should win because it represents team intent (version controlled, shared)
+- User overrides still useful for personal experimentation without affecting team
+- Package built-ins are the fallback defaults
+
+```
+1. ./openspec/schemas/<name>/              # Project-local (highest)
+2. ~/.local/share/openspec/schemas/<name>/ # User override
+3. <npm-package>/schemas/<name>/           # Package built-in (lowest)
+```
+
+### Decision 3: Add `getProjectSchemasDir()` helper function
+
+**Choice:** Create a dedicated function to get the project schemas directory path.
+
+```typescript
+function getProjectSchemasDir(projectRoot: string): string {
+  return path.join(projectRoot, 'openspec', 'schemas');
+}
+```
+
+**Rationale:** Matches existing pattern with `getPackageSchemasDir()` and `getUserSchemasDir()`. Keeps path logic centralized.
+
+### Decision 4: Extend `SchemaInfo.source` to include `'project'`
+
+**Choice:** Update the source type from `'package' | 'user'` to `'project' | 'user' | 'package'`.
+
+**Rationale:** Consumers need to distinguish project-local schemas for display purposes (e.g., `schemasCommand` output).
+
+### Decision 5: No special handling for schema name conflicts
+
+**Choice:** If a project-local schema has the same name as a built-in (e.g., `spec-driven`), the project-local version wins. No warning, no error.
+
+**Rationale:** This is intentional shadowing. Teams may want to customize a built-in schema while keeping the same name for familiarity.
+
+## Risks / Trade-offs
+
+### Risk: Confusion when project schema shadows built-in
+A team could create `openspec/schemas/spec-driven/` that shadows the built-in, causing confusion when someone expects default behavior.
+
+**Mitigation:** The `openspec schemas` command shows the source of each schema. Users can see `spec-driven (project)` vs `spec-driven (package)`.
+
+### Risk: Missing projectRoot parameter
+If callers forget to pass `projectRoot`, project-local schemas won't be found.
+
+**Mitigation:**
+- Make the change incrementally, updating call sites that need project-local support
+- Existing behavior (user + package only) is preserved when `projectRoot` is undefined
+
+### Trade-off: Optional parameter vs required
+Making `projectRoot` optional maintains backward compatibility but means some code paths may silently skip project-local resolution.
+
+**Accepted:** Backward compatibility is more important. The main entry points (CLI commands) will always pass `projectRoot`.
+
+## Implementation Approach
+
+1. **Update `resolver.ts`:**
+   - Add `getProjectSchemasDir(projectRoot: string)` function
+   - Update `getSchemaDir()` to check project-local first when `projectRoot` provided
+   - Update `listSchemas()` to include project schemas when `projectRoot` provided
+   - Update `listSchemasWithInfo()` to return `source: 'project'` for project schemas
+   - Update `SchemaInfo` type to include `'project'` in source union
+
+2. **Update `artifact-workflow.ts`:**
+   - Update `schemasCommand` to pass `projectRoot` and display source labels
+
+3. **Update call sites:**
+   - Any existing code that needs project-local resolution should pass `projectRoot`
+   - `config.yaml` schema resolution already has access to `projectRoot`

--- a/openspec/changes/project-local-schemas/specs/schema-resolution/spec.md
+++ b/openspec/changes/project-local-schemas/specs/schema-resolution/spec.md
@@ -1,0 +1,88 @@
+## ADDED Requirements
+
+### Requirement: Project-local schema resolution
+
+The system SHALL resolve schemas from the project-local directory (`./openspec/schemas/<name>/`) with highest priority when a `projectRoot` is provided.
+
+#### Scenario: Project-local schema takes precedence over user override
+- **WHEN** a schema named "my-workflow" exists at `./openspec/schemas/my-workflow/schema.yaml`
+- **AND** a schema named "my-workflow" exists at `~/.local/share/openspec/schemas/my-workflow/schema.yaml`
+- **AND** `getSchemaDir("my-workflow", projectRoot)` is called
+- **THEN** the system SHALL return the project-local path
+
+#### Scenario: Project-local schema takes precedence over package built-in
+- **WHEN** a schema named "spec-driven" exists at `./openspec/schemas/spec-driven/schema.yaml`
+- **AND** "spec-driven" is a package built-in schema
+- **AND** `getSchemaDir("spec-driven", projectRoot)` is called
+- **THEN** the system SHALL return the project-local path
+
+#### Scenario: Falls back to user override when no project-local schema
+- **WHEN** no schema named "my-workflow" exists at `./openspec/schemas/my-workflow/`
+- **AND** a schema named "my-workflow" exists at `~/.local/share/openspec/schemas/my-workflow/schema.yaml`
+- **AND** `getSchemaDir("my-workflow", projectRoot)` is called
+- **THEN** the system SHALL return the user override path
+
+#### Scenario: Falls back to package built-in when no project-local or user schema
+- **WHEN** no schema named "spec-driven" exists at `./openspec/schemas/spec-driven/`
+- **AND** no schema named "spec-driven" exists at `~/.local/share/openspec/schemas/spec-driven/`
+- **AND** "spec-driven" is a package built-in schema
+- **AND** `getSchemaDir("spec-driven", projectRoot)` is called
+- **THEN** the system SHALL return the package built-in path
+
+#### Scenario: Backward compatibility when projectRoot not provided
+- **WHEN** `getSchemaDir("my-workflow")` is called without a `projectRoot` parameter
+- **THEN** the system SHALL only check user override and package built-in locations
+- **AND** the system SHALL NOT check project-local location
+
+### Requirement: Project schemas directory helper
+
+The system SHALL provide a `getProjectSchemasDir(projectRoot)` function that returns the project-local schemas directory path.
+
+#### Scenario: Returns correct path
+- **WHEN** `getProjectSchemasDir("/path/to/project")` is called
+- **THEN** the system SHALL return `/path/to/project/openspec/schemas`
+
+### Requirement: List schemas includes project-local
+
+The system SHALL include project-local schemas when listing available schemas if `projectRoot` is provided.
+
+#### Scenario: Project-local schemas appear in list
+- **WHEN** a schema named "team-flow" exists at `./openspec/schemas/team-flow/schema.yaml`
+- **AND** `listSchemas(projectRoot)` is called
+- **THEN** the returned list SHALL include "team-flow"
+
+#### Scenario: Project-local schema shadows same-named user schema in list
+- **WHEN** a schema named "custom" exists at both project-local and user override locations
+- **AND** `listSchemas(projectRoot)` is called
+- **THEN** the returned list SHALL include "custom" exactly once
+
+#### Scenario: Backward compatibility for listSchemas
+- **WHEN** `listSchemas()` is called without a `projectRoot` parameter
+- **THEN** the system SHALL only include user override and package built-in schemas
+
+### Requirement: Schema info includes project source
+
+The system SHALL indicate `source: 'project'` for project-local schemas in `listSchemasWithInfo()` results.
+
+#### Scenario: Project-local schema shows project source
+- **WHEN** a schema named "team-flow" exists at `./openspec/schemas/team-flow/schema.yaml`
+- **AND** `listSchemasWithInfo(projectRoot)` is called
+- **THEN** the schema info for "team-flow" SHALL have `source: 'project'`
+
+#### Scenario: User override schema shows user source
+- **WHEN** a schema named "my-custom" exists only at `~/.local/share/openspec/schemas/my-custom/`
+- **AND** `listSchemasWithInfo(projectRoot)` is called
+- **THEN** the schema info for "my-custom" SHALL have `source: 'user'`
+
+#### Scenario: Package built-in schema shows package source
+- **WHEN** "spec-driven" exists only as a package built-in
+- **AND** `listSchemasWithInfo(projectRoot)` is called
+- **THEN** the schema info for "spec-driven" SHALL have `source: 'package'`
+
+### Requirement: Schemas command shows source
+
+The `openspec schemas` command SHALL display the source of each schema.
+
+#### Scenario: Display format includes source
+- **WHEN** user runs `openspec schemas`
+- **THEN** the output SHALL show each schema with its source label (project, user, or package)

--- a/openspec/changes/project-local-schemas/tasks.md
+++ b/openspec/changes/project-local-schemas/tasks.md
@@ -1,0 +1,28 @@
+## 1. Update Resolver Types and Helpers
+
+- [x] 1.1 Update `SchemaInfo.source` type to include `'project'` in `src/core/artifact-graph/resolver.ts`
+- [x] 1.2 Add `getProjectSchemasDir(projectRoot: string): string` function
+
+## 2. Update Schema Resolution Functions
+
+- [x] 2.1 Update `getSchemaDir(name, projectRoot?)` to check project-local first when projectRoot provided
+- [x] 2.2 Update `resolveSchema(name, projectRoot?)` to pass projectRoot to getSchemaDir
+- [x] 2.3 Update `listSchemas(projectRoot?)` to include project-local schemas
+- [x] 2.4 Update `listSchemasWithInfo(projectRoot?)` to include project schemas with `source: 'project'`
+
+## 3. Update CLI Commands
+
+- [x] 3.1 Update `schemasCommand` to pass projectRoot and display source labels in output
+
+## 4. Update Call Sites
+
+- [x] 4.1 Review and update call sites that need project-local schema support to pass projectRoot
+
+## 5. Testing
+
+- [x] 5.1 Add unit tests for `getProjectSchemasDir()`
+- [x] 5.2 Add unit tests for project-local schema resolution priority
+- [x] 5.3 Add unit tests for backward compatibility (no projectRoot = user + package only)
+- [x] 5.4 Add unit tests for `listSchemas()` including project schemas
+- [x] 5.5 Add unit tests for `listSchemasWithInfo()` with `source: 'project'`
+- [x] 5.6 Add integration test with temp project containing local schema

--- a/src/core/config-prompts.ts
+++ b/src/core/config-prompts.ts
@@ -33,10 +33,13 @@ export interface ConfigPromptResult {
  * Prompt user to create project config interactively.
  * Used by experimental setup command.
  *
+ * @param projectRoot - Optional project root for project-local schema resolution
  * @returns Config prompt result
  * @throws ExitPromptError if user cancels (Ctrl+C)
  */
-export async function promptForConfig(): Promise<ConfigPromptResult> {
+export async function promptForConfig(
+  projectRoot?: string
+): Promise<ConfigPromptResult> {
   // Dynamic imports to prevent pre-commit hook hangs (see #367)
   const { confirm, select, editor, checkbox } = await import('@inquirer/prompts');
 
@@ -51,7 +54,7 @@ export async function promptForConfig(): Promise<ConfigPromptResult> {
   }
 
   // Get available schemas
-  const schemas = listSchemasWithInfo();
+  const schemas = listSchemasWithInfo(projectRoot);
 
   if (schemas.length === 0) {
     throw new Error('No schemas found. Cannot create config.');
@@ -90,7 +93,7 @@ export async function promptForConfig(): Promise<ConfigPromptResult> {
 
   if (addRules) {
     // Load the selected schema to get artifact list
-    const schema = resolveSchema(selectedSchema);
+    const schema = resolveSchema(selectedSchema, projectRoot);
     const artifactIds = schema.artifacts.map((a) => a.id);
 
     // Let user select which artifacts to add rules for

--- a/src/utils/change-utils.ts
+++ b/src/utils/change-utils.ts
@@ -136,7 +136,7 @@ export async function createChange(
   }
 
   // Validate the resolved schema
-  validateSchemaName(schemaName);
+  validateSchemaName(schemaName, projectRoot);
 
   // Build the change directory path
   const changeDir = path.join(projectRoot, 'openspec', 'changes', name);
@@ -154,7 +154,7 @@ export async function createChange(
   writeChangeMetadata(changeDir, {
     schema: schemaName,
     created: today,
-  });
+  }, projectRoot);
 
   return { schema: schemaName };
 }

--- a/test/core/artifact-graph/resolver.test.ts
+++ b/test/core/artifact-graph/resolver.test.ts
@@ -5,10 +5,12 @@ import * as os from 'node:os';
 import {
   resolveSchema,
   listSchemas,
+  listSchemasWithInfo,
   SchemaLoadError,
   getSchemaDir,
   getPackageSchemasDir,
   getUserSchemasDir,
+  getProjectSchemasDir,
 } from '../../../src/core/artifact-graph/resolver.js';
 
 describe('artifact-graph/resolver', () => {
@@ -322,6 +324,338 @@ version: [[[invalid yaml
 
       expect(schemas).toContain('valid-schema');
       expect(schemas).not.toContain('empty-dir');
+    });
+  });
+
+  // =========================================================================
+  // Project-local schema tests
+  // =========================================================================
+
+  describe('getProjectSchemasDir', () => {
+    it('should return correct path', () => {
+      const projectRoot = '/path/to/project';
+      const schemasDir = getProjectSchemasDir(projectRoot);
+      expect(schemasDir).toBe('/path/to/project/openspec/schemas');
+    });
+
+    it('should work with relative-looking paths', () => {
+      const schemasDir = getProjectSchemasDir('./my-project');
+      expect(schemasDir).toBe('my-project/openspec/schemas');
+    });
+  });
+
+  describe('getSchemaDir with projectRoot', () => {
+    it('should return null for non-existent project schema', () => {
+      const dir = getSchemaDir('nonexistent-schema', tempDir);
+      expect(dir).toBeNull();
+    });
+
+    it('should prefer project-local schema over user override', () => {
+      // Set up user override
+      process.env.XDG_DATA_HOME = tempDir;
+      const userSchemaDir = path.join(tempDir, 'openspec', 'schemas', 'my-schema');
+      fs.mkdirSync(userSchemaDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(userSchemaDir, 'schema.yaml'),
+        'name: user-version\nversion: 1\nartifacts: []'
+      );
+
+      // Set up project-local schema
+      const projectRoot = path.join(tempDir, 'project');
+      const projectSchemaDir = path.join(projectRoot, 'openspec', 'schemas', 'my-schema');
+      fs.mkdirSync(projectSchemaDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(projectSchemaDir, 'schema.yaml'),
+        'name: project-version\nversion: 2\nartifacts: []'
+      );
+
+      const dir = getSchemaDir('my-schema', projectRoot);
+      expect(dir).toBe(projectSchemaDir);
+    });
+
+    it('should prefer project-local schema over package built-in', () => {
+      // Set up project-local schema that overrides built-in
+      const projectRoot = path.join(tempDir, 'project');
+      const projectSchemaDir = path.join(projectRoot, 'openspec', 'schemas', 'spec-driven');
+      fs.mkdirSync(projectSchemaDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(projectSchemaDir, 'schema.yaml'),
+        'name: project-spec-driven\nversion: 99\nartifacts: []\n'
+      );
+
+      const dir = getSchemaDir('spec-driven', projectRoot);
+      expect(dir).toBe(projectSchemaDir);
+    });
+
+    it('should fall back to user override when no project-local schema', () => {
+      // Set up user override only
+      process.env.XDG_DATA_HOME = tempDir;
+      const userSchemaDir = path.join(tempDir, 'openspec', 'schemas', 'user-only-schema');
+      fs.mkdirSync(userSchemaDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(userSchemaDir, 'schema.yaml'),
+        'name: user-only\nversion: 1\nartifacts: []'
+      );
+
+      const projectRoot = path.join(tempDir, 'project');
+      fs.mkdirSync(projectRoot, { recursive: true });
+
+      const dir = getSchemaDir('user-only-schema', projectRoot);
+      expect(dir).toBe(userSchemaDir);
+    });
+
+    it('should fall back to package built-in when no project or user schema', () => {
+      const projectRoot = path.join(tempDir, 'project');
+      fs.mkdirSync(projectRoot, { recursive: true });
+
+      const dir = getSchemaDir('spec-driven', projectRoot);
+      expect(dir).not.toBeNull();
+      // Should be package path, not project or user
+      expect(dir).not.toContain(projectRoot);
+    });
+
+    it('should maintain backward compatibility when projectRoot not provided', () => {
+      // Set up user override
+      process.env.XDG_DATA_HOME = tempDir;
+      const userSchemaDir = path.join(tempDir, 'openspec', 'schemas', 'my-schema');
+      fs.mkdirSync(userSchemaDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(userSchemaDir, 'schema.yaml'),
+        'name: user-version\nversion: 1\nartifacts: []'
+      );
+
+      // Set up project-local schema (should be ignored when projectRoot not provided)
+      const projectRoot = path.join(tempDir, 'project');
+      const projectSchemaDir = path.join(projectRoot, 'openspec', 'schemas', 'my-schema');
+      fs.mkdirSync(projectSchemaDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(projectSchemaDir, 'schema.yaml'),
+        'name: project-version\nversion: 2\nartifacts: []'
+      );
+
+      // Without projectRoot, should get user version
+      const dir = getSchemaDir('my-schema');
+      expect(dir).toBe(userSchemaDir);
+    });
+  });
+
+  describe('resolveSchema with projectRoot', () => {
+    it('should resolve project-local schema', () => {
+      const projectRoot = path.join(tempDir, 'project');
+      const projectSchemaDir = path.join(projectRoot, 'openspec', 'schemas', 'team-workflow');
+      fs.mkdirSync(projectSchemaDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(projectSchemaDir, 'schema.yaml'),
+        `name: team-workflow
+version: 1
+description: Team workflow
+artifacts:
+  - id: spec
+    generates: spec.md
+    description: Specification
+    template: spec.md
+`
+      );
+
+      const schema = resolveSchema('team-workflow', projectRoot);
+      expect(schema.name).toBe('team-workflow');
+      expect(schema.version).toBe(1);
+    });
+
+    it('should prefer project-local over user override when resolving', () => {
+      // Set up user override
+      process.env.XDG_DATA_HOME = tempDir;
+      const userSchemaDir = path.join(tempDir, 'openspec', 'schemas', 'shared-schema');
+      fs.mkdirSync(userSchemaDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(userSchemaDir, 'schema.yaml'),
+        `name: user-version
+version: 1
+artifacts:
+  - id: user-artifact
+    generates: user.md
+    description: User artifact
+    template: user.md
+`
+      );
+
+      // Set up project-local schema
+      const projectRoot = path.join(tempDir, 'project');
+      const projectSchemaDir = path.join(projectRoot, 'openspec', 'schemas', 'shared-schema');
+      fs.mkdirSync(projectSchemaDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(projectSchemaDir, 'schema.yaml'),
+        `name: project-version
+version: 2
+artifacts:
+  - id: project-artifact
+    generates: project.md
+    description: Project artifact
+    template: project.md
+`
+      );
+
+      const schema = resolveSchema('shared-schema', projectRoot);
+      expect(schema.name).toBe('project-version');
+      expect(schema.version).toBe(2);
+    });
+  });
+
+  describe('listSchemas with projectRoot', () => {
+    it('should include project-local schemas', () => {
+      const projectRoot = path.join(tempDir, 'project');
+      const projectSchemaDir = path.join(projectRoot, 'openspec', 'schemas', 'team-workflow');
+      fs.mkdirSync(projectSchemaDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(projectSchemaDir, 'schema.yaml'),
+        'name: team-workflow\nversion: 1\nartifacts: []'
+      );
+
+      const schemas = listSchemas(projectRoot);
+      expect(schemas).toContain('team-workflow');
+      expect(schemas).toContain('spec-driven'); // built-in still included
+    });
+
+    it('should deduplicate project-local schema that shadows user override', () => {
+      // Set up user override
+      process.env.XDG_DATA_HOME = tempDir;
+      const userSchemaDir = path.join(tempDir, 'openspec', 'schemas', 'my-schema');
+      fs.mkdirSync(userSchemaDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(userSchemaDir, 'schema.yaml'),
+        'name: user\nversion: 1\nartifacts: []'
+      );
+
+      // Set up project-local schema with same name
+      const projectRoot = path.join(tempDir, 'project');
+      const projectSchemaDir = path.join(projectRoot, 'openspec', 'schemas', 'my-schema');
+      fs.mkdirSync(projectSchemaDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(projectSchemaDir, 'schema.yaml'),
+        'name: project\nversion: 2\nartifacts: []'
+      );
+
+      const schemas = listSchemas(projectRoot);
+      const count = schemas.filter(s => s === 'my-schema').length;
+      expect(count).toBe(1);
+    });
+
+    it('should maintain backward compatibility when projectRoot not provided', () => {
+      // Set up project-local schema
+      const projectRoot = path.join(tempDir, 'project');
+      const projectSchemaDir = path.join(projectRoot, 'openspec', 'schemas', 'project-only');
+      fs.mkdirSync(projectSchemaDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(projectSchemaDir, 'schema.yaml'),
+        'name: project-only\nversion: 1\nartifacts: []'
+      );
+
+      // Without projectRoot, project-only schema should not appear
+      const schemas = listSchemas();
+      expect(schemas).not.toContain('project-only');
+    });
+  });
+
+  describe('listSchemasWithInfo with projectRoot', () => {
+    it('should return source: project for project-local schemas', () => {
+      const projectRoot = path.join(tempDir, 'project');
+      const projectSchemaDir = path.join(projectRoot, 'openspec', 'schemas', 'team-workflow');
+      fs.mkdirSync(projectSchemaDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(projectSchemaDir, 'schema.yaml'),
+        `name: team-workflow
+version: 1
+description: Team workflow
+artifacts:
+  - id: spec
+    generates: spec.md
+    description: Specification
+    template: spec.md
+`
+      );
+
+      const schemas = listSchemasWithInfo(projectRoot);
+      const teamSchema = schemas.find(s => s.name === 'team-workflow');
+      expect(teamSchema).toBeDefined();
+      expect(teamSchema!.source).toBe('project');
+    });
+
+    it('should return source: package for built-in schemas', () => {
+      const projectRoot = path.join(tempDir, 'project');
+      fs.mkdirSync(projectRoot, { recursive: true });
+
+      const schemas = listSchemasWithInfo(projectRoot);
+      const specDriven = schemas.find(s => s.name === 'spec-driven');
+      expect(specDriven).toBeDefined();
+      expect(specDriven!.source).toBe('package');
+    });
+
+    it('should return source: user for user override schemas', () => {
+      process.env.XDG_DATA_HOME = tempDir;
+      const userSchemaDir = path.join(tempDir, 'openspec', 'schemas', 'user-custom');
+      fs.mkdirSync(userSchemaDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(userSchemaDir, 'schema.yaml'),
+        `name: user-custom
+version: 1
+description: User custom
+artifacts:
+  - id: artifact
+    generates: artifact.md
+    description: Artifact
+    template: artifact.md
+`
+      );
+
+      const projectRoot = path.join(tempDir, 'project');
+      fs.mkdirSync(projectRoot, { recursive: true });
+
+      const schemas = listSchemasWithInfo(projectRoot);
+      const userSchema = schemas.find(s => s.name === 'user-custom');
+      expect(userSchema).toBeDefined();
+      expect(userSchema!.source).toBe('user');
+    });
+
+    it('should show project source when project-local shadows user override', () => {
+      // Set up user override
+      process.env.XDG_DATA_HOME = tempDir;
+      const userSchemaDir = path.join(tempDir, 'openspec', 'schemas', 'shared');
+      fs.mkdirSync(userSchemaDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(userSchemaDir, 'schema.yaml'),
+        `name: user-shared
+version: 1
+description: User shared
+artifacts:
+  - id: a
+    generates: a.md
+    description: A
+    template: a.md
+`
+      );
+
+      // Set up project-local with same name
+      const projectRoot = path.join(tempDir, 'project');
+      const projectSchemaDir = path.join(projectRoot, 'openspec', 'schemas', 'shared');
+      fs.mkdirSync(projectSchemaDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(projectSchemaDir, 'schema.yaml'),
+        `name: project-shared
+version: 2
+description: Project shared
+artifacts:
+  - id: b
+    generates: b.md
+    description: B
+    template: b.md
+`
+      );
+
+      const schemas = listSchemasWithInfo(projectRoot);
+      const sharedSchema = schemas.find(s => s.name === 'shared');
+      expect(sharedSchema).toBeDefined();
+      expect(sharedSchema!.source).toBe('project');
+      expect(sharedSchema!.description).toBe('Project shared'); // project version wins
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add 3-level schema resolution: project-local → user override → package built-in
- Enable projects to define custom schemas at `./openspec/schemas/<name>/`
- Extend `SchemaInfo.source` type to include `'project'` alongside existing `'user'` and `'package'`
- Update CLI commands to display schema source labels for better visibility
- Add `projectRoot` to `ChangeContext` for proper resolution throughout workflow

## Test plan
- [x] Add unit tests for `getProjectSchemasDir()`
- [x] Add unit tests for project-local schema resolution priority (project shadows user/package)
- [x] Add unit tests for backward compatibility (no projectRoot = user + package only)
- [x] Add unit tests for `listSchemas()` and `listSchemasWithInfo()` with project schemas
- [x] Add integration test with temp project containing local schema
- [x] Verify all 996 existing tests pass
- [x] Verify build and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for project-local schemas, enabling users to store custom schemas within their project directory for easy sharing and version control
  * Schema resolution now prioritizes project-local schemas over user overrides and built-in schemas
  * Enhanced schema listings to display the source of each schema (project, user, or package origin)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->