### PR TITLE
fix: Windows path compatibility in resolver tests

### DIFF
--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,24 @@
+schema: spec-driven
+
+context: |
+  Tech stack: TypeScript, Node.js (≥20.19.0), ESM modules
+  Package manager: pnpm
+  CLI framework: Commander.js
+
+  Cross-platform requirements:
+  - This tool runs on macOS, Linux, AND Windows
+  - Always use path.join() or path.resolve() for file paths - never hardcode slashes
+  - Never assume forward-slash path separators
+  - Tests must use path.join() for expected path values, not hardcoded strings
+  - Consider case sensitivity differences in file systems
+
+rules:
+  specs:
+    - Include scenarios for Windows path handling when dealing with file paths
+    - Requirements involving paths must specify cross-platform behavior
+  tasks:
+    - Add Windows CI verification as a task when changes involve file paths
+    - Include cross-platform testing considerations
+  design:
+    - Document any platform-specific behavior or limitations
+    - Prefer Node.js path module over string manipulation for paths

--- a/test/core/artifact-graph/resolver.test.ts
+++ b/test/core/artifact-graph/resolver.test.ts
@@ -335,12 +335,12 @@ version: [[[invalid yaml
     it('should return correct path', () => {
       const projectRoot = '/path/to/project';
       const schemasDir = getProjectSchemasDir(projectRoot);
-      expect(schemasDir).toBe('/path/to/project/openspec/schemas');
+      expect(schemasDir).toBe(path.join('/path/to/project', 'openspec', 'schemas'));
     });
 
     it('should work with relative-looking paths', () => {
       const schemasDir = getProjectSchemasDir('./my-project');
-      expect(schemasDir).toBe('my-project/openspec/schemas');
+      expect(schemasDir).toBe(path.join('my-project', 'openspec', 'schemas'));
     });
   });
 


### PR DESCRIPTION
## Summary
- Fix failing tests on Windows by using `path.join()` in test expectations instead of hardcoded forward slashes
- Add `openspec/config.yaml` with cross-platform requirements to prevent similar issues in future proposals

## Problem
The `getProjectSchemasDir` tests were failing on Windows CI:
```
Expected: "/path/to/project/openspec/schemas"
Received: "\path\to\project\openspec\schemas"
```

The function correctly uses `path.join()` which produces OS-specific separators, but the tests hardcoded forward slashes.

## Solution
1. **Test fix**: Use `path.join()` for expected values so tests pass on all platforms
2. **Prevention**: Add `openspec/config.yaml` that injects cross-platform requirements into all OpenSpec proposals, including:
   - Global context reminding that this tool runs on Windows, macOS, and Linux
   - Requirement to use `path.join()` for file paths
   - Per-artifact rules for specs/tasks/design to consider Windows compatibility

## Test plan
- [x] Verify tests pass locally
- [ ] Windows CI should now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced cross-platform compatibility with improved file path handling across Windows, macOS, and Linux.

* **Tests**
  * Updated tests to verify OS-agnostic file path behavior and cross-platform consistency.

* **Chores**
  * Added development configuration defining platform-specific requirements and best practices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->