### PR TITLE
fix(config): handle null rules field in project config

### DIFF
--- a/src/core/project-config.ts
+++ b/src/core/project-config.ts
@@ -117,8 +117,8 @@ export function readProjectConfig(projectRoot: string): ProjectConfig | null {
     if (raw.rules !== undefined) {
       const rulesField = z.record(z.string(), z.array(z.string()));
 
-      // First check if it's an object structure
-      if (typeof raw.rules === 'object' && !Array.isArray(raw.rules)) {
+      // First check if it's an object structure (guard against null since typeof null === 'object')
+      if (typeof raw.rules === 'object' && raw.rules !== null && !Array.isArray(raw.rules)) {
         const parsedRules: Record<string, string[]> = {};
         let hasValidRules = false;
 

--- a/test/core/project-config.test.ts
+++ b/test/core/project-config.test.ts
@@ -142,6 +142,30 @@ rules: ["not", "an", "object"]
         );
       });
 
+      it('should handle rules: null without aborting config parsing', () => {
+        // YAML `rules:` with no value parses to null
+        const configDir = path.join(tempDir, 'openspec');
+        fs.mkdirSync(configDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(configDir, 'config.yaml'),
+          `schema: spec-driven
+context: Valid context
+rules:
+`
+        );
+
+        const config = readProjectConfig(tempDir);
+
+        // Should still parse schema and context despite null rules
+        expect(config).toEqual({
+          schema: 'spec-driven',
+          context: 'Valid context',
+        });
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+          expect.stringContaining("Invalid 'rules' field")
+        );
+      });
+
       it('should filter out invalid rules for specific artifact', () => {
         const configDir = path.join(tempDir, 'openspec');
         fs.mkdirSync(configDir, { recursive: true });


### PR DESCRIPTION
## Summary
- Add null check when parsing `rules` field in project config
- YAML `rules:` with no value parses to `null`, and `typeof null === 'object'` in JavaScript
- Without this check, `Object.entries(null)` would throw an error

## Test plan
- [x] Added test case for `rules: null` scenario
- [x] Verified test passes with the fix
- [x] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed project configuration parsing to properly handle empty or null rules fields without validation errors.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->