### PR TITLE
chore: add changeset for project config and schema commands

### DIFF
--- a/.changeset/project-config-schema-commands.md
+++ b/.changeset/project-config-schema-commands.md
@@ -1,0 +1,15 @@
+---
+"@fission-ai/openspec": minor
+---
+
+### New Features
+
+- **Project-level configuration** — Configure OpenSpec behavior per-project via `openspec/config.yaml`, including custom rules injection, context files, and schema resolution settings
+
+- **Project-local schemas** — Define custom artifact schemas within your project's `openspec/schemas/` directory for project-specific workflows
+
+- **Schema management commands** — New `openspec schema` commands (`list`, `show`, `export`, `validate`) for inspecting and managing artifact schemas (experimental)
+
+### Bug Fixes
+
+- Fixed config loading to handle null `rules` field in project configuration


### PR DESCRIPTION
## Summary

Adds a changeset for the changes since v0.21.0:

### New Features

- **Project-level configuration** — Configure OpenSpec behavior per-project via `openspec/config.yaml`, including custom rules injection, context files, and schema resolution settings (#499)

- **Project-local schemas** — Define custom artifact schemas within your project's `openspec/schemas/` directory for project-specific workflows (#522)

- **Schema management commands** — New `openspec schema` commands (`list`, `show`, `export`, `validate`) for inspecting and managing artifact schemas (experimental) (#525)

### Bug Fixes

- Fixed config loading to handle null `rules` field in project configuration (#529)

---

**Version bump:** `minor` (new features)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project-level configuration enabling per-project behavior and settings
  * Project-local schemas for custom artifact schemas
  * Schema management commands to list, display, export, and validate schemas

* **Bug Fixes**
  * Fixed configuration loading to handle null rules field

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->