### PR TITLE
test: validate repository_dispatch for polish workflow

### DIFF
--- a/.github/workflows/test-polish-dispatch.yml
+++ b/.github/workflows/test-polish-dispatch.yml
@@ -1,0 +1,133 @@
+name: Test Polish Dispatch
+
+# Temporary workflow to test repository_dispatch before modifying release pipeline.
+# Delete this file after validation.
+
+on:
+  repository_dispatch:
+    types: [test-polish-notes]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Release tag to test (e.g., v0.23.0)'
+        required: true
+        type: string
+
+env:
+  # repository_dispatch passes tag via client_payload, workflow_dispatch via inputs
+  TAG_NAME: ${{ github.event.client_payload.tag_name || inputs.tag_name }}
+
+permissions:
+  contents: write
+
+jobs:
+  test-polish:
+    if: github.repository == 'Fission-AI/OpenSpec'
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Debug context
+        run: |
+          echo "Event name: ${{ github.event_name }}"
+          echo "Tag name: ${{ env.TAG_NAME }}"
+
+      - name: Get current release body
+        id: get-release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release view "${{ env.TAG_NAME }}" --json body -q '.body' > current-notes.md
+          echo "Fetched release notes for ${{ env.TAG_NAME }}"
+          echo "--- Content preview ---"
+          head -20 current-notes.md
+
+      - name: Transform release notes with Claude
+        uses: anthropics/claude-code-action@v1
+        id: claude
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          claude_args: "--allowedTools Write,Read"
+          prompt: |
+            Transform the changelog in `current-notes.md` into release notes for OpenSpec ${{ env.TAG_NAME }}.
+
+            ## Voice
+
+            OpenSpec is a developer tool. Write like you're talking to a peer:
+            - Direct and practical, not marketing copy
+            - Focus on what changed and why it matters
+            - Skip the hype, keep it real
+
+            ## Output
+
+            Create two files:
+
+            ### 1. `release-title.txt`
+
+            A short title in this format:
+            ```
+            ${{ env.TAG_NAME }} - [1-4 words describing the release]
+            ```
+
+            Examples:
+            - `v0.18.0 - OPSX Experimental Workflow`
+            - `v0.16.0 - Antigravity, iFlow Support`
+            - `v0.15.0 - Gemini CLI, RooCode`
+
+            Rules for title:
+            - Lead with the most notable addition
+            - 1-4 words after the dash, no fluff
+            - If multiple features, comma-separate the top 2
+            - For bugfix-only releases, use something like `v0.17.2 - Pre-commit Hook Fix`
+
+            ### 2. `polished-notes.md`
+
+            ```markdown
+            ## What's New in ${{ env.TAG_NAME }}
+
+            [One sentence: what's the theme of this release?]
+
+            ### New
+
+            - **Feature name** - What it does and why you'd use it
+
+            ### Improved
+
+            - **Area** - What got better
+
+            ### Fixed
+
+            - What was broken, now works
+            ```
+
+            Omit empty sections.
+
+            ## Rules
+
+            1. Write for developers using OpenSpec with AI coding assistants
+            2. Remove commit hashes (like `eb152eb:`), PR numbers, and changesets wrappers (`### Minor Changes`)
+            3. Lead with what users can do, not implementation details
+            4. One to two sentences per item, max
+            5. Use **bold** for feature/area names
+            6. Skip internal changes (CI, refactors, tests) unless they affect users
+            7. If the input is already well-formatted, just clean up structure and remove noise
+
+            Write both files. No other output.
+
+      - name: Show results (dry run - no actual update)
+        run: |
+          echo "=== DRY RUN - Would update release ${{ env.TAG_NAME }} ==="
+          echo ""
+          if [ -f "release-title.txt" ]; then
+            echo "--- Title ---"
+            cat release-title.txt
+            echo ""
+          fi
+          if [ -f "polished-notes.md" ]; then
+            echo "--- Notes ---"
+            cat polished-notes.md
+          fi
+          echo ""
+          echo "=== Test complete. If this looks good, the real workflow will work. ==="


### PR DESCRIPTION
## Summary

Temporary test workflow to validate `repository_dispatch` works before modifying the release pipeline.

## Context

The release pipeline is failing because:
1. `release` event is not supported by claude-code-action
2. `workflow_dispatch` requires `actions:write` permission (which the GitHub App doesn't have)
3. `repository_dispatch` IS supported and works with existing `contents:write` permission

## Test Plan

1. Merge this PR
2. Test via `workflow_dispatch` (manual trigger in Actions UI)
3. Test via `repository_dispatch`:
   ```bash
   gh api repos/Fission-AI/OpenSpec/dispatches --method POST --input - <<< '{"event_type":"test-polish-notes","client_payload":{"tag_name":"v0.23.0"}}'
   ```
4. If both work, implement the real fix in release-prepare.yml
5. Delete this test workflow

## Note

This is a **dry-run** workflow - it does NOT modify the release. Safe to merge and test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release notes generation process with automated formatting and structured sections for improved clarity and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->