### PR TITLE
fix: correct regex trailing whitespace and add missing projectRoot param

### DIFF
--- a/src/commands/workflow/instructions.ts
+++ b/src/commands/workflow/instructions.ts
@@ -221,7 +221,7 @@ function parseTasksFile(content: string): TaskItem[] {
 
   for (const line of lines) {
     // Match checkbox patterns: - [ ] or - [x] or - [X]
-    const checkboxMatch = line.match(/^[-*]\s*\[([ xX])\]\s*(.+)$/);
+    const checkboxMatch = line.match(/^[-*]\s*\[([ xX])\]\s*(.+)\s*$/);
     if (checkboxMatch) {
       taskIndex++;
       const done = checkboxMatch[1].toLowerCase() === 'x';
@@ -314,7 +314,7 @@ export async function generateApplyInstructions(
   const changeDir = path.join(projectRoot, 'openspec', 'changes', changeName);
 
   // Get the full schema to access the apply phase configuration
-  const schema = resolveSchema(context.schemaName);
+  const schema = resolveSchema(context.schemaName, projectRoot);
   const applyConfig = schema.apply;
 
   // Determine required artifacts and tracking file from schema


### PR DESCRIPTION
## Summary
- Add `\s*` to `parseTasksFile` regex to handle trailing whitespace in task lines
- Add missing `projectRoot` argument to `resolveSchema` call in `generateApplyInstructions`

## Test plan
- [ ] Verify task parsing works with lines containing trailing whitespace
- [ ] Verify `generateApplyInstructions` correctly resolves schema with project root

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task parsing to gracefully handle trailing whitespace in task items
  * Enhanced schema resolution to better utilize project context for improved accuracy

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->