### PR TITLE
chore: add changeset for 1.0.0 release

### DIFF
--- a/.changeset/opsx-1.0.md
+++ b/.changeset/opsx-1.0.md
@@ -2,47 +2,82 @@
 "@fission-ai/openspec": major
 ---
 
-### OpenSpec is now OPSX
+## OpenSpec 1.0 — The OPSX Release
 
-The workflow has been rebuilt from the ground up.
+The workflow has been rebuilt from the ground up. OPSX replaces the old phase-locked `/openspec:*` commands with an action-based system where AI understands what artifacts exist, what's ready to create, and what each action unlocks.
 
 ### Breaking Changes
 
-- **Old commands removed** — `/openspec:proposal`, `/openspec:apply`, and `/openspec:archive` no longer exist. Use the new `/opsx:*` commands instead.
-- **Config files removed** — Tool-specific config files (`CLAUDE.md`, `.cursorrules`, `openspec/AGENTS.md`, `openspec/project.md`) are no longer generated. OpenSpec now uses Agent Skills.
-- **Migration required** — Run `openspec update` to get the new workflow. Legacy artifacts are detected and cleaned up automatically with confirmation.
+- **Old commands removed** — `/openspec:proposal`, `/openspec:apply`, and `/openspec:archive` no longer exist
+- **Config files removed** — Tool-specific instruction files (`CLAUDE.md`, `.cursorrules`, `AGENTS.md`, `project.md`) are no longer generated
+- **Migration** — Run `openspec init` to upgrade. Legacy artifacts are detected and cleaned up with confirmation.
 
-### New Workflow
+### From Static Prompts to Dynamic Instructions
 
-- **Dynamic instructions** — AI gets contextually relevant instructions based on what artifacts exist and what's ready, not the same static prompts every time
-- **Semantic spec syncing** — Archive parses ADDED/MODIFIED/REMOVED/RENAMED at the requirement level. No more brittle header matching. Validation happens automatically.
-- **Step through changes** — `/opsx:continue` creates one artifact at a time for better context management. Or `/opsx:ff` for everything at once.
-- **Skills support** — Now using the Agent Skills standard alongside tool-specific commands
+**Before:** AI received the same static instructions every time, regardless of project state.
 
-### New Commands
+**Now:** Instructions are dynamically assembled from three layers:
+1. **Context** — Project background from `config.yaml` (tech stack, conventions)
+2. **Rules** — Artifact-specific constraints (e.g., "propose spike tasks for unknowns")
+3. **Template** — The actual structure for the output file
 
-| Command | Description |
-|---------|-------------|
+AI queries the CLI for real-time state: which artifacts exist, what's ready to create, what dependencies are satisfied, and what each action unlocks.
+
+### From Phase-Locked to Action-Based
+
+**Before:** Linear workflow — proposal → apply → archive. Couldn't easily go back or iterate.
+
+**Now:** Flexible actions on a change. Edit any artifact anytime. The artifact graph tracks state automatically.
+
+| Command | What it does |
+|---------|--------------|
+| `/opsx:explore` | Think through ideas before committing to a change |
 | `/opsx:new` | Start a new change |
-| `/opsx:ff` | Create all planning artifacts at once |
-| `/opsx:continue` | Create one artifact at a time |
+| `/opsx:continue` | Create one artifact at a time (step-through) |
+| `/opsx:ff` | Create all planning artifacts at once (fast-forward) |
 | `/opsx:apply` | Implement tasks |
-| `/opsx:archive` | Sync specs and archive the change |
-| `/opsx:onboard` | Guided walkthrough of your first complete workflow cycle |
+| `/opsx:verify` | Validate implementation matches artifacts |
+| `/opsx:sync` | Sync delta specs to main specs |
+| `/opsx:archive` | Archive completed change |
+| `/opsx:bulk-archive` | Archive multiple changes with conflict detection |
+| `/opsx:onboard` | Guided 15-minute walkthrough of complete workflow |
+
+### From Text Merging to Semantic Spec Syncing
+
+**Before:** Spec updates required manual merging or wholesale file replacement.
+
+**Now:** Delta specs use semantic markers that AI understands:
+- `## ADDED Requirements` — New requirements to add
+- `## MODIFIED Requirements` — Partial updates (add scenario without copying existing ones)
+- `## REMOVED Requirements` — Delete with reason and migration notes
+- `## RENAMED Requirements` — Rename preserving content
+
+Archive parses these at the requirement level, not brittle header matching.
+
+### From Scattered Files to Agent Skills
+
+**Before:** 8+ config files at project root + slash commands scattered across 21 tool-specific locations with different formats.
+
+**Now:** Single `.claude/skills/` directory with YAML-fronted markdown files. Auto-detected by Claude Code, Cursor, Windsurf. Cross-editor compatible.
 
 ### New Features
 
-- **Onboarding skill** — `/opsx:onboard` guides new users through their first complete OpenSpec workflow with codebase-aware task suggestions
-- **Multi-provider support** — Generate skills for 21 AI tools including Claude, Cursor, Windsurf, Continue, Gemini, GitHub Copilot, Amazon Q, and more
-- **Interactive setup** — `openspec init` launches a searchable multi-select UI for choosing which AI tools to configure
-- **Agent Skills metadata** — Skills now include license, compatibility, and metadata fields per the Agent Skills specification
+- **Onboarding skill** — `/opsx:onboard` walks new users through their first complete change with codebase-aware task suggestions and step-by-step narration (11 phases, ~15 minutes)
+
+- **21 AI tools supported** — Claude Code, Cursor, Windsurf, Continue, Gemini CLI, GitHub Copilot, Amazon Q, Cline, RooCode, Kilo Code, Auggie, CodeBuddy, Qoder, Qwen, CoStrict, Crush, Factory, OpenCode, Antigravity, iFlow, and Codex
+
+- **Interactive setup** — `openspec init` shows animated welcome screen and searchable multi-select for choosing tools. Pre-selects already-configured tools for easy refresh.
+
+- **Customizable schemas** — Define custom artifact workflows in `openspec/schemas/` without touching package code. Teams can share workflows via version control.
 
 ### Bug Fixes
 
-- Fixed Claude Code slash command parsing where colons in names caused incorrect description fallback
-- Fixed task file parsing to handle trailing whitespace
-- Fixed JSON instruction output to separate context and rules from template
+- Fixed Claude Code YAML parsing failure when command names contained colons
+- Fixed task file parsing to handle trailing whitespace on checkbox lines
+- Fixed JSON instruction output to separate context/rules from template — AI was copying constraint blocks into artifact files
 
-### Other
+### Documentation
 
-- Comprehensive documentation overhaul with new getting-started guide, workflow patterns, and customization guides
+- New getting-started guide, CLI reference, concepts documentation
+- Removed misleading "edit mid-flight and continue" claims that weren't implemented
+- Added migration guide for upgrading from pre-OPSX versions


### PR DESCRIPTION
## OpenSpec 1.0 — The OPSX Release

The workflow has been rebuilt from the ground up.

### Breaking Changes
- Old `/openspec:*` commands removed
- Config files (`CLAUDE.md`, `.cursorrules`, `AGENTS.md`, `project.md`) no longer generated
- Run `openspec init` or `openspec update` to upgrade

### What Changed

| Before | After |
|--------|-------|
| Static prompts (same every time) | Dynamic instructions (context + rules + template based on artifact state) |
| Phase-locked (proposal → apply → archive) | Action-based (any action anytime, artifact graph tracks state) |
| Text-based spec merging | Semantic syncing (ADDED/MODIFIED/REMOVED/RENAMED at requirement level) |
| 8+ scattered config files | Single `.claude/skills/` directory (Agent Skills standard) |
| 3 commands | 10 commands including explore, verify, bulk-archive, onboard |

### New Commands
- `/opsx:explore` — Think through ideas before committing
- `/opsx:new` — Start a change
- `/opsx:continue` — Create one artifact at a time (step-through)
- `/opsx:ff` — Create all artifacts at once (fast-forward)
- `/opsx:apply` — Implement tasks
- `/opsx:verify` — Validate implementation matches artifacts
- `/opsx:sync` — Sync delta specs to main specs
- `/opsx:archive` — Archive completed change
- `/opsx:bulk-archive` — Archive multiple changes with conflict detection
- `/opsx:onboard` — Guided 15-minute walkthrough

### New Features
- **Onboarding skill** — 11-phase guided first experience with codebase-aware task suggestions
- **21 AI tools** — Claude, Cursor, Windsurf, Continue, Gemini, GitHub Copilot, Amazon Q, and 14 more
- **Interactive setup** — Animated welcome screen + searchable multi-select
- **Customizable schemas** — Define workflows in `openspec/schemas/` without touching code

### Bug Fixes
- Claude Code YAML parsing failure with colons in names
- Task file trailing whitespace handling
- JSON instruction output separating context/rules from template

### Documentation
- New getting-started, CLI reference, concepts docs
- Removed misleading mid-flight editing claims
- Added migration guide

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)