### PR TITLE
chore: add changeset for spec naming clarification

### DIFF
--- a/.changeset/spec-naming-clarification.md
+++ b/.changeset/spec-naming-clarification.md
@@ -1,0 +1,8 @@
+---
+"@fission-ai/openspec": patch
+---
+
+### Bug Fixes
+
+- Clarified spec naming convention — Specs should be named after capabilities (`specs/<capability>/spec.md`), not changes
+- Fixed task checkbox format guidance — Tasks now clearly require `- [ ]` checkbox format for apply phase tracking


### PR DESCRIPTION
## Summary

Adds a changeset for changes since v1.0.1.

## Changes Included

- **Spec naming clarification** — Updated docs, schema, and templates to clarify that specs should be named after capabilities (`specs/<capability>/spec.md`), not changes
- **Task checkbox format** — Emphasized that tasks MUST use checkbox format (`- [ ]`) for apply phase tracking

## PR Reference

- fc0d798 fix: clarify spec naming convention and task checkbox format (#595)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified naming conventions for specs: they should be organized under `specs/<capability>/` directories.
  * Updated task checkbox format guidance for apply phase tracking.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->