### PR TITLE
feat: Trae Skill-only support + docs updates

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -569,6 +569,7 @@ Different AI tools use slightly different command syntax. Use the format that ma
 | Cursor | `/opsx-new`, `/opsx-apply` |
 | Windsurf | `/opsx-new`, `/opsx-apply` |
 | Copilot | `/opsx-new`, `/opsx-apply` |
+| Trae | `/openspec-new-change`, `/openspec-apply-change` |
 
 The functionality is identical regardless of syntax.
 

--- a/docs/supported-tools.md
+++ b/docs/supported-tools.md
@@ -33,6 +33,7 @@ For each tool you select, OpenSpec installs:
 | Qoder | `.qoder/skills/` | `.qoder/commands/opsx/` |
 | Qwen Code | `.qwen/skills/` | `.qwen/commands/` |
 | RooCode | `.roo/skills/` | `.roo/commands/` |
+| Trae | `.trae/skills/` | `.trae/skills/` (via `/openspec-*`) |
 | Windsurf | `.windsurf/skills/` | `.windsurf/commands/opsx/` |
 
 ## Non-Interactive Setup
@@ -50,7 +51,7 @@ openspec init --tools all
 openspec init --tools none
 ```
 
-**Available tool IDs:** `amazon-q`, `antigravity`, `auggie`, `claude`, `cline`, `codebuddy`, `codex`, `continue`, `costrict`, `crush`, `cursor`, `factory`, `gemini`, `github-copilot`, `iflow`, `kilocode`, `opencode`, `qoder`, `qwen`, `roocode`, `windsurf`
+**Available tool IDs:** `amazon-q`, `antigravity`, `auggie`, `claude`, `cline`, `codebuddy`, `codex`, `continue`, `costrict`, `crush`, `cursor`, `factory`, `gemini`, `github-copilot`, `iflow`, `kilocode`, `opencode`, `qoder`, `qwen`, `roocode`, `trae`, `windsurf`
 
 ## What Gets Installed
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -38,6 +38,7 @@ export const AI_TOOLS: AIToolOption[] = [
   { name: 'Qoder', value: 'qoder', available: true, successLabel: 'Qoder', skillsDir: '.qoder' },
   { name: 'Qwen Code', value: 'qwen', available: true, successLabel: 'Qwen Code', skillsDir: '.qwen' },
   { name: 'RooCode', value: 'roocode', available: true, successLabel: 'RooCode', skillsDir: '.roo' },
+  { name: 'Trae', value: 'trae', available: true, successLabel: 'Trae', skillsDir: '.trae' },
   { name: 'Windsurf', value: 'windsurf', available: true, successLabel: 'Windsurf', skillsDir: '.windsurf' },
   { name: 'AGENTS.md (works with Amp, VS Code, …)', value: 'agents', available: false, successLabel: 'your AGENTS.md-compatible assistant' }
 ];


### PR DESCRIPTION
Summary
- Add Trae to AI_TOOLS with skillsDir `.trae` (Skill-only)
- Keep init message logic unchanged; Trae generates skills only
- Align docs: Trae uses skill-name commands (`/openspec-new-change`, `/openspec-apply-change`)

Details
- src/core/config.ts: add Trae tool
- src/core/init.ts: unchanged message path; commands skipped for Trae (no adapter)
- docs/supported-tools.md: Trae commands location clarified as `.trae/skills/ (via /openspec-*)`
- docs/commands.md: add Trae syntax row and troubleshooting note for `.trae/skills/`

Notes
- No command adapter introduced for Trae to minimize code changes.
- Behavior verified locally: `openspec init --tools trae` creates `.trae/skills` only and shows the default message.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trae is now available as a supported AI tool option with commands `/openspec-new-change` and `/openspec-apply-change`.

* **Documentation**
  * Updated tool directory reference, available tool IDs, and setup guides to reflect Trae integration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->