### PR TITLE
Fix schema listing command in migration guide

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -466,7 +466,7 @@ When determining which schema to use, OPSX checks in order:
 List all available schemas:
 
 ```bash
-openspec workflow schemas
+openspec schemas
 ```
 
 ### Custom Schemas
@@ -510,7 +510,7 @@ Check that your `rules:` keys match your schema's artifact IDs:
 Run this to see valid artifact IDs:
 
 ```bash
-openspec workflow schemas --json
+openspec schemas --json
 ```
 
 ### Config not being applied


### PR DESCRIPTION
### Motivation
- The migration guide referenced an incorrect CLI invocation for listing schemas; the correct command is `openspec schemas` rather than `openspec workflow schemas`.

### Description
- Updated `docs/migration-guide.md` to replace `openspec workflow schemas` with `openspec schemas` and to replace `openspec workflow schemas --json` with `openspec schemas --json`.

### Testing
- Docs-only change; no automated tests were run and no runtime code paths were modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69798592c78c8322b091ca3051b2a7e8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated migration guide with corrected CLI command syntax for schema listing operations, ensuring users have accurate reference information for schema management tasks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->