### PR TITLE
fix: use path.resolve in Codex adapter test for Windows compatibility

### DIFF
--- a/test/core/command-generation/adapters.test.ts
+++ b/test/core/command-generation/adapters.test.ts
@@ -235,7 +235,7 @@ describe('command-generation/adapters', () => {
       process.env.CODEX_HOME = '/custom/codex-home';
       try {
         const filePath = codexAdapter.getFilePath('explore');
-        expect(filePath).toBe(path.join('/custom/codex-home', 'prompts', 'opsx-explore.md'));
+        expect(filePath).toBe(path.join(path.resolve('/custom/codex-home'), 'prompts', 'opsx-explore.md'));
       } finally {
         if (original !== undefined) {
           process.env.CODEX_HOME = original;


### PR DESCRIPTION
## Summary
- The `should respect CODEX_HOME env var` test failed on the Windows CI runner because the implementation uses `path.resolve()` (which adds the drive letter, e.g. `D:\`), but the test expectation used `path.join()` (which does not)
- Wraps the test's expected path with `path.resolve()` to match the implementation behavior on all platforms

## Test plan
- [x] Verified tests pass locally
- [ ] CI passes on all platforms (linux, macOS, **Windows**)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test expectations for path normalization to ensure consistent handling of custom CODEX_HOME configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->