### PR TITLE
chore: add changeset for combined v1.0.2+ fixes

### DIFF
--- a/.changeset/combined-since-v1.0.2.md
+++ b/.changeset/combined-since-v1.0.2.md
@@ -1,0 +1,10 @@
+---
+"@fission-ai/openspec": minor
+---
+
+### Bug Fixes
+
+- **Codex global path support** — Codex adapter now resolves global paths correctly, fixing workflow file generation when run outside the project directory (#622)
+- **Archive operations on cross-device or restricted paths** — Archive now falls back to copy+remove when rename fails with EPERM or EXDEV errors, fixing failures on networked/external drives (#605)
+- **Slash command hints in workflow messages** — Workflow completion messages now display helpful slash command hints for next steps (#603)
+- **Windsurf workflow file path** — Updated Windsurf adapter to use the correct `workflows` directory instead of the legacy `commands` path (#610)


### PR DESCRIPTION
## Summary

- Adds a single changeset covering all non-docs PRs merged since v1.0.2 that didn't already have changesets
- Once merged, the changeset bot will automatically update the existing "Version Packages" PR #606 to include everything in one combined release

## PRs included

- **#622** — Codex global path support (fix)
- **#605** — Archive fallback to copy+remove on EPERM/EXDEV (fix)
- **#603** — Slash command hints in workflow completion messages (fix)
- **#610** — Windsurf workflow file path update (fix)

## PRs excluded (already covered or out of scope)

- **#550** — Nix flake improvements (already has changeset at `.changeset/nix-flake-improvements.md`)
- **#615 / #623** — Dashboard command added then reverted (net zero)
- **#624** — Test-only change (Codex adapter test Windows compat)
- **#616, #601, #608** — Docs-only changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)