### PR TITLE
chore: add changeset for OpenCode command reference fix

### DIFF
--- a/.changeset/opencode-command-references.md
+++ b/.changeset/opencode-command-references.md
@@ -1,0 +1,7 @@
+---
+"@fission-ai/openspec": patch
+---
+
+### Bug Fixes
+
+- **OpenCode command references** — Command references in generated files now use the correct `/opsx-` hyphen format instead of `/opsx:` colon format, ensuring commands work properly in OpenCode


### PR DESCRIPTION
## Summary

- Adds a changeset for the OpenCode command reference fix (#626) which transforms `/opsx:` colon-based command references to `/opsx-` hyphen-based format in generated command and skill files

## Changes included

- **fix(opencode): transform command references from colon to hyphen format** — Created shared `transformToHyphenCommands()` utility, updated OpenCode adapter and skill generation to produce correct `/opsx-` references

## Test plan

- [ ] CI passes
- [ ] Changeset file is valid and triggers version bump on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected OpenCode command references in generated files to use the proper hyphen format, resolving command execution issues.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->