### PR TITLE
fix: use Skill tool for sync invocation in archive templates

### DIFF
--- a/src/core/templates/skill-templates.ts
+++ b/src/core/templates/skill-templates.ts
@@ -2155,7 +2155,7 @@ export function getArchiveChangeSkillTemplate(): SkillTemplate {
    - If changes needed: "Sync now (recommended)", "Archive without syncing"
    - If already synced: "Archive now", "Sync anyway", "Cancel"
 
-   If user chooses sync, use the Skill tool to invoke \`openspec-sync-specs\` with the change name. Proceed to archive regardless of choice.
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
 
 5. **Perform the archive**
 
@@ -2832,7 +2832,7 @@ export function getOpsxArchiveCommandTemplate(): CommandTemplate {
    - If changes needed: "Sync now (recommended)", "Archive without syncing"
    - If already synced: "Archive now", "Sync anyway", "Cancel"
 
-   If user chooses sync, use the Skill tool to invoke \`opsx:sync\` with the change name. Proceed to archive regardless of choice.
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
 
 5. **Perform the archive**
 
@@ -2926,7 +2926,7 @@ Target archive directory already exists.
 - Don't block archive on warnings - just inform and confirm
 - Preserve .openspec.yaml when moving to archive (it moves with the directory)
 - Show clear summary of what happened
-- If sync is requested, use the Skill tool to invoke \`opsx:sync\` (agent-driven)
+- If sync is requested, use the Skill tool to invoke \`openspec-sync-specs\` (agent-driven)
 - If delta specs exist, always run the sync assessment and show the combined summary before prompting`
   };
 }


### PR DESCRIPTION
**Summary**
Fix `/opsx:archive` template to properly invoke sync via Skill tool instead of referencing slash command logic

**Problem**
The archive template told the agent to "execute `/opsx:sync` logic" - but agents can't directly execute slash commands. They must use the Skill tool to invoke skills programmatically.  
This caused the agent to improvise sync behavior incorrectly, resulting in malformed spec files without `## Purpose` section. `openspec list --specs` would show **0 requirements** even when specs existed.

**Fix**
Replace command references with explicit Skill tool invocations:
```diff
- If user chooses sync, execute /opsx:sync logic
+ If user chooses sync, use the Skill tool to invoke `openspec-sync-specs`
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Refined the synchronization flow used during archival for more consistent handling of delta specs.
  * Clarified final guidance wording around sync options so instructions are more actionable.
  * Delta-spec analysis summary is now shown before prompting; archival proceeds regardless of the sync choice.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->