### PR TITLE
fix(onboard): replace broken preflight check with direct config file test

### DIFF
--- a/.changeset/fix-onboarding-preflight.md
+++ b/.changeset/fix-onboarding-preflight.md
@@ -1,0 +1,5 @@
+---
+"openspec": patch
+---
+
+Fix onboarding preflight check that incorrectly reported freshly initialized projects as not initialized. Replaced `openspec status --json` (which requires an existing change) with a direct `openspec/config.yaml` existence check. Also added an `openspec --version` check to verify the CLI is installed.

--- a/src/core/templates/skill-templates.ts
+++ b/src/core/templates/skill-templates.ts
@@ -937,16 +937,23 @@ function getOnboardInstructions(): string {
 
 ## Preflight
 
-Before starting, check if OpenSpec is initialized:
+Before starting, check if the OpenSpec CLI is installed and the project is initialized:
 
 \`\`\`bash
-openspec status --json 2>&1 || echo "NOT_INITIALIZED"
+openspec --version 2>&1 || echo "CLI_NOT_INSTALLED"
 \`\`\`
+
+\`\`\`bash
+test -f openspec/config.yaml && echo "INITIALIZED" || echo "NOT_INITIALIZED"
+\`\`\`
+
+**If CLI not installed:**
+> OpenSpec CLI is not installed. Install it first, then come back to \`/opsx:onboard\`.
 
 **If not initialized:**
 > OpenSpec isn't set up in this project yet. Run \`openspec init\` first, then come back to \`/opsx:onboard\`.
 
-Stop here if not initialized.
+Stop here if either check fails.
 
 ---
 


### PR DESCRIPTION
## Summary

- The onboarding preflight used `openspec status --json` to detect project initialization, but that command requires an existing change — so it always failed on a freshly initialized project (no changes yet), creating a loop where users were told to run `openspec init` again
- Replaced with two direct checks: `openspec --version` (CLI installed?) and `test -f openspec/config.yaml` (project initialized?)

## Test plan

- [ ] Run `openspec init` in a fresh project, then trigger onboarding — preflight should pass
- [ ] Run onboarding in a directory without `openspec/config.yaml` — should report "not initialized"
- [ ] Run onboarding without the CLI installed — should report "CLI not installed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved onboarding preflight validation to properly detect CLI installation and project initialization status, providing clearer feedback when requirements are missing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->