### PR TITLE
chore: remove broken changeset from #637

### DIFF
--- a/.changeset/fix-onboarding-preflight.md
+++ b/.changeset/fix-onboarding-preflight.md
@@ -1,5 +1,0 @@
----
-"openspec": patch
----
-
-Fix onboarding preflight check that incorrectly reported freshly initialized projects as not initialized. Replaced `openspec status --json` (which requires an existing change) with a direct `openspec/config.yaml` existence check. Also added an `openspec --version` check to verify the CLI is installed.


### PR DESCRIPTION
## Summary

- Removes the changeset added in #637 which referenced `"openspec"` instead of `"@fission-ai/openspec"`, causing the Release (prepare) action to fail on main

## Test plan

- [ ] Verify Release (prepare) action passes on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)