### PR TITLE
feat: add Kimi CLI as a supported AI tool

### DIFF
--- a/.changeset/plenty-bats-smile.md
+++ b/.changeset/plenty-bats-smile.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+Add Kimi CLI as a supported AI tool

--- a/docs/supported-tools.md
+++ b/docs/supported-tools.md
@@ -35,6 +35,7 @@ For each tool you select, OpenSpec installs:
 | RooCode | `.roo/skills/` | `.roo/commands/` |
 | Trae | `.trae/skills/` | `.trae/skills/` (via `/openspec-*`) |
 | Windsurf | `.windsurf/skills/` | `.windsurf/workflows/` |
+| Kimi CLI | `.kimi/skills/` | `.kimi/commands/` |
 
 \* Codex commands are installed to the global home directory (`~/.codex/prompts/` or `$CODEX_HOME/prompts/`), not the project directory.
 
@@ -53,7 +54,7 @@ openspec init --tools all
 openspec init --tools none
 ```
 
-**Available tool IDs:** `amazon-q`, `antigravity`, `auggie`, `claude`, `cline`, `codebuddy`, `codex`, `continue`, `costrict`, `crush`, `cursor`, `factory`, `gemini`, `github-copilot`, `iflow`, `kilocode`, `opencode`, `qoder`, `qwen`, `roocode`, `trae`, `windsurf`
+**Available tool IDs:** `amazon-q`, `antigravity`, `auggie`, `claude`, `cline`, `codebuddy`, `codex`, `continue`, `costrict`, `crush`, `cursor`, `factory`, `gemini`, `github-copilot`, `iflow`, `kilocode`, `opencode`, `qoder`, `qwen`, `roocode`, `trae`, `windsurf`, `kimi`
 
 ## What Gets Installed
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -40,5 +40,6 @@ export const AI_TOOLS: AIToolOption[] = [
   { name: 'RooCode', value: 'roocode', available: true, successLabel: 'RooCode', skillsDir: '.roo' },
   { name: 'Trae', value: 'trae', available: true, successLabel: 'Trae', skillsDir: '.trae' },
   { name: 'Windsurf', value: 'windsurf', available: true, successLabel: 'Windsurf', skillsDir: '.windsurf' },
+  { name: 'Kimi CLI', value: 'kimi', available: true, successLabel: 'Kimi CLI', skillsDir: '.kimi' },
   { name: 'AGENTS.md (works with Amp, VS Code, …)', value: 'agents', available: false, successLabel: 'your AGENTS.md-compatible assistant' }
 ];


### PR DESCRIPTION
## Description

Adds Kimi CLI as a new supported AI tool in OpenSpec.

## Changes

- Added Kimi CLI configuration to `AI_TOOLS` array in `src/core/config.ts`
- Updated `docs/supported-tools.md` with Kimi CLI documentation

## Skills Directory

- Skills are installed to `.kimi/skills/`
- Commands are installed to `.kimi/commands/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kimi CLI as a supported AI tool, expanding available options.

* **Documentation**
  * Updated tool directory reference and setup documentation to include Kimi CLI with configuration details and command locations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->