### PR TITLE
fix(nix): remove unnecessary dontNpmPrune option

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,8 @@
               runHook postBuild
             '';
 
+            dontNpmPrune = true;
+
             meta = with pkgs.lib; {
               description = "AI-native system for spec-driven development";
               homepage = "https://github.com/Fission-AI/OpenSpec";


### PR DESCRIPTION
## Summary

- Remove the `dontNpmPrune = true` option from `flake.nix` as it is not needed when using `pnpmConfigHook`

## Context

The `dontNpmPrune` option was originally added to prevent npm from pruning devDependencies after installation. However, since this project uses pnpm (via `pnpmConfigHook`), this option is unnecessary as pnpm handles dependency management differently.

## Testing

This change will be validated by the `nix-flake-validate` CI job which:
- Runs `nix build`
- Verifies the build output exists
- Tests binary execution with `--version`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted build pruning behavior to follow default tooling during builds.
  * Increased CI validation job timeout to allow longer execution windows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->