### PR TITLE
fix: improve Windows compatibility in tests

### DIFF
--- a/test/commands/spec.test.ts
+++ b/test/commands/spec.test.ts
@@ -55,7 +55,7 @@ The system SHALL process credit card payments securely`;
   });
 
   describe('spec show', () => {
-    it('should display spec in text format', () => {
+    it('should display spec in text format', async () => {
       const originalCwd = process.cwd();
       try {
         process.chdir(testDir);
@@ -64,7 +64,7 @@ The system SHALL process credit card payments securely`;
         });
         
         // Raw passthrough should match spec.md content
-        const raw = execSync(`cat ${path.join(specsDir, 'auth', 'spec.md')}`, { encoding: 'utf-8' });
+        const raw = await fs.readFile(path.join(specsDir, 'auth', 'spec.md'), 'utf-8');
         expect(output.trim()).toBe(raw.trim());
       } finally {
         process.chdir(originalCwd);

--- a/test/commands/validate.enriched-output.test.ts
+++ b/test/commands/validate.enriched-output.test.ts
@@ -18,12 +18,12 @@ describe('validate command enriched human output', () => {
     await fs.rm(testDir, { recursive: true, force: true });
   });
 
-  it('prints Next steps footer and guidance on invalid change', () => {
+  it('prints Next steps footer and guidance on invalid change', async () => {
     const changeContent = `# Test Change\n\n## Why\nThis is a sufficiently long explanation to pass the why length requirement for validation purposes.\n\n## What Changes\nThere are changes proposed, but no delta specs provided yet.`;
     const changeId = 'c-next-steps';
     const changePath = path.join(changesDir, changeId);
-    execSync(`mkdir -p ${changePath}`);
-    execSync(`bash -lc "cat > ${path.join(changePath, 'proposal.md')} <<'EOF'\n${changeContent}\nEOF"`);
+    await fs.mkdir(changePath, { recursive: true });
+    await fs.writeFile(path.join(changePath, 'proposal.md'), changeContent);
 
     const originalCwd = process.cwd();
     try {

--- a/test/utils/file-system.test.ts
+++ b/test/utils/file-system.test.ts
@@ -237,7 +237,8 @@ describe('FileSystemUtils', () => {
       expect(canWrite).toBe(false);
     });
 
-    it('should follow symbolic links to files', async () => {
+    // Skip on Windows: creating symlinks requires elevated privileges or Developer Mode
+    it.skipIf(process.platform === 'win32')('should follow symbolic links to files', async () => {
       const realFile = path.join(testDir, 'real-file.txt');
       const linkFile = path.join(testDir, 'link-file.txt');
       await fs.writeFile(realFile, 'content');


### PR DESCRIPTION
- Replace Unix 'cat' command with fs.readFile in spec.test.ts

- Replace 'mkdir -p' and 'bash' commands with fs.mkdir/writeFile in validate.enriched-output.test.ts

- Skip symlink test on Windows (requires admin privileges) in file-system.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure with asynchronous file operations for improved reliability and maintainability.
  * Enhanced Windows platform compatibility by adding conditional test skipping for platform-specific scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->