### PR TITLE
feat: Support Trae by Slash Command

### DIFF
--- a/src/core/command-generation/adapters/index.ts
+++ b/src/core/command-generation/adapters/index.ts
@@ -24,4 +24,5 @@ export { opencodeAdapter } from './opencode.js';
 export { qoderAdapter } from './qoder.js';
 export { qwenAdapter } from './qwen.js';
 export { roocodeAdapter } from './roocode.js';
+export { traeAdapter } from './trae.js';
 export { windsurfAdapter } from './windsurf.js';

--- a/src/core/command-generation/adapters/trae.ts
+++ b/src/core/command-generation/adapters/trae.ts
@@ -1,0 +1,47 @@
+/**
+ * Trae Command Adapter
+ *
+ * Formats commands for Trae following its frontmatter specification.
+ * Trae uses a similar frontmatter format to Cursor with file naming convention.
+ */
+
+import path from 'path';
+import type { CommandContent, ToolCommandAdapter } from '../types.js';
+
+/**
+ * Escapes a string value for safe YAML output.
+ * Quotes the string if it contains special YAML characters.
+ */
+function escapeYamlValue(value: string): string {
+  const needsQuoting = /[:\n\r#{}[\],&*!|>'"%@`]|^\s|\s$/.test(value);
+  if (needsQuoting) {
+    const escaped = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n');
+    return `"${escaped}"`;
+  }
+  return value;
+}
+
+/**
+ * Trae adapter for command generation.
+ * File path: .trae/commands/opsx-<id>.md
+ * Frontmatter: name (as /opsx-<id>), id, category, description
+ */
+export const traeAdapter: ToolCommandAdapter = {
+  toolId: 'trae',
+
+  getFilePath(commandId: string): string {
+    return path.join('.trae', 'commands', `opsx-${commandId}.md`);
+  },
+
+  formatFile(content: CommandContent): string {
+    return `---
+name: /opsx-${content.id}
+id: opsx-${content.id}
+category: ${escapeYamlValue(content.category)}
+description: ${escapeYamlValue(content.description)}
+---
+
+${content.body}
+`;
+  },
+};

--- a/src/core/command-generation/registry.ts
+++ b/src/core/command-generation/registry.ts
@@ -26,6 +26,7 @@ import { opencodeAdapter } from './adapters/opencode.js';
 import { qoderAdapter } from './adapters/qoder.js';
 import { qwenAdapter } from './adapters/qwen.js';
 import { roocodeAdapter } from './adapters/roocode.js';
+import { traeAdapter } from './adapters/trae.js';
 import { windsurfAdapter } from './adapters/windsurf.js';
 
 /**
@@ -56,6 +57,7 @@ export class CommandAdapterRegistry {
     CommandAdapterRegistry.register(qoderAdapter);
     CommandAdapterRegistry.register(qwenAdapter);
     CommandAdapterRegistry.register(roocodeAdapter);
+    CommandAdapterRegistry.register(traeAdapter);
     CommandAdapterRegistry.register(windsurfAdapter);
   }
 


### PR DESCRIPTION
# Description
Enhance the use of OpenSpec in Trae by supporting slash commands.
# Changes
A new adapter has been added to src/core/command-generation/adapters/trae.ts to generate trae slash command files.
# Commands Directory
Commands are installed to .trae/commands/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Trae adapter for the command generation system, enabling commands to be formatted and stored as Markdown files with structured metadata including name, ID, category, and description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->