### PR TITLE
feat(core): add Lingma IDE support

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -84,7 +84,7 @@ openspec init [path] [options]
 | `--tools <list>` | Configure AI tools non-interactively. Use `all`, `none`, or comma-separated list |
 | `--force` | Auto-cleanup legacy files without prompting |
 
-**Supported tools:** `amazon-q`, `antigravity`, `auggie`, `claude`, `cline`, `codex`, `codebuddy`, `continue`, `costrict`, `crush`, `cursor`, `factory`, `gemini`, `github-copilot`, `iflow`, `kilocode`, `opencode`, `qoder`, `qwen`, `roocode`, `windsurf`
+**Supported tools:** `amazon-q`, `antigravity`, `auggie`, `claude`, `cline`, `codex`, `codebuddy`, `continue`, `costrict`, `crush`, `cursor`, `factory`, `gemini`, `github-copilot`, `iflow`, `kilocode`, `lingma`, `opencode`, `qoder`, `qwen`, `roocode`, `windsurf`
 
 **Examples:**
 

--- a/docs/supported-tools.md
+++ b/docs/supported-tools.md
@@ -28,6 +28,7 @@ For each tool you select, OpenSpec installs:
 | Gemini CLI | `.gemini/skills/` | `.gemini/commands/opsx/` |
 | GitHub Copilot | `.github/skills/` | `.github/prompts/` |
 | iFlow | `.iflow/skills/` | `.iflow/commands/` |
+| Lingma | `.lingma/skills/` | `.lingma/commands/` |
 | Kilo Code | `.kilocode/skills/` | `.kilocode/workflows/` |
 | OpenCode | `.opencode/skills/` | `.opencode/command/` |
 | Qoder | `.qoder/skills/` | `.qoder/commands/opsx/` |
@@ -53,7 +54,7 @@ openspec init --tools all
 openspec init --tools none
 ```
 
-**Available tool IDs:** `amazon-q`, `antigravity`, `auggie`, `claude`, `cline`, `codebuddy`, `codex`, `continue`, `costrict`, `crush`, `cursor`, `factory`, `gemini`, `github-copilot`, `iflow`, `kilocode`, `opencode`, `qoder`, `qwen`, `roocode`, `trae`, `windsurf`
+**Available tool IDs:** `amazon-q`, `antigravity`, `auggie`, `claude`, `cline`, `codebuddy`, `codex`, `continue`, `costrict`, `crush`, `cursor`, `factory`, `gemini`, `github-copilot`, `iflow`, `lingma`, `kilocode`, `opencode`, `qoder`, `qwen`, `roocode`, `trae`, `windsurf`
 
 ## What Gets Installed
 

--- a/docs/supported-tools.md
+++ b/docs/supported-tools.md
@@ -28,8 +28,8 @@ For each tool you select, OpenSpec installs:
 | Gemini CLI | `.gemini/skills/` | `.gemini/commands/opsx/` |
 | GitHub Copilot | `.github/skills/` | `.github/prompts/` |
 | iFlow | `.iflow/skills/` | `.iflow/commands/` |
-| Lingma | `.lingma/skills/` | `.lingma/commands/` |
 | Kilo Code | `.kilocode/skills/` | `.kilocode/workflows/` |
+| Lingma | `.lingma/skills/` | `.lingma/commands/opsx/` |
 | OpenCode | `.opencode/skills/` | `.opencode/command/` |
 | Qoder | `.qoder/skills/` | `.qoder/commands/opsx/` |
 | Qwen Code | `.qwen/skills/` | `.qwen/commands/` |
@@ -54,7 +54,7 @@ openspec init --tools all
 openspec init --tools none
 ```
 
-**Available tool IDs:** `amazon-q`, `antigravity`, `auggie`, `claude`, `cline`, `codebuddy`, `codex`, `continue`, `costrict`, `crush`, `cursor`, `factory`, `gemini`, `github-copilot`, `iflow`, `lingma`, `kilocode`, `opencode`, `qoder`, `qwen`, `roocode`, `trae`, `windsurf`
+**Available tool IDs:** `amazon-q`, `antigravity`, `auggie`, `claude`, `cline`, `codebuddy`, `codex`, `continue`, `costrict`, `crush`, `cursor`, `factory`, `gemini`, `github-copilot`, `iflow`, `kilocode`, `lingma`, `opencode`, `qoder`, `qwen`, `roocode`, `trae`, `windsurf`
 
 ## What Gets Installed
 

--- a/src/core/command-generation/adapters/index.ts
+++ b/src/core/command-generation/adapters/index.ts
@@ -20,6 +20,7 @@ export { geminiAdapter } from './gemini.js';
 export { githubCopilotAdapter } from './github-copilot.js';
 export { iflowAdapter } from './iflow.js';
 export { kilocodeAdapter } from './kilocode.js';
+export { lingmaAdapter } from './lingma.js';
 export { opencodeAdapter } from './opencode.js';
 export { qoderAdapter } from './qoder.js';
 export { qwenAdapter } from './qwen.js';

--- a/src/core/command-generation/adapters/lingma.ts
+++ b/src/core/command-generation/adapters/lingma.ts
@@ -9,25 +9,25 @@ import type { CommandContent, ToolCommandAdapter } from '../types.js';
 
 /**
  * Lingma adapter for command generation.
- * File path: .lingma/commands/opsx-<id>.md
+ * File path: .lingma/commands/opsx/<id>.md
  * Structure: Command markdown files with YAML frontmatter
  */
 export const lingmaAdapter: ToolCommandAdapter = {
   toolId: 'lingma',
 
   getFilePath(commandId: string): string {
-    return path.join('.lingma', 'commands', `opsx-${commandId}.md`);
+    return path.join('.lingma', 'commands', 'opsx', `${commandId}.md`);
   },
 
   formatFile(content: CommandContent): string {
+    const tagsStr = content.tags.join(', ');
     return `---
-name: /opsx-${content.id}
-id: opsx-${content.id}
-category: ${content.category}
+name: ${content.name}
 description: ${content.description}
+category: ${content.category}
+tags: [${tagsStr}]
 ---
 
-${content.body}
-`;
+${content.body}`;
   },
 };

--- a/src/core/command-generation/adapters/lingma.ts
+++ b/src/core/command-generation/adapters/lingma.ts
@@ -1,0 +1,33 @@
+/**
+ * Lingma Command Adapter
+ *
+ * Formats commands for Lingma following its skill specification.
+ */
+ 
+import path from 'path';
+import type { CommandContent, ToolCommandAdapter } from '../types.js';
+
+/**
+ * Lingma adapter for command generation.
+ * File path: .lingma/commands/opsx-<id>.md
+ * Structure: Command markdown files with YAML frontmatter
+ */
+export const lingmaAdapter: ToolCommandAdapter = {
+  toolId: 'lingma',
+
+  getFilePath(commandId: string): string {
+    return path.join('.lingma', 'commands', `opsx-${commandId}.md`);
+  },
+
+  formatFile(content: CommandContent): string {
+    return `---
+name: /opsx-${content.id}
+id: opsx-${content.id}
+category: ${content.category}
+description: ${content.description}
+---
+
+${content.body}
+`;
+  },
+};

--- a/src/core/command-generation/registry.ts
+++ b/src/core/command-generation/registry.ts
@@ -22,6 +22,7 @@ import { geminiAdapter } from './adapters/gemini.js';
 import { githubCopilotAdapter } from './adapters/github-copilot.js';
 import { iflowAdapter } from './adapters/iflow.js';
 import { kilocodeAdapter } from './adapters/kilocode.js';
+import { lingmaAdapter } from './adapters/lingma.js';
 import { opencodeAdapter } from './adapters/opencode.js';
 import { qoderAdapter } from './adapters/qoder.js';
 import { qwenAdapter } from './adapters/qwen.js';
@@ -52,6 +53,7 @@ export class CommandAdapterRegistry {
     CommandAdapterRegistry.register(githubCopilotAdapter);
     CommandAdapterRegistry.register(iflowAdapter);
     CommandAdapterRegistry.register(kilocodeAdapter);
+    CommandAdapterRegistry.register(lingmaAdapter);
     CommandAdapterRegistry.register(opencodeAdapter);
     CommandAdapterRegistry.register(qoderAdapter);
     CommandAdapterRegistry.register(qwenAdapter);

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -39,6 +39,7 @@ export const AI_TOOLS: AIToolOption[] = [
   { name: 'Qwen Code', value: 'qwen', available: true, successLabel: 'Qwen Code', skillsDir: '.qwen' },
   { name: 'RooCode', value: 'roocode', available: true, successLabel: 'RooCode', skillsDir: '.roo' },
   { name: 'Trae', value: 'trae', available: true, successLabel: 'Trae', skillsDir: '.trae' },
+  { name: 'Lingma', value: 'lingma', available: true, successLabel: 'Lingma', skillsDir: '.lingma' },
   { name: 'Windsurf', value: 'windsurf', available: true, successLabel: 'Windsurf', skillsDir: '.windsurf' },
   { name: 'AGENTS.md (works with Amp, VS Code, …)', value: 'agents', available: false, successLabel: 'your AGENTS.md-compatible assistant' }
 ];

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -34,12 +34,12 @@ export const AI_TOOLS: AIToolOption[] = [
   { name: 'GitHub Copilot', value: 'github-copilot', available: true, successLabel: 'GitHub Copilot', skillsDir: '.github' },
   { name: 'iFlow', value: 'iflow', available: true, successLabel: 'iFlow', skillsDir: '.iflow' },
   { name: 'Kilo Code', value: 'kilocode', available: true, successLabel: 'Kilo Code', skillsDir: '.kilocode' },
+  { name: 'Lingma', value: 'lingma', available: true, successLabel: 'Lingma', skillsDir: '.lingma' },
   { name: 'OpenCode', value: 'opencode', available: true, successLabel: 'OpenCode', skillsDir: '.opencode' },
   { name: 'Qoder', value: 'qoder', available: true, successLabel: 'Qoder', skillsDir: '.qoder' },
   { name: 'Qwen Code', value: 'qwen', available: true, successLabel: 'Qwen Code', skillsDir: '.qwen' },
   { name: 'RooCode', value: 'roocode', available: true, successLabel: 'RooCode', skillsDir: '.roo' },
   { name: 'Trae', value: 'trae', available: true, successLabel: 'Trae', skillsDir: '.trae' },
-  { name: 'Lingma', value: 'lingma', available: true, successLabel: 'Lingma', skillsDir: '.lingma' },
   { name: 'Windsurf', value: 'windsurf', available: true, successLabel: 'Windsurf', skillsDir: '.windsurf' },
   { name: 'AGENTS.md (works with Amp, VS Code, …)', value: 'agents', available: false, successLabel: 'your AGENTS.md-compatible assistant' }
 ];

--- a/src/core/legacy-cleanup.ts
+++ b/src/core/legacy-cleanup.ts
@@ -33,7 +33,6 @@ export const LEGACY_SLASH_COMMAND_PATHS: Record<string, LegacySlashCommandPatter
   // Directory-based: .tooldir/commands/openspec/ or .tooldir/commands/openspec/*.md
   'claude': { type: 'directory', path: '.claude/commands/openspec' },
   'codebuddy': { type: 'directory', path: '.codebuddy/commands/openspec' },
-  'lingma': { type: 'directory', path: '.lingma/commands/opsx' },
   'qoder': { type: 'directory', path: '.qoder/commands/openspec' },
   'crush': { type: 'directory', path: '.crush/commands/openspec' },
   'gemini': { type: 'directory', path: '.gemini/commands/openspec' },

--- a/src/core/legacy-cleanup.ts
+++ b/src/core/legacy-cleanup.ts
@@ -33,6 +33,7 @@ export const LEGACY_SLASH_COMMAND_PATHS: Record<string, LegacySlashCommandPatter
   // Directory-based: .tooldir/commands/openspec/ or .tooldir/commands/openspec/*.md
   'claude': { type: 'directory', path: '.claude/commands/openspec' },
   'codebuddy': { type: 'directory', path: '.codebuddy/commands/openspec' },
+  'lingma': { type: 'directory', path: '.lingma/commands/opsx' },
   'qoder': { type: 'directory', path: '.qoder/commands/openspec' },
   'crush': { type: 'directory', path: '.crush/commands/openspec' },
   'gemini': { type: 'directory', path: '.gemini/commands/openspec' },
@@ -52,7 +53,6 @@ export const LEGACY_SLASH_COMMAND_PATHS: Record<string, LegacySlashCommandPatter
   'continue': { type: 'files', pattern: '.continue/prompts/openspec-*.prompt' },
   'antigravity': { type: 'files', pattern: '.agent/workflows/openspec-*.md' },
   'iflow': { type: 'files', pattern: '.iflow/commands/openspec-*.md' },
-  'lingma': { type: 'files', pattern: '.lingma/commands/openspec-*.md' },
   'qwen': { type: 'files', pattern: '.qwen/commands/openspec-*.toml' },
   'codex': { type: 'files', pattern: '.codex/prompts/openspec-*.md' },
 };

--- a/src/core/legacy-cleanup.ts
+++ b/src/core/legacy-cleanup.ts
@@ -52,6 +52,7 @@ export const LEGACY_SLASH_COMMAND_PATHS: Record<string, LegacySlashCommandPatter
   'continue': { type: 'files', pattern: '.continue/prompts/openspec-*.prompt' },
   'antigravity': { type: 'files', pattern: '.agent/workflows/openspec-*.md' },
   'iflow': { type: 'files', pattern: '.iflow/commands/openspec-*.md' },
+  'lingma': { type: 'files', pattern: '.lingma/commands/openspec-*.md' },
   'qwen': { type: 'files', pattern: '.qwen/commands/openspec-*.toml' },
   'codex': { type: 'files', pattern: '.codex/prompts/openspec-*.md' },
 };

--- a/test/core/command-generation/adapters.test.ts
+++ b/test/core/command-generation/adapters.test.ts
@@ -550,21 +550,21 @@ describe('command-generation/adapters', () => {
 
     it('should generate correct file path', () => {
       const filePath = lingmaAdapter.getFilePath('explore');
-      expect(filePath).toBe(path.join('.lingma', 'commands', 'opsx-explore.md'));
+      expect(filePath).toBe(path.join('.lingma', 'commands', 'opsx', 'explore.md'));
     });
 
     it('should generate correct file paths for different commands', () => {
-      expect(lingmaAdapter.getFilePath('new')).toBe(path.join('.lingma', 'commands', 'opsx-new.md'));
-      expect(lingmaAdapter.getFilePath('apply')).toBe(path.join('.lingma', 'commands', 'opsx-apply.md'));
+      expect(lingmaAdapter.getFilePath('new')).toBe(path.join('.lingma', 'commands', 'opsx', 'new.md'));
+      expect(lingmaAdapter.getFilePath('apply')).toBe(path.join('.lingma', 'commands', 'opsx', 'apply.md'));
     });
 
-    it('should format file with name, id, category, and description', () => {
+    it('should format file with name, description, category, and tags', () => {
       const output = lingmaAdapter.formatFile(sampleContent);
       expect(output).toContain('---\n');
-      expect(output).toContain('name: /opsx-explore');
-      expect(output).toContain('id: opsx-explore');
-      expect(output).toContain('category: Workflow');
+      expect(output).toContain('name: OpenSpec Explore');
       expect(output).toContain('description: Enter explore mode for thinking');
+      expect(output).toContain('category: Workflow');
+      expect(output).toContain('tags: [workflow, explore, experimental]');
       expect(output).toContain('---\n\n');
       expect(output).toContain('This is the command body.\n\nWith multiple lines.');
     });

--- a/test/core/command-generation/adapters.test.ts
+++ b/test/core/command-generation/adapters.test.ts
@@ -17,6 +17,7 @@ import { geminiAdapter } from '../../../src/core/command-generation/adapters/gem
 import { githubCopilotAdapter } from '../../../src/core/command-generation/adapters/github-copilot.js';
 import { iflowAdapter } from '../../../src/core/command-generation/adapters/iflow.js';
 import { kilocodeAdapter } from '../../../src/core/command-generation/adapters/kilocode.js';
+import { lingmaAdapter } from '../../../src/core/command-generation/adapters/lingma.js';
 import { opencodeAdapter } from '../../../src/core/command-generation/adapters/opencode.js';
 import { qoderAdapter } from '../../../src/core/command-generation/adapters/qoder.js';
 import { qwenAdapter } from '../../../src/core/command-generation/adapters/qwen.js';
@@ -542,6 +543,33 @@ describe('command-generation/adapters', () => {
     });
   });
 
+  describe('lingmaAdapter', () => {
+    it('should have correct toolId', () => {
+      expect(lingmaAdapter.toolId).toBe('lingma');
+    });
+
+    it('should generate correct file path', () => {
+      const filePath = lingmaAdapter.getFilePath('explore');
+      expect(filePath).toBe(path.join('.lingma', 'commands', 'opsx-explore.md'));
+    });
+
+    it('should generate correct file paths for different commands', () => {
+      expect(lingmaAdapter.getFilePath('new')).toBe(path.join('.lingma', 'commands', 'opsx-new.md'));
+      expect(lingmaAdapter.getFilePath('apply')).toBe(path.join('.lingma', 'commands', 'opsx-apply.md'));
+    });
+
+    it('should format file with name, id, category, and description', () => {
+      const output = lingmaAdapter.formatFile(sampleContent);
+      expect(output).toContain('---\n');
+      expect(output).toContain('name: /opsx-explore');
+      expect(output).toContain('id: opsx-explore');
+      expect(output).toContain('category: Workflow');
+      expect(output).toContain('description: Enter explore mode for thinking');
+      expect(output).toContain('---\n\n');
+      expect(output).toContain('This is the command body.\n\nWith multiple lines.');
+    });
+  });
+
   describe('cross-platform path handling', () => {
     it('Claude adapter uses path.join for paths', () => {
       // path.join handles platform-specific separators
@@ -566,7 +594,7 @@ describe('command-generation/adapters', () => {
         amazonQAdapter, antigravityAdapter, auggieAdapter, clineAdapter,
         codexAdapter, codebuddyAdapter, continueAdapter, costrictAdapter,
         crushAdapter, factoryAdapter, geminiAdapter, githubCopilotAdapter,
-        iflowAdapter, kilocodeAdapter, opencodeAdapter, qoderAdapter,
+        iflowAdapter, kilocodeAdapter, lingmaAdapter, opencodeAdapter, qoderAdapter,
         qwenAdapter, roocodeAdapter
       ];
       for (const adapter of adapters) {


### PR DESCRIPTION
# PR Description

## Summary
Added Lingma IDE support to OpenSpec. Lingma IDE is an Alibaba product with millions of users in China. It recently added skills and slash command support, making OpenSpec integration essential to serve this large user base with structured AI-assisted development workflows. Official website:https://lingma.aliyun.com/

## Changes
- Added `lingma.ts` command adapter with proper file path structure (`.lingma/commands/opsx-<id>.md`)
- Updated registry to include Lingma adapter
- Added Lingma to legacy cleanup patterns
- Created comprehensive tests covering all adapter functionality
- Updated documentation in `supported-tools.md`

## Key Features
- Generates 10 command files with YAML frontmatter format
- Creates proper skill directory structure
- Supports all standard OPSX workflow commands
- Cross-platform path handling

Generated with Qwen using Lingma IDE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lingma is now available as a supported tool in OpenSpec for command generation and skill management.

* **Documentation**
  * CLI docs and tool reference updated to list Lingma and include it in non-interactive setup examples.

* **Tests**
  * Added test coverage to validate Lingma adapter behavior and cross-platform path handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->