### PR TITLE
docs: recommend bun for global installs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,6 +6,14 @@
 
 ## Package Managers
 
+### bun (recommended)
+
+```bash
+bun add -g @fission-ai/openspec@latest
+```
+
+> **Why bun?** Bun blocks untrusted postinstall scripts by default, giving you visibility into what runs during installation. For example, OpenSpec includes a postinstall script that auto-installs shell completions — npm runs it silently, while bun surfaces it so you can review and opt in via `bun pm trust`. For packages you install globally, this default-deny behavior is a meaningful supply chain security improvement.
+
 ### npm
 
 ```bash
@@ -22,12 +30,6 @@ pnpm add -g @fission-ai/openspec@latest
 
 ```bash
 yarn global add @fission-ai/openspec@latest
-```
-
-### bun
-
-```bash
-bun add -g @fission-ai/openspec@latest
 ```
 
 ## Nix


### PR DESCRIPTION
Bun blocks untrusted postinstall scripts by default. OpenSpec's `postinstall` auto-installs shell completions — npm runs it silently, bun surfaces it for review. For globally installed CLIs, that matters.

Moves bun to the top of the install options in `docs/installation.md` with a short note explaining why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Installation guide restructured to highlight bun as the recommended package manager option, now prominently positioned with detailed information about its security posture and postinstall behavior to help users make informed installation choices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->