### PR TITLE
feat: add extensible lifecycle hooks for schemas and project config (…

### DIFF
--- a/openspec/changes/add-lifecycle-hooks/.openspec.yaml
+++ b/openspec/changes/add-lifecycle-hooks/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-09

--- a/openspec/changes/add-lifecycle-hooks/design.md
+++ b/openspec/changes/add-lifecycle-hooks/design.md
@@ -1,0 +1,196 @@
+## Context
+
+OpenSpec schemas define artifact creation workflows (proposal, specs, design, tasks) with instructions for each artifact. Operations like archive, sync, new, and apply are orchestrated by skills (LLM prompt files) that call CLI commands. There is currently no mechanism for schemas or projects to inject custom behavior at operation lifecycle points.
+
+The existing `openspec instructions` command already demonstrates the pattern: it reads schema + config, merges them (instruction from schema, context/rules from config), and outputs enriched data for the LLM. Hooks follow the same architecture.
+
+Key files:
+- Schema types: `src/core/artifact-graph/types.ts` (Zod schemas for `SchemaYaml`)
+- Schema resolution: `src/core/artifact-graph/resolver.ts`
+- Instruction loading: `src/core/artifact-graph/instruction-loader.ts`
+- Project config: `src/core/project-config.ts`
+- CLI commands: `src/commands/workflow/instructions.ts`
+- Skill templates: `src/core/templates/skill-templates.ts` (source of truth, generates agent skills via `openspec update`)
+
+## Goals / Non-Goals
+
+**Goals:**
+- Allow schemas to define LLM instruction hooks at operation lifecycle points
+- Allow projects to add/extend hooks via config.yaml
+- Expose hooks via a CLI command for skills to consume
+- Update archive skill as first consumer (other skills follow same pattern)
+
+**Non-Goals:**
+- Shell script execution (`run` field) — deferred to future iteration
+- Variable substitution in hook instructions — deferred
+- Hook-level dependency/ordering between hooks — schema first, config second is sufficient
+- Hooks on artifact creation — artifact `instruction` already covers this
+
+## Decisions
+
+### Decision 1: Hook YAML structure
+
+Hooks use a flat key-value structure under a `hooks` key, where each key is a lifecycle point:
+
+```yaml
+# In schema.yaml or config.yaml
+hooks:
+  post-archive:
+    instruction: |
+      Review the archived change and generate ADR entries...
+  pre-apply:
+    instruction: |
+      Before implementing, verify all specs are consistent...
+```
+
+**Why this over nested structure**: Flat keys are simpler to parse, validate, and merge. Each lifecycle point maps to exactly one hook per source (schema or config). No need for arrays of hooks per point — if a schema author needs multiple actions, they write them as a single instruction.
+
+**Alternative considered**: Array of hooks per lifecycle point (`post-archive: [{instruction: ...}, {instruction: ...}]`). Rejected because it adds complexity without clear benefit — a single instruction can contain multiple steps, and the schema/config split already provides two layers.
+
+### Decision 2: New CLI command `openspec hooks`
+
+A new top-level command rather than a flag on `openspec instructions`:
+
+```bash
+openspec hooks <lifecycle-point> [--change "<name>"] [--json]
+```
+
+The `--change` flag is optional. When provided, hooks are resolved from the change's schema (via metadata) and the project config. When omitted, the schema is resolved from `config.yaml`'s default `schema` field, and hooks are returned from both schema and config. This ensures lifecycle points like `pre-new` (where no change exists yet) still receive schema-level hooks.
+
+Output (JSON mode, with change):
+```json
+{
+  "lifecyclePoint": "post-archive",
+  "changeName": "add-dark-mode",
+  "hooks": [
+    { "source": "schema", "instruction": "Generate ADR entries..." },
+    { "source": "config", "instruction": "Notify Slack channel..." }
+  ]
+}
+```
+
+Output (JSON mode, without change — schema resolved from config.yaml):
+```json
+{
+  "lifecyclePoint": "pre-new",
+  "changeName": null,
+  "hooks": [
+    { "source": "schema", "instruction": "Verify prerequisites before creating change..." },
+    { "source": "config", "instruction": "Notify Slack channel..." }
+  ]
+}
+```
+
+Output (text mode):
+```
+## Hooks: post-archive (change: add-dark-mode)
+
+### From schema (spec-driven)
+Generate ADR entries...
+
+### From config
+Notify Slack channel...
+```
+
+**Why new command over extending `instructions`**: The `instructions` command is artifact-scoped — it takes an artifact ID and returns creation instructions. Hooks are operation-scoped — they relate to lifecycle events, not artifacts. A separate command keeps concerns clean and makes skill integration straightforward.
+
+**Alternative considered**: `openspec instructions --hook post-archive`. Rejected because it conflates two different concepts (artifact instructions vs operation hooks) in one command.
+
+### Decision 3: Schema type extension
+
+Extend `SchemaYamlSchema` in `types.ts` with an optional `hooks` field:
+
+```typescript
+const HookSchema = z.object({
+  instruction: z.string().min(1),
+});
+
+const HooksSchema = z.record(z.string(), HookSchema).optional();
+
+// Added to SchemaYamlSchema
+hooks: HooksSchema,
+```
+
+Validation of lifecycle point keys happens at a higher level (in the hook resolution function), not in the Zod schema. This keeps the schema format forward-compatible — new lifecycle points can be added without changing the Zod schema.
+
+**Why not validate keys in Zod**: Using `z.enum()` for keys would make the schema rigid. A `z.record()` with runtime validation of keys (with warnings for unknown keys) is more resilient and matches the pattern used for config `rules` validation.
+
+### Decision 4: Config extension
+
+Extend `ProjectConfigSchema` in `project-config.ts` with the same `hooks` structure:
+
+```typescript
+hooks: z.record(z.string(), z.object({
+  instruction: z.string(),
+})).optional(),
+```
+
+Parsed using the same resilient field-by-field approach already used for `rules`.
+
+### Decision 5: Hook resolution function
+
+New function in `instruction-loader.ts`:
+
+```typescript
+interface ResolvedHook {
+  source: 'schema' | 'config';
+  instruction: string;
+}
+
+function resolveHooks(
+  projectRoot: string,
+  changeName: string | null,
+  lifecyclePoint: string
+): ResolvedHook[]
+```
+
+This function:
+1. If `changeName` is provided, resolves the schema from the change's metadata (via existing `resolveSchemaForChange`)
+2. If `changeName` is null, resolves the schema from `config.yaml`'s `schema` field (if configured)
+3. Reads schema hooks for the lifecycle point (if a schema was resolved)
+4. Reads config hooks for the lifecycle point
+5. Returns array: schema hooks first (if any), then config hooks
+6. Warns on unrecognized lifecycle points
+
+### Decision 6: Skill integration pattern
+
+Skills call the CLI command and follow the returned instructions. Example for archive skill:
+
+```
+# Before archive operation:
+openspec hooks pre-archive --change "<name>" --json
+→ If hooks returned, follow each instruction in order
+
+# [normal archive steps...]
+
+# After archive operation:
+openspec hooks post-archive --change "<name>" --json
+→ If hooks returned, follow each instruction in order
+```
+
+The skill templates in `src/core/templates/skill-templates.ts` are updated to include these steps, and `openspec generate` regenerates the output files. This is the same pattern as how skills already call `openspec instructions` and `openspec status`.
+
+## Testing Strategy
+
+Three levels of testing, following existing patterns in the codebase:
+
+**Unit tests** — Pure logic, no filesystem or CLI:
+- `test/core/artifact-graph/schema.test.ts` — Extend with hook parsing tests: valid hooks, missing hooks, empty hooks, invalid instruction
+- `test/core/project-config.test.ts` — Extend with config hook parsing: valid, invalid, unknown lifecycle points, resilient parsing
+- `test/core/artifact-graph/instruction-loader.test.ts` — Extend with `resolveHooks()` tests: schema only, config only, both (ordering), neither, null changeName (config-only)
+
+**CLI integration tests** — Run the actual CLI binary:
+- `test/commands/artifact-workflow.test.ts` — Extend with `openspec hooks` command tests: with --change, without --change, no hooks found, invalid lifecycle point, JSON output format
+
+**Skill template tests** — Verify generated content:
+- Existing skill template tests (if any) extended to verify hook steps appear in generated output
+
+## Risks / Trade-offs
+
+- **[LLM compliance]** Hooks are instructions the LLM should follow, but there's no guarantee it will execute them perfectly. → Mitigation: Same limitation applies to artifact instructions, which work well in practice. Hook instructions should be written as clear, actionable prompts.
+- **[Hook sprawl]** Users might define too many hooks, making operations slow. → Mitigation: Start with 8 lifecycle points only. Each hook adds one CLI call + LLM reasoning time, which is bounded.
+- **[Schema/config conflict]** Both define hooks for the same point — user might expect override semantics. → Mitigation: Document clearly that both execute (schema first, config second). This is additive, not override.
+
+## Resolved Questions
+
+- **Should `openspec hooks` work without `--change`?** Yes. Without `--change`, the schema is resolved from `config.yaml`'s default `schema` field, so both schema and config hooks are returned. This is essential for lifecycle points like `pre-new` where the change doesn't exist yet but the project's default schema is known. If no schema is configured in `config.yaml`, only config hooks are returned.

--- a/openspec/changes/add-lifecycle-hooks/proposal.md
+++ b/openspec/changes/add-lifecycle-hooks/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+OpenSpec schemas define artifact creation instructions but have no way to inject custom behavior at operation lifecycle points (archive, sync, new, apply). Users need project-specific and workflow-specific actions at these points — consolidating error logs on archive, generating ADRs, notifying external systems, updating documentation indexes — but today the only option is manual post-hoc work or hardcoding behavior into skills.
+
+Related issues: #682 (extensible hook capability), #557 (ADR lifecycle hooks), #328 (Claude Hooks integration), #331 (auto-update project.md on archive), #369 (post-archive actions).
+
+## What Changes
+
+- Add a `hooks` section to `schema.yaml` for workflow-level lifecycle hooks (LLM instructions that run at operation boundaries)
+- Add a `hooks` section to `config.yaml` for project-level lifecycle hooks
+- Create a CLI command to resolve and return hooks for a given lifecycle point. With `--change`, resolves schema from the change's metadata. Without `--change`, resolves schema from `config.yaml`'s default `schema` field. Both modes return schema + config hooks (schema first)
+- Update skills (archive, sync, new, apply) to query and execute hooks at their lifecycle points
+- Hooks are LLM instructions only in this iteration — no `run` field for shell execution (deferred to future iteration)
+
+Supported lifecycle points:
+- `pre-new` / `post-new` — creating a change
+- `pre-archive` / `post-archive` — archiving a change
+- `pre-sync` / `post-sync` — syncing delta specs
+- `pre-apply` / `post-apply` — implementing tasks
+
+## Capabilities
+
+### New Capabilities
+- `lifecycle-hooks`: Core hook resolution system — schema/config parsing, merging, and CLI exposure of lifecycle hook instructions
+
+### Modified Capabilities
+- `artifact-graph`: Schema YAML type extended with optional `hooks` section
+- `instruction-loader`: New function/command to resolve hooks for a lifecycle point
+- `cli-archive`: Archive operation awareness of pre/post hooks (CLI level)
+- `opsx-archive-skill`: Archive skill executes hooks at pre/post-archive points
+- `specs-sync-skill`: Sync skill executes hooks at pre/post-sync points
+- `cli-artifact-workflow`: New `openspec hooks` command registered alongside existing workflow commands
+
+## Impact
+
+- **Schema format**: `schema.yaml` gains optional `hooks` field — fully backward compatible (no hooks = no change)
+- **Config format**: `config.yaml` gains optional `hooks` field — fully backward compatible
+- **CLI**: New `openspec hooks` command to resolve and retrieve hooks for a lifecycle point (with optional `--change` flag)
+- **Skills**: Archive, sync, new, and apply skills gain hook execution steps
+- **Existing schemas**: Unaffected — `hooks` is optional
+- **Tests**: New tests for hook parsing, merging, resolution, and validation

--- a/openspec/changes/add-lifecycle-hooks/specs/artifact-graph/spec.md
+++ b/openspec/changes/add-lifecycle-hooks/specs/artifact-graph/spec.md
@@ -1,0 +1,43 @@
+# artifact-graph Delta Spec
+
+## MODIFIED Requirements
+
+### Requirement: Schema Loading
+
+The system SHALL load artifact graph definitions from YAML schema files within schema directories, including an optional `hooks` section.
+
+#### Scenario: Valid schema loaded
+
+- **WHEN** a schema directory contains a valid `schema.yaml` file
+- **THEN** the system returns an ArtifactGraph with all artifacts and dependencies
+
+#### Scenario: Schema with hooks section
+
+- **WHEN** a schema `schema.yaml` contains a `hooks` section
+- **THEN** the system parses the hooks alongside artifacts
+- **AND** the parsed schema includes the hooks data
+
+#### Scenario: Invalid schema rejected
+
+- **WHEN** a schema YAML file is missing required fields
+- **THEN** the system throws an error with a descriptive message
+
+#### Scenario: Cyclic dependencies detected
+
+- **WHEN** a schema contains cyclic artifact dependencies
+- **THEN** the system throws an error listing the artifact IDs in the cycle
+
+#### Scenario: Invalid dependency reference
+
+- **WHEN** an artifact's `requires` array references a non-existent artifact ID
+- **THEN** the system throws an error identifying the invalid reference
+
+#### Scenario: Duplicate artifact IDs rejected
+
+- **WHEN** a schema contains multiple artifacts with the same ID
+- **THEN** the system throws an error identifying the duplicate
+
+#### Scenario: Schema directory not found
+
+- **WHEN** resolving a schema name that has no corresponding directory
+- **THEN** the system throws an error listing available schemas

--- a/openspec/changes/add-lifecycle-hooks/specs/cli-artifact-workflow/spec.md
+++ b/openspec/changes/add-lifecycle-hooks/specs/cli-artifact-workflow/spec.md
@@ -1,0 +1,44 @@
+# cli-artifact-workflow Delta Spec
+
+## ADDED Requirements
+
+### Requirement: Hooks Command
+
+The system SHALL provide an `openspec hooks` command to retrieve resolved lifecycle hooks for a given point and change.
+
+#### Scenario: Retrieve hooks with change context
+
+- **WHEN** user runs `openspec hooks <lifecycle-point> --change "<name>"`
+- **THEN** the system resolves the schema from the change's metadata
+- **AND** reads hooks from both schema and config
+- **AND** outputs the resolved hooks in order (schema first, config second)
+
+#### Scenario: Retrieve hooks without change context
+
+- **WHEN** user runs `openspec hooks <lifecycle-point>` without `--change`
+- **THEN** the system resolves the schema from `config.yaml`'s default `schema` field
+- **AND** reads hooks from both the resolved schema and config (schema first, config second)
+- **AND** sets `changeName` to null in JSON output
+- **AND** if no schema is configured in `config.yaml`, returns config hooks only
+
+#### Scenario: JSON output
+
+- **WHEN** user runs `openspec hooks <lifecycle-point> [--change "<name>"] --json`
+- **THEN** the system outputs JSON with `lifecyclePoint`, `changeName` (string or null), and `hooks` array
+- **AND** each hook includes `source` ("schema" or "config") and `instruction` fields
+
+#### Scenario: Text output
+
+- **WHEN** user runs `openspec hooks <lifecycle-point>` without `--json`
+- **THEN** the system outputs human-readable formatted hooks grouped by source
+
+#### Scenario: No hooks found
+
+- **WHEN** no hooks are defined for the given lifecycle point
+- **THEN** the system outputs an empty hooks array in JSON mode
+- **AND** an informational message in text mode
+
+#### Scenario: Invalid lifecycle point
+
+- **WHEN** the lifecycle point argument is not a recognized value
+- **THEN** the system exits with an error listing valid lifecycle points

--- a/openspec/changes/add-lifecycle-hooks/specs/instruction-loader/spec.md
+++ b/openspec/changes/add-lifecycle-hooks/specs/instruction-loader/spec.md
@@ -1,0 +1,31 @@
+# instruction-loader Delta Spec
+
+## ADDED Requirements
+
+### Requirement: Hook Resolution
+
+The system SHALL resolve lifecycle hooks for a given lifecycle point by reading from both schema and project config, returning them in execution order.
+
+#### Scenario: Resolve hooks with change context
+
+- **WHEN** `resolveHooks(projectRoot, changeName, lifecyclePoint)` is called with a non-null `changeName`
+- **THEN** the system reads the schema associated with the change
+- **AND** reads the project config
+- **AND** returns hooks from both sources, schema hooks first, config hooks second
+
+#### Scenario: Resolve hooks without change context
+
+- **WHEN** `resolveHooks(projectRoot, null, lifecyclePoint)` is called with null `changeName`
+- **THEN** the system resolves the schema from `config.yaml`'s default `schema` field
+- **AND** reads hooks from both the resolved schema and project config (schema first, config second)
+- **AND** if no schema is configured in `config.yaml`, returns only config hooks
+
+#### Scenario: No hooks defined
+
+- **WHEN** neither schema nor config define hooks for the given lifecycle point
+- **THEN** the system returns an empty array
+
+#### Scenario: Hook result structure
+
+- **WHEN** hooks are resolved
+- **THEN** each hook object includes `source` (string: "schema" or "config") and `instruction` (string)

--- a/openspec/changes/add-lifecycle-hooks/specs/lifecycle-hooks/spec.md
+++ b/openspec/changes/add-lifecycle-hooks/specs/lifecycle-hooks/spec.md
@@ -1,0 +1,137 @@
+# Lifecycle Hooks Specification
+
+## Purpose
+Lifecycle hooks allow schemas and projects to define LLM instructions that execute at operation boundaries (pre/post archive, sync, new, apply). Schema-level hooks define workflow-inherent behavior; project-level hooks add project-specific customization. Both are surfaced to the LLM via a CLI command.
+
+## Requirements
+
+### Requirement: Hook Definition in Schema
+
+The system SHALL support an optional `hooks` section in `schema.yaml` where each key is a lifecycle point and each value contains an `instruction` field.
+
+#### Scenario: Schema with hooks defined
+
+- **WHEN** a `schema.yaml` contains a `hooks` section with valid lifecycle point keys
+- **THEN** the system parses each hook with its `instruction` field
+- **AND** makes them available for resolution
+
+#### Scenario: Schema without hooks
+
+- **WHEN** a `schema.yaml` does not contain a `hooks` section
+- **THEN** the system proceeds normally with no hooks
+- **AND** no errors are raised
+
+#### Scenario: Invalid lifecycle point key
+
+- **WHEN** a `hooks` section contains a key that is not a recognized lifecycle point
+- **THEN** the system emits a warning identifying the unrecognized key
+- **AND** ignores the invalid entry
+
+### Requirement: Hook Definition in Project Config
+
+The system SHALL support an optional `hooks` section in `config.yaml` with the same structure as schema hooks.
+
+#### Scenario: Config with hooks defined
+
+- **WHEN** `config.yaml` contains a `hooks` section with valid lifecycle point keys
+- **THEN** the system parses each hook with its `instruction` field
+- **AND** makes them available for resolution
+
+#### Scenario: Config without hooks
+
+- **WHEN** `config.yaml` does not contain a `hooks` section
+- **THEN** the system proceeds normally with no hooks
+
+### Requirement: Valid Lifecycle Points
+
+The system SHALL recognize the following lifecycle points as valid hook keys:
+
+- `pre-new`, `post-new`
+- `pre-archive`, `post-archive`
+- `pre-sync`, `post-sync`
+- `pre-apply`, `post-apply`
+
+#### Scenario: All valid lifecycle points accepted
+
+- **WHEN** hooks are defined for any of the recognized lifecycle points
+- **THEN** the system accepts and stores them without warnings
+
+#### Scenario: Unknown lifecycle point
+
+- **WHEN** a hook is defined for an unrecognized lifecycle point (e.g., `post-deploy`)
+- **THEN** the system emits a warning: `Unknown lifecycle point: "post-deploy"`
+- **AND** ignores the entry
+
+### Requirement: Hook Resolution Order
+
+The system SHALL resolve hooks for a given lifecycle point by returning schema hooks first, then config hooks.
+
+#### Scenario: Both schema and config define hooks for the same point
+
+- **WHEN** both `schema.yaml` and `config.yaml` define a hook for `post-archive`
+- **THEN** the system returns both hooks in order: schema hook first, config hook second
+- **AND** each hook is tagged with its source (`schema` or `config`)
+
+#### Scenario: Only schema defines a hook
+
+- **WHEN** only `schema.yaml` defines a hook for `post-archive`
+- **THEN** the system returns only the schema hook
+
+#### Scenario: Only config defines a hook
+
+- **WHEN** only `config.yaml` defines a hook for `post-archive`
+- **THEN** the system returns only the config hook
+
+#### Scenario: No hooks defined for a point
+
+- **WHEN** neither schema nor config define a hook for a lifecycle point
+- **THEN** the system returns an empty list
+
+### Requirement: Hook CLI Command
+
+The system SHALL expose a CLI command to retrieve resolved hooks for a given lifecycle point, optionally scoped to a change.
+
+#### Scenario: Retrieve hooks with change context
+
+- **WHEN** executing `openspec hooks <lifecycle-point> --change "<name>"`
+- **THEN** the system resolves the schema from the change's metadata
+- **AND** reads hooks from both schema and config
+- **AND** outputs the resolved hooks in order (schema first, config second)
+
+#### Scenario: Retrieve hooks without change context
+
+- **WHEN** executing `openspec hooks <lifecycle-point>` without `--change`
+- **THEN** the system resolves the schema from `config.yaml`'s default `schema` field
+- **AND** reads hooks from both the resolved schema and config (schema first, config second)
+- **AND** sets `changeName` to null in JSON output
+- **AND** if no schema is configured in `config.yaml`, returns config hooks only
+
+#### Scenario: JSON output
+
+- **WHEN** executing with `--json` flag
+- **THEN** the system outputs a JSON object with `lifecyclePoint`, `changeName` (string or null), and `hooks` array
+- **AND** each hook includes `source` ("schema" or "config") and `instruction` fields
+
+#### Scenario: No hooks found
+
+- **WHEN** no hooks are defined for the given lifecycle point
+- **THEN** the system outputs an empty result (empty array in JSON mode, informational message in text mode)
+
+#### Scenario: Invalid lifecycle point argument
+
+- **WHEN** the lifecycle point argument is not a recognized value
+- **THEN** the system exits with an error listing valid lifecycle points
+
+### Requirement: Hook Instruction Content
+
+Hook instructions SHALL be free-form text intended as LLM prompts. The system does not interpret or execute them — it surfaces them for the LLM agent to follow.
+
+#### Scenario: Multiline instruction
+
+- **WHEN** a hook instruction contains multiple lines
+- **THEN** the system preserves the full content including newlines
+
+#### Scenario: Instruction with template references
+
+- **WHEN** a hook instruction references file paths or change context
+- **THEN** the system passes the instruction as-is (no variable substitution in this iteration)

--- a/openspec/changes/add-lifecycle-hooks/specs/opsx-archive-skill/spec.md
+++ b/openspec/changes/add-lifecycle-hooks/specs/opsx-archive-skill/spec.md
@@ -1,0 +1,33 @@
+# opsx-archive-skill Delta Spec
+
+## ADDED Requirements
+
+### Requirement: Lifecycle Hook Execution
+
+The archive skill SHALL execute lifecycle hooks at the pre-archive and post-archive points.
+
+#### Scenario: Pre-archive hooks exist
+
+- **WHEN** the agent begins the archive operation
+- **AND** hooks are defined for the `pre-archive` lifecycle point
+- **THEN** the agent retrieves hook instructions via `openspec hooks pre-archive --change "<name>" --json`
+- **AND** follows each hook instruction in order (schema hooks first, then config hooks)
+- **AND** proceeds with the archive operation after completing hook instructions
+
+#### Scenario: Post-archive hooks exist
+
+- **WHEN** the archive operation completes successfully (change moved to archive)
+- **AND** hooks are defined for the `post-archive` lifecycle point
+- **THEN** the agent retrieves hook instructions via `openspec hooks post-archive --change "<name>" --json`
+- **AND** follows each hook instruction in order (schema hooks first, then config hooks)
+
+#### Scenario: No hooks defined
+
+- **WHEN** no hooks are defined for `pre-archive` or `post-archive`
+- **THEN** the agent proceeds with the archive operation as normal
+- **AND** no additional steps are added
+
+#### Scenario: Hook instruction references change context
+
+- **WHEN** a hook instruction references the change name, archived location, or change artifacts
+- **THEN** the agent uses its knowledge of the current operation context to fulfill the instruction

--- a/openspec/changes/add-lifecycle-hooks/specs/specs-sync-skill/spec.md
+++ b/openspec/changes/add-lifecycle-hooks/specs/specs-sync-skill/spec.md
@@ -1,0 +1,28 @@
+# specs-sync-skill Delta Spec
+
+## ADDED Requirements
+
+### Requirement: Lifecycle Hook Execution
+
+The sync skill SHALL execute lifecycle hooks at the pre-sync and post-sync points.
+
+#### Scenario: Pre-sync hooks exist
+
+- **WHEN** the agent begins the sync operation
+- **AND** hooks are defined for the `pre-sync` lifecycle point
+- **THEN** the agent retrieves hook instructions via `openspec hooks pre-sync --change "<name>" --json`
+- **AND** follows each hook instruction in order (schema hooks first, then config hooks)
+- **AND** proceeds with the sync operation after completing hook instructions
+
+#### Scenario: Post-sync hooks exist
+
+- **WHEN** the sync operation completes successfully
+- **AND** hooks are defined for the `post-sync` lifecycle point
+- **THEN** the agent retrieves hook instructions via `openspec hooks post-sync --change "<name>" --json`
+- **AND** follows each hook instruction in order (schema hooks first, then config hooks)
+
+#### Scenario: No hooks defined
+
+- **WHEN** no hooks are defined for `pre-sync` or `post-sync`
+- **THEN** the agent proceeds with the sync operation as normal
+- **AND** no additional steps are added

--- a/openspec/changes/add-lifecycle-hooks/tasks.md
+++ b/openspec/changes/add-lifecycle-hooks/tasks.md
@@ -1,0 +1,42 @@
+## 1. Schema Type Extension
+
+- [x] 1.1 Add `HookSchema` and `HooksSchema` Zod types to `src/core/artifact-graph/types.ts`
+- [x] 1.2 Add optional `hooks` field to `SchemaYamlSchema`
+- [x] 1.3 Export `Hook` and `Hooks` TypeScript types
+
+## 2. Project Config Extension
+
+- [x] 2.1 Add optional `hooks` field to `ProjectConfigSchema` in `src/core/project-config.ts`
+- [x] 2.2 Add resilient parsing for hooks field (field-by-field, consistent with existing `rules` parsing)
+- [x] 2.3 Add validation: warn on unrecognized lifecycle point keys
+
+## 3. Hook Resolution Function
+
+- [x] 3.1 Define `ResolvedHook` interface and `VALID_LIFECYCLE_POINTS` constant in `src/core/artifact-graph/types.ts` (exported via index)
+- [x] 3.2 Implement `resolveHooks(projectRoot, changeName | null, lifecyclePoint)` function (null changeName = config-only hooks)
+- [x] 3.3 Handle edge cases: no schema hooks, no config hooks, no hooks at all, invalid lifecycle point, null changeName
+
+## 4. CLI Command
+
+- [x] 4.1 Create `openspec hooks` command in `src/commands/workflow/hooks.ts`
+- [x] 4.2 Implement text output format (human-readable)
+- [x] 4.3 Implement JSON output format
+- [x] 4.4 Add argument validation (lifecycle point must be valid, --change is optional)
+- [x] 4.5 Implement config-only mode: when --change is omitted, return only config hooks (no schema resolution)
+- [x] 4.6 Register command in CLI entry point (`src/cli/index.ts`)
+
+## 5. Skill Template Updates
+
+- [x] 5.1 Update `getArchiveChangeSkillTemplate()` and `getOpsxArchiveCommandTemplate()` in `src/core/templates/skill-templates.ts` to call `openspec hooks pre-archive` and `openspec hooks post-archive`
+- [x] 5.2 Update apply skill templates in `src/core/templates/skill-templates.ts` to call hooks at pre/post-apply points
+- [x] 5.3 Update new change skill templates in `src/core/templates/skill-templates.ts` to call hooks at pre/post-new points
+- [x] 5.4 Update sync skill templates in `src/core/templates/skill-templates.ts` to call hooks at pre/post-sync points
+- [x] 5.5 Regenerate agent skills with `openspec update` to update generated files
+
+## 6. Tests
+
+- [x] 6.1 Unit: Extend `test/core/artifact-graph/schema.test.ts` — schema parsing with hooks (valid, missing, empty, invalid instruction)
+- [x] 6.2 Unit: Extend `test/core/project-config.test.ts` — config hooks parsing (valid, invalid, unknown lifecycle points, resilient field-by-field)
+- [x] 6.3 Unit: Extend `test/core/artifact-graph/instruction-loader.test.ts` — `resolveHooks()` (schema only, config only, both with ordering, neither, null changeName = config-only)
+- [x] 6.4 CLI integration: Extend `test/commands/artifact-workflow.test.ts` — `openspec hooks` command (with --change, without --change, no hooks, invalid lifecycle point, JSON output)
+- [x] 6.5 Verify existing tests still pass (no regressions from schema/config type changes)

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -23,12 +23,14 @@ import {
   templatesCommand,
   schemasCommand,
   newChangeCommand,
+  hooksCommand,
   DEFAULT_SCHEMA,
   type StatusOptions,
   type InstructionsOptions,
   type TemplatesOptions,
   type SchemasOptions,
   type NewChangeOptions,
+  type HooksOptions,
 } from '../commands/workflow/index.js';
 import { maybeShowTelemetryNotice, trackCommand, shutdown } from '../telemetry/index.js';
 
@@ -480,6 +482,22 @@ program
   .action(async (options: SchemasOptions) => {
     try {
       await schemasCommand(options);
+    } catch (error) {
+      console.log();
+      ora().fail(`Error: ${(error as Error).message}`);
+      process.exit(1);
+    }
+  });
+
+// Hooks command
+program
+  .command('hooks [lifecycle-point]')
+  .description('Retrieve resolved lifecycle hooks for a given point')
+  .option('--change <id>', 'Change name (omit for config-only hooks)')
+  .option('--json', 'Output as JSON (for agent use)')
+  .action(async (lifecyclePoint: string | undefined, options: HooksOptions) => {
+    try {
+      await hooksCommand(lifecyclePoint, options);
     } catch (error) {
       console.log();
       ora().fail(`Error: ${(error as Error).message}`);

--- a/src/commands/workflow/hooks.ts
+++ b/src/commands/workflow/hooks.ts
@@ -1,0 +1,106 @@
+/**
+ * Hooks Command
+ *
+ * Retrieves resolved lifecycle hooks for a given lifecycle point.
+ * Merges schema hooks (if change provided) and config hooks.
+ */
+
+import ora from 'ora';
+import {
+  resolveHooks,
+  VALID_LIFECYCLE_POINTS,
+  type ResolvedHook,
+} from '../../core/artifact-graph/index.js';
+import { validateChangeExists } from './shared.js';
+
+// -----------------------------------------------------------------------------
+// Types
+// -----------------------------------------------------------------------------
+
+export interface HooksOptions {
+  change?: string;
+  json?: boolean;
+}
+
+export interface HooksOutput {
+  lifecyclePoint: string;
+  changeName: string | null;
+  hooks: ResolvedHook[];
+}
+
+// -----------------------------------------------------------------------------
+// Command
+// -----------------------------------------------------------------------------
+
+export async function hooksCommand(
+  lifecyclePoint: string | undefined,
+  options: HooksOptions
+): Promise<void> {
+  const spinner = ora('Resolving hooks...').start();
+
+  try {
+    const projectRoot = process.cwd();
+
+    // Validate lifecycle point
+    if (!lifecyclePoint) {
+      spinner.stop();
+      throw new Error(
+        `Missing required argument <lifecycle-point>. Valid points:\n  ${VALID_LIFECYCLE_POINTS.join('\n  ')}`
+      );
+    }
+
+    const validPoints = new Set<string>(VALID_LIFECYCLE_POINTS);
+    if (!validPoints.has(lifecyclePoint)) {
+      spinner.stop();
+      throw new Error(
+        `Invalid lifecycle point: "${lifecyclePoint}". Valid points:\n  ${VALID_LIFECYCLE_POINTS.join('\n  ')}`
+      );
+    }
+
+    // Resolve change name if provided
+    let changeName: string | null = null;
+    if (options.change) {
+      changeName = await validateChangeExists(options.change, projectRoot);
+    }
+
+    const hooks = resolveHooks(projectRoot, changeName, lifecyclePoint);
+
+    spinner.stop();
+
+    const output: HooksOutput = {
+      lifecyclePoint,
+      changeName,
+      hooks,
+    };
+
+    if (options.json) {
+      console.log(JSON.stringify(output, null, 2));
+      return;
+    }
+
+    printHooksText(output);
+  } catch (error) {
+    spinner.stop();
+    throw error;
+  }
+}
+
+function printHooksText(output: HooksOutput): void {
+  const { lifecyclePoint, changeName, hooks } = output;
+
+  const context = changeName ? `change: ${changeName}` : 'project-wide';
+  console.log(`## Hooks: ${lifecyclePoint} (${context})`);
+  console.log();
+
+  if (hooks.length === 0) {
+    console.log('No hooks defined for this lifecycle point.');
+    return;
+  }
+
+  for (const hook of hooks) {
+    const label = hook.source === 'schema' ? 'From schema' : 'From config';
+    console.log(`### ${label}`);
+    console.log(hook.instruction.trim());
+    console.log();
+  }
+}

--- a/src/commands/workflow/index.ts
+++ b/src/commands/workflow/index.ts
@@ -19,4 +19,7 @@ export type { SchemasOptions } from './schemas.js';
 export { newChangeCommand } from './new-change.js';
 export type { NewChangeOptions } from './new-change.js';
 
+export { hooksCommand } from './hooks.js';
+export type { HooksOptions } from './hooks.js';
+
 export { DEFAULT_SCHEMA } from './shared.js';

--- a/src/core/artifact-graph/index.ts
+++ b/src/core/artifact-graph/index.ts
@@ -1,8 +1,14 @@
 // Types
 export {
   ArtifactSchema,
+  HookSchema,
+  HooksSchema,
   SchemaYamlSchema,
+  VALID_LIFECYCLE_POINTS,
   type Artifact,
+  type Hook,
+  type Hooks,
+  type LifecyclePoint,
   type SchemaYaml,
   type CompletedSet,
   type BlockedArtifacts,
@@ -35,10 +41,12 @@ export {
   loadChangeContext,
   generateInstructions,
   formatChangeStatus,
+  resolveHooks,
   TemplateLoadError,
   type ChangeContext,
   type ArtifactInstructions,
   type DependencyInfo,
   type ArtifactStatus,
   type ChangeStatus,
+  type ResolvedHook,
 } from './instruction-loader.js';

--- a/src/core/artifact-graph/instruction-loader.ts
+++ b/src/core/artifact-graph/instruction-loader.ts
@@ -6,6 +6,7 @@ import { detectCompleted } from './state.js';
 import { resolveSchemaForChange } from '../../utils/change-metadata.js';
 import { readProjectConfig, validateConfigRules } from '../project-config.js';
 import type { Artifact, CompletedSet } from './types.js';
+import { VALID_LIFECYCLE_POINTS } from './types.js';
 
 // Session-level cache for validation warnings (avoid repeating same warnings)
 const shownWarnings = new Set<string>();
@@ -360,4 +361,76 @@ export function formatChangeStatus(context: ChangeContext): ChangeStatus {
     applyRequires,
     artifacts: artifactStatuses,
   };
+}
+
+// -----------------------------------------------------------------------------
+// Hook Resolution
+// -----------------------------------------------------------------------------
+
+/**
+ * A resolved lifecycle hook with its source and instruction.
+ */
+export interface ResolvedHook {
+  /** Where this hook was defined */
+  source: 'schema' | 'config';
+  /** LLM instruction to follow at this lifecycle point */
+  instruction: string;
+}
+
+/**
+ * Resolves lifecycle hooks for a given lifecycle point.
+ *
+ * Resolution order:
+ * 1. Schema hooks (from the change's schema, or from config.yaml's default schema)
+ * 2. Config hooks (from project config.yaml)
+ *
+ * @param projectRoot - Project root directory
+ * @param changeName - Change name (null = resolve schema from config.yaml)
+ * @param lifecyclePoint - The lifecycle point to resolve hooks for
+ * @returns Array of resolved hooks in execution order (schema first, config second)
+ */
+export function resolveHooks(
+  projectRoot: string,
+  changeName: string | null,
+  lifecyclePoint: string
+): ResolvedHook[] {
+  const validPoints = new Set<string>(VALID_LIFECYCLE_POINTS);
+  if (!validPoints.has(lifecyclePoint)) {
+    const valid = VALID_LIFECYCLE_POINTS.join(', ');
+    throw new Error(`Invalid lifecycle point: "${lifecyclePoint}". Valid points: ${valid}`);
+  }
+
+  const hooks: ResolvedHook[] = [];
+  const config = readProjectConfig(projectRoot);
+
+  // 1. Schema hooks
+  // If a change is specified, resolve schema from the change's metadata.
+  // Otherwise, resolve schema from config.yaml's default schema.
+  let schemaName: string | undefined;
+  if (changeName) {
+    const changeDir = path.join(projectRoot, 'openspec', 'changes', changeName);
+    schemaName = resolveSchemaForChange(changeDir);
+  } else {
+    schemaName = config?.schema ?? undefined;
+  }
+
+  if (schemaName) {
+    const schema = resolveSchema(schemaName, projectRoot);
+    if (schema.hooks?.[lifecyclePoint]) {
+      hooks.push({
+        source: 'schema',
+        instruction: schema.hooks[lifecyclePoint].instruction,
+      });
+    }
+  }
+
+  // 2. Config hooks
+  if (config?.hooks?.[lifecyclePoint]) {
+    hooks.push({
+      source: 'config',
+      instruction: config.hooks[lifecyclePoint].instruction,
+    });
+  }
+
+  return hooks;
 }

--- a/src/core/artifact-graph/types.ts
+++ b/src/core/artifact-graph/types.ts
@@ -20,6 +20,14 @@ export const ApplyPhaseSchema = z.object({
   instruction: z.string().optional(),
 });
 
+// Single lifecycle hook definition
+export const HookSchema = z.object({
+  instruction: z.string().min(1, { error: 'Hook instruction is required' }),
+});
+
+// Hooks section: record of lifecycle point → hook definition
+export const HooksSchema = z.record(z.string(), HookSchema);
+
 // Full schema YAML structure
 export const SchemaYamlSchema = z.object({
   name: z.string().min(1, { error: 'Schema name is required' }),
@@ -28,11 +36,15 @@ export const SchemaYamlSchema = z.object({
   artifacts: z.array(ArtifactSchema).min(1, { error: 'At least one artifact required' }),
   // Optional apply phase configuration (for schema-aware apply instructions)
   apply: ApplyPhaseSchema.optional(),
+  // Optional lifecycle hooks (LLM instructions at operation boundaries)
+  hooks: HooksSchema.optional(),
 });
 
 // Derived TypeScript types
 export type Artifact = z.infer<typeof ArtifactSchema>;
 export type ApplyPhase = z.infer<typeof ApplyPhaseSchema>;
+export type Hook = z.infer<typeof HookSchema>;
+export type Hooks = z.infer<typeof HooksSchema>;
 export type SchemaYaml = z.infer<typeof SchemaYamlSchema>;
 
 // Per-change metadata schema
@@ -52,6 +64,16 @@ export const ChangeMetadataSchema = z.object({
 });
 
 export type ChangeMetadata = z.infer<typeof ChangeMetadataSchema>;
+
+// Valid lifecycle points for hooks
+export const VALID_LIFECYCLE_POINTS = [
+  'pre-new', 'post-new',
+  'pre-archive', 'post-archive',
+  'pre-sync', 'post-sync',
+  'pre-apply', 'post-apply',
+] as const;
+
+export type LifecyclePoint = typeof VALID_LIFECYCLE_POINTS[number];
 
 // Runtime state types (not Zod - internal only)
 

--- a/src/core/project-config.ts
+++ b/src/core/project-config.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, statSync } from 'fs';
 import path from 'path';
 import { parse as parseYaml } from 'yaml';
 import { z } from 'zod';
+import { VALID_LIFECYCLE_POINTS } from './artifact-graph/types.js';
 
 /**
  * Zod schema for project configuration.
@@ -38,6 +39,15 @@ export const ProjectConfigSchema = z.object({
     )
     .optional()
     .describe('Per-artifact rules, keyed by artifact ID'),
+
+  // Optional: lifecycle hooks (LLM instructions at operation boundaries)
+  hooks: z
+    .record(
+      z.string(), // lifecycle point (e.g., "post-archive")
+      z.object({ instruction: z.string().min(1) })
+    )
+    .optional()
+    .describe('Lifecycle hooks keyed by lifecycle point'),
 });
 
 export type ProjectConfig = z.infer<typeof ProjectConfigSchema>;
@@ -149,6 +159,39 @@ export function readProjectConfig(projectRoot: string): ProjectConfig | null {
         }
       } else {
         console.warn(`Invalid 'rules' field in config (must be object)`);
+      }
+    }
+
+    // Parse hooks field
+    if (raw.hooks !== undefined) {
+      if (typeof raw.hooks === 'object' && raw.hooks !== null && !Array.isArray(raw.hooks)) {
+        const parsedHooks: Record<string, { instruction: string }> = {};
+        let hasValidHooks = false;
+        const validPoints = new Set<string>(VALID_LIFECYCLE_POINTS);
+
+        for (const [point, hook] of Object.entries(raw.hooks)) {
+          // Warn on unrecognized lifecycle points
+          if (!validPoints.has(point)) {
+            console.warn(`Unknown lifecycle point in hooks: "${point}". Valid points: ${VALID_LIFECYCLE_POINTS.join(', ')}`);
+            continue;
+          }
+
+          const hookResult = z.object({ instruction: z.string().min(1) }).safeParse(hook);
+          if (hookResult.success) {
+            parsedHooks[point] = hookResult.data;
+            hasValidHooks = true;
+          } else {
+            console.warn(
+              `Invalid hook for '${point}': instruction must be a non-empty string, ignoring`
+            );
+          }
+        }
+
+        if (hasValidHooks) {
+          config.hooks = parsedHooks;
+        }
+      } else {
+        console.warn(`Invalid 'hooks' field in config (must be object)`);
       }
     }
 

--- a/src/core/templates/skill-templates.ts
+++ b/src/core/templates/skill-templates.ts
@@ -343,20 +343,36 @@ export function getNewChangeSkillTemplate(): SkillTemplate {
 
    **Otherwise**: Omit \`--schema\` to use the default.
 
-3. **Create the change directory**
+3. **Execute pre-new hooks**
+
+   Run \`openspec hooks pre-new --json\` to check for lifecycle hooks (config-only, since the change does not exist yet).
+
+   If the \`hooks\` array is non-empty, follow each hook's \`instruction\` in order. Complete all hook instructions before proceeding.
+
+   If the \`hooks\` array is empty, skip this step.
+
+4. **Create the change directory**
    \`\`\`bash
    openspec new change "<name>"
    \`\`\`
    Add \`--schema <name>\` only if the user requested a specific workflow.
    This creates a scaffolded change at \`openspec/changes/<name>/\` with the selected schema.
 
-4. **Show the artifact status**
+5. **Execute post-new hooks**
+
+   Run \`openspec hooks post-new --change "<name>" --json\` to check for lifecycle hooks.
+
+   If the \`hooks\` array is non-empty, follow each hook's \`instruction\` in order (schema hooks first, then config hooks). Complete all hook instructions before proceeding.
+
+   If the \`hooks\` array is empty, skip this step.
+
+6. **Show the artifact status**
    \`\`\`bash
    openspec status --change "<name>"
    \`\`\`
    This shows which artifacts need to be created and which are ready (dependencies satisfied).
 
-5. **Get instructions for the first artifact**
+7. **Get instructions for the first artifact**
    The first artifact depends on the schema (e.g., \`proposal\` for spec-driven).
    Check the status output to find the first artifact with status "ready".
    \`\`\`bash
@@ -364,7 +380,7 @@ export function getNewChangeSkillTemplate(): SkillTemplate {
    \`\`\`
    This outputs the template and context for creating the first artifact.
 
-6. **STOP and wait for user direction**
+8. **STOP and wait for user direction**
 
 **Output**
 
@@ -531,7 +547,15 @@ export function getApplyChangeSkillTemplate(): SkillTemplate {
 
    Always announce: "Using change: <name>" and how to override (e.g., \`/opsx:apply <other>\`).
 
-2. **Check status to understand the schema**
+2. **Execute pre-apply hooks**
+
+   Run \`openspec hooks pre-apply --change "<name>" --json\` to check for lifecycle hooks.
+
+   If the \`hooks\` array is non-empty, follow each hook's \`instruction\` in order (schema hooks first, then config hooks). Complete all hook instructions before proceeding.
+
+   If the \`hooks\` array is empty, skip this step.
+
+3. **Check status to understand the schema**
    \`\`\`bash
    openspec status --change "<name>" --json
    \`\`\`
@@ -539,7 +563,7 @@ export function getApplyChangeSkillTemplate(): SkillTemplate {
    - \`schemaName\`: The workflow being used (e.g., "spec-driven")
    - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
 
-3. **Get apply instructions**
+4. **Get apply instructions**
 
    \`\`\`bash
    openspec instructions apply --change "<name>" --json
@@ -556,14 +580,14 @@ export function getApplyChangeSkillTemplate(): SkillTemplate {
    - If \`state: "all_done"\`: congratulate, suggest archive
    - Otherwise: proceed to implementation
 
-4. **Read context files**
+5. **Read context files**
 
    Read the files listed in \`contextFiles\` from the apply instructions output.
    The files depend on the schema being used:
    - **spec-driven**: proposal, specs, design, tasks
    - Other schemas: follow the contextFiles from CLI output
 
-5. **Show current progress**
+6. **Show current progress**
 
    Display:
    - Schema being used
@@ -571,7 +595,7 @@ export function getApplyChangeSkillTemplate(): SkillTemplate {
    - Remaining tasks overview
    - Dynamic instruction from CLI
 
-6. **Implement tasks (loop until done or blocked)**
+7. **Implement tasks (loop until done or blocked)**
 
    For each pending task:
    - Show which task is being worked on
@@ -586,7 +610,15 @@ export function getApplyChangeSkillTemplate(): SkillTemplate {
    - Error or blocker encountered → report and wait for guidance
    - User interrupts
 
-7. **On completion or pause, show status**
+8. **Execute post-apply hooks**
+
+   Run \`openspec hooks post-apply --change "<name>" --json\` to check for lifecycle hooks.
+
+   If the \`hooks\` array is non-empty, follow each hook's \`instruction\` in order. Complete all hook instructions before displaying the summary.
+
+   If the \`hooks\` array is empty, skip this step.
+
+9. **On completion or pause, show status**
 
    Display:
    - Tasks completed this session
@@ -795,7 +827,15 @@ This is an **agent-driven** operation - you will read delta specs and directly e
 
    **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
 
-2. **Find delta specs**
+2. **Execute pre-sync hooks**
+
+   Run \`openspec hooks pre-sync --change "<name>" --json\` to check for lifecycle hooks.
+
+   If the \`hooks\` array is non-empty, follow each hook's \`instruction\` in order (schema hooks first, then config hooks). Complete all hook instructions before proceeding.
+
+   If the \`hooks\` array is empty, skip this step.
+
+3. **Find delta specs**
 
    Look for delta spec files in \`openspec/changes/<name>/specs/*/spec.md\`.
 
@@ -807,7 +847,7 @@ This is an **agent-driven** operation - you will read delta specs and directly e
 
    If no delta specs found, inform user and stop.
 
-3. **For each delta spec, apply changes to main specs**
+4. **For each delta spec, apply changes to main specs**
 
    For each capability with a delta spec at \`openspec/changes/<name>/specs/<capability>/spec.md\`:
 
@@ -840,7 +880,15 @@ This is an **agent-driven** operation - you will read delta specs and directly e
       - Add Purpose section (can be brief, mark as TBD)
       - Add Requirements section with the ADDED requirements
 
-4. **Show summary**
+5. **Execute post-sync hooks**
+
+   Run \`openspec hooks post-sync --change "<name>" --json\` to check for lifecycle hooks.
+
+   If the \`hooks\` array is non-empty, follow each hook's \`instruction\` in order. Complete all hook instructions before displaying the summary.
+
+   If the \`hooks\` array is empty, skip this step.
+
+6. **Show summary**
 
    After applying all changes, summarize:
    - Which capabilities were updated
@@ -1686,27 +1734,43 @@ export function getOpsxNewCommandTemplate(): CommandTemplate {
 
    **Otherwise**: Omit \`--schema\` to use the default.
 
-3. **Create the change directory**
+3. **Execute pre-new hooks**
+
+   Run \`openspec hooks pre-new --json\` to check for lifecycle hooks (config-only, since the change does not exist yet).
+
+   If the \`hooks\` array is non-empty, follow each hook's \`instruction\` in order. Complete all hook instructions before proceeding.
+
+   If the \`hooks\` array is empty, skip this step.
+
+4. **Create the change directory**
    \`\`\`bash
    openspec new change "<name>"
    \`\`\`
    Add \`--schema <name>\` only if the user requested a specific workflow.
    This creates a scaffolded change at \`openspec/changes/<name>/\` with the selected schema.
 
-4. **Show the artifact status**
+5. **Execute post-new hooks**
+
+   Run \`openspec hooks post-new --change "<name>" --json\` to check for lifecycle hooks.
+
+   If the \`hooks\` array is non-empty, follow each hook's \`instruction\` in order (schema hooks first, then config hooks). Complete all hook instructions before proceeding.
+
+   If the \`hooks\` array is empty, skip this step.
+
+6. **Show the artifact status**
    \`\`\`bash
    openspec status --change "<name>"
    \`\`\`
    This shows which artifacts need to be created and which are ready (dependencies satisfied).
 
-5. **Get instructions for the first artifact**
+7. **Get instructions for the first artifact**
    The first artifact depends on the schema. Check the status output to find the first artifact with status "ready".
    \`\`\`bash
    openspec instructions <first-artifact-id> --change "<name>"
    \`\`\`
    This outputs the template and context for creating the first artifact.
 
-6. **STOP and wait for user direction**
+8. **STOP and wait for user direction**
 
 **Output**
 
@@ -1869,7 +1933,15 @@ export function getOpsxApplyCommandTemplate(): CommandTemplate {
 
    Always announce: "Using change: <name>" and how to override (e.g., \`/opsx:apply <other>\`).
 
-2. **Check status to understand the schema**
+2. **Execute pre-apply hooks**
+
+   Run \`openspec hooks pre-apply --change "<name>" --json\` to check for lifecycle hooks.
+
+   If the \`hooks\` array is non-empty, follow each hook's \`instruction\` in order (schema hooks first, then config hooks). Complete all hook instructions before proceeding.
+
+   If the \`hooks\` array is empty, skip this step.
+
+3. **Check status to understand the schema**
    \`\`\`bash
    openspec status --change "<name>" --json
    \`\`\`
@@ -1877,7 +1949,7 @@ export function getOpsxApplyCommandTemplate(): CommandTemplate {
    - \`schemaName\`: The workflow being used (e.g., "spec-driven")
    - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
 
-3. **Get apply instructions**
+4. **Get apply instructions**
 
    \`\`\`bash
    openspec instructions apply --change "<name>" --json
@@ -1894,14 +1966,14 @@ export function getOpsxApplyCommandTemplate(): CommandTemplate {
    - If \`state: "all_done"\`: congratulate, suggest archive
    - Otherwise: proceed to implementation
 
-4. **Read context files**
+5. **Read context files**
 
    Read the files listed in \`contextFiles\` from the apply instructions output.
    The files depend on the schema being used:
    - **spec-driven**: proposal, specs, design, tasks
    - Other schemas: follow the contextFiles from CLI output
 
-5. **Show current progress**
+6. **Show current progress**
 
    Display:
    - Schema being used
@@ -1909,7 +1981,7 @@ export function getOpsxApplyCommandTemplate(): CommandTemplate {
    - Remaining tasks overview
    - Dynamic instruction from CLI
 
-6. **Implement tasks (loop until done or blocked)**
+7. **Implement tasks (loop until done or blocked)**
 
    For each pending task:
    - Show which task is being worked on
@@ -1924,7 +1996,15 @@ export function getOpsxApplyCommandTemplate(): CommandTemplate {
    - Error or blocker encountered → report and wait for guidance
    - User interrupts
 
-7. **On completion or pause, show status**
+8. **Execute post-apply hooks**
+
+   Run \`openspec hooks post-apply --change "<name>" --json\` to check for lifecycle hooks.
+
+   If the \`hooks\` array is non-empty, follow each hook's \`instruction\` in order. Complete all hook instructions before displaying the summary.
+
+   If the \`hooks\` array is empty, skip this step.
+
+9. **On completion or pause, show status**
 
    Display:
    - Tasks completed this session
@@ -2125,7 +2205,15 @@ export function getArchiveChangeSkillTemplate(): SkillTemplate {
 
    **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
 
-2. **Check artifact completion status**
+2. **Execute pre-archive hooks**
+
+   Run \`openspec hooks pre-archive --change "<name>" --json\` to check for lifecycle hooks.
+
+   If the \`hooks\` array is non-empty, follow each hook's \`instruction\` in order (schema hooks first, then config hooks). Complete all hook instructions before proceeding.
+
+   If the \`hooks\` array is empty, skip this step.
+
+3. **Check artifact completion status**
 
    Run \`openspec status --change "<name>" --json\` to check artifact completion.
 
@@ -2138,7 +2226,7 @@ export function getArchiveChangeSkillTemplate(): SkillTemplate {
    - Use **AskUserQuestion tool** to confirm user wants to proceed
    - Proceed if user confirms
 
-3. **Check task completion status**
+4. **Check task completion status**
 
    Read the tasks file (typically \`tasks.md\`) to check for incomplete tasks.
 
@@ -2151,7 +2239,7 @@ export function getArchiveChangeSkillTemplate(): SkillTemplate {
 
    **If no tasks file exists:** Proceed without task-related warning.
 
-4. **Assess delta spec sync state**
+5. **Assess delta spec sync state**
 
    Check for delta specs at \`openspec/changes/<name>/specs/\`. If none exist, proceed without sync prompt.
 
@@ -2166,7 +2254,7 @@ export function getArchiveChangeSkillTemplate(): SkillTemplate {
 
    If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
 
-5. **Perform the archive**
+6. **Perform the archive**
 
    Create the archive directory if it doesn't exist:
    \`\`\`bash
@@ -2183,7 +2271,17 @@ export function getArchiveChangeSkillTemplate(): SkillTemplate {
    mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
    \`\`\`
 
-6. **Display summary**
+7. **Execute post-archive hooks**
+
+   Run \`openspec hooks post-archive --change "<name>" --json\` to check for lifecycle hooks.
+
+   **Note:** The change has been moved to archive, so the \`--change\` flag may not resolve. If this fails, fall back to \`openspec hooks post-archive --json\` (config-only hooks).
+
+   If the \`hooks\` array is non-empty, follow each hook's \`instruction\` in order. Complete all hook instructions before displaying the summary.
+
+   If the \`hooks\` array is empty, skip this step.
+
+8. **Display summary**
 
    Show archive completion summary including:
    - Change name
@@ -2493,7 +2591,15 @@ This is an **agent-driven** operation - you will read delta specs and directly e
 
    **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
 
-2. **Find delta specs**
+2. **Execute pre-sync hooks**
+
+   Run \`openspec hooks pre-sync --change "<name>" --json\` to check for lifecycle hooks.
+
+   If the \`hooks\` array is non-empty, follow each hook's \`instruction\` in order (schema hooks first, then config hooks). Complete all hook instructions before proceeding.
+
+   If the \`hooks\` array is empty, skip this step.
+
+3. **Find delta specs**
 
    Look for delta spec files in \`openspec/changes/<name>/specs/*/spec.md\`.
 
@@ -2505,7 +2611,7 @@ This is an **agent-driven** operation - you will read delta specs and directly e
 
    If no delta specs found, inform user and stop.
 
-3. **For each delta spec, apply changes to main specs**
+4. **For each delta spec, apply changes to main specs**
 
    For each capability with a delta spec at \`openspec/changes/<name>/specs/<capability>/spec.md\`:
 
@@ -2538,7 +2644,15 @@ This is an **agent-driven** operation - you will read delta specs and directly e
       - Add Purpose section (can be brief, mark as TBD)
       - Add Requirements section with the ADDED requirements
 
-4. **Show summary**
+5. **Execute post-sync hooks**
+
+   Run \`openspec hooks post-sync --change "<name>" --json\` to check for lifecycle hooks.
+
+   If the \`hooks\` array is non-empty, follow each hook's \`instruction\` in order. Complete all hook instructions before displaying the summary.
+
+   If the \`hooks\` array is empty, skip this step.
+
+6. **Show summary**
 
    After applying all changes, summarize:
    - Which capabilities were updated
@@ -2802,7 +2916,15 @@ export function getOpsxArchiveCommandTemplate(): CommandTemplate {
 
    **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
 
-2. **Check artifact completion status**
+2. **Execute pre-archive hooks**
+
+   Run \`openspec hooks pre-archive --change "<name>" --json\` to check for lifecycle hooks.
+
+   If the \`hooks\` array is non-empty, follow each hook's \`instruction\` in order (schema hooks first, then config hooks). Complete all hook instructions before proceeding.
+
+   If the \`hooks\` array is empty, skip this step.
+
+3. **Check artifact completion status**
 
    Run \`openspec status --change "<name>" --json\` to check artifact completion.
 
@@ -2815,7 +2937,7 @@ export function getOpsxArchiveCommandTemplate(): CommandTemplate {
    - Prompt user for confirmation to continue
    - Proceed if user confirms
 
-3. **Check task completion status**
+4. **Check task completion status**
 
    Read the tasks file (typically \`tasks.md\`) to check for incomplete tasks.
 
@@ -2828,7 +2950,7 @@ export function getOpsxArchiveCommandTemplate(): CommandTemplate {
 
    **If no tasks file exists:** Proceed without task-related warning.
 
-4. **Assess delta spec sync state**
+5. **Assess delta spec sync state**
 
    Check for delta specs at \`openspec/changes/<name>/specs/\`. If none exist, proceed without sync prompt.
 
@@ -2843,7 +2965,7 @@ export function getOpsxArchiveCommandTemplate(): CommandTemplate {
 
    If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
 
-5. **Perform the archive**
+6. **Perform the archive**
 
    Create the archive directory if it doesn't exist:
    \`\`\`bash
@@ -2860,7 +2982,17 @@ export function getOpsxArchiveCommandTemplate(): CommandTemplate {
    mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
    \`\`\`
 
-6. **Display summary**
+7. **Execute post-archive hooks**
+
+   Run \`openspec hooks post-archive --change "<name>" --json\` to check for lifecycle hooks.
+
+   **Note:** The change has been moved to archive, so the \`--change\` flag may not resolve. If this fails, fall back to \`openspec hooks post-archive --json\` (config-only hooks).
+
+   If the \`hooks\` array is non-empty, follow each hook's \`instruction\` in order. Complete all hook instructions before displaying the summary.
+
+   If the \`hooks\` array is empty, skip this step.
+
+8. **Display summary**
 
    Show archive completion summary including:
    - Change name

--- a/test/core/artifact-graph/schema.test.ts
+++ b/test/core/artifact-graph/schema.test.ts
@@ -203,5 +203,88 @@ artifacts:
       const schema = parseSchema(yaml);
       expect(schema.artifacts[0].requires).toEqual([]);
     });
+
+    describe('hooks parsing', () => {
+      it('should parse schema with valid hooks', () => {
+        const yaml = `
+name: test-schema
+version: 1
+description: A test schema
+artifacts:
+  - id: proposal
+    generates: proposal.md
+    description: Initial proposal
+    template: templates/proposal.md
+    requires: []
+hooks:
+  pre-archive:
+    instruction: Run pre-archive validation
+  post-archive:
+    instruction: Run post-archive cleanup
+`;
+        const schema = parseSchema(yaml);
+
+        expect(schema.hooks).toBeDefined();
+        expect(schema.hooks).toHaveProperty('pre-archive');
+        expect(schema.hooks).toHaveProperty('post-archive');
+        expect(schema.hooks?.['pre-archive'].instruction).toBe('Run pre-archive validation');
+        expect(schema.hooks?.['post-archive'].instruction).toBe('Run post-archive cleanup');
+      });
+
+      it('should parse schema without hooks', () => {
+        const yaml = `
+name: test-schema
+version: 1
+description: A test schema
+artifacts:
+  - id: proposal
+    generates: proposal.md
+    description: Initial proposal
+    template: templates/proposal.md
+    requires: []
+`;
+        const schema = parseSchema(yaml);
+
+        expect(schema.hooks).toBeUndefined();
+      });
+
+      it('should parse schema with empty hooks', () => {
+        const yaml = `
+name: test-schema
+version: 1
+description: A test schema
+artifacts:
+  - id: proposal
+    generates: proposal.md
+    description: Initial proposal
+    template: templates/proposal.md
+    requires: []
+hooks: {}
+`;
+        const schema = parseSchema(yaml);
+
+        expect(schema.hooks).toBeDefined();
+        expect(Object.keys(schema.hooks || {})).toHaveLength(0);
+      });
+
+      it('should reject hook with empty instruction', () => {
+        const yaml = `
+name: test-schema
+version: 1
+description: A test schema
+artifacts:
+  - id: proposal
+    generates: proposal.md
+    description: Initial proposal
+    template: templates/proposal.md
+    requires: []
+hooks:
+  pre-archive:
+    instruction: ""
+`;
+        expect(() => parseSchema(yaml)).toThrow(SchemaValidationError);
+        expect(() => parseSchema(yaml)).toThrow(/instruction/);
+      });
+    });
   });
 });

--- a/test/core/project-config.test.ts
+++ b/test/core/project-config.test.ts
@@ -480,6 +480,155 @@ rules:
         ]);
       });
     });
+
+    describe('hooks parsing', () => {
+      it('should parse valid hooks', () => {
+        const configDir = path.join(tempDir, 'openspec');
+        fs.mkdirSync(configDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(configDir, 'config.yaml'),
+          `schema: spec-driven
+hooks:
+  pre-archive:
+    instruction: "Run cleanup"
+  post-archive:
+    instruction: "Notify team"
+`
+        );
+
+        const config = readProjectConfig(tempDir);
+
+        expect(config).toEqual({
+          schema: 'spec-driven',
+          hooks: {
+            'pre-archive': { instruction: 'Run cleanup' },
+            'post-archive': { instruction: 'Notify team' },
+          },
+        });
+        expect(consoleWarnSpy).not.toHaveBeenCalled();
+      });
+
+      it('should ignore hooks with unknown lifecycle points', () => {
+        const configDir = path.join(tempDir, 'openspec');
+        fs.mkdirSync(configDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(configDir, 'config.yaml'),
+          `schema: spec-driven
+hooks:
+  invalid-point:
+    instruction: "something"
+  pre-archive:
+    instruction: "valid"
+`
+        );
+
+        const config = readProjectConfig(tempDir);
+
+        expect(config).toEqual({
+          schema: 'spec-driven',
+          hooks: {
+            'pre-archive': { instruction: 'valid' },
+          },
+        });
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Unknown lifecycle point')
+        );
+      });
+
+      it('should skip hooks with empty instruction', () => {
+        const configDir = path.join(tempDir, 'openspec');
+        fs.mkdirSync(configDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(configDir, 'config.yaml'),
+          `schema: spec-driven
+hooks:
+  pre-archive:
+    instruction: ""
+`
+        );
+
+        const config = readProjectConfig(tempDir);
+
+        expect(config).toEqual({
+          schema: 'spec-driven',
+        });
+        expect(consoleWarnSpy).toHaveBeenCalled();
+      });
+
+      it('should handle hooks that is not an object', () => {
+        const configDir = path.join(tempDir, 'openspec');
+        fs.mkdirSync(configDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(configDir, 'config.yaml'),
+          `schema: spec-driven
+hooks: "not an object"
+`
+        );
+
+        const config = readProjectConfig(tempDir);
+
+        expect(config).toEqual({
+          schema: 'spec-driven',
+        });
+        expect(consoleWarnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('Invalid')
+        );
+      });
+
+      it('should parse config with hooks alongside other fields', () => {
+        const configDir = path.join(tempDir, 'openspec');
+        fs.mkdirSync(configDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(configDir, 'config.yaml'),
+          `schema: spec-driven
+context: "Project context here"
+rules:
+  proposal:
+    - Valid rule one
+    - Valid rule two
+hooks:
+  pre-sync:
+    instruction: "Backup data"
+  post-apply:
+    instruction: "Deploy changes"
+`
+        );
+
+        const config = readProjectConfig(tempDir);
+
+        expect(config).toEqual({
+          schema: 'spec-driven',
+          context: 'Project context here',
+          rules: {
+            proposal: ['Valid rule one', 'Valid rule two'],
+          },
+          hooks: {
+            'pre-sync': { instruction: 'Backup data' },
+            'post-apply': { instruction: 'Deploy changes' },
+          },
+        });
+        expect(consoleWarnSpy).not.toHaveBeenCalled();
+      });
+
+      it('should handle hooks: null gracefully', () => {
+        const configDir = path.join(tempDir, 'openspec');
+        fs.mkdirSync(configDir, { recursive: true });
+        fs.writeFileSync(
+          path.join(configDir, 'config.yaml'),
+          `schema: spec-driven
+context: "Valid context"
+hooks:
+`
+        );
+
+        const config = readProjectConfig(tempDir);
+
+        expect(config).toEqual({
+          schema: 'spec-driven',
+          context: 'Valid context',
+        });
+      });
+    });
   });
 
   describe('validateConfigRules', () => {


### PR DESCRIPTION
Add hooks system that allows schemas and projects to define LLM instructions at operation lifecycle points (pre/post for new, archive, sync, apply).

- Schema YAML and project config support optional `hooks` section
- New `openspec hooks` CLI command resolves and returns hooks for a lifecycle point
- Without --change, schema is resolved from config.yaml's default schema field
- Skill templates updated to call hooks at all lifecycle boundaries
- 23 new tests covering parsing, resolution, CLI, and edge cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced lifecycle hooks that enable custom instructions at key workflow points: pre-/post-new, pre-/post-archive, pre-/post-sync, and pre-/post-apply.
  * Added `openspec hooks` CLI command to retrieve and display lifecycle hooks for a given lifecycle point.
  * Hooks can now be defined in both schema and project configuration files; schema hooks execute before config hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->