### PR TITLE
Prune deselected workflows during update sync

### DIFF
--- a/openspec/changes/simplify-skill-installation/specs/cli-update/spec.md
+++ b/openspec/changes/simplify-skill-installation/specs/cli-update/spec.md
@@ -160,15 +160,14 @@ The update command SHALL only run inside an initialized OpenSpec project.
 - **THEN** the system SHALL display: "No OpenSpec project found. Run 'openspec init' to set up."
 - **THEN** the system SHALL exit with code 1
 
-### Requirement: Extra workflows preserved
-The update command SHALL NOT remove workflow files that aren't in the current profile.
+### Requirement: Extra workflows synchronized to active profile
+The update command SHALL remove workflow files that are no longer selected in the current profile.
 
-#### Scenario: Extra workflows from previous profile
+#### Scenario: Deselected workflows from previous profile
 - **WHEN** user runs `openspec update`
-- **AND** project has workflows not in current profile (e.g., user switched from custom to core)
-- **THEN** the system SHALL NOT delete those extra workflow files
-- **THEN** the system SHALL only add/update workflows in the current profile
-- **THEN** the system SHALL display a note: "Note: <count> extra workflows not in profile (use `openspec config profile` to manage)"
+- **AND** project has workflows not in current profile (e.g., user switched from custom to core or deselected workflows via `openspec config profile`)
+- **THEN** the system SHALL delete skill and command workflow files for deselected workflows (respecting active delivery mode)
+- **THEN** the system SHALL keep only workflows currently selected in profile
 
 #### Scenario: Delivery change with extra workflows
 - **WHEN** user runs `openspec update`


### PR DESCRIPTION
## Summary
- treat deselected workflows as profile sync drift
- remove deselected skill directories and command files during `openspec update`
- update tests to assert pruning behavior instead of note-only behavior
- align simplify-skill-installation spec with intentional deselection semantics

## Why
Migration should preserve existing workflows for legacy users, but explicit deselection via `openspec config profile` should remove those workflow artifacts on update.

## Testing
- `pnpm test -- test/core/profile-sync-drift.test.ts test/core/update.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profile updates now automatically remove workflows that have been deselected across profile changes, including corresponding skill and command files.
  * Improved logging displays counts of cleaned-up workflow artifacts during synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->