### PR TITLE
chore: add changeset for profiles, Pi, Kiro, and fixes

### DIFF
--- a/.changeset/profiles-pi-kiro.md
+++ b/.changeset/profiles-pi-kiro.md
@@ -1,0 +1,19 @@
+---
+"@fission-ai/openspec": minor
+---
+
+### New Features
+
+- **Profile system** — Choose between `core` (4 essential workflows) and `custom` (pick any subset) profiles to control which skills get installed. Manage profiles with the new `openspec config profile` command
+- **Propose workflow** — New one-step workflow creates a complete change proposal with design, specs, and tasks from a single request — no need to run `new` then `ff` separately
+- **AI tool auto-detection** — `openspec init` now scans your project for existing tool directories (`.claude/`, `.cursor/`, etc.) and pre-selects detected tools
+- **Pi (pi.dev) support** — Pi coding agent is now a supported tool with prompt and skill generation
+- **Kiro support** — AWS Kiro IDE is now a supported tool with prompt and skill generation
+- **Sync prunes deselected workflows** — `openspec update` now removes command files and skill directories for workflows you've deselected, keeping your project clean
+- **Config drift warning** — `openspec config list` warns when global config is out of sync with the current project
+
+### Bug Fixes
+
+- Fixed onboard preflight giving a false "not initialized" error on freshly initialized projects
+- Fixed archive workflow stopping mid-way when syncing — it now properly resumes after sync completes
+- Added Windows PowerShell alternatives for onboard shell commands


### PR DESCRIPTION
## Summary

Adds a changeset covering all user-facing changes since v1.1.1:

### New Features
- **Profile system** — `core` vs `custom` profiles with `openspec config profile` command
- **Propose workflow** — One-step change proposal creation
- **AI tool auto-detection** — `openspec init` pre-selects detected tools
- **Pi (pi.dev) support** — New supported coding agent
- **Kiro support** — New supported AWS IDE
- **Sync prunes deselected workflows** — `openspec update` cleans up removed workflows
- **Config drift warning** — `openspec config list` warns on out-of-sync config

### Bug Fixes
- Fixed false "not initialized" error on fresh projects during onboard
- Fixed archive workflow stopping mid-way when syncing
- Added Windows PowerShell alternatives for onboard

**Version bump:** minor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profile system with core and custom profiles
  * One-step proposal workflow for design, specs, and tasks
  * AI tool auto-detection and pre-selection
  * Pi and Kiro coding agent support
  * Automatic cleanup for deselected workflows
  * Config sync warnings

* **Bug Fixes**
  * Fixed onboarding initialization errors
  * Fixed archive workflow interruption during sync
  * Added Windows PowerShell support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->