### PR TITLE
fix(parser): skip hash symbols inside code blocks when parsing headers

### DIFF
--- a/src/core/parsers/markdown-parser.ts
+++ b/src/core/parsers/markdown-parser.ts
@@ -78,9 +78,20 @@ export class MarkdownParser {
   protected parseSections(): Section[] {
     const sections: Section[] = [];
     const stack: Section[] = [];
+    let inCodeBlock = false;
     
     for (let i = 0; i < this.lines.length; i++) {
       const line = this.lines[i];
+
+      if (line.trim().startsWith('```')) {
+        inCodeBlock = !inCodeBlock;
+        continue;
+      }
+
+      if (inCodeBlock) {
+        continue;
+      }
+
       const headerMatch = line.match(/^(#{1,6})\s+(.+)$/);
       
       if (headerMatch) {
@@ -114,9 +125,22 @@ export class MarkdownParser {
 
   protected getContentUntilNextHeader(startLine: number, currentLevel: number): string {
     const contentLines: string[] = [];
+    let inCodeBlock = false;
     
     for (let i = startLine; i < this.lines.length; i++) {
       const line = this.lines[i];
+
+      if (line.trim().startsWith('```')) {
+        inCodeBlock = !inCodeBlock;
+        contentLines.push(line);
+        continue;
+      }
+
+      if (inCodeBlock) {
+        contentLines.push(line);
+        continue;
+      }
+
       const headerMatch = line.match(/^(#{1,6})\s+/);
       
       if (headerMatch && headerMatch[1].length <= currentLevel) {

--- a/test/core/parsers/markdown-parser.test.ts
+++ b/test/core/parsers/markdown-parser.test.ts
@@ -287,5 +287,48 @@ Then result`;
       
       expect(spec.requirements[0].text).toBe('This is the actual requirement text.');
     });
+
+    it('should not treat hash symbols inside code blocks as headers', () => {
+      const content = `# test-bug Specification
+
+## Purpose
+Minimal test case to reproduce the code block parsing bug.
+
+## Requirements
+
+### Requirement: First requirement before code block
+This requirement comes before the problematic code block.
+
+#### Scenario: Example with code block containing hash symbols
+- **GIVEN** a code block with bash comments
+\`\`\`bash
+# This is a comment
+echo "hello"
+# Another comment
+\`\`\`
+- **THEN** the parser should ignore hash symbols inside code blocks
+
+### Requirement: Second requirement after code block
+This requirement comes after the code block.
+
+#### Scenario: Another scenario
+- **GIVEN** something
+- **THEN** something happens
+
+### Requirement: Third requirement
+This is the third requirement.
+
+#### Scenario: Third scenario
+- **GIVEN** more conditions
+- **THEN** more results`;
+
+      const parser = new MarkdownParser(content);
+      const spec = parser.parseSpec('test-bug');
+
+      expect(spec.requirements).toHaveLength(3);
+      expect(spec.requirements[0].text).toContain('before the problematic code block');
+      expect(spec.requirements[1].text).toContain('after the code block');
+      expect(spec.requirements[2].text).toContain('third requirement');
+    });
   });
 });


### PR DESCRIPTION
## Problem

The markdown parser's `parseSections()` and `getContentUntilNextHeader()` methods use a regex pattern `^(#{1,6})\s+(.+)$` to detect headers, but they don't account for fenced code blocks. Lines starting with `#` inside code blocks (e.g. bash comments like `# install dependencies`) are incorrectly treated as section headers, causing the parser to split content at those lines and produce incorrect section boundaries.

## Solution

Added `inCodeBlock` state tracking to both `parseSections()` and `getContentUntilNextHeader()`:
- Toggle the flag when encountering lines that start with triple backticks (```````)
- Skip header regex matching while inside a code block
- Preserve code block content in the output as-is

## Changes

- `src/core/parsers/markdown-parser.ts`: Added code block fence detection to `parseSections()` and `getContentUntilNextHeader()`
- `test/core/parsers/markdown-parser.test.ts`: Added test case with a spec containing code blocks with bash comments (`#` lines), verifying all 3 requirements are correctly parsed

## Verification

- All 14 parser tests pass
- ESLint passes with no errors
- Full test suite: all failures are pre-existing in `zsh-installer.test.ts` (unrelated)

Fixes #312

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed markdown parser to correctly handle code blocks when identifying section headers. Hash symbols and markdown syntax inside code blocks are no longer incorrectly treated as actual headers. Code block delimiters are properly preserved during parsing, ensuring accurate document structure identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->