### PR TITLE
feat(archive): use sequence numbers instead of date prefix for deterministic ordering

### DIFF
--- a/src/core/archive.ts
+++ b/src/core/archive.ts
@@ -264,8 +264,9 @@ export class ArchiveCommand {
       }
     }
 
-    // Create archive directory with date prefix
-    const archiveName = `${this.getArchiveDate()}-${changeName}`;
+    // Create archive directory with sequence number prefix
+    const sequenceNumber = await this.getNextSequenceNumber(archiveDir);
+    const archiveName = `${sequenceNumber}-${changeName}`;
     const archivePath = path.join(archiveDir, archiveName);
 
     // Check if archive already exists
@@ -332,8 +333,20 @@ export class ArchiveCommand {
     }
   }
 
-  private getArchiveDate(): string {
-    // Returns date in YYYY-MM-DD format
-    return new Date().toISOString().split('T')[0];
+  private async getNextSequenceNumber(archiveDir: string): Promise<string> {
+    let max = 0;
+    try {
+      const entries = await fs.readdir(archiveDir);
+      for (const entry of entries) {
+        const match = entry.match(/^(\d+)-/);
+        if (match) {
+          const num = parseInt(match[1], 10);
+          if (num > max) max = num;
+        }
+      }
+    } catch {
+      // Archive directory may not exist yet
+    }
+    return String(max + 1).padStart(3, '0');
   }
 }

--- a/src/core/archive.ts
+++ b/src/core/archive.ts
@@ -344,9 +344,16 @@ export class ArchiveCommand {
           if (num > max) max = num;
         }
       }
-    } catch {
+    } catch (error: any) {
       // Archive directory may not exist yet
+      if (error?.code !== 'ENOENT') {
+        throw error;
+      }
     }
-    return String(max + 1).padStart(3, '0');
+    const next = max + 1;
+    if (next > 999) {
+      throw new Error('Archive sequence overflow (>999). Increase prefix width before continuing.');
+    }
+    return String(next).padStart(3, '0');
   }
 }

--- a/src/core/archive.ts
+++ b/src/core/archive.ts
@@ -264,7 +264,9 @@ export class ArchiveCommand {
       }
     }
 
-    // Create archive directory with sequence number prefix
+    // Create archive directory with sequence number prefix.
+    // Note: sequence assignment is non-atomic, but this is a single-user CLI
+    // tool where concurrent archive operations are not a realistic scenario.
     const sequenceNumber = await this.getNextSequenceNumber(archiveDir);
     const archiveName = `${sequenceNumber}-${changeName}`;
     const archivePath = path.join(archiveDir, archiveName);


### PR DESCRIPTION
## Problem

When multiple specs are archived on the same day, the current `YYYY-MM-DD-spec-name` naming convention causes them to be sorted alphabetically by spec name, obscuring the actual order in which they were completed.

## Solution

Replaced the date-based prefix with a zero-padded, monotonically increasing sequence number (`001`, `002`, `003`, ...). The new `getNextSequenceNumber()` method scans existing archive entries for the highest numeric prefix and increments by one.

Example archive directory:
```
001-user-auth-spec
002-payment-flow-spec
003-notifications-spec
```

## Changes

- `src/core/archive.ts`: Replaced `getArchiveDate()` with `getNextSequenceNumber()` that reads existing archives and returns the next zero-padded number
- `test/core/archive.test.ts`: Updated all archive name assertions from date regex to sequence number regex; added test for monotonic ordering across multiple archives

## Verification

- All 24 archive tests pass
- ESLint passes with no errors

Fixes #409

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Archive naming switched from date-based to sequential 3-digit numeric prefixes (e.g., 001-name, 002-name) for clearer ordering and collision-resistant naming.

* **Tests**
  * Updated tests to expect 3-digit sequence prefixes and added coverage to verify sequential numbering and collision resolution when creating multiple archives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->