### PR TITLE
feat(validation): allow dots in change names as valid separators

### DIFF
--- a/src/utils/change-utils.ts
+++ b/src/utils/change-utils.ts
@@ -34,7 +34,7 @@ export interface ValidationResult {
  *
  * Valid names:
  * - Start with a lowercase letter
- * - Contain only lowercase letters, numbers, and hyphens
+ * - Contain only lowercase letters, numbers, hyphens, and dots
  * - Do not start or end with a hyphen
  * - Do not contain consecutive hyphens
  *
@@ -47,8 +47,8 @@ export interface ValidationResult {
  */
 export function validateChangeName(name: string): ValidationResult {
   // Pattern: starts with lowercase letter, followed by lowercase letters/numbers,
-  // optionally followed by hyphen + lowercase letters/numbers (repeatable)
-  const kebabCasePattern = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/;
+  // optionally followed by hyphen/dot + lowercase letters/numbers (repeatable)
+  const kebabCasePattern = /^[a-z][a-z0-9]*([-.][a-z0-9]+)*$/;
 
   if (!name) {
     return { valid: false, error: 'Change name cannot be empty' };
@@ -74,8 +74,11 @@ export function validateChangeName(name: string): ValidationResult {
     if (/--/.test(name)) {
       return { valid: false, error: 'Change name cannot contain consecutive hyphens' };
     }
-    if (/[^a-z0-9-]/.test(name)) {
-      return { valid: false, error: 'Change name can only contain lowercase letters, numbers, and hyphens' };
+    if (/\.\./.test(name)) {
+      return { valid: false, error: 'Change name cannot contain consecutive dots' };
+    }
+    if (/[^a-z0-9.\-]/.test(name)) {
+      return { valid: false, error: 'Change name can only contain lowercase letters, numbers, hyphens, and dots' };
     }
     if (/^[0-9]/.test(name)) {
       return { valid: false, error: 'Change name must start with a letter' };

--- a/test/utils/change-utils.test.ts
+++ b/test/utils/change-utils.test.ts
@@ -31,6 +31,21 @@ describe('validateChangeName', () => {
       const result = validateChangeName('upgrade-to-v2');
       expect(result).toEqual({ valid: true });
     });
+
+    it('should accept name with dot separator', () => {
+      const result = validateChangeName('v1.2');
+      expect(result).toEqual({ valid: true });
+    });
+
+    it('should accept name with mixed dot and hyphen separators', () => {
+      const result = validateChangeName('add-auth.v2');
+      expect(result).toEqual({ valid: true });
+    });
+
+    it('should accept name with dot between words', () => {
+      const result = validateChangeName('feature.sub-task');
+      expect(result).toEqual({ valid: true });
+    });
   });
 
   describe('invalid names - uppercase rejected', () => {
@@ -96,6 +111,14 @@ describe('validateChangeName', () => {
       const result = validateChangeName('add--auth');
       expect(result.valid).toBe(false);
       expect(result.error).toContain('consecutive hyphens');
+    });
+  });
+
+  describe('invalid names - consecutive dots rejected', () => {
+    it('should reject name with double dots', () => {
+      const result = validateChangeName('add..auth');
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('consecutive dots');
     });
   });
 


### PR DESCRIPTION
## Summary

  - Allow dots (`.`) as valid separators in change names alongside hyphens, enabling names like `v1.2.0`, `add-auth.v2`, `feature.sub-task`
  - Add dedicated error message for consecutive dots (`..`) to give clear feedback
  - Update validation regex, error messages, JSDoc comments, and tests

## Motivation

Dotted naming conventions are common in versioning and hierarchical naming (e.g., `v1.2.0`, `api.auth`). The current strict kebab-case validation
rejects dots entirely, which limits expressiveness without a strong reason — path traversal can be prevented without banning dots altogether.

## Changes

`src/utils/change-utils.ts`
  - Updated regex from `/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/` to `/^[a-z][a-z0-9]*([-.][a-z0-9]+)*$/`
  - Added consecutive dots (`..`) check with specific error message
  - Updated fallback error message and JSDoc to reflect the new allowed character set

`test/utils/change-utils.test.ts`
  - Added 3 valid name tests: `v1.2`, `add-auth.v2`, `feature.sub-task`
  - Added 1 invalid name test: `add..auth` (consecutive dots)

## Security

Path traversal is still fully prevented by the regex design:

``` 
  ┌────────────────────────┬───────────────────────────────────────────────────────────────┐
  │     Attack vector      │                          Prevention                           │
  ├────────────────────────┼───────────────────────────────────────────────────────────────┤
  │ .. (path traversal)    │ Separator must be followed by at least one [a-z0-9] character │
  ├────────────────────────┼───────────────────────────────────────────────────────────────┤
  │ .hidden (hidden files) │ Name must start with a lowercase letter [a-z]                 │
  ├────────────────────────┼───────────────────────────────────────────────────────────────┤
  │ name. (trailing dot)   │ Separator must be followed by at least one character          │
  └────────────────────────┴───────────────────────────────────────────────────────────────┘
```

## Test plan

  - All 28 tests in change-utils.test.ts pass
  - Dotted names (v1.2, add-auth.v2) are accepted
  - Consecutive dots (add..auth) are rejected
  - Existing invalid names (uppercase, spaces, underscores, etc.) remain rejected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Change names now support dots (.) as separators alongside hyphens, enabling formats like "feature.sub-task" and "add-auth.v2".

* **Improvements**
  * Validation error messages updated to clearly indicate allowed characters.
  * Consecutive dots are now detected and rejected with explicit error feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->