### PR TITLE
feat(sync): ensure front matter consistency for monorepo specs

### DIFF
--- a/src/core/project-config.ts
+++ b/src/core/project-config.ts
@@ -38,6 +38,13 @@ export const ProjectConfigSchema = z.object({
     )
     .optional()
     .describe('Per-artifact rules, keyed by artifact ID'),
+
+  // Optional: whether the project is a monorepo (affects front matter sync behavior)
+  // Set to false to skip monorepo-related prompts (e.g., app label in spec front matter)
+  monorepo: z
+    .boolean()
+    .optional()
+    .describe('Set to false to opt out of monorepo front matter conventions'),
 });
 
 export type ProjectConfig = z.infer<typeof ProjectConfigSchema>;
@@ -149,6 +156,17 @@ export function readProjectConfig(projectRoot: string): ProjectConfig | null {
         }
       } else {
         console.warn(`Invalid 'rules' field in config (must be object)`);
+      }
+    }
+
+    // Parse monorepo field using Zod
+    if (raw.monorepo !== undefined) {
+      const monorepoField = z.boolean();
+      const monorepoResult = monorepoField.safeParse(raw.monorepo);
+      if (monorepoResult.success) {
+        config.monorepo = monorepoResult.data;
+      } else {
+        console.warn(`Invalid 'monorepo' field in config (must be boolean)`);
       }
     }
 

--- a/src/core/templates/workflows/archive-change.ts
+++ b/src/core/templates/workflows/archive-change.ts
@@ -66,6 +66,9 @@ export function getArchiveChangeSkillTemplate(): SkillTemplate {
 
    If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
 
+   **Front matter consistency (after sync):**
+   Ensure newly synced specs follow existing front matter conventions. See sync-specs step 3e for full logic (monorepo detection, opt-out via \`monorepoAppLabel: false\` in \`openspec/config.yaml\`).
+
 5. **Perform the archive**
 
    Create the archive directory if it doesn't exist:
@@ -180,6 +183,9 @@ export function getOpsxArchiveCommandTemplate(): CommandTemplate {
    - If already synced: "Archive now", "Sync anyway", "Cancel"
 
    If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+   **Front matter consistency (after sync):**
+   Ensure newly synced specs follow existing front matter conventions. See sync-specs step 3e for full logic (monorepo detection, opt-out via \`monorepoAppLabel: false\` in \`openspec/config.yaml\`).
 
 5. **Perform the archive**
 

--- a/src/core/templates/workflows/archive-change.ts
+++ b/src/core/templates/workflows/archive-change.ts
@@ -67,7 +67,7 @@ export function getArchiveChangeSkillTemplate(): SkillTemplate {
    If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
 
    **Front matter consistency (after sync):**
-   Ensure newly synced specs follow existing front matter conventions. See sync-specs step 3e for full logic (monorepo detection, opt-out via \`monorepoAppLabel: false\` in \`openspec/config.yaml\`).
+   Ensure newly synced specs follow existing front matter conventions. See sync-specs step 3e for full logic (monorepo detection, opt-out via \`monorepo: false\` in config).
 
 5. **Perform the archive**
 
@@ -185,7 +185,7 @@ export function getOpsxArchiveCommandTemplate(): CommandTemplate {
    If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
 
    **Front matter consistency (after sync):**
-   Ensure newly synced specs follow existing front matter conventions. See sync-specs step 3e for full logic (monorepo detection, opt-out via \`monorepoAppLabel: false\` in \`openspec/config.yaml\`).
+   Ensure newly synced specs follow existing front matter conventions. See sync-specs step 3e for full logic (monorepo detection, opt-out via \`monorepo: false\` in config).
 
 5. **Perform the archive**
 

--- a/src/core/templates/workflows/bulk-archive-change.ts
+++ b/src/core/templates/workflows/bulk-archive-change.ts
@@ -125,6 +125,7 @@ This skill allows you to batch-archive changes, handling spec conflicts intellig
       - Use the openspec-sync-specs approach (agent-driven intelligent merge)
       - For conflicts, apply in resolved order
       - Track if sync was done
+      - Ensure front matter consistency on newly synced specs (see sync-specs step 3e)
 
    b. **Perform the archive**:
       \`\`\`bash
@@ -372,6 +373,7 @@ This skill allows you to batch-archive changes, handling spec conflicts intellig
       - Use the openspec-sync-specs approach (agent-driven intelligent merge)
       - For conflicts, apply in resolved order
       - Track if sync was done
+      - Ensure front matter consistency on newly synced specs (see sync-specs step 3e)
 
    b. **Perform the archive**:
       \`\`\`bash

--- a/src/core/templates/workflows/sync-specs.ts
+++ b/src/core/templates/workflows/sync-specs.ts
@@ -71,6 +71,17 @@ This is an **agent-driven** operation - you will read delta specs and directly e
       - Add Purpose section (can be brief, mark as TBD)
       - Add Requirements section with the ADDED requirements
 
+   e. **Ensure front matter consistency** on newly synced specs (common in monorepos where specs need to indicate which app/package they belong to):
+      - If \`openspec/config.yaml\` contains \`monorepoAppLabel: false\` → skip
+      - Sample existing main specs in \`openspec/specs/\` for YAML front matter convention
+      - If existing specs use front matter → apply same pattern to newly created/updated specs
+      - If no existing specs have front matter AND project is single-app → skip
+      - If no existing specs have front matter AND project is a monorepo (multiple apps/packages detected):
+
+        **Prompt options:**
+        - "Establish front matter convention (recommended)" — suggest \`app: <name>\` based on project structure, apply to newly synced specs
+        - "Skip and don't ask again" — add \`monorepoAppLabel: false\` to \`openspec/config.yaml\`
+
 4. **Show summary**
 
    After applying all changes, summarize:
@@ -209,6 +220,17 @@ This is an **agent-driven** operation - you will read delta specs and directly e
       - Create \`openspec/specs/<capability>/spec.md\`
       - Add Purpose section (can be brief, mark as TBD)
       - Add Requirements section with the ADDED requirements
+
+   e. **Ensure front matter consistency** on newly synced specs (common in monorepos where specs need to indicate which app/package they belong to):
+      - If \`openspec/config.yaml\` contains \`monorepoAppLabel: false\` → skip
+      - Sample existing main specs in \`openspec/specs/\` for YAML front matter convention
+      - If existing specs use front matter → apply same pattern to newly created/updated specs
+      - If no existing specs have front matter AND project is single-app → skip
+      - If no existing specs have front matter AND project is a monorepo (multiple apps/packages detected):
+
+        **Prompt options:**
+        - "Establish front matter convention (recommended)" — suggest \`app: <name>\` based on project structure, apply to newly synced specs
+        - "Skip and don't ask again" — add \`monorepoAppLabel: false\` to \`openspec/config.yaml\`
 
 4. **Show summary**
 

--- a/src/core/templates/workflows/sync-specs.ts
+++ b/src/core/templates/workflows/sync-specs.ts
@@ -72,7 +72,7 @@ This is an **agent-driven** operation - you will read delta specs and directly e
       - Add Requirements section with the ADDED requirements
 
    e. **Ensure front matter consistency** on newly synced specs (common in monorepos where specs need to indicate which app/package they belong to):
-      - If \`openspec/config.yaml\` contains \`monorepoAppLabel: false\` → skip
+      - If the project config (\`openspec/config.yaml\` or \`openspec/config.yml\`) contains \`monorepoAppLabel: false\` → skip
       - Sample existing main specs in \`openspec/specs/\` for YAML front matter convention
       - If existing specs use front matter → apply same pattern to newly created/updated specs
       - If no existing specs have front matter AND project is single-app → skip
@@ -80,7 +80,7 @@ This is an **agent-driven** operation - you will read delta specs and directly e
 
         **Prompt options:**
         - "Establish front matter convention (recommended)" — suggest \`app: <name>\` based on project structure, apply to newly synced specs
-        - "Skip and don't ask again" — add \`monorepoAppLabel: false\` to \`openspec/config.yaml\`
+        - "Skip and don't ask again" — add \`monorepoAppLabel: false\` to the existing OpenSpec config file without overwriting other keys
 
 4. **Show summary**
 
@@ -222,7 +222,7 @@ This is an **agent-driven** operation - you will read delta specs and directly e
       - Add Requirements section with the ADDED requirements
 
    e. **Ensure front matter consistency** on newly synced specs (common in monorepos where specs need to indicate which app/package they belong to):
-      - If \`openspec/config.yaml\` contains \`monorepoAppLabel: false\` → skip
+      - If the project config (\`openspec/config.yaml\` or \`openspec/config.yml\`) contains \`monorepoAppLabel: false\` → skip
       - Sample existing main specs in \`openspec/specs/\` for YAML front matter convention
       - If existing specs use front matter → apply same pattern to newly created/updated specs
       - If no existing specs have front matter AND project is single-app → skip
@@ -230,7 +230,7 @@ This is an **agent-driven** operation - you will read delta specs and directly e
 
         **Prompt options:**
         - "Establish front matter convention (recommended)" — suggest \`app: <name>\` based on project structure, apply to newly synced specs
-        - "Skip and don't ask again" — add \`monorepoAppLabel: false\` to \`openspec/config.yaml\`
+        - "Skip and don't ask again" — add \`monorepoAppLabel: false\` to the existing OpenSpec config file without overwriting other keys
 
 4. **Show summary**
 

--- a/src/core/templates/workflows/sync-specs.ts
+++ b/src/core/templates/workflows/sync-specs.ts
@@ -72,7 +72,7 @@ This is an **agent-driven** operation - you will read delta specs and directly e
       - Add Requirements section with the ADDED requirements
 
    e. **Ensure front matter consistency** on newly synced specs (common in monorepos where specs need to indicate which app/package they belong to):
-      - If the project config (\`openspec/config.yaml\` or \`openspec/config.yml\`) contains \`monorepoAppLabel: false\` → skip
+      - If the project config (\`openspec/config.yaml\` or \`openspec/config.yml\`) contains \`monorepo: false\` → skip
       - Sample existing main specs in \`openspec/specs/\` for YAML front matter convention
       - If existing specs use front matter → apply same pattern to newly created/updated specs
       - If no existing specs have front matter AND project is single-app → skip
@@ -80,7 +80,7 @@ This is an **agent-driven** operation - you will read delta specs and directly e
 
         **Prompt options:**
         - "Establish front matter convention (recommended)" — suggest \`app: <name>\` based on project structure, apply to newly synced specs
-        - "Skip and don't ask again" — add \`monorepoAppLabel: false\` to the existing OpenSpec config file without overwriting other keys
+        - "Skip and don't ask again" — add \`monorepo: false\` to the existing OpenSpec config file without overwriting other keys
 
 4. **Show summary**
 
@@ -222,7 +222,7 @@ This is an **agent-driven** operation - you will read delta specs and directly e
       - Add Requirements section with the ADDED requirements
 
    e. **Ensure front matter consistency** on newly synced specs (common in monorepos where specs need to indicate which app/package they belong to):
-      - If the project config (\`openspec/config.yaml\` or \`openspec/config.yml\`) contains \`monorepoAppLabel: false\` → skip
+      - If the project config (\`openspec/config.yaml\` or \`openspec/config.yml\`) contains \`monorepo: false\` → skip
       - Sample existing main specs in \`openspec/specs/\` for YAML front matter convention
       - If existing specs use front matter → apply same pattern to newly created/updated specs
       - If no existing specs have front matter AND project is single-app → skip
@@ -230,7 +230,7 @@ This is an **agent-driven** operation - you will read delta specs and directly e
 
         **Prompt options:**
         - "Establish front matter convention (recommended)" — suggest \`app: <name>\` based on project structure, apply to newly synced specs
-        - "Skip and don't ask again" — add \`monorepoAppLabel: false\` to the existing OpenSpec config file without overwriting other keys
+        - "Skip and don't ask again" — add \`monorepo: false\` to the existing OpenSpec config file without overwriting other keys
 
 4. **Show summary**
 


### PR DESCRIPTION
  ## Problem

  In monorepo projects, specs need YAML front matter (e.g., `app: web-dashboard`, `app: api-server`) to indicate which app/package they belong to. When syncing delta specs to main specs via `opsx:sync` or `opsx:archive`, newly created specs don't inherit this
  convention — leading to inconsistent specs that are missing their app label.

  ## Solution

  Add a **front matter consistency step** (step 3e) to the sync workflow. After syncing, it checks whether existing main specs use front matter and applies the same pattern to newly synced specs.

  **Decision flow:**

  openspec/config.yaml has monorepoAppLabel: false?
    → skip (user opted out)

  Existing specs have front matter?
    → yes: apply same pattern to new specs
    → no + single-app project: skip
    → no + monorepo detected: prompt user
         → "Establish convention": apply app: , future syncs auto-detect
         → "Skip and don't ask again": write monorepoAppLabel: false to config.yaml

  ## Changes

  | File | Change |
  |------|--------|
  | `sync-specs.ts` | Step 3e: full front matter consistency logic (both skill + command templates) |
  | `archive-change.ts` | Reference sync step 3e after sync (both skill + command templates) |
  | `bulk-archive-change.ts` | Reference sync step 3e after sync (both skill + command templates) |

  ## Design decisions

  - **Logic lives in sync only** — archive and bulk-archive reference it, avoiding duplication
  - **Convention-based, not prescriptive** — samples existing specs to detect the pattern rather than hardcoding a specific front matter schema
  - **Opt-out is persistent** — `monorepoAppLabel: false` in `openspec/config.yaml` prevents repeated prompts
  - **Single-app projects are unaffected** — skips entirely when no monorepo is detected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Automatic front-matter consistency when syncing specs: newly synced specs will align with existing front-matter conventions.
  * New project setting to opt out of monorepo front-matter conventions, with adaptive behavior for monorepos vs single-app projects and an option to establish conventions when detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->