### PR TITLE
feat: add quick-task lightweight schema for simple changes

### DIFF
--- a/schemas/quick-task/schema.yaml
+++ b/schemas/quick-task/schema.yaml
@@ -1,0 +1,63 @@
+name: quick-task
+version: 1
+description: Lightweight workflow for simple tasks - proposal → tasks (skip specs and design)
+artifacts:
+  - id: proposal
+    generates: proposal.md
+    description: Brief proposal outlining the change
+    template: proposal.md
+    instruction: |
+      Create a brief proposal document for this change.
+
+      Sections:
+      - **Why**: 1-2 sentences on the problem or opportunity. What problem does this solve? Why now?
+      - **What Changes**: Bullet list of changes. Be specific about what will be added, modified, or removed.
+      - **Impact**: Affected code, APIs, dependencies, or systems.
+
+      This is a lightweight schema for simple tasks. Keep it concise -
+      a few paragraphs at most. No need for capabilities or spec mappings.
+
+      If the change turns out to be more complex than expected, consider
+      switching to the spec-driven schema instead.
+    requires: []
+
+  - id: tasks
+    generates: tasks.md
+    description: Implementation checklist with trackable tasks
+    template: tasks.md
+    instruction: |
+      Create the task list that breaks down the implementation work.
+
+      **IMPORTANT: Follow the template below exactly.** The apply phase parses
+      checkbox format to track progress. Tasks not using `- [ ]` won't be tracked.
+
+      Guidelines:
+      - Group related tasks under ## numbered headings
+      - Each task MUST be a checkbox: `- [ ] X.Y Task description`
+      - Tasks should be small enough to complete in one session
+      - Order tasks by dependency (what must be done first?)
+
+      Example:
+      ```
+      ## 1. Setup
+
+      - [ ] 1.1 Create new module structure
+      - [ ] 1.2 Add dependencies to package.json
+
+      ## 2. Core Implementation
+
+      - [ ] 2.1 Implement the main function
+      - [ ] 2.2 Add error handling
+      ```
+
+      Reference the proposal for what needs to be built.
+      Each task should be verifiable - you know when it's done.
+    requires:
+      - proposal
+
+apply:
+  requires: [tasks]
+  tracks: tasks.md
+  instruction: |
+    Read the proposal for context, work through pending tasks, mark complete as you go.
+    Pause if you hit blockers or need clarification.

--- a/schemas/quick-task/templates/proposal.md
+++ b/schemas/quick-task/templates/proposal.md
@@ -1,0 +1,11 @@
+## Why
+
+<!-- 1-2 sentences: What problem does this solve? Why now? -->
+
+## What Changes
+
+<!-- Bullet list of changes. Be specific about additions, modifications, or removals. -->
+
+## Impact
+
+<!-- Affected code, APIs, dependencies, systems -->

--- a/schemas/quick-task/templates/tasks.md
+++ b/schemas/quick-task/templates/tasks.md
@@ -1,0 +1,9 @@
+## 1. <!-- Task Group Name -->
+
+- [ ] 1.1 <!-- Task description -->
+- [ ] 1.2 <!-- Task description -->
+
+## 2. <!-- Task Group Name -->
+
+- [ ] 2.1 <!-- Task description -->
+- [ ] 2.2 <!-- Task description -->


### PR DESCRIPTION
## Summary

- Adds a new built-in `quick-task` schema with a streamlined 2-phase workflow: **proposal -> tasks**
- Skips specs and design phases, making it ideal for simple bug fixes, config changes, and small features
- Fully compatible with existing schema infrastructure (validated via `openspec schema validate`)

## Motivation

The existing `spec-driven` schema has 4 phases (proposal -> specs -> design -> tasks), which is great for complex features but overkill for simple tasks. This lightweight alternative reduces ceremony while maintaining structure.

## What's included

```
schemas/quick-task/
├── schema.yaml              # Schema definition (2 artifacts + apply phase)
└── templates/
    ├── proposal.md          # Simplified proposal (Why / What Changes / Impact)
    └── tasks.md             # Standard checkbox task list
```

## Comparison

| | spec-driven | quick-task |
|---|---|---|
| Phases | proposal → specs → design → tasks | proposal → tasks |
| Best for | Complex features, architecture changes | Bug fixes, config tweaks, small features |

## Verification

- `openspec schema validate quick-task` passes
- `openspec schemas` lists both schemas correctly
- All 1332 existing tests pass with no regressions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new "quick-task" workflow for lightweight project management with guided templates.
  * Added proposal template with structured sections (Why, What Changes, Impact) to document project rationale and impact.
  * Added task checklist template with grouping and dependency tracking for organizing work items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->