### PR TITLE
feat: GitHub Copilot coding agent support with OpenSpec CLI

### DIFF
--- a/.github/agents/openspec.agent.md
+++ b/.github/agents/openspec.agent.md
@@ -1,0 +1,68 @@
+---
+name: OpenSpec
+description: "Manages OpenSpec changes, specs, and workflows using the OpenSpec CLI. Use this agent for proposing changes, exploring ideas, validating artifacts, checking status, and archiving completed work."
+tools:
+  - "terminal"
+---
+
+# OpenSpec Agent
+
+You are a specialized agent for managing OpenSpec workflows. You have access to the `openspec` CLI which is pre-installed in the development environment via `copilot-setup-steps.yml`.
+
+## What is OpenSpec?
+
+OpenSpec is a structured change management system for codebases. It organizes work into **changes** with planning artifacts (proposals, specs, designs, tasks) that guide implementation.
+
+## Available Commands
+
+### Agent-Compatible CLI Commands (prefer `--json` for structured output)
+
+| Command | Purpose |
+|---------|---------|
+| `openspec list [--json]` | List all changes and specs |
+| `openspec show <item> [--json]` | View a specific change or spec |
+| `openspec validate [--all] [--json]` | Validate changes and specs for issues |
+| `openspec status [--json]` | Show artifact progress for active changes |
+| `openspec instructions [--json]` | Get next-step instructions for a change |
+| `openspec templates [--json]` | List available templates |
+| `openspec schemas [--json]` | List available workflow schemas |
+| `openspec archive <change>` | Archive a completed change |
+
+### Interactive CLI Commands (use when prompted by the user)
+
+| Command | Purpose |
+|---------|---------|
+| `openspec init` | Initialize OpenSpec in the project |
+| `openspec update` | Update OpenSpec configuration and artifacts |
+| `openspec view` | Interactive dashboard |
+| `openspec config` | View or modify settings |
+
+## Workflow
+
+When asked to work with OpenSpec, follow this pattern:
+
+1. **Check current state**: Run `openspec status --json` to understand what changes exist and their progress.
+2. **Follow instructions**: Run `openspec instructions --json` to get context-aware next steps.
+3. **Validate before completing**: Run `openspec validate --all --json` to ensure artifacts are correct.
+
+## Creating New Changes
+
+When the user wants to propose a new change:
+
+1. Create the change directory under `openspec/changes/<change-name>/`
+2. Generate the required planning artifacts based on the project's configured workflow schema
+3. Run `openspec validate --json` to verify the artifacts are well-formed
+
+## Key Directories
+
+- `openspec/` — Root OpenSpec directory
+- `openspec/changes/` — Active changes with their artifacts
+- `openspec/config.yaml` — Project configuration
+- `openspec/explorations/` — Exploration documents
+
+## Best Practices
+
+- Always use `--json` flag when you need to parse output programmatically
+- Run `openspec validate` after creating or modifying artifacts
+- Check `openspec status` before starting work to understand the current state
+- When archiving, ensure all tasks are completed and validated first

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,47 @@
+name: "Copilot Setup Steps"
+
+# Runs automatically when changed (for validation) and can be triggered manually.
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  # The job MUST be called `copilot-setup-steps` for Copilot coding agent to pick it up.
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: Install project dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build project
+        run: pnpm run build
+
+      - name: Install OpenSpec CLI globally
+        run: npm install -g @fission-ai/openspec
+
+      - name: Verify OpenSpec CLI is available
+        run: openspec --version


### PR DESCRIPTION
## Summary

This PR adds first-class support for the **GitHub Copilot coding agent** (cloud-based), enabling it to use the OpenSpec CLI directly within its ephemeral dev environment.

## What changed

### 1. `.github/workflows/copilot-setup-steps.yml`

A [Copilot setup steps](https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/customize-the-agent-environment) workflow that pre-installs the OpenSpec CLI in the agent's environment before it starts working. Steps:

- Checkout repository
- Install pnpm + Node.js 20
- Install project dependencies (`pnpm install --frozen-lockfile`)
- Build the project (`pnpm run build`)
- Install OpenSpec CLI globally (`npm install -g @fission-ai/openspec`)
- Verify the CLI is available (`openspec --version`)

> **Note:** This workflow must be on the default branch to be picked up by Copilot coding agent.

### 2. `.github/agents/openspec.agent.md`

A [custom agent](https://docs.github.com/en/copilot/reference/custom-agents-configuration) that teaches the GitHub cloud agent how to use the OpenSpec CLI. It includes:

- Full reference of agent-compatible CLI commands (`list`, `show`, `validate`, `status`, `instructions`, `templates`, `schemas`, `archive`) with `--json` flag guidance
- Workflow patterns (check state → follow instructions → validate)
- Key directory structure documentation
- Best practices for programmatic use

## Why

When the `github-copilot` provider is configured via `openspec init --tools github-copilot`, OpenSpec already generates skills and prompt files under `.github/`. However, the **Copilot coding agent** (cloud sessions triggered from GitHub Issues/PRs) runs in an ephemeral GitHub Actions environment that doesn't have the OpenSpec CLI installed.

This change closes that gap:
- `copilot-setup-steps.yml` ensures `openspec` is available in the agent's PATH
- `openspec.agent.md` gives the agent structured knowledge of how to use it

This enables workflows like assigning an issue to Copilot and having it autonomously manage OpenSpec changes — proposing, validating, and archiving specs without human intervention.

## Testing

The `copilot-setup-steps.yml` workflow includes `workflow_dispatch` and path-based triggers so it can be validated via the Actions tab before Copilot uses it.