### PR TITLE
feat: add sub-agent spec discovery step to proposal workflows

### DIFF
--- a/schemas/spec-driven/schema.yaml
+++ b/schemas/spec-driven/schema.yaml
@@ -13,12 +13,13 @@ artifacts:
       - **Why**: 1-2 sentences on the problem or opportunity. What problem does this solve? Why now?
       - **What Changes**: Bullet list of changes. Be specific about new capabilities, modifications, or removals. Mark breaking changes with **BREAKING**.
       - **Capabilities**: Identify which specs will be created or modified:
-        - **New Capabilities**: List capabilities being introduced. Each becomes a new `specs/<name>/spec.md`. Use kebab-case names (e.g., `user-auth`, `data-export`).
-        - **Modified Capabilities**: List existing capabilities whose REQUIREMENTS are changing. Only include if spec-level behavior changes (not just implementation details). Each needs a delta spec file. Check `openspec/specs/` for existing spec names. Leave empty if no requirement changes.
+        - Before filling this in, discover existing specs by running `openspec list --specs --json --detail`. Review each spec's `overview` to understand what it covers. If `--detail` is unavailable, browse `openspec/specs/` and read each spec's Purpose section instead.
+        - **New Capabilities**: List capabilities being introduced that don't overlap with any existing spec. Each becomes a new `specs/<name>/spec.md`. Use kebab-case names (e.g., `user-auth`, `data-export`).
+        - **Modified Capabilities**: List existing capabilities whose REQUIREMENTS are changing. Only include if spec-level behavior changes (not just implementation details). Each needs a delta spec file. Use the `id` from the catalog output above. Leave empty if no requirement changes.
       - **Impact**: Affected code, APIs, dependencies, or systems.
 
       IMPORTANT: The Capabilities section is critical. It creates the contract between
-      proposal and specs phases. Research existing specs before filling this in.
+      proposal and specs phases. Always run spec discovery before filling this in.
       Each capability listed here will need a corresponding spec file.
 
       Keep it concise (1-2 pages). Focus on the "why" not the "how" -

--- a/src/core/templates/workflows/continue-change.ts
+++ b/src/core/templates/workflows/continue-change.ts
@@ -100,6 +100,7 @@ Common artifact patterns:
 
 **spec-driven schema** (proposal → specs → design → tasks):
 - **proposal.md**: Ask user about the change if not clear. Fill in Why, What Changes, Capabilities, Impact.
+  - Before writing Capabilities, run \`openspec list --specs --json --detail\` to discover existing specs. Compare each spec's overview against the proposed change to determine New vs Modified capabilities.
   - The Capabilities section is critical - each capability listed will need a spec file.
 - **specs/<capability>/spec.md**: Create one spec per capability listed in the proposal's Capabilities section (use the capability name, not the change name).
 - **design.md**: Document technical decisions, architecture, and implementation approach.
@@ -219,6 +220,7 @@ Common artifact patterns:
 
 **spec-driven schema** (proposal → specs → design → tasks):
 - **proposal.md**: Ask user about the change if not clear. Fill in Why, What Changes, Capabilities, Impact.
+  - Before writing Capabilities, run \`openspec list --specs --json --detail\` to discover existing specs. Compare each spec's overview against the proposed change to determine New vs Modified capabilities.
   - The Capabilities section is critical - each capability listed will need a spec file.
 - **specs/<capability>/spec.md**: Create one spec per capability listed in the proposal's Capabilities section (use the capability name, not the change name).
 - **design.md**: Document technical decisions, architecture, and implementation approach.

--- a/src/core/templates/workflows/continue-change.ts
+++ b/src/core/templates/workflows/continue-change.ts
@@ -53,6 +53,11 @@ export function getContinueChangeSkillTemplate(): SkillTemplate {
 
    **If artifacts are ready to create** (status shows artifacts with \`status: "ready"\`):
    - Pick the FIRST artifact with \`status: "ready"\` from the status output
+   - **If the artifact is \`proposal\`**: Before creating it, discover existing specs first.
+     Use the **Agent tool** to spawn a sub-agent for spec discovery:
+     - **prompt**: "Run \`openspec list --specs --json --detail\` in the project directory. Parse the JSON output — each spec has id, title, overview, and requirementCount. The user wants to build: [describe the change]. Compare each spec's overview against this description and return ONLY the specs that are related. Format your response as a JSON array: [{id, overview, reason}]. Do not return unrelated specs."
+     - Use the sub-agent's results to classify the proposal's Capabilities section (New vs Modified).
+     - If sub-agents are unavailable, run \`openspec list --specs --json --detail\` directly.
    - Get its instructions:
      \`\`\`bash
      openspec instructions <artifact-id> --change "<name>" --json
@@ -100,7 +105,7 @@ Common artifact patterns:
 
 **spec-driven schema** (proposal → specs → design → tasks):
 - **proposal.md**: Ask user about the change if not clear. Fill in Why, What Changes, Capabilities, Impact.
-  - Before writing Capabilities, run \`openspec list --specs --json --detail\` to discover existing specs. Compare each spec's overview against the proposed change to determine New vs Modified capabilities.
+  - Before writing Capabilities, use the **Agent tool** to spawn a sub-agent for spec discovery: "Run \`openspec list --specs --json --detail\` and find specs related to [the proposed change]. Return a JSON array of related specs with id, overview, and reason." If sub-agents are unavailable, run the CLI directly.
   - The Capabilities section is critical - each capability listed will need a spec file.
 - **specs/<capability>/spec.md**: Create one spec per capability listed in the proposal's Capabilities section (use the capability name, not the change name).
 - **design.md**: Document technical decisions, architecture, and implementation approach.
@@ -173,6 +178,11 @@ export function getOpsxContinueCommandTemplate(): CommandTemplate {
 
    **If artifacts are ready to create** (status shows artifacts with \`status: "ready"\`):
    - Pick the FIRST artifact with \`status: "ready"\` from the status output
+   - **If the artifact is \`proposal\`**: Before creating it, discover existing specs first.
+     Use the **Agent tool** to spawn a sub-agent for spec discovery:
+     - **prompt**: "Run \`openspec list --specs --json --detail\` in the project directory. Parse the JSON output — each spec has id, title, overview, and requirementCount. The user wants to build: [describe the change]. Compare each spec's overview against this description and return ONLY the specs that are related. Format your response as a JSON array: [{id, overview, reason}]. Do not return unrelated specs."
+     - Use the sub-agent's results to classify the proposal's Capabilities section (New vs Modified).
+     - If sub-agents are unavailable, run \`openspec list --specs --json --detail\` directly.
    - Get its instructions:
      \`\`\`bash
      openspec instructions <artifact-id> --change "<name>" --json
@@ -220,7 +230,7 @@ Common artifact patterns:
 
 **spec-driven schema** (proposal → specs → design → tasks):
 - **proposal.md**: Ask user about the change if not clear. Fill in Why, What Changes, Capabilities, Impact.
-  - Before writing Capabilities, run \`openspec list --specs --json --detail\` to discover existing specs. Compare each spec's overview against the proposed change to determine New vs Modified capabilities.
+  - Before writing Capabilities, use the **Agent tool** to spawn a sub-agent for spec discovery: "Run \`openspec list --specs --json --detail\` and find specs related to [the proposed change]. Return a JSON array of related specs with id, overview, and reason." If sub-agents are unavailable, run the CLI directly.
   - The Capabilities section is critical - each capability listed will need a spec file.
 - **specs/<capability>/spec.md**: Create one spec per capability listed in the proposal's Capabilities section (use the capability name, not the change name).
 - **design.md**: Document technical decisions, architecture, and implementation approach.

--- a/src/core/templates/workflows/ff-change.ts
+++ b/src/core/templates/workflows/ff-change.ts
@@ -31,7 +31,18 @@ export function getFfChangeSkillTemplate(): SkillTemplate {
    \`\`\`
    This creates a scaffolded change at \`openspec/changes/<name>/\`.
 
-3. **Get the artifact build order**
+3. **Discover existing specs (via sub-agent)**
+   Use the **Agent tool** to spawn a sub-agent for spec discovery. This keeps the catalog analysis in a separate context:
+   - **prompt**: "Run \`openspec list --specs --json --detail\` in the project directory. Parse the JSON output — each spec has id, title, overview, and requirementCount. The user wants to build: [paste the user's description here]. Compare each spec's overview against this description and return ONLY the specs that are related. Format your response as a JSON array: [{id, overview, reason}]. Do not return unrelated specs."
+   - The sub-agent analyzes all specs in its own context window and returns only the relevant ones.
+   - Use the sub-agent's results to classify the proposal's Capabilities section (New vs Modified).
+
+   If your tool does not support sub-agents, run the CLI directly instead:
+   \`\`\`bash
+   openspec list --specs --json --detail
+   \`\`\`
+
+4. **Get the artifact build order**
    \`\`\`bash
    openspec status --change "<name>" --json
    \`\`\`
@@ -39,7 +50,7 @@ export function getFfChangeSkillTemplate(): SkillTemplate {
    - \`applyRequires\`: array of artifact IDs needed before implementation (e.g., \`["tasks"]\`)
    - \`artifacts\`: list of all artifacts with their status and dependencies
 
-4. **Create artifacts in sequence until apply-ready**
+5. **Create artifacts in sequence until apply-ready**
 
    Use the **TodoWrite tool** to track progress through the artifacts.
 
@@ -133,7 +144,18 @@ export function getOpsxFfCommandTemplate(): CommandTemplate {
    \`\`\`
    This creates a scaffolded change at \`openspec/changes/<name>/\`.
 
-3. **Get the artifact build order**
+3. **Discover existing specs (via sub-agent)**
+   Use the **Agent tool** to spawn a sub-agent for spec discovery. This keeps the catalog analysis in a separate context:
+   - **prompt**: "Run \`openspec list --specs --json --detail\` in the project directory. Parse the JSON output — each spec has id, title, overview, and requirementCount. The user wants to build: [paste the user's description here]. Compare each spec's overview against this description and return ONLY the specs that are related. Format your response as a JSON array: [{id, overview, reason}]. Do not return unrelated specs."
+   - The sub-agent analyzes all specs in its own context window and returns only the relevant ones.
+   - Use the sub-agent's results to classify the proposal's Capabilities section (New vs Modified).
+
+   If your tool does not support sub-agents, run the CLI directly instead:
+   \`\`\`bash
+   openspec list --specs --json --detail
+   \`\`\`
+
+4. **Get the artifact build order**
    \`\`\`bash
    openspec status --change "<name>" --json
    \`\`\`
@@ -141,7 +163,7 @@ export function getOpsxFfCommandTemplate(): CommandTemplate {
    - \`applyRequires\`: array of artifact IDs needed before implementation (e.g., \`["tasks"]\`)
    - \`artifacts\`: list of all artifacts with their status and dependencies
 
-4. **Create artifacts in sequence until apply-ready**
+5. **Create artifacts in sequence until apply-ready**
 
    Use the **TodoWrite tool** to track progress through the artifacts.
 

--- a/src/core/templates/workflows/propose.ts
+++ b/src/core/templates/workflows/propose.ts
@@ -40,7 +40,18 @@ When ready to implement, run /opsx:apply
    \`\`\`
    This creates a scaffolded change at \`openspec/changes/<name>/\` with \`.openspec.yaml\`.
 
-3. **Get the artifact build order**
+3. **Discover existing specs (via sub-agent)**
+   Use the **Agent tool** to spawn a sub-agent for spec discovery. This keeps the catalog analysis in a separate context:
+   - **prompt**: "Run \`openspec list --specs --json --detail\` in the project directory. Parse the JSON output — each spec has id, title, overview, and requirementCount. The user wants to build: [paste the user's description here]. Compare each spec's overview against this description and return ONLY the specs that are related. Format your response as a JSON array: [{id, overview, reason}]. Do not return unrelated specs."
+   - The sub-agent analyzes all specs in its own context window and returns only the relevant ones.
+   - Use the sub-agent's results to classify the proposal's Capabilities section (New vs Modified).
+
+   If your tool does not support sub-agents, run the CLI directly instead:
+   \`\`\`bash
+   openspec list --specs --json --detail
+   \`\`\`
+
+4. **Get the artifact build order**
    \`\`\`bash
    openspec status --change "<name>" --json
    \`\`\`
@@ -48,7 +59,7 @@ When ready to implement, run /opsx:apply
    - \`applyRequires\`: array of artifact IDs needed before implementation (e.g., \`["tasks"]\`)
    - \`artifacts\`: list of all artifacts with their status and dependencies
 
-4. **Create artifacts in sequence until apply-ready**
+5. **Create artifacts in sequence until apply-ready**
 
    Use the **TodoWrite tool** to track progress through the artifacts.
 
@@ -151,7 +162,18 @@ When ready to implement, run /opsx:apply
    \`\`\`
    This creates a scaffolded change at \`openspec/changes/<name>/\` with \`.openspec.yaml\`.
 
-3. **Get the artifact build order**
+3. **Discover existing specs (via sub-agent)**
+   Use the **Agent tool** to spawn a sub-agent for spec discovery. This keeps the catalog analysis in a separate context:
+   - **prompt**: "Run \`openspec list --specs --json --detail\` in the project directory. Parse the JSON output — each spec has id, title, overview, and requirementCount. The user wants to build: [paste the user's description here]. Compare each spec's overview against this description and return ONLY the specs that are related. Format your response as a JSON array: [{id, overview, reason}]. Do not return unrelated specs."
+   - The sub-agent analyzes all specs in its own context window and returns only the relevant ones.
+   - Use the sub-agent's results to classify the proposal's Capabilities section (New vs Modified).
+
+   If your tool does not support sub-agents, run the CLI directly instead:
+   \`\`\`bash
+   openspec list --specs --json --detail
+   \`\`\`
+
+4. **Get the artifact build order**
    \`\`\`bash
    openspec status --change "<name>" --json
    \`\`\`
@@ -159,7 +181,7 @@ When ready to implement, run /opsx:apply
    - \`applyRequires\`: array of artifact IDs needed before implementation (e.g., \`["tasks"]\`)
    - \`artifacts\`: list of all artifacts with their status and dependencies
 
-4. **Create artifacts in sequence until apply-ready**
+5. **Create artifacts in sequence until apply-ready**
 
    Use the **TodoWrite tool** to track progress through the artifacts.
 


### PR DESCRIPTION
## Summary

Adds an explicit **spec discovery step** to all proposal-creating workflows (`propose`, `ff`, `continue`), using the Agent tool to spawn a sub-agent that runs `openspec list --specs --json --detail` and identifies related specs before writing the Capabilities section.

> **Dependency:** This PR depends on #700 (`--detail` flag for `openspec list --specs --json`). The discovery step uses `--detail` to get spec overviews without loading full spec content. Without #700, it falls back to browsing `openspec/specs/` directories directly.

## Problem

The current proposal instruction says:

> Check `openspec/specs/` for existing spec names.

In practice, the AI treats this as optional guidance and often skips it entirely. When it does check, it reads full spec files into context — wasteful at scale. With 100+ specs, the AI has no efficient way to determine which existing specs relate to a new change.

## Solution

### What changed

| File | Change |
|------|--------|
| `schemas/spec-driven/schema.yaml` | Updated proposal instruction with concrete `openspec list --specs --json --detail` guidance |
| `src/core/templates/workflows/propose.ts` | Added **Step 3: Discover existing specs (via sub-agent)** before artifact creation |
| `src/core/templates/workflows/ff-change.ts` | Same Step 3 addition |
| `src/core/templates/workflows/continue-change.ts` | Added conditional discovery step when the artifact being created is `proposal` |

### Key insight from testing

Instructions placed in `schema.yaml` (loaded via `openspec instructions proposal --json`) are treated as optional guidance — the AI ignores them. But steps placed directly in the **skill template** as explicit numbered steps are consistently followed. This PR adds the discovery step as a first-class workflow step, not just instruction text.

### Sub-agent approach

The discovery step instructs the AI to use the **Agent tool** to delegate spec catalog analysis to a sub-agent:

```
3. **Discover existing specs (via sub-agent)**
   Use the Agent tool to spawn a sub-agent for spec discovery:
   - prompt: "Run `openspec list --specs --json --detail`...
     Compare each spec's overview against this description 
     and return ONLY the specs that are related."
```

This keeps the catalog analysis (potentially 100+ spec overviews) in a **separate context window**, preventing main context pollution. Tools without sub-agent support fall back to running the CLI directly.

## Test Results

### Benchmark: 100 specs (5 related, 95 unrelated)

Prompt: "Add ability to create routines directly from pool search results" (3 runs each)

| Metric | Before | After |
|--------|--------|-------|
| **Agent tool usage** | 0% (0/3) | **100%** (3/3) |
| **CLI --detail usage** | 0% (0/3) | **100%** (3/3) |
| **Consistency** | Unstable (40%, 60%, 60%) | **Stable** (60%, 60%, 60%) |

### Benchmark: 500 specs (15 related, 485 unrelated)

| Metric | Before | After |
|--------|--------|-------|
| **Agent tool usage** | 0% (0/3) | **100%** (3/3) |
| **CLI --detail usage** | 33% (1/3) | **100%** (3/3) |
| **Consistency** | Unstable (0%, 33%, 33%) | **Stable** (20%, 20%, 20%) |

### Workflow verification: `new → continue` flow

Hook log confirming sub-agent and `--detail` usage:
```
[1] openspec status --change "pool-routine-link" --json
[2] openspec instructions proposal --json
[3] openspec list --specs --json --detail          ← CLI --detail ✅
[4] >>> AGENT: Discover related specs               ← Sub-agent ✅
[5] openspec status --change "pool-routine-link"
```

### Token savings

```
Full spec load (100 specs): 27,622 tokens
Catalog only (--detail):     4,935 tokens → 82% reduction
```

## Personal usage

I've already updated my local OpenSpec installation with these changes and have been using them in my daily workflow. The sub-agent consistently discovers related specs before proposal creation across `propose`, `ff`, and `new → continue` flows. It works very well.

## Related issues

- Closes #901
- Depends on #700 (`--detail` flag)
- Addresses #878 (main specs now actively queried during every proposal)
- Addresses #872 (overview-based filtering avoids loading full spec content)