### PR TITLE
feat(schema): add adr-constrained-dag workflow

### DIFF
--- a/docs/adr-constrained-dag.md
+++ b/docs/adr-constrained-dag.md
@@ -1,0 +1,54 @@
+# ADR-Constrained DAG Schema
+
+`adr-constrained-dag` is a spec-driven workflow variant for teams that want:
+
+- project constraints defined in `openspec/config.yaml`
+- every constraint backed by an ADR
+- design docs that explicitly show constraint alignment
+- task lists with dependency metadata (`depends_on`) and traceability
+
+## Philosophy
+
+This schema does not add a new required artifact type.
+It keeps OpenSpec's familiar flow:
+
+proposal → specs → design → tasks → apply
+
+The governance additions are lightweight:
+
+- `config.yaml` carries project constraints in `context`
+- `openspec/adrs/` stores the rationale for each constraint
+- `tasks.md` stays a checkbox list for apply compatibility
+- task items include DAG metadata and traceability fields
+
+## Example config
+
+```yaml
+schema: adr-constrained-dag
+
+context: |
+  Project constraints:
+  - API-001: Preserve backward compatibility for public APIs by default. Backed by ADR-0003.
+  - ARCH-002: Cross-domain async workflows must use the event bus. Backed by ADR-0007.
+
+  Constraint policy:
+  - Every change must identify which constraints apply.
+  - If a change touches a constraint, proposal and design must reference its ADR.
+  - If a change introduces a new long-lived architectural rule, create a new ADR and add the constraint here.
+  - Archive is not allowed until artifacts, implementation, and ADR references are aligned.
+
+rules:
+  proposal:
+    - State the intended outcome clearly.
+    - List the applicable constraints by ID.
+    - Reference the ADRs for those constraints.
+  design:
+    - Explain how the design satisfies each applicable constraint.
+    - Reference the ADRs behind those constraints.
+    - State whether a new ADR is required.
+  tasks:
+    - Every task must use checkbox format.
+    - Every task must have a stable task ID.
+    - Every task must declare depends_on.
+    - Every task should reference requirements, constraints, and ADRs where applicable.
+    - Order tasks topologically.

--- a/schemas/adr-constrained-dag/schema.yaml
+++ b/schemas/adr-constrained-dag/schema.yaml
@@ -1,0 +1,75 @@
+name: adr-constrained-dag
+version: 1
+description: >
+  Spec-driven workflow with ADR-backed project constraints in config context
+  and DAG-style task metadata inside tasks.md.
+
+artifacts:
+  - id: proposal
+    generates: proposal.md
+    description: Why this change exists and which constraints apply
+    template: proposal.md
+    instruction: |
+      Create a proposal for this change.
+
+      The proposal must:
+      - State the intended outcome clearly
+      - List applicable project constraints by ID
+      - Reference the ADRs backing those constraints
+      - Call out compatibility impact on APIs, events, and persisted contracts
+      - Mention rollback or containment when behavior changes are hard to reverse
+    requires: []
+
+  - id: specs
+    generates: specs/**/*.md
+    description: Behavioral deltas for this change
+    template: spec.md
+    instruction: |
+      Create delta specs for this change.
+
+      The spec must:
+      - Use OpenSpec delta sections such as ADDED and MODIFIED Requirements
+      - Focus on behavior deltas for this change
+      - Make constrained behavior observable in scenarios
+      - Avoid duplicating full ADR text; reference constraint IDs where relevant
+    requires:
+      - proposal
+
+  - id: design
+    generates: design.md
+    description: Technical design and constraint alignment
+    template: design.md
+    instruction: |
+      Create a design document explaining how to implement this change.
+
+      The design must:
+      - List applicable constraints
+      - Reference the ADRs behind those constraints
+      - Explain how the design satisfies each applicable constraint
+      - State whether a new ADR is required
+      - Highlight impact on APIs, storage, messaging, jobs, and deployment assumptions
+    requires:
+      - proposal
+
+  - id: tasks
+    generates: tasks.md
+    description: DAG-aware implementation checklist
+    template: tasks.md
+    instruction: |
+      Create an implementation task list.
+
+      Requirements:
+      - Every task MUST be a checkbox item in markdown
+      - Every task MUST have a stable task ID like T01, T02, T03
+      - Every task MUST declare depends_on metadata
+      - Every task SHOULD reference requirements, constraints, and ADRs where applicable
+      - Keep tasks in topological order
+      - Prefer small, verifiable tasks
+      - Include tests and docs tasks when required by the change
+    requires:
+      - specs
+      - design
+
+apply:
+  requires: [tasks]
+  tracks: tasks.md

--- a/schemas/adr-constrained-dag/templates/design.md
+++ b/schemas/adr-constrained-dag/templates/design.md
@@ -1,0 +1,33 @@
+# Design: {{CHANGE_NAME}}
+
+## Summary
+Explain the technical approach at a high level.
+
+## Applicable constraints
+- <constraint-id>: <constraint statement>. Backed by <ADR-id>.
+- <constraint-id>: <constraint statement>. Backed by <ADR-id>.
+
+## Design
+Describe the implementation approach.
+
+## Constraint alignment
+
+### <constraint-id> / <ADR-id>
+Explain how this design satisfies the constraint.
+
+### <constraint-id> / <ADR-id>
+Explain how this design satisfies the constraint.
+
+## Data and operations
+Describe any impact on:
+- storage/schema
+- events/messages
+- background jobs
+- deployment/configuration
+- observability/docs
+
+## ADR impact
+State one of:
+- No new ADR is required
+- Update existing ADR: <ADR-id>
+- Create new ADR: <ADR-id>

--- a/schemas/adr-constrained-dag/templates/proposal.md
+++ b/schemas/adr-constrained-dag/templates/proposal.md
@@ -1,0 +1,29 @@
+# Proposal: {{CHANGE_NAME}}
+
+## Why
+Explain the problem or opportunity.
+
+## Outcome
+Describe the user-visible or system-visible outcome in one short paragraph.
+
+## Applicable constraints
+- <constraint-id>
+- <constraint-id>
+
+## ADR references
+- <ADR-id>
+- <ADR-id>
+
+## Compatibility impact
+Describe impact on:
+- public APIs
+- events/messages
+- persisted data/contracts
+
+State explicitly whether the change is backward compatible by default.
+
+## Rollback / containment
+Describe how this change can be rolled back, disabled, or contained if needed.
+
+## Notes
+Anything reviewers should know before implementation begins.

--- a/schemas/adr-constrained-dag/templates/spec.md
+++ b/schemas/adr-constrained-dag/templates/spec.md
@@ -1,0 +1,24 @@
+# Spec: <capability-name>
+
+## ADDED Requirements
+
+### Requirement: <new behavior>
+The system SHALL <describe new behavior>.
+
+#### Scenario: <observable case>
+- **WHEN** <trigger>
+- **THEN** <observable outcome>
+
+## MODIFIED Requirements
+
+### Requirement: <existing behavior being changed>
+The system SHALL <describe the updated behavior>.
+
+#### Scenario: <updated case>
+- **WHEN** <trigger>
+- **THEN** <observable outcome>
+
+## REMOVED Requirements
+
+### Requirement: <behavior being removed>
+This requirement is removed because <reason>.

--- a/schemas/adr-constrained-dag/templates/tasks.md
+++ b/schemas/adr-constrained-dag/templates/tasks.md
@@ -1,0 +1,37 @@
+# Tasks: {{CHANGE_NAME}}
+
+## Dependency map
+- T01 is a root task
+- T02 depends on T01
+- T03 depends on T01
+- T04 depends on T02, T03
+
+## Tasks
+
+- [ ] T01 <task title>
+  - depends_on: []
+  - requirements: [<requirement-id>]
+  - constraints: [<constraint-id>]
+  - adrs: [<ADR-id>]
+  - done_when: <clear completion condition>
+
+- [ ] T02 <task title>
+  - depends_on: [T01]
+  - requirements: [<requirement-id>]
+  - constraints: [<constraint-id>]
+  - adrs: [<ADR-id>]
+  - done_when: <clear completion condition>
+
+- [ ] T03 <task title>
+  - depends_on: [T01]
+  - requirements: [<requirement-id>]
+  - constraints: []
+  - adrs: []
+  - done_when: <clear completion condition>
+
+- [ ] T04 <task title>
+  - depends_on: [T02, T03]
+  - requirements: [<requirement-id>]
+  - constraints: [<constraint-id>]
+  - adrs: [<ADR-id>]
+  - done_when: <clear completion condition>


### PR DESCRIPTION
Introduce an ADR-backed schema variant for teams that need explicit project constraints and DAG-style task metadata. This adds the schema definition, authoring templates, and documentation so changes can be traced back to architectural decisions.