### PR TITLE
feat: add category prefix to change name derivation

### DIFF
--- a/src/core/templates/workflows/ff-change.ts
+++ b/src/core/templates/workflows/ff-change.ts
@@ -12,7 +12,7 @@ export function getFfChangeSkillTemplate(): SkillTemplate {
     description: 'Fast-forward through OpenSpec artifact creation. Use when the user wants to quickly create all artifacts needed for implementation without stepping through each one individually.',
     instructions: `Fast-forward through artifact creation - generate everything needed to start implementation in one go.
 
-**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+**Input**: The user's request should include a change name (<category>_<kebab-case>, e.g., feat_add-user-auth) OR a description of what they want to build.
 
 **Steps**
 
@@ -114,7 +114,7 @@ export function getOpsxFfCommandTemplate(): CommandTemplate {
     tags: ['workflow', 'artifacts', 'experimental'],
     content: `Fast-forward through artifact creation - generate everything needed to start implementation.
 
-**Input**: The argument after \`/opsx:ff\` is the change name (kebab-case), OR a description of what the user wants to build.
+**Input**: The argument after \`/opsx:ff\` is the change name (<category>_<kebab-case>, e.g., feat_add-user-auth), OR a description of what the user wants to build.
 
 **Steps**
 

--- a/src/core/templates/workflows/ff-change.ts
+++ b/src/core/templates/workflows/ff-change.ts
@@ -12,7 +12,7 @@ export function getFfChangeSkillTemplate(): SkillTemplate {
     description: 'Fast-forward through OpenSpec artifact creation. Use when the user wants to quickly create all artifacts needed for implementation without stepping through each one individually.',
     instructions: `Fast-forward through artifact creation - generate everything needed to start implementation in one go.
 
-**Input**: The user's request should include a change name (<category>_<kebab-case>, e.g., feat_add-user-auth) OR a description of what they want to build.
+**Input**: The user's request should include a change name (kebab-case, optionally prefixed with a category like feat_, fix_, chore_, or docs_; e.g., feat_add-user-auth or add-user-auth) OR a description of what they want to build.
 
 **Steps**
 
@@ -21,7 +21,7 @@ export function getFfChangeSkillTemplate(): SkillTemplate {
    Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
    > "What change do you want to work on? Describe what you want to build or fix."
 
-   From their description, choose which one of the following categories applies best: feat, fix, chore, or docs. Then derive a kebab-case name and prepend the category with an underscore (e.g., "add user authentication" → \`feat_add-user-auth\`).
+   From their description, derive a kebab-case name. If the change clearly fits a category (feat, fix, chore, or docs), prepend it with an underscore (e.g., "add user authentication" → \`feat_add-user-auth\`), otherwise use the plain kebab-case name (e.g., \`add-user-auth\`).
 
    **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
 
@@ -114,7 +114,7 @@ export function getOpsxFfCommandTemplate(): CommandTemplate {
     tags: ['workflow', 'artifacts', 'experimental'],
     content: `Fast-forward through artifact creation - generate everything needed to start implementation.
 
-**Input**: The argument after \`/opsx:ff\` is the change name (<category>_<kebab-case>, e.g., feat_add-user-auth), OR a description of what the user wants to build.
+**Input**: The argument after \`/opsx:ff\` is the change name (kebab-case, optionally prefixed with a category like feat_, fix_, chore_, or docs_; e.g., feat_add-user-auth or add-user-auth), OR a description of what the user wants to build.
 
 **Steps**
 
@@ -123,7 +123,7 @@ export function getOpsxFfCommandTemplate(): CommandTemplate {
    Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
    > "What change do you want to work on? Describe what you want to build or fix."
 
-   From their description, choose which one of the following categories applies best: feat, fix, chore, or docs. Then derive a kebab-case name and prepend the category with an underscore (e.g., "add user authentication" → \`feat_add-user-auth\`).
+   From their description, derive a kebab-case name. If the change clearly fits a category (feat, fix, chore, or docs), prepend it with an underscore (e.g., "add user authentication" → \`feat_add-user-auth\`), otherwise use the plain kebab-case name (e.g., \`add-user-auth\`).
 
    **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
 

--- a/src/core/templates/workflows/ff-change.ts
+++ b/src/core/templates/workflows/ff-change.ts
@@ -21,7 +21,7 @@ export function getFfChangeSkillTemplate(): SkillTemplate {
    Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
    > "What change do you want to work on? Describe what you want to build or fix."
 
-   From their description, derive a kebab-case name (e.g., "add user authentication" → \`add-user-auth\`).
+   From their description, choose which one of the following categories applies best: feat, fix, chore, or docs. Then derive a kebab-case name and prepend the category with an underscore (e.g., "add user authentication" → \`feat_add-user-auth\`).
 
    **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
 
@@ -123,7 +123,7 @@ export function getOpsxFfCommandTemplate(): CommandTemplate {
    Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
    > "What change do you want to work on? Describe what you want to build or fix."
 
-   From their description, derive a kebab-case name (e.g., "add user authentication" → \`add-user-auth\`).
+   From their description, choose which one of the following categories applies best: feat, fix, chore, or docs. Then derive a kebab-case name and prepend the category with an underscore (e.g., "add user authentication" → \`feat_add-user-auth\`).
 
    **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
 

--- a/src/core/templates/workflows/new-change.ts
+++ b/src/core/templates/workflows/new-change.ts
@@ -12,7 +12,7 @@ export function getNewChangeSkillTemplate(): SkillTemplate {
     description: 'Start a new OpenSpec change using the experimental artifact workflow. Use when the user wants to create a new feature, fix, or modification with a structured step-by-step approach.',
     instructions: `Start a new change using the experimental artifact-driven approach.
 
-**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+**Input**: The user's request should include a change name (<category>_<kebab-case>, e.g., feat_add-user-auth) OR a description of what they want to build.
 
 **Steps**
 
@@ -70,7 +70,7 @@ After completing the steps, summarize:
 **Guardrails**
 - Do NOT create any artifacts yet - just show the instructions
 - Do NOT advance beyond showing the first artifact template
-- If the name is invalid (not kebab-case), ask for a valid name
+- If the name is invalid (not <category>_<kebab-case>), ask for a valid name
 - If a change with that name already exists, suggest continuing that change instead
 - Pass --schema if using a non-default workflow`,
     license: 'MIT',
@@ -87,7 +87,7 @@ export function getOpsxNewCommandTemplate(): CommandTemplate {
     tags: ['workflow', 'artifacts', 'experimental'],
     content: `Start a new change using the experimental artifact-driven approach.
 
-**Input**: The argument after \`/opsx:new\` is the change name (kebab-case), OR a description of what the user wants to build.
+**Input**: The argument after \`/opsx:new\` is the change name (<category>_<kebab-case>, e.g., feat_add-user-auth), OR a description of what the user wants to build.
 
 **Steps**
 
@@ -144,7 +144,7 @@ After completing the steps, summarize:
 **Guardrails**
 - Do NOT create any artifacts yet - just show the instructions
 - Do NOT advance beyond showing the first artifact template
-- If the name is invalid (not kebab-case), ask for a valid name
+- If the name is invalid (not <category>_<kebab-case>), ask for a valid name
 - If a change with that name already exists, suggest using \`/opsx:continue\` instead
 - Pass --schema if using a non-default workflow`
   };

--- a/src/core/templates/workflows/new-change.ts
+++ b/src/core/templates/workflows/new-change.ts
@@ -21,7 +21,7 @@ export function getNewChangeSkillTemplate(): SkillTemplate {
    Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
    > "What change do you want to work on? Describe what you want to build or fix."
 
-   From their description, derive a kebab-case name (e.g., "add user authentication" → \`add-user-auth\`).
+   From their description, choose which one of the following categories applies best: feat, fix, chore, or docs. Then derive a kebab-case name and prepend the category with an underscore (e.g., "add user authentication" → \`feat_add-user-auth\`).
 
    **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
 
@@ -96,7 +96,7 @@ export function getOpsxNewCommandTemplate(): CommandTemplate {
    Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
    > "What change do you want to work on? Describe what you want to build or fix."
 
-   From their description, derive a kebab-case name (e.g., "add user authentication" → \`add-user-auth\`).
+   From their description, choose which one of the following categories applies best: feat, fix, chore, or docs. Then derive a kebab-case name and prepend the category with an underscore (e.g., "add user authentication" → \`feat_add-user-auth\`).
 
    **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
 

--- a/src/core/templates/workflows/new-change.ts
+++ b/src/core/templates/workflows/new-change.ts
@@ -12,7 +12,7 @@ export function getNewChangeSkillTemplate(): SkillTemplate {
     description: 'Start a new OpenSpec change using the experimental artifact workflow. Use when the user wants to create a new feature, fix, or modification with a structured step-by-step approach.',
     instructions: `Start a new change using the experimental artifact-driven approach.
 
-**Input**: The user's request should include a change name (<category>_<kebab-case>, e.g., feat_add-user-auth) OR a description of what they want to build.
+**Input**: The user's request should include a change name (kebab-case, optionally prefixed with a category like feat_, fix_, chore_, or docs_; e.g., feat_add-user-auth or add-user-auth) OR a description of what they want to build.
 
 **Steps**
 
@@ -21,7 +21,7 @@ export function getNewChangeSkillTemplate(): SkillTemplate {
    Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
    > "What change do you want to work on? Describe what you want to build or fix."
 
-   From their description, choose which one of the following categories applies best: feat, fix, chore, or docs. Then derive a kebab-case name and prepend the category with an underscore (e.g., "add user authentication" → \`feat_add-user-auth\`).
+   From their description, derive a kebab-case name. If the change clearly fits a category (feat, fix, chore, or docs), prepend it with an underscore (e.g., "add user authentication" → \`feat_add-user-auth\`), otherwise use the plain kebab-case name (e.g., \`add-user-auth\`).
 
    **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
 
@@ -70,7 +70,7 @@ After completing the steps, summarize:
 **Guardrails**
 - Do NOT create any artifacts yet - just show the instructions
 - Do NOT advance beyond showing the first artifact template
-- If the name is invalid (not <category>_<kebab-case>), ask for a valid name
+- If the name is invalid (not kebab-case, with or without a category prefix), ask for a valid name
 - If a change with that name already exists, suggest continuing that change instead
 - Pass --schema if using a non-default workflow`,
     license: 'MIT',
@@ -87,7 +87,7 @@ export function getOpsxNewCommandTemplate(): CommandTemplate {
     tags: ['workflow', 'artifacts', 'experimental'],
     content: `Start a new change using the experimental artifact-driven approach.
 
-**Input**: The argument after \`/opsx:new\` is the change name (<category>_<kebab-case>, e.g., feat_add-user-auth), OR a description of what the user wants to build.
+**Input**: The argument after \`/opsx:new\` is the change name (kebab-case, optionally prefixed with a category like feat_, fix_, chore_, or docs_; e.g., feat_add-user-auth or add-user-auth), OR a description of what the user wants to build.
 
 **Steps**
 
@@ -96,7 +96,7 @@ export function getOpsxNewCommandTemplate(): CommandTemplate {
    Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
    > "What change do you want to work on? Describe what you want to build or fix."
 
-   From their description, choose which one of the following categories applies best: feat, fix, chore, or docs. Then derive a kebab-case name and prepend the category with an underscore (e.g., "add user authentication" → \`feat_add-user-auth\`).
+   From their description, derive a kebab-case name. If the change clearly fits a category (feat, fix, chore, or docs), prepend it with an underscore (e.g., "add user authentication" → \`feat_add-user-auth\`), otherwise use the plain kebab-case name (e.g., \`add-user-auth\`).
 
    **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
 
@@ -144,7 +144,7 @@ After completing the steps, summarize:
 **Guardrails**
 - Do NOT create any artifacts yet - just show the instructions
 - Do NOT advance beyond showing the first artifact template
-- If the name is invalid (not <category>_<kebab-case>), ask for a valid name
+- If the name is invalid (not kebab-case, with or without a category prefix), ask for a valid name
 - If a change with that name already exists, suggest using \`/opsx:continue\` instead
 - Pass --schema if using a non-default workflow`
   };

--- a/src/core/templates/workflows/propose.ts
+++ b/src/core/templates/workflows/propose.ts
@@ -21,7 +21,7 @@ When ready to implement, run /opsx:apply
 
 ---
 
-**Input**: The user's request should include a change name (<category>_<kebab-case>, e.g., feat_add-user-auth) OR a description of what they want to build.
+**Input**: The user's request should include a change name (kebab-case, optionally prefixed with a category like feat_, fix_, chore_, or docs_; e.g., feat_add-user-auth or add-user-auth) OR a description of what they want to build.
 
 **Steps**
 
@@ -30,7 +30,7 @@ When ready to implement, run /opsx:apply
    Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
    > "What change do you want to work on? Describe what you want to build or fix."
 
-   From their description, choose which one of the following categories applies best: feat, fix, chore, or docs. Then derive a kebab-case name and prepend the category with an underscore (e.g., "add user authentication" → \`feat_add-user-auth\`).
+   From their description, derive a kebab-case name. If the change clearly fits a category (feat, fix, chore, or docs), prepend it with an underscore (e.g., "add user authentication" → \`feat_add-user-auth\`), otherwise use the plain kebab-case name (e.g., \`add-user-auth\`).
 
    **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
 
@@ -132,7 +132,7 @@ When ready to implement, run /opsx:apply
 
 ---
 
-**Input**: The argument after \`/opsx:propose\` is the change name (<category>_<kebab-case>, e.g., feat_add-user-auth), OR a description of what the user wants to build.
+**Input**: The argument after \`/opsx:propose\` is the change name (kebab-case, optionally prefixed with a category like feat_, fix_, chore_, or docs_; e.g., feat_add-user-auth or add-user-auth), OR a description of what the user wants to build.
 
 **Steps**
 
@@ -141,7 +141,7 @@ When ready to implement, run /opsx:apply
    Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
    > "What change do you want to work on? Describe what you want to build or fix."
 
-   From their description, choose which one of the following categories applies best: feat, fix, chore, or docs. Then derive a kebab-case name and prepend the category with an underscore (e.g., "add user authentication" → \`feat_add-user-auth\`).
+   From their description, derive a kebab-case name. If the change clearly fits a category (feat, fix, chore, or docs), prepend it with an underscore (e.g., "add user authentication" → \`feat_add-user-auth\`), otherwise use the plain kebab-case name (e.g., \`add-user-auth\`).
 
    **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
 

--- a/src/core/templates/workflows/propose.ts
+++ b/src/core/templates/workflows/propose.ts
@@ -30,7 +30,7 @@ When ready to implement, run /opsx:apply
    Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
    > "What change do you want to work on? Describe what you want to build or fix."
 
-   From their description, derive a kebab-case name (e.g., "add user authentication" → \`add-user-auth\`).
+   From their description, choose which one of the following categories applies best: feat, fix, chore, or docs. Then derive a kebab-case name and prepend the category with an underscore (e.g., "add user authentication" → \`feat_add-user-auth\`).
 
    **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
 
@@ -141,7 +141,7 @@ When ready to implement, run /opsx:apply
    Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
    > "What change do you want to work on? Describe what you want to build or fix."
 
-   From their description, derive a kebab-case name (e.g., "add user authentication" → \`add-user-auth\`).
+   From their description, choose which one of the following categories applies best: feat, fix, chore, or docs. Then derive a kebab-case name and prepend the category with an underscore (e.g., "add user authentication" → \`feat_add-user-auth\`).
 
    **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
 

--- a/src/core/templates/workflows/propose.ts
+++ b/src/core/templates/workflows/propose.ts
@@ -21,7 +21,7 @@ When ready to implement, run /opsx:apply
 
 ---
 
-**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+**Input**: The user's request should include a change name (<category>_<kebab-case>, e.g., feat_add-user-auth) OR a description of what they want to build.
 
 **Steps**
 
@@ -132,7 +132,7 @@ When ready to implement, run /opsx:apply
 
 ---
 
-**Input**: The argument after \`/opsx:propose\` is the change name (kebab-case), OR a description of what the user wants to build.
+**Input**: The argument after \`/opsx:propose\` is the change name (<category>_<kebab-case>, e.g., feat_add-user-auth), OR a description of what the user wants to build.
 
 **Steps**
 


### PR DESCRIPTION
## Summary

Updates the change name derivation instructions across all workflow templates to prepend a category prefix (feat, fix, chore, or docs) with an underscore to the kebab-case name. In our team, the openspec/changes folder is effectively functioning as a backlog of proposed changes. The category prefix could help in viewing and understanding them at a glance.

## Changes

- **`src/core/templates/workflows/propose.ts`**: Updated name derivation in both skill and command templates
- **`src/core/templates/workflows/new-change.ts`**: Updated name derivation in both skill and command templates
- **`src/core/templates/workflows/ff-change.ts`**: Updated name derivation in both skill and command templates

## Details

Previously, the AI was instructed to derive a plain kebab-case name (e.g., `add-user-auth`). Now it will choose a category (feat, fix, chore, or docs) and prepend it with an underscore (e.g., `feat_add-user-auth`), giving change directories a consistent categorical prefix.

After running `openspec init`, the updated instructions will appear in both SKILL.md files and command files (e.g., `.claude/commands/opsx/propose.md`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded change-naming guidance: users may provide names as plain kebab-case or optionally prefix with a category (feat_, fix_, chore_, docs_), e.g., feat_add-user-auth. Validation and instructions were updated to accept both forms, and derived-name guidance now conditionally prepends a category when the description clearly matches one.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->