### PR TITLE
test: fix Windows PowerShell CI expectation

### DIFF
--- a/test/core/completions/installers/powershell-installer.test.ts
+++ b/test/core/completions/installers/powershell-installer.test.ts
@@ -640,6 +640,7 @@ Register-ArgumentCompleter -CommandName openspec -ScriptBlock $openspecCompleter
 
     it('should skip UTF-16 BE profile and leave it unchanged', async () => {
       delete process.env.OPENSPEC_NO_AUTO_CONFIG;
+      process.env.PROFILE = path.join(testHomeDir, 'custom-profile.ps1');
       const profilePath = installer.getProfilePath();
       await fs.mkdir(path.dirname(profilePath), { recursive: true });
 


### PR DESCRIPTION
## Summary
- pin the UTF-16 BE PowerShell profile test to a single profile path via `PROFILE`
- keep the test focused on the unsupported-encoding case instead of Windows dual-profile behavior

## Root cause
Windows PowerShell installer logic checks two profile paths when `$PROFILE` is unset. The failing test expected `configureProfile()` to return `false` after skipping a UTF-16 BE profile, but on Windows the installer would skip the first profile and still configure the second one, returning `true`.

## Verification
- `pnpm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test reliability for PowerShell profile configuration handling to ensure tests run against specified custom profile paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->