### PR TITLE
chore: add changeset for v1.3.0

### DIFF
--- a/.changeset/new-tools-and-fixes.md
+++ b/.changeset/new-tools-and-fixes.md
@@ -7,8 +7,10 @@
 - **Junie support** — Added tool and command generation for JetBrains Junie
 - **Lingma IDE support** — Added configuration support for Lingma IDE
 - **ForgeCode support** — Added tool support for ForgeCode
+- **IBM Bob support** — Added support for IBM Bob coding assistant
 
 ### Bug Fixes
 
 - **Shell completions opt-in** — Completion install is now opt-in, fixing PowerShell encoding corruption
 - **Copilot auto-detection** — Prevented false GitHub Copilot detection from a bare `.github/` directory
+- **pi.dev command generation** — Fixed command reference transforms and template argument passing

--- a/.changeset/new-tools-and-fixes.md
+++ b/.changeset/new-tools-and-fixes.md
@@ -1,0 +1,14 @@
+---
+"@fission-ai/openspec": minor
+---
+
+### New Features
+
+- **Junie support** — Added tool and command generation for JetBrains Junie
+- **Lingma IDE support** — Added configuration support for Lingma IDE
+- **ForgeCode support** — Added tool support for ForgeCode
+
+### Bug Fixes
+
+- **Shell completions opt-in** — Completion install is now opt-in, fixing PowerShell encoding corruption
+- **Copilot auto-detection** — Prevented false GitHub Copilot detection from a bare `.github/` directory


### PR DESCRIPTION
## Summary

Adds a changeset for the next release, covering all user-facing changes since v1.2.0:

### New Features
- **Junie support** — Tool and command generation for JetBrains Junie (#853)
- **Lingma IDE support** — Configuration support for Lingma IDE (#864)
- **ForgeCode support** — Tool support for ForgeCode (#941)
- **IBM Bob support** — Support for IBM Bob coding assistant (#886)

### Bug Fixes
- **Shell completions opt-in** — Completion install is now opt-in, fixing PowerShell encoding corruption (#949)
- **Copilot auto-detection** — Prevented false GitHub Copilot detection from bare `.github/` directory (#917)
- **pi.dev command generation** — Fixed command reference transforms and template args passing (#950)
- **OpenCode commands directory** — Uses plural `commands/` to match OpenCode convention (#760)
- **Graceful status exit** — `openspec status` exits gracefully when no changes exist (#759)

### Skipped (docs/CI/test only)
- Formatting fixes (#892, #882, #763)
- Docs realignment (#746, #761)
- CI merge queue support (#918)
- Windows PowerShell CI fix (#951)

---

Closes the previous changeset PR #774 which was stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for JetBrains Junie tools and command generation
  * Added Lingma IDE configuration support
  * Added ForgeCode and IBM Bob coding-assistant tool support

* **Bug Fixes**
  * Made shell completion installation opt-in to avoid PowerShell encoding corruption
  * Prevented false GitHub Copilot detection when only a bare directory exists
  * Fixed command-generation issues (pi.dev) related to reference transforms and template arguments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->