### PR TITLE
fix: suppress ora spinner when --json is used

### DIFF
--- a/src/commands/workflow/instructions.ts
+++ b/src/commands/workflow/instructions.ts
@@ -45,7 +45,7 @@ export async function instructionsCommand(
   artifactId: string | undefined,
   options: InstructionsOptions
 ): Promise<void> {
-  const spinner = ora('Generating instructions...').start();
+  const spinner = options.json ? undefined : ora('Generating instructions...').start();
 
   try {
     const projectRoot = process.cwd();
@@ -60,7 +60,7 @@ export async function instructionsCommand(
     const context = loadChangeContext(projectRoot, changeName, options.schema);
 
     if (!artifactId) {
-      spinner.stop();
+      spinner?.stop();
       const validIds = context.graph.getAllArtifacts().map((a) => a.id);
       throw new Error(
         `Missing required argument <artifact>. Valid artifacts:\n  ${validIds.join('\n  ')}`
@@ -70,7 +70,7 @@ export async function instructionsCommand(
     const artifact = context.graph.getArtifact(artifactId);
 
     if (!artifact) {
-      spinner.stop();
+      spinner?.stop();
       const validIds = context.graph.getAllArtifacts().map((a) => a.id);
       throw new Error(
         `Artifact '${artifactId}' not found in schema '${context.schemaName}'. Valid artifacts:\n  ${validIds.join('\n  ')}`
@@ -80,7 +80,7 @@ export async function instructionsCommand(
     const instructions = generateInstructions(context, artifactId, projectRoot);
     const isBlocked = instructions.dependencies.some((d) => !d.done);
 
-    spinner.stop();
+    spinner?.stop();
 
     if (options.json) {
       console.log(JSON.stringify(instructions, null, 2));
@@ -89,7 +89,7 @@ export async function instructionsCommand(
 
     printInstructionsText(instructions, isBlocked);
   } catch (error) {
-    spinner.stop();
+    spinner?.stop();
     throw error;
   }
 }
@@ -400,7 +400,7 @@ export async function generateApplyInstructions(
 }
 
 export async function applyInstructionsCommand(options: ApplyInstructionsOptions): Promise<void> {
-  const spinner = ora('Generating apply instructions...').start();
+  const spinner = options.json ? undefined : ora('Generating apply instructions...').start();
 
   try {
     const projectRoot = process.cwd();
@@ -414,7 +414,7 @@ export async function applyInstructionsCommand(options: ApplyInstructionsOptions
     // generateApplyInstructions uses loadChangeContext which auto-detects schema
     const instructions = await generateApplyInstructions(projectRoot, changeName, options.schema);
 
-    spinner.stop();
+    spinner?.stop();
 
     if (options.json) {
       console.log(JSON.stringify(instructions, null, 2));
@@ -423,7 +423,7 @@ export async function applyInstructionsCommand(options: ApplyInstructionsOptions
 
     printApplyInstructionsText(instructions);
   } catch (error) {
-    spinner.stop();
+    spinner?.stop();
     throw error;
   }
 }

--- a/src/commands/workflow/status.ts
+++ b/src/commands/workflow/status.ts
@@ -34,7 +34,7 @@ export interface StatusOptions {
 // -----------------------------------------------------------------------------
 
 export async function statusCommand(options: StatusOptions): Promise<void> {
-  const spinner = ora('Loading change status...').start();
+  const spinner = options.json ? undefined : ora('Loading change status...').start();
 
   try {
     const projectRoot = process.cwd();
@@ -44,7 +44,7 @@ export async function statusCommand(options: StatusOptions): Promise<void> {
     if (!options.change) {
       const available = await getAvailableChanges(projectRoot);
       if (available.length === 0) {
-        spinner.stop();
+        spinner?.stop();
         if (options.json) {
           console.log(JSON.stringify({ changes: [], message: 'No active changes.' }, null, 2));
           return;
@@ -53,7 +53,7 @@ export async function statusCommand(options: StatusOptions): Promise<void> {
         return;
       }
       // Changes exist but --change not provided
-      spinner.stop();
+      spinner?.stop();
       throw new Error(
         `Missing required option --change. Available changes:\n  ${available.join('\n  ')}`
       );
@@ -70,7 +70,7 @@ export async function statusCommand(options: StatusOptions): Promise<void> {
     const context = loadChangeContext(projectRoot, changeName, options.schema);
     const status = formatChangeStatus(context);
 
-    spinner.stop();
+    spinner?.stop();
 
     if (options.json) {
       console.log(JSON.stringify(status, null, 2));
@@ -79,7 +79,7 @@ export async function statusCommand(options: StatusOptions): Promise<void> {
 
     printStatusText(status);
   } catch (error) {
-    spinner.stop();
+    spinner?.stop();
     throw error;
   }
 }

--- a/src/commands/workflow/templates.ts
+++ b/src/commands/workflow/templates.ts
@@ -33,7 +33,7 @@ export interface TemplateInfo {
 // -----------------------------------------------------------------------------
 
 export async function templatesCommand(options: TemplatesOptions): Promise<void> {
-  const spinner = ora('Loading templates...').start();
+  const spinner = options.json ? undefined : ora('Loading templates...').start();
 
   try {
     const projectRoot = process.cwd();
@@ -72,7 +72,7 @@ export async function templatesCommand(options: TemplatesOptions): Promise<void>
       source,
     }));
 
-    spinner.stop();
+    spinner?.stop();
 
     if (options.json) {
       const output: Record<string, { path: string; source: string }> = {};
@@ -92,7 +92,7 @@ export async function templatesCommand(options: TemplatesOptions): Promise<void>
       console.log(`  ${t.templatePath}`);
     }
   } catch (error) {
-    spinner.stop();
+    spinner?.stop();
     throw error;
   }
 }

--- a/test/cli-e2e/basic.test.ts
+++ b/test/cli-e2e/basic.test.ts
@@ -26,6 +26,12 @@ async function prepareFixture(fixtureName: string): Promise<string> {
   return projectDir;
 }
 
+function expectJsonOnlyOutput(result: Awaited<ReturnType<typeof runCLI>>) {
+  expect(result.exitCode).toBe(0);
+  expect(result.stderr).toBe('');
+  expect(() => JSON.parse(result.stdout)).not.toThrow();
+}
+
 afterAll(async () => {
   await Promise.all(tempRoots.map((dir) => fs.rm(dir, { recursive: true, force: true })));
 });
@@ -69,6 +75,46 @@ describe('openspec CLI e2e basics', () => {
     const json = JSON.parse(output);
     expect(json.summary?.totals?.failed).toBe(0);
     expect(json.items.some((item: any) => item.id === 'c1' && item.type === 'change')).toBe(true);
+  });
+
+  it('keeps list --json free of spinner output', async () => {
+    const projectDir = await prepareFixture('tmp-init');
+    const result = await runCLI(['list', '--json'], { cwd: projectDir });
+    expectJsonOnlyOutput(result);
+  });
+
+  it('keeps schemas --json free of spinner output', async () => {
+    const projectDir = await prepareFixture('tmp-init');
+    const result = await runCLI(['schemas', '--json'], { cwd: projectDir });
+    expectJsonOnlyOutput(result);
+  });
+
+  it('keeps status --json free of spinner output', async () => {
+    const projectDir = await prepareFixture('tmp-init');
+    const result = await runCLI(['status', '--change', 'c1', '--json'], { cwd: projectDir });
+    expectJsonOnlyOutput(result);
+  });
+
+  it('keeps instructions --json free of spinner output', async () => {
+    const projectDir = await prepareFixture('tmp-init');
+    const result = await runCLI(['instructions', 'proposal', '--change', 'c1', '--json'], {
+      cwd: projectDir,
+    });
+    expectJsonOnlyOutput(result);
+  });
+
+  it('keeps instructions apply --json free of spinner output', async () => {
+    const projectDir = await prepareFixture('tmp-init');
+    const result = await runCLI(['instructions', 'apply', '--change', 'c1', '--json'], {
+      cwd: projectDir,
+    });
+    expectJsonOnlyOutput(result);
+  });
+
+  it('keeps templates --json free of spinner output', async () => {
+    const projectDir = await prepareFixture('tmp-init');
+    const result = await runCLI(['templates', '--json'], { cwd: projectDir });
+    expectJsonOnlyOutput(result);
   });
 
   it('returns an error for unknown items in the fixture', async () => {

--- a/test/commands/artifact-workflow.test.ts
+++ b/test/commands/artifact-workflow.test.ts
@@ -110,6 +110,7 @@ describe('artifact-workflow CLI commands', () => {
         cwd: tempDir,
       });
       expect(result.exitCode).toBe(0);
+      expect(result.stderr).toBe('');
 
       const json = JSON.parse(result.stdout);
       expect(json.changeName).toBe('json-change');
@@ -256,6 +257,7 @@ describe('artifact-workflow CLI commands', () => {
         cwd: tempDir,
       });
       expect(result.exitCode).toBe(0);
+      expect(result.stderr).toBe('');
 
       const json = JSON.parse(result.stdout);
       expect(json.artifactId).toBe('design');
@@ -309,6 +311,7 @@ describe('artifact-workflow CLI commands', () => {
     it('outputs JSON mapping of templates', async () => {
       const result = await runCLI(['templates', '--json'], { cwd: tempDir });
       expect(result.exitCode).toBe(0);
+      expect(result.stderr).toBe('');
 
       const json = JSON.parse(result.stdout);
       expect(json.proposal).toBeDefined();
@@ -405,6 +408,7 @@ describe('artifact-workflow CLI commands', () => {
         { cwd: tempDir }
       );
       expect(result.exitCode).toBe(0);
+      expect(result.stderr).toBe('');
 
       const json = JSON.parse(result.stdout);
       expect(json.changeName).toBe('json-apply');


### PR DESCRIPTION
## Summary
- Conditionally skip `ora` spinner creation when `--json` flag is passed in `status`, `instructions`, `instructions apply`, and `templates` commands
- Prevents spinner text from leaking to stderr, which broke JSON parsing for AI agents that combine stdout+stderr (Claude Code, Cursor, Windsurf, Copilot)
- Adds e2e tests asserting clean JSON output (no stderr, valid JSON on stdout) for all `--json` commands

Closes #957

## Test plan
- [ ] `openspec status --change <name> --json 2>&1 | jq .` parses cleanly
- [ ] `openspec instructions <artifact> --change <name> --json 2>&1 | jq .` parses cleanly
- [ ] `openspec instructions apply --change <name> --json 2>&1 | jq .` parses cleanly
- [ ] `openspec templates --json 2>&1 | jq .` parses cleanly
- [ ] `openspec list --json 2>&1 | jq .` parses cleanly
- [ ] `openspec schemas --json 2>&1 | jq .` parses cleanly
- [ ] Non-JSON mode still shows spinners as before
- [ ] New e2e tests pass (`basic.test.ts`, `artifact-workflow.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed spinner animations from appearing in JSON output mode, ensuring clean JSON output and preventing parsing failures.

* **Tests**
  * Added comprehensive end-to-end and unit tests validating clean JSON output across all workflow commands when using JSON mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->