### PR TITLE
fix: detect hidden requirements in main specs

### DIFF
--- a/openspec/specs/cli-update/spec.md
+++ b/openspec/specs/cli-update/spec.md
@@ -168,7 +168,7 @@ The archive slash command template SHALL support optional change ID arguments fo
 
 ## Edge Cases
 
-### Requirement: Error Handling
+### Error Handling
 
 The command SHALL handle edge cases gracefully.
 

--- a/openspec/specs/openspec-conventions/spec.md
+++ b/openspec/specs/openspec-conventions/spec.md
@@ -255,7 +255,7 @@ The system SHALL follow these principles:
 
 ## Directory Structure
 
-### Requirement: Project Structure
+### Project Structure
 
 An OpenSpec project SHALL maintain a consistent directory structure for specifications and changes.
 
@@ -285,7 +285,7 @@ openspec/
 
 ## Specification Format
 
-### Requirement: Structured Format for Behavioral Specs
+### Behavioral Spec Format
 
 Behavioral specifications SHALL use a structured format with consistent section headers and keywords to ensure visual consistency and parseability.
 
@@ -316,7 +316,7 @@ Behavioral specifications SHALL use a structured format with consistent section 
 
 ## Change Storage Convention
 
-### Requirement: Header-Based Requirement Identification
+### Header-Based Requirement Identification
 
 Requirement headers SHALL serve as unique identifiers for programmatic matching between current specs and proposed changes.
 
@@ -345,7 +345,7 @@ Requirement headers SHALL serve as unique identifiers for programmatic matching 
 - **THEN** ensure no duplicate headers exist within a spec
 - **AND** validation tools SHALL flag duplicate headers as errors
 
-### Requirement: Change Storage Convention
+### Change Storage Convention
 
 Change proposals SHALL store only the additions, modifications, and removals to specifications, not complete future states.
 
@@ -388,7 +388,7 @@ The `changes/[name]/specs/` directory SHALL contain:
   - `-` for REMOVED (red)
   - `→` for RENAMED (cyan)
 
-### Requirement: Archive Process Enhancement
+### Archive Process Enhancement
 
 The archive process SHALL programmatically apply delta changes to current specifications using header-based matching.
 
@@ -411,7 +411,7 @@ The archive process SHALL programmatically apply delta changes to current specif
 - **AND** require manual resolution before proceeding
 - **AND** provide clear guidance on resolving conflicts
 
-### Requirement: Proposal Format
+### Proposal Format
 
 Proposals SHALL explicitly document all changes with clear from/to comparisons.
 
@@ -444,7 +444,7 @@ The change process SHALL follow these states:
 
 ## Viewing Changes
 
-### Requirement: Change Review
+### Change Review
 
 The system SHALL support multiple methods for reviewing proposed changes.
 

--- a/src/core/parsers/change-parser.ts
+++ b/src/core/parsers/change-parser.ts
@@ -179,17 +179,21 @@ export class ChangeParser extends MarkdownParser {
   private parseSectionsFromContent(content: string): Section[] {
     const normalizedContent = ChangeParser.normalizeContent(content);
     const lines = normalizedContent.split('\n');
+    const codeFenceLineMask = ChangeParser.buildCodeFenceMask(lines);
     const sections: Section[] = [];
     const stack: Section[] = [];
     
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i];
+      if (codeFenceLineMask[i]) {
+        continue;
+      }
       const headerMatch = line.match(/^(#{1,6})\s+(.+)$/);
       
       if (headerMatch) {
         const level = headerMatch[1].length;
         const title = headerMatch[2].trim();
-        const contentLines = this.getContentUntilNextHeaderFromLines(lines, i + 1, level);
+        const contentLines = this.getContentUntilNextHeaderFromLines(lines, codeFenceLineMask, i + 1, level);
         
         const section = {
           level,
@@ -215,12 +219,17 @@ export class ChangeParser extends MarkdownParser {
     return sections;
   }
 
-  private getContentUntilNextHeaderFromLines(lines: string[], startLine: number, currentLevel: number): string[] {
+  private getContentUntilNextHeaderFromLines(
+    lines: string[],
+    codeFenceLineMask: boolean[],
+    startLine: number,
+    currentLevel: number
+  ): string[] {
     const contentLines: string[] = [];
     
     for (let i = startLine; i < lines.length; i++) {
       const line = lines[i];
-      const headerMatch = line.match(/^(#{1,6})\s+/);
+      const headerMatch = codeFenceLineMask[i] ? null : line.match(/^(#{1,6})\s+/);
       
       if (headerMatch && headerMatch[1].length <= currentLevel) {
         break;

--- a/src/core/parsers/markdown-parser.ts
+++ b/src/core/parsers/markdown-parser.ts
@@ -9,16 +9,54 @@ export interface Section {
 
 export class MarkdownParser {
   private lines: string[];
+  private codeFenceLineMask: boolean[];
   private currentLine: number;
 
   constructor(content: string) {
     const normalized = MarkdownParser.normalizeContent(content);
     this.lines = normalized.split('\n');
+    this.codeFenceLineMask = MarkdownParser.buildCodeFenceMask(this.lines);
     this.currentLine = 0;
   }
 
   protected static normalizeContent(content: string): string {
     return content.replace(/\r\n?/g, '\n');
+  }
+
+  protected static buildCodeFenceMask(lines: string[]): boolean[] {
+    const mask = new Array(lines.length).fill(false);
+    let activeFence: { marker: '`' | '~'; length: number } | null = null;
+
+    for (let i = 0; i < lines.length; i++) {
+      const fence = MarkdownParser.getFenceMarker(lines[i]);
+
+      if (!activeFence) {
+        if (fence) {
+          activeFence = fence;
+          mask[i] = true;
+        }
+        continue;
+      }
+
+      mask[i] = true;
+      if (fence && fence.marker === activeFence.marker && fence.length >= activeFence.length) {
+        activeFence = null;
+      }
+    }
+
+    return mask;
+  }
+
+  private static getFenceMarker(line: string): { marker: '`' | '~'; length: number } | null {
+    const fenceMatch = line.match(/^\s*(`{3,}|~{3,})/);
+    if (!fenceMatch) {
+      return null;
+    }
+
+    return {
+      marker: fenceMatch[1][0] as '`' | '~',
+      length: fenceMatch[1].length,
+    };
   }
 
   parseSpec(name: string): Spec {
@@ -81,6 +119,9 @@ export class MarkdownParser {
     
     for (let i = 0; i < this.lines.length; i++) {
       const line = this.lines[i];
+      if (this.codeFenceLineMask[i]) {
+        continue;
+      }
       const headerMatch = line.match(/^(#{1,6})\s+(.+)$/);
       
       if (headerMatch) {
@@ -117,7 +158,7 @@ export class MarkdownParser {
     
     for (let i = startLine; i < this.lines.length; i++) {
       const line = this.lines[i];
-      const headerMatch = line.match(/^(#{1,6})\s+/);
+      const headerMatch = this.codeFenceLineMask[i] ? null : line.match(/^(#{1,6})\s+/);
       
       if (headerMatch && headerMatch[1].length <= currentLevel) {
         break;

--- a/src/core/parsers/markdown-parser.ts
+++ b/src/core/parsers/markdown-parser.ts
@@ -39,7 +39,7 @@ export class MarkdownParser {
       }
 
       mask[i] = true;
-      if (fence && fence.marker === activeFence.marker && fence.length >= activeFence.length) {
+      if (MarkdownParser.isClosingFence(lines[i], activeFence)) {
         activeFence = null;
       }
     }
@@ -57,6 +57,18 @@ export class MarkdownParser {
       marker: fenceMatch[1][0] as '`' | '~',
       length: fenceMatch[1].length,
     };
+  }
+
+  private static isClosingFence(
+    line: string,
+    activeFence: { marker: '`' | '~'; length: number }
+  ): boolean {
+    const fenceMatch = line.match(/^\s*(`{3,}|~{3,})\s*$/);
+    return Boolean(
+      fenceMatch &&
+      fenceMatch[1][0] === activeFence.marker &&
+      fenceMatch[1].length >= activeFence.length
+    );
   }
 
   parseSpec(name: string): Spec {

--- a/src/core/parsers/spec-structure.ts
+++ b/src/core/parsers/spec-structure.ts
@@ -73,7 +73,7 @@ export function findMainSpecStructureIssues(content: string): MainSpecStructureI
   return issues;
 }
 
-function stripFencedCodeBlocksPreservingLines(content: string): string {
+export function stripFencedCodeBlocksPreservingLines(content: string): string {
   const lines = content.split('\n');
   const output: string[] = [];
   let activeFence: { marker: '`' | '~'; length: number } | null = null;
@@ -96,13 +96,22 @@ function stripFencedCodeBlocksPreservingLines(content: string): string {
 
     output.push('');
 
-    if (fenceMatch) {
-      const marker = fenceMatch[1][0] as '`' | '~';
-      if (marker === activeFence.marker && fenceMatch[1].length >= activeFence.length) {
-        activeFence = null;
-      }
+    if (isClosingFence(line, activeFence)) {
+      activeFence = null;
     }
   }
 
   return output.join('\n');
+}
+
+function isClosingFence(
+  line: string,
+  activeFence: { marker: '`' | '~'; length: number }
+): boolean {
+  const fenceMatch = line.match(/^\s*(`{3,}|~{3,})\s*$/);
+  return Boolean(
+    fenceMatch &&
+    fenceMatch[1][0] === activeFence.marker &&
+    fenceMatch[1].length >= activeFence.length
+  );
 }

--- a/src/core/parsers/spec-structure.ts
+++ b/src/core/parsers/spec-structure.ts
@@ -1,0 +1,108 @@
+const REQUIREMENTS_SECTION_HEADER = /^##\s+Requirements\s*$/i;
+const TOP_LEVEL_SECTION_HEADER = /^##\s+/;
+const DELTA_HEADER = /^##\s+(ADDED|MODIFIED|REMOVED|RENAMED)\s+Requirements\s*$/i;
+const REQUIREMENT_HEADER = /^###\s+Requirement:\s*(.+)\s*$/;
+
+export interface MainSpecStructureIssue {
+  kind: 'delta-header' | 'requirement-outside-requirements';
+  line: number;
+  header: string;
+  message: string;
+}
+
+export function findMainSpecStructureIssues(content: string): MainSpecStructureIssue[] {
+  const normalized = content.replace(/\r\n?/g, '\n');
+  const stripped = stripFencedCodeBlocksPreservingLines(normalized);
+  const lines = stripped.split('\n');
+  const issues: MainSpecStructureIssue[] = [];
+
+  const requirementsHeaderIndex = lines.findIndex(line => REQUIREMENTS_SECTION_HEADER.test(line));
+  let requirementsEndIndex = lines.length;
+
+  if (requirementsHeaderIndex !== -1) {
+    for (let i = requirementsHeaderIndex + 1; i < lines.length; i++) {
+      if (TOP_LEVEL_SECTION_HEADER.test(lines[i])) {
+        requirementsEndIndex = i;
+        break;
+      }
+    }
+  }
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+
+    if (DELTA_HEADER.test(line)) {
+      issues.push({
+        kind: 'delta-header',
+        line: i + 1,
+        header: trimmed,
+        message:
+          `Main spec contains delta header "${trimmed}". ` +
+          'Delta headers are only valid inside openspec/changes/<name>/specs/<capability>/spec.md ' +
+          'and truncate the parsed ## Requirements section.',
+      });
+      continue;
+    }
+
+    const requirementMatch = line.match(REQUIREMENT_HEADER);
+    if (!requirementMatch) {
+      continue;
+    }
+
+    const insideRequirements =
+      requirementsHeaderIndex !== -1 &&
+      i > requirementsHeaderIndex &&
+      i < requirementsEndIndex;
+
+    if (!insideRequirements) {
+      issues.push({
+        kind: 'requirement-outside-requirements',
+        line: i + 1,
+        header: trimmed,
+        message:
+          `Requirement header "${trimmed}" appears outside the main ## Requirements section. ` +
+          'Main specs only parse requirements inside that section, so this requirement is currently invisible to validate, list, and archive.',
+      });
+    }
+  }
+
+  return issues;
+}
+
+function stripFencedCodeBlocksPreservingLines(content: string): string {
+  const lines = content.split('\n');
+  const output: string[] = [];
+  let activeFence: { marker: '`' | '~'; length: number } | null = null;
+
+  for (const line of lines) {
+    const fenceMatch = line.match(/^\s*(`{3,}|~{3,})(.*)$/);
+
+    if (!activeFence) {
+      if (fenceMatch) {
+        activeFence = {
+          marker: fenceMatch[1][0] as '`' | '~',
+          length: fenceMatch[1].length,
+        };
+        output.push('');
+      } else {
+        output.push(line);
+      }
+      continue;
+    }
+
+    output.push('');
+
+    if (fenceMatch) {
+      const marker = fenceMatch[1][0] as '`' | '~';
+      if (marker === activeFence.marker && fenceMatch[1].length >= activeFence.length) {
+        activeFence = null;
+      }
+    }
+  }
+
+  return output.join('\n');
+}

--- a/src/core/specs-apply.ts
+++ b/src/core/specs-apply.ts
@@ -14,6 +14,7 @@ import {
   normalizeRequirementName,
   type RequirementBlock,
 } from './parsers/requirement-blocks.js';
+import { findMainSpecStructureIssues } from './parsers/spec-structure.js';
 import { Validator } from './validation/validator.js';
 
 // -----------------------------------------------------------------------------
@@ -221,6 +222,16 @@ export async function buildUpdatedSpec(
     }
     isNewSpec = true;
     targetContent = buildSpecSkeleton(specName, changeName);
+  }
+
+  const structureIssues = findMainSpecStructureIssues(targetContent);
+  if (structureIssues.length > 0) {
+    const details = structureIssues
+      .map(issue => `line ${issue.line}: ${issue.message}`)
+      .join('\n');
+    throw new Error(
+      `${specName}: target spec is structurally invalid and cannot be updated until fixed:\n${details}`
+    );
   }
 
   // Extract requirements section and build name->block map

--- a/src/core/validation/validator.ts
+++ b/src/core/validation/validator.ts
@@ -11,6 +11,7 @@ import {
   VALIDATION_MESSAGES
 } from './constants.js';
 import { parseDeltaSpec, normalizeRequirementName } from '../parsers/requirement-blocks.js';
+import { findMainSpecStructureIssues } from '../parsers/spec-structure.js';
 import { FileSystemUtils } from '../../utils/file-system.js';
 
 export class Validator {
@@ -288,6 +289,15 @@ export class Validator {
 
   private applySpecRules(spec: Spec, content: string): ValidationIssue[] {
     const issues: ValidationIssue[] = [];
+
+    for (const structuralIssue of findMainSpecStructureIssues(content)) {
+      issues.push({
+        level: 'ERROR',
+        path: 'file',
+        line: structuralIssue.line,
+        message: structuralIssue.message,
+      });
+    }
     
     if (spec.overview.length < MIN_PURPOSE_LENGTH) {
       issues.push({

--- a/test/core/archive.test.ts
+++ b/test/core/archive.test.ts
@@ -561,6 +561,68 @@ new text
       await expect(fs.access(changeDir)).resolves.not.toThrow();
     });
 
+    it('should abort with a structural error when target spec hides requirements outside ## Requirements', async () => {
+      const changeName = 'hidden-requirement-target';
+      const changeDir = path.join(tempDir, 'openspec', 'changes', changeName);
+      const changeSpecDir = path.join(changeDir, 'specs', 'delta-target');
+      await fs.mkdir(changeSpecDir, { recursive: true });
+
+      const mainSpecDir = path.join(tempDir, 'openspec', 'specs', 'delta-target');
+      await fs.mkdir(mainSpecDir, { recursive: true });
+      const malformedMain = `# delta-target Specification
+
+## Purpose
+Delta target purpose.
+
+## Requirements
+
+### Requirement: A
+The system SHALL do A.
+
+#### Scenario: A works
+- **WHEN** foo
+- **THEN** bar
+
+## Edge Cases
+
+### Requirement: B
+The system SHALL do B.
+
+#### Scenario: B works
+- **WHEN** baz
+- **THEN** qux`;
+      await fs.writeFile(path.join(mainSpecDir, 'spec.md'), malformedMain);
+
+      const deltaContent = `# Delta Target Changes
+
+## MODIFIED Requirements
+
+### Requirement: B
+The system SHALL do B differently.
+
+#### Scenario: B changes
+- **WHEN** baz changes
+- **THEN** qux changes`;
+      await fs.writeFile(path.join(changeSpecDir, 'spec.md'), deltaContent);
+
+      await archiveCommand.execute(changeName, { yes: true, noValidate: true });
+
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining('delta-target: target spec is structurally invalid and cannot be updated until fixed:')
+      );
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining('Requirement header "### Requirement: B" appears outside the main ## Requirements section.')
+      );
+      expect(console.log).toHaveBeenCalledWith('Aborted. No files were changed.');
+
+      const still = await fs.readFile(path.join(mainSpecDir, 'spec.md'), 'utf-8');
+      expect(still).toBe(malformedMain);
+
+      const archiveDir = path.join(tempDir, 'openspec', 'changes', 'archive');
+      const archives = await fs.readdir(archiveDir);
+      expect(archives.some(a => a.includes(changeName))).toBe(false);
+    });
+
     it('should require MODIFIED to reference the NEW header when a rename exists (error format)', async () => {
       const changeName = 'rename-modify-new-header';
       const changeDir = path.join(tempDir, 'openspec', 'changes', changeName);

--- a/test/core/parsers/markdown-parser.test.ts
+++ b/test/core/parsers/markdown-parser.test.ts
@@ -135,6 +135,37 @@ The system SHALL ...
       expect(spec.requirements[0].scenarios).toHaveLength(1);
       expect(spec.requirements[0].scenarios[0].rawText).toContain('- **WHEN** a reader reviews the documentation');
     });
+
+    it('should not treat fence-like lines with trailing content as closing fences', () => {
+      const content = `# Test Spec
+
+## Purpose
+This spec includes a fence-like line with trailing content inside a fenced block.
+
+## Requirements
+
+### Requirement: Explain fence parsing
+The system SHALL keep fenced examples isolated until a real closing fence appears.
+
+\`\`\`markdown
+\`\`\` still inside the example
+## ADDED Requirements
+
+### Requirement: Example
+The system SHALL remain part of the example.
+\`\`\`
+
+#### Scenario: reader follows the example
+- **WHEN** a reader reviews the documentation
+- **THEN** the parser ignores headings until the real closing fence`;
+
+      const parser = new MarkdownParser(content);
+      const spec = parser.parseSpec('test');
+
+      expect(spec.requirements).toHaveLength(1);
+      expect(spec.requirements[0].scenarios).toHaveLength(1);
+      expect(spec.requirements[0].scenarios[0].rawText).toContain('parser ignores headings until the real closing fence');
+    });
   });
 
   describe('parseChange', () => {

--- a/test/core/parsers/markdown-parser.test.ts
+++ b/test/core/parsers/markdown-parser.test.ts
@@ -102,6 +102,39 @@ This is a test spec`;
       const parser = new MarkdownParser(content);
       expect(() => parser.parseSpec('test')).toThrow('must have a Requirements section');
     });
+
+    it('should ignore headings that appear inside fenced code blocks', () => {
+      const content = `# Test Spec
+
+## Purpose
+This spec documents delta syntax with a fenced example.
+
+## Requirements
+
+### Requirement: Explain delta syntax
+The system SHALL allow quoted markdown examples without changing parsed structure.
+
+\`\`\`markdown
+## ADDED Requirements
+
+### Requirement: Example
+The system SHALL ...
+\`\`\`
+
+#### Scenario: reader follows the example
+- **WHEN** a reader reviews the documentation
+- **THEN** the fenced heading stays part of the example`;
+
+      const parser = new MarkdownParser(content);
+      const spec = parser.parseSpec('test');
+
+      expect(spec.requirements).toHaveLength(1);
+      expect(spec.requirements[0].text).toBe(
+        'The system SHALL allow quoted markdown examples without changing parsed structure.'
+      );
+      expect(spec.requirements[0].scenarios).toHaveLength(1);
+      expect(spec.requirements[0].scenarios[0].rawText).toContain('- **WHEN** a reader reviews the documentation');
+    });
   });
 
   describe('parseChange', () => {

--- a/test/core/validation.test.ts
+++ b/test/core/validation.test.ts
@@ -247,6 +247,111 @@ Then authenticated`;
       expect(report.summary.errors).toBeGreaterThan(0);
       expect(report.issues.some(i => i.message.includes('Purpose'))).toBe(true);
     });
+
+    it('should error on delta headers inside a main spec', async () => {
+      const specContent = `# Test Specification
+
+## Purpose
+This specification validates that stray delta headers are rejected in main specs.
+
+## Requirements
+
+### Requirement: A
+The system SHALL do A.
+
+#### Scenario: A works
+- **WHEN** foo
+- **THEN** bar
+
+## MODIFIED Requirements
+
+### Requirement: B
+The system SHALL do B.
+
+#### Scenario: B works
+- **WHEN** baz
+- **THEN** qux`;
+
+      const specPath = path.join(testDir, 'spec.md');
+      await fs.writeFile(specPath, specContent);
+
+      const report = await new Validator().validateSpec(specPath);
+
+      expect(report.valid).toBe(false);
+      expect(
+        report.issues.some(i => i.level === 'ERROR' && i.message.includes('Main spec contains delta header'))
+      ).toBe(true);
+      expect(
+        report.issues.some(i => i.level === 'ERROR' && i.message.includes('Requirement header "### Requirement: B" appears outside'))
+      ).toBe(true);
+    });
+
+    it('should error on requirement headers that appear after the Requirements section ends', async () => {
+      const specContent = `# Test Specification
+
+## Purpose
+This specification validates that hidden requirements are rejected even without delta headers.
+
+## Requirements
+
+### Requirement: A
+The system SHALL do A.
+
+#### Scenario: A works
+- **WHEN** foo
+- **THEN** bar
+
+## Edge Cases
+
+### Requirement: B
+The system SHALL do B.
+
+#### Scenario: B works
+- **WHEN** baz
+- **THEN** qux`;
+
+      const specPath = path.join(testDir, 'spec.md');
+      await fs.writeFile(specPath, specContent);
+
+      const report = await new Validator().validateSpec(specPath);
+
+      expect(report.valid).toBe(false);
+      expect(
+        report.issues.some(i => i.level === 'ERROR' && i.message.includes('Requirement header "### Requirement: B" appears outside'))
+      ).toBe(true);
+    });
+
+    it('should ignore delta header examples inside fenced code blocks', async () => {
+      const specContent = `# Test Specification
+
+## Purpose
+This specification documents delta syntax without being flagged for quoted examples.
+
+## Requirements
+
+### Requirement: Explain delta syntax
+The system SHALL allow documentation specs to quote delta headers inside fenced code blocks.
+
+\`\`\`markdown
+## ADDED Requirements
+
+### Requirement: Example
+The system SHALL ...
+\`\`\`
+
+#### Scenario: reader follows the example
+- **WHEN** a reader reviews the documentation
+- **THEN** the quoted delta header remains an example only`;
+
+      const specPath = path.join(testDir, 'spec.md');
+      await fs.writeFile(specPath, specContent);
+
+      const report = await new Validator().validateSpec(specPath);
+
+      expect(report.valid).toBe(true);
+      expect(report.issues.some(i => i.message.includes('Main spec contains delta header'))).toBe(false);
+      expect(report.issues.some(i => i.message.includes('appears outside the main ## Requirements section'))).toBe(false);
+    });
   });
 
   describe('validateChange', () => {

--- a/test/specs/source-specs-normalization.test.ts
+++ b/test/specs/source-specs-normalization.test.ts
@@ -3,7 +3,10 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { describe, it, expect } from 'vitest';
 import { MarkdownParser } from '../../src/core/parsers/markdown-parser.js';
-import { findMainSpecStructureIssues } from '../../src/core/parsers/spec-structure.js';
+import {
+  findMainSpecStructureIssues,
+  stripFencedCodeBlocksPreservingLines,
+} from '../../src/core/parsers/spec-structure.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -42,7 +45,8 @@ describe('source-of-truth specs normalization', () => {
       const structureIssues = findMainSpecStructureIssues(content);
       const parser = new MarkdownParser(content);
       const spec = parser.parseSpec(path.basename(path.dirname(file)));
-      const rawRequirementCount = content.match(REQUIREMENT_HEADER_PATTERN)?.length ?? 0;
+      const rawRequirementCount =
+        stripFencedCodeBlocksPreservingLines(content).match(REQUIREMENT_HEADER_PATTERN)?.length ?? 0;
 
       expect(content, `${relativeFile} must include ## Purpose`).toMatch(/^## Purpose$/m);
       expect(content, `${relativeFile} must include ## Requirements`).toMatch(/^## Requirements$/m);

--- a/test/specs/source-specs-normalization.test.ts
+++ b/test/specs/source-specs-normalization.test.ts
@@ -2,14 +2,16 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { describe, it, expect } from 'vitest';
+import { MarkdownParser } from '../../src/core/parsers/markdown-parser.js';
+import { findMainSpecStructureIssues } from '../../src/core/parsers/spec-structure.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const projectRoot = path.resolve(__dirname, '..', '..');
 const specsRoot = path.join(projectRoot, 'openspec', 'specs');
 
-const DELTA_HEADER_PATTERN = /^## (ADDED|MODIFIED|REMOVED|RENAMED) Requirements$/m;
 const PURPOSE_PLACEHOLDER_PATTERN = /TBD - created by archiving change .*?\. Update Purpose after archive\./;
+const REQUIREMENT_HEADER_PATTERN = /^###\s+Requirement:/gm;
 
 async function getSpecFiles(): Promise<string[]> {
   const entries = await fs.readdir(specsRoot, { withFileTypes: true });
@@ -30,22 +32,28 @@ async function getSpecFiles(): Promise<string[]> {
 }
 
 describe('source-of-truth specs normalization', () => {
-  it('enforces required sections and bans archive placeholders/delta headers', async () => {
+  it('enforces required sections and bans hidden requirements, placeholders, and delta headers', async () => {
     const files = await getSpecFiles();
     expect(files.length).toBeGreaterThan(0);
 
     for (const file of files) {
       const content = await fs.readFile(file, 'utf8');
       const relativeFile = path.relative(projectRoot, file);
+      const structureIssues = findMainSpecStructureIssues(content);
+      const parser = new MarkdownParser(content);
+      const spec = parser.parseSpec(path.basename(path.dirname(file)));
+      const rawRequirementCount = content.match(REQUIREMENT_HEADER_PATTERN)?.length ?? 0;
 
       expect(content, `${relativeFile} must include ## Purpose`).toMatch(/^## Purpose$/m);
       expect(content, `${relativeFile} must include ## Requirements`).toMatch(/^## Requirements$/m);
       expect(content, `${relativeFile} must not include archive placeholder purpose text`).not.toMatch(
         PURPOSE_PLACEHOLDER_PATTERN
       );
-      expect(content, `${relativeFile} must not include delta headers in source-of-truth specs`).not.toMatch(
-        DELTA_HEADER_PATTERN
-      );
+      expect(structureIssues, `${relativeFile} must not contain hidden requirements or delta headers`).toHaveLength(0);
+      expect(
+        spec.requirements.length,
+        `${relativeFile} parsed requirement count must match visible requirement headers`
+      ).toBe(rawRequirementCount);
     }
   });
 });


### PR DESCRIPTION
Closes #954

## Summary
- detect stray delta headers and hidden `### Requirement:` blocks outside the parsed `## Requirements` section in main specs
- fail archive early with a structural error when a target main spec is malformed instead of surfacing a misleading missing-requirement error
- ignore fenced-code headings during markdown parsing and normalize existing source-of-truth specs so parsed requirement counts match visible headers

## Testing
- npm test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Simplified spec headings by removing redundant "Requirement:" prefixes for clearer reading.

* **Bug Fixes**
  * Headings inside Markdown code blocks no longer affect document structure.
  * Spec updates now abort when structural issues (misplaced requirement headers or delta headers) are detected.

* **Tests**
  * Added tests covering fenced-code handling and structural validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->