### PR TITLE
docs: clarify initiative-first workspace model

### DIFF
--- a/openspec/explorations/explore-workflow-ux.md
+++ b/openspec/explorations/explore-workflow-ux.md
@@ -6,6 +6,8 @@ The explore workflow is part of the core loop (`propose`, `explore`, `apply`, `a
 
 Currently, explore references `/opsx:new` and `/opsx:ff` which are being replaced with `/opsx:propose`. But beyond just updating references, there are deeper UX questions about how explore should work.
 
+This exploration is also affected by the emerging workspace direction: for larger cross-team or cross-repo work, OpenSpec may need to treat the **initiative** as the first-class planning object and repo-local changes as execution artifacts. That means explore may sometimes be seeding an initiative, not just a single change.
+
 ## Open Questions
 
 ### Exploration Artifacts
@@ -17,6 +19,7 @@ Currently, explore references `/opsx:new` and `/opsx:ff` which are being replace
 2. **Where should exploration files live?**
    - `openspec/explorations/<name>.md`?
    - `openspec/changes/<change>/explorations/`?
+   - `.openspec-workspace/initiatives/<initiative>/explorations/` for coordinated work?
    - Somewhere else?
 
 3. **What should the format be?**
@@ -30,15 +33,17 @@ Currently, explore references `/opsx:new` and `/opsx:ff` which are being replace
    - e.g., exploring auth approaches separately from UI approaches
    - How would these relate to each other?
 
-5. **How do explorations relate to changes?**
+5. **How do explorations relate to changes or initiatives?**
    - Before change exists: standalone exploration
-   - After change exists: exploration linked to change?
+   - After repo-local change exists: exploration linked to change?
+   - For coordinated work: exploration linked to initiative first, then optionally referenced by repo-local changes?
 
 ### Lifecycle & Transitions
 
 6. **What happens before a change proposal exists?**
    - Exploration is standalone
    - When ready, user runs `/opsx:propose`
+   - For coordinated work, should exploration context seed an initiative first?
    - Should exploration context automatically seed the proposal?
 
 7. **What happens after a change proposal exists?**
@@ -90,11 +95,19 @@ Currently, explore references `/opsx:new` and `/opsx:ff` which are being replace
 - **Pro:** Clear relationship to changes
 - **Con:** Where do pre-change explorations go?
 
+### Approach E: Initiative-First Explorations for Coordinated Work
+- Local work can stay standalone or change-linked
+- Coordinated work saves exploration notes under an initiative in the coordination workspace
+- Repo-local changes can reference the shared exploration when execution starts
+- **Pro:** Matches the emerging split between shared planning and repo-local execution
+- **Con:** Adds another context where exploration artifacts may live
+
 ## Next Steps
 
 - [ ] User research: How do people actually use explore today?
 - [ ] Prototype: Try saving explorations and see if propose benefits
 - [ ] Decide: Pick an approach based on findings
+- [ ] Reconcile explore UX with initiative-first coordinated planning
 - [ ] Implement: Update explore workflow accordingly
 
 ## Related

--- a/openspec/explorations/workspace-architecture.md
+++ b/openspec/explorations/workspace-architecture.md
@@ -651,25 +651,89 @@ After evaluating the models above against real multi-repo use cases (see [#725](
 
 ### Core Insight
 
-The durable thing is the spec or the change, not the workspace. The set of repos involved in a feature is typically feature-scoped and changes over time. A static workspace manifest that must be configured before work begins creates ceremony that doesn't match how teams actually work.
+The workspace itself is not the durable thing. For large teams, the durable planning object is the **initiative** or **plan**, while repo-local specs and changes remain the execution artifacts owned by each repo. The set of repos involved in a feature is typically feature-scoped and changes over time, so a static workspace manifest that must be configured before work begins creates ceremony that doesn't match how teams actually work.
 
 ### Decision: Model D with Lazy Workspace
 
 Choose Model D (Hybrid) from Part 4, but make the workspace manifest **optional and lazy, not prerequisite**.
 
 - **Each repo keeps its own canonical `openspec/`** — no change to the fundamental storage model.
-- **Specs and changes declare cross-project links** — the coordination metadata lives on the artifacts themselves.
-- **"Workspace" is a derived view** over those links, not something users must register up front.
+- **Cross-root work can be coordinated through an initiative in a coordination workspace** — this is where shared planning lives when the work stops being cleanly repo-scoped.
+- **"Workspace" is a derived or explicit coordination view** over linked repos and linked changes, not something users must register up front.
 - **Persist a workspace manifest only when someone explicitly wants a reusable cross-repo bundle** — this is an opt-in convenience, not a requirement.
 
-### Decision: Change-Scoped Linking via Initiative Records
+### Decision: Initiative-First Planning with Linked Repo-Local Changes
 
-Cross-repo coordination happens at the change level, not the workspace level:
+For larger multi-team work, repo-centric planning is the wrong primary abstraction. Teams and repos are many-to-many facets over the same work. OpenSpec should treat the **initiative / plan** as the first-class planning object, then link repo-local changes to it.
+
+This is especially important because a change today bundles:
+
+- `proposal.md`
+- `design.md`
+- `tasks.md`
+- delta specs
+- `.openspec.yaml`
+
+That bundled shape works well for repo-local work, but becomes awkward when one piece of work spans multiple repos or teams. In those cases, a single repo-local change is trying to act as both:
+
+- the shared planning object
+- the repo-specific execution artifact
+
+Those should be split.
+
+The preferred model is:
+
+```text
+coordination workspace /
+  .openspec-workspace/
+    workspace.yaml
+    initiatives/
+      add-3ds/
+        initiative.yaml
+        proposal.md
+        design.md
+        links.yaml
+
+repo-A/
+  openspec/
+    changes/
+      add-3ds-api/
+        .openspec.yaml
+        tasks.md
+        specs/
+
+repo-B/
+  openspec/
+    changes/
+      add-3ds-web/
+        .openspec.yaml
+        tasks.md
+        specs/
+```
+
+The initiative holds the shared planning layer:
+
+- proposal / intent
+- shared design and tradeoffs
+- participating teams
+- impacted repos
+- milestones, risks, and dependencies
+- links to repo-local changes
+
+Each repo-local change holds the execution layer for that repo:
+
+- repo-specific tasks
+- delta specs
+- local implementation status
+- optional local notes that should archive with that repo's work
+
+Cross-repo linking still matters, but it should hang off the initiative and the repo-local changes:
 
 ```yaml
 # billing-service/openspec/changes/add-3ds/.openspec.yaml
 schema: spec-driven
 created: 2026-04-12
+initiative: add-3ds
 links:
   - project: github.com/fission/web-client
     change: add-3ds-checkout
@@ -677,12 +741,13 @@ links:
     change: add-3ds-checkout
 ```
 
-Each repo holds its own change with its own deltas. A "cross-repo change" is N linked single-repo changes. This is preferable to a single mega-change because:
+Each repo still holds its own change with its own deltas. A cross-repo effort is represented as one initiative plus N linked single-repo changes. This is preferable to a single mega-change because:
+- Shared planning has one truthful home
 - Each repo's change goes through its own archive cycle
 - No need to resolve cross-repo file paths in delta specs
 - Teams can move at different speeds (web ships before iOS)
 
-An **initiative record** is the optional connective tissue — a lightweight, feature-scoped coordination artifact that ties linked changes together for visibility. It is not a workspace; it is ephemeral and scoped to one feature.
+For small single-repo work, a repo-local change may still be "good enough" as both plan and execution bundle. The initiative-first split matters once work becomes cross-team, cross-module, cross-repo, or otherwise coordination-heavy.
 
 ### Decision: Stable Project Identifiers, Not Paths
 
@@ -734,18 +799,20 @@ When a spec cannot be mapped to a single implementation repo (e.g., a shared API
 |---------|----------|------------|
 | **Spec organization** | Nested specs inside one `openspec/` (Model B) | Each repo has its own `openspec/` |
 | **Cross-cutting specs** | Nested under a `contracts/` or `shared/` directory | Dedicated owner repo, others reference it |
-| **Changes** | One change can touch multiple nested specs | Linked per-repo changes via initiative records |
+| **Planning object** | Initiative optional for simple work, useful for large cross-team efforts | Initiative is the primary coordination object |
+| **Changes** | One or more repo-local changes can implement one initiative | Linked per-repo changes implement one initiative |
 | **Relationships** | References (no inheritance in v1) | Project identifier links, informational only |
-| **Workspace** | Not needed (single repo) | Derived from change links; optional manifest for reuse |
+| **Workspace** | Usually not needed, but can host initiative planning for complex work | Coordination workspace hosts initiative planning; optional manifest for reuse |
 
 ### Implementation Path
 
-1. **Extend change metadata** — add `links` field to `.openspec.yaml` for cross-repo change linking.
-2. **Extend spec metadata** — add `references` field for cross-repo spec pointers.
-3. **Build project resolution** — implement the offline-first resolution chain and local registry.
-4. **Build `openspec links`** — a command that resolves and displays the cross-repo graph for a change.
-5. **Support ad-hoc multi-root** — "add these dirs for this run" or "derive roots from this change's links."
-6. **Optional workspace manifest** — add saved workspaces only if teams demonstrate reuse patterns.
+1. **Define initiative artifacts** — add an initiative format for shared planning in coordination workspaces.
+2. **Extend change metadata** — let repo-local changes point at an initiative and linked sibling changes.
+3. **Extend spec metadata** — add `references` field for cross-repo spec pointers.
+4. **Build project resolution** — implement the offline-first resolution chain and local registry.
+5. **Build initiative and link views** — commands that resolve and display the initiative graph plus linked repo-local changes.
+6. **Support ad-hoc multi-root** — "add these dirs for this run" or "derive roots from this initiative's links."
+7. **Optional workspace manifest** — add saved workspaces only if teams demonstrate reuse patterns.
 
 Nested specs (Model B inside a single repo) are a prerequisite for clean monorepo support and should be tackled first, as outlined in #662.
 
@@ -757,10 +824,11 @@ Nested specs (Model B inside a single repo) are a prerequisite for clean monorep
 |----------|--------|-------|
 | Profile UX | Decided | `openspec config profile` with presets |
 | Config layering | Decided | Two layers: global + project (no workspace layer) |
-| Spec organization | **Direction set** | Model D (hybrid): nested specs per repo + cross-repo linking |
+| Spec organization | **Direction set** | Nested specs per repo, explicit owner repos for shared contracts, references for cross-repo context |
 | Spec philosophy | Direction set | Behavior-first contracts, progressive rigor, and agent-aligned authoring |
 | Spec inheritance | **Decided** | References only, no inheritance in v1 |
-| Multi-repo support | **Direction set** | Change-scoped linking with stable identifiers; workspace is derived, not prerequisite |
+| Initiative / planning model | **Direction set** | Initiative-first planning for larger work, with repo-local changes as execution artifacts |
+| Multi-repo support | **Direction set** | Linked per-repo changes under shared initiatives; workspace is coordination, not canonical execution storage |
 | Dependency tracking | **Decided** | Out of scope for v1; references are informational only |
 | Cross-repo resolution | **Decided** | Offline-first resolution chain with local registry |
 | Shared contracts | **Decided** | Explicit owner repo required; no default pure-spec-repo pattern |
@@ -769,7 +837,7 @@ Nested specs (Model B inside a single repo) are a prerequisite for clean monorep
 
 The "workspace" question is really two separate questions:
 1. **Config/profile scope** → Solved with global + project (no workspace needed)
-2. **Spec/change organization** → Direction set: Model D with lazy workspace, change-scoped linking, stable identifiers, informational references
+2. **Plan vs. execution organization** → Direction set: initiatives coordinate, repo-local changes implement, workspace remains a coordination layer
 
 These should be separate changes with separate explorations.
 

--- a/openspec/explorations/workspace-roadmap.md
+++ b/openspec/explorations/workspace-roadmap.md
@@ -47,18 +47,19 @@ OpenSpec needs a better way to organize:
 
 References help agents and humans navigate related specs without requiring OpenSpec to build a dependency graph system on day one.
 
-### 3. Linked per-repo changes are the right primitive
+### 3. Initiatives plus linked per-repo changes are the right primitive
 
 For true multi-repo work, the likely durable primitive is:
 
-- one linked change per owning repo
+- one initiative as the shared planning object
+- one linked change per owning repo as the execution artifact
 - stable identifiers connecting them
 
 ### 4. Cross-repo work needs a neutral planning location
 
 For multi-repo work, a single repo is not an honest home for the whole planning artifact.
 
-Some form of coordination workspace or coordination repo is needed.
+Some form of coordination workspace or coordination repo is needed for the initiative-level plan.
 
 ### 5. Team-shared coordination is a real requirement
 
@@ -124,8 +125,8 @@ Support real multi-repo planning demand with the thinnest credible coordination 
 
 ### Ship
 
-1. Linked per-repo changes using stable project identifiers
-2. A neutral coordination workspace or coordination repo for planning
+1. Initiative artifacts for shared planning in a neutral coordination workspace or coordination repo
+2. Linked per-repo changes using stable project identifiers
 3. Explicit repo linking via project IDs
 4. Resolution through:
    - explicit input
@@ -137,6 +138,7 @@ Support real multi-repo planning demand with the thinnest credible coordination 
 
 - users have an honest place to stand for multi-repo work
 - cross-repo plans are no longer buried in one repo
+- shared planning and repo-local execution are clearly separated
 - ownership stays with the real repos
 - agents can be told what roots matter
 
@@ -157,6 +159,7 @@ This phase should feel like:
 
 - local planning by default
 - upgrade to a coordinated initiative when needed
+- initiative-level planning in the coordination workspace
 - linked repo-local changes underneath
 
 Not like:
@@ -257,7 +260,7 @@ Because demand is already real, some things should not be treated as purely futu
 
 - nested spec paths
 - references
-- linked change primitive
+- initiative artifact + linked change primitive
 - stable project identifiers
 - thin coordination layer for multi-repo planning
 
@@ -310,10 +313,11 @@ If this roadmap were translated into actual change proposals, the sequence would
 
 1. nested spec paths + references
 2. monorepo scope filtering and multi-area planning improvements
-3. linked change metadata across repos
-4. thin coordination workspace / repo for multi-repo planning
-5. team-shared coordination hardening
-6. optional shared contract maturity features
+3. initiative artifact for shared planning
+4. linked change metadata across repos
+5. thin coordination workspace / repo for multi-repo planning
+6. team-shared coordination hardening
+7. optional shared contract maturity features
 
 ---
 

--- a/openspec/explorations/workspace-user-journeys.md
+++ b/openspec/explorations/workspace-user-journeys.md
@@ -1234,19 +1234,24 @@ Or OpenSpec may have already scaffolded the initiative and tell the agent to con
 
 ### Storage outcome
 
-The coordination workspace stores:
+The coordination workspace stores the **initiative-level planning object**:
 
+- proposal.md
+- design.md
 - initiative summary
 - cross-repo scope map
+- ownership, milestones, risks, and dependencies
 - links to repo-local changes
 - agent workspace instructions
 
-Each repo stores its own change:
+Each repo stores its own execution change:
 
 - `contracts/openspec/changes/add-3ds-contract/`
 - `billing-service/openspec/changes/add-3ds-billing/`
 - `web-client/openspec/changes/add-3ds-web/`
 - `ios-client/openspec/changes/add-3ds-ios/`
+
+Those repo-local changes are where repo-specific tasks, delta specs, and local implementation state live.
 
 ### Why this matters
 
@@ -1654,13 +1659,18 @@ Examples:
 - `contracts/openspec/changes/add-3ds-contract/`
 - `web-client/openspec/changes/add-3ds-web/`
 
+These changes are the execution artifacts for each owning repo. They should carry repo-specific tasks, delta specs, and local implementation state.
+
 ### Rule 3: Initiative-level planning lives in the coordination workspace
 
 Examples:
 
+- proposal.md
+- design.md
 - initiative summary
 - rollout sequencing
 - cross-repo assumptions
+- ownership, milestones, risks, and dependencies
 - links between repo-local changes
 
 ### Rule 4: Workspace never becomes canonical spec storage


### PR DESCRIPTION
## Summary
- update workspace architecture to frame initiatives as the first-class planning object for larger multi-team work
- keep repo-local changes as execution artifacts, linked back to shared initiatives
- update workspace user journeys to show initiative-level planning in the coordination workspace and execution state in repo-local changes

## Why
Changes currently bundle proposal, design, tasks, delta specs, and metadata. That works well for repo-local work, but gets awkward for cross-team and cross-repo planning because one repo-local change ends up trying to act as both the shared plan and the local execution artifact.

This exploration update makes the split explicit:
- initiatives coordinate
- repo-local changes implement
- workspaces stay a coordination layer, not canonical execution storage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reframed workspace as a non-durable, coordination-only view.
  * Introduced an initiative-first planning model for cross-repo work.
  * Clarified initiative as the coordination layer, with repo-local changes as execution artifacts.
  * Defined initiative artifact structure (proposal/design/metadata/links) and initiative field examples.
  * Added initiative-scoped explorations guidance and placement.
  * Updated roadmap, UX guidance, and storage rules to separate planning vs execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->