### PR TITLE
fix: canonicalize workflow artifact paths

### DIFF
--- a/src/commands/workflow/instructions.ts
+++ b/src/commands/workflow/instructions.ts
@@ -250,7 +250,7 @@ export async function generateApplyInstructions(
 ): Promise<ApplyInstructions> {
   // loadChangeContext will auto-detect schema from metadata if not provided
   const context = loadChangeContext(projectRoot, changeName, schemaName);
-  const changeDir = path.join(projectRoot, 'openspec', 'changes', changeName);
+  const changeDir = context.changeDir;
 
   // Get the full schema to access the apply phase configuration
   const schema = resolveSchema(context.schemaName, projectRoot);

--- a/src/commands/workflow/templates.ts
+++ b/src/commands/workflow/templates.ts
@@ -11,6 +11,7 @@ import {
   getSchemaDir,
   ArtifactGraph,
 } from '../../core/artifact-graph/index.js';
+import { FileSystemUtils } from '../../utils/file-system.js';
 import { validateSchemaExists, DEFAULT_SCHEMA } from './shared.js';
 
 // -----------------------------------------------------------------------------
@@ -68,7 +69,9 @@ export async function templatesCommand(options: TemplatesOptions): Promise<void>
 
     const templates: TemplateInfo[] = graph.getAllArtifacts().map((artifact) => ({
       artifactId: artifact.id,
-      templatePath: path.join(schemaDir, 'templates', artifact.template),
+      templatePath: FileSystemUtils.canonicalizeExistingPath(
+        path.join(schemaDir, 'templates', artifact.template)
+      ),
       source,
     }));
 

--- a/src/core/artifact-graph/instruction-loader.ts
+++ b/src/core/artifact-graph/instruction-loader.ts
@@ -4,6 +4,7 @@ import { getSchemaDir, resolveSchema } from './resolver.js';
 import { ArtifactGraph } from './graph.js';
 import { detectCompleted } from './state.js';
 import { resolveSchemaForChange } from '../../utils/change-metadata.js';
+import { FileSystemUtils } from '../../utils/file-system.js';
 import { readProjectConfig, validateConfigRules } from '../project-config.js';
 import type { Artifact, CompletedSet } from './types.js';
 
@@ -137,14 +138,16 @@ export function loadTemplate(
     );
   }
 
-  const fullPath = path.join(schemaDir, 'templates', templatePath);
+  const templatePathOnDisk = path.join(schemaDir, 'templates', templatePath);
 
-  if (!fs.existsSync(fullPath)) {
+  if (!fs.existsSync(templatePathOnDisk)) {
     throw new TemplateLoadError(
-      `Template not found: ${fullPath}`,
-      fullPath
+      `Template not found: ${templatePathOnDisk}`,
+      templatePathOnDisk
     );
   }
+
+  const fullPath = FileSystemUtils.canonicalizeExistingPath(templatePathOnDisk);
 
   try {
     return fs.readFileSync(fullPath, 'utf-8');
@@ -175,7 +178,9 @@ export function loadChangeContext(
   changeName: string,
   schemaName?: string
 ): ChangeContext {
-  const changeDir = path.join(projectRoot, 'openspec', 'changes', changeName);
+  const changeDir = FileSystemUtils.canonicalizeExistingPath(
+    path.join(projectRoot, 'openspec', 'changes', changeName)
+  );
 
   // Resolve schema: explicit > metadata > default
   const resolvedSchemaName = resolveSchemaForChange(changeDir, schemaName);

--- a/src/core/artifact-graph/outputs.ts
+++ b/src/core/artifact-graph/outputs.ts
@@ -19,14 +19,18 @@ export function resolveArtifactOutputs(changeDir: string, generates: string): st
 
   if (!isGlobPattern(generates)) {
     try {
-      return fs.statSync(fullPattern).isFile() ? [fullPattern] : [];
+      return fs.statSync(fullPattern).isFile()
+        ? [FileSystemUtils.canonicalizeExistingPath(fullPattern)]
+        : [];
     } catch {
       return [];
     }
   }
 
   const normalizedPattern = FileSystemUtils.toPosixPath(fullPattern);
-  const matches = fg.sync(normalizedPattern, { onlyFiles: true }).map((match) => path.normalize(match));
+  const matches = fg
+    .sync(normalizedPattern, { onlyFiles: true })
+    .map((match) => FileSystemUtils.canonicalizeExistingPath(path.normalize(match)));
 
   return Array.from(new Set(matches)).sort();
 }

--- a/src/utils/file-system.ts
+++ b/src/utils/file-system.ts
@@ -1,4 +1,4 @@
-import { promises as fs, constants as fsConstants } from 'fs';
+import { promises as fs, constants as fsConstants, realpathSync } from 'fs';
 import path from 'path';
 
 function isMarkerOnOwnLine(content: string, markerIndex: number, markerLength: number): boolean {
@@ -48,6 +48,18 @@ export class FileSystemUtils {
    */
   static toPosixPath(p: string): string {
     return p.replace(/\\/g, '/');
+  }
+
+  /**
+   * Returns a canonical absolute path when the target exists.
+   * Falls back to path.resolve() so callers can still produce a stable absolute path.
+   */
+  static canonicalizeExistingPath(targetPath: string): string {
+    try {
+      return realpathSync(targetPath);
+    } catch {
+      return path.resolve(targetPath);
+    }
   }
 
   private static isWindowsBasePath(basePath: string): boolean {

--- a/test/core/artifact-graph/outputs.test.ts
+++ b/test/core/artifact-graph/outputs.test.ts
@@ -20,7 +20,7 @@ describe('artifact-graph/outputs', () => {
     const filePath = path.join(tempDir, 'proposal.md');
     fs.writeFileSync(filePath, 'content');
 
-    expect(resolveArtifactOutputs(tempDir, 'proposal.md')).toEqual([filePath]);
+    expect(resolveArtifactOutputs(tempDir, 'proposal.md')).toEqual([fs.realpathSync(filePath)]);
     expect(artifactOutputExists(tempDir, 'proposal.md')).toBe(true);
   });
 
@@ -38,7 +38,7 @@ describe('artifact-graph/outputs', () => {
     fs.mkdirSync(nestedDir, { recursive: true });
     fs.writeFileSync(filePath, 'content');
 
-    expect(resolveArtifactOutputs(tempDir, 'specs/*/spec.md')).toEqual([filePath]);
+    expect(resolveArtifactOutputs(tempDir, 'specs/*/spec.md')).toEqual([fs.realpathSync(filePath)]);
     expect(artifactOutputExists(tempDir, 'specs/*/spec.md')).toBe(true);
   });
 
@@ -50,7 +50,7 @@ describe('artifact-graph/outputs', () => {
     fs.writeFileSync(matching, 'content');
     fs.writeFileSync(nonMatching, 'content');
 
-    expect(resolveArtifactOutputs(tempDir, 'specs/foo*.md')).toEqual([matching]);
+    expect(resolveArtifactOutputs(tempDir, 'specs/foo*.md')).toEqual([fs.realpathSync(matching)]);
   });
 
   it('supports question-mark glob patterns', () => {
@@ -60,7 +60,7 @@ describe('artifact-graph/outputs', () => {
     fs.writeFileSync(matching, 'content');
     fs.writeFileSync(path.join(specsDir, 'a10.md'), 'content');
 
-    expect(resolveArtifactOutputs(tempDir, 'specs/a?.md')).toEqual([matching]);
+    expect(resolveArtifactOutputs(tempDir, 'specs/a?.md')).toEqual([fs.realpathSync(matching)]);
   });
 
   it('supports character class glob patterns', () => {
@@ -72,7 +72,31 @@ describe('artifact-graph/outputs', () => {
     fs.writeFileSync(bPath, 'content');
     fs.writeFileSync(path.join(specsDir, 'c.md'), 'content');
 
-    expect(resolveArtifactOutputs(tempDir, 'specs/[ab].md')).toEqual([aPath, bPath]);
+    expect(resolveArtifactOutputs(tempDir, 'specs/[ab].md')).toEqual([
+      fs.realpathSync(aPath),
+      fs.realpathSync(bPath),
+    ]);
+  });
+
+  it('canonicalizes resolved paths when the change directory is accessed through an alias', () => {
+    const rootDir = path.join(tempDir, 'workspace');
+    const realChangeDir = path.join(rootDir, 'real-change');
+    const aliasChangeDir = path.join(rootDir, 'alias-change');
+    const specDir = path.join(realChangeDir, 'specs', 'change-a');
+    const proposalPath = path.join(realChangeDir, 'proposal.md');
+    const specPath = path.join(specDir, 'spec.md');
+
+    fs.mkdirSync(specDir, { recursive: true });
+    fs.writeFileSync(proposalPath, 'content');
+    fs.writeFileSync(specPath, 'content');
+    fs.symlinkSync(realChangeDir, aliasChangeDir, process.platform === 'win32' ? 'junction' : 'dir');
+
+    expect(resolveArtifactOutputs(aliasChangeDir, 'proposal.md')).toEqual([
+      fs.realpathSync(proposalPath),
+    ]);
+    expect(resolveArtifactOutputs(aliasChangeDir, 'specs/*/spec.md')).toEqual([
+      fs.realpathSync(specPath),
+    ]);
   });
 
   it('returns an empty list when no files match the artifact output', () => {


### PR DESCRIPTION
## Summary
- canonicalize artifact output paths before returning them in workflow JSON/text outputs
- normalize adjacent existing-file workflow paths (changeDir and template paths) to avoid OS-specific aliases leaking into machine-readable output
- add regression coverage for aliased change directories so Windows-style path aliasing is caught cross-platform

## Testing
- pnpm run build
- pnpm test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filesystem path canonicalization for more consistent artifact and template resolution
  * Added support for symlinked directories in project structures
  * Enhanced change directory detection with context-aware path resolution for better reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->