### PR TITLE
fix: prefer native realpath for canonical paths

### DIFF
--- a/src/utils/file-system.ts
+++ b/src/utils/file-system.ts
@@ -1,5 +1,8 @@
-import { promises as fs, constants as fsConstants, realpathSync } from 'fs';
+import * as nodeFs from 'fs';
 import path from 'path';
+
+const fs = nodeFs.promises;
+const { constants: fsConstants } = nodeFs;
 
 function isMarkerOnOwnLine(content: string, markerIndex: number, markerLength: number): boolean {
   let leftIndex = markerIndex - 1;
@@ -56,9 +59,14 @@ export class FileSystemUtils {
    */
   static canonicalizeExistingPath(targetPath: string): string {
     try {
-      return realpathSync(targetPath);
+      // Prefer the native resolver so Windows short-path aliases are expanded.
+      return nodeFs.realpathSync.native(targetPath);
     } catch {
-      return path.resolve(targetPath);
+      try {
+        return nodeFs.realpathSync(targetPath);
+      } catch {
+        return path.resolve(targetPath);
+      }
     }
   }
 

--- a/test/utils/file-system.test.ts
+++ b/test/utils/file-system.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as nodeFs from 'fs';
 import { promises as fs } from 'fs';
 import path from 'path';
 import os from 'os';
@@ -89,6 +90,22 @@ describe('FileSystemUtils', () => {
       
       const exists = await FileSystemUtils.directoryExists(filePath);
       expect(exists).toBe(false);
+    });
+  });
+
+  describe('canonicalizeExistingPath', () => {
+    it('should prefer the native realpath resolver when available', async () => {
+      const filePath = path.join(testDir, 'canonical.txt');
+      await fs.writeFile(filePath, 'content');
+
+      const nativeSpy = vi.spyOn(nodeFs.realpathSync, 'native');
+
+      const resolved = FileSystemUtils.canonicalizeExistingPath(filePath);
+
+      expect(nativeSpy).toHaveBeenCalledWith(filePath);
+      expect(resolved).toBe(nodeFs.realpathSync.native(filePath));
+
+      nativeSpy.mockRestore();
     });
   });
 


### PR DESCRIPTION
## Summary
- prefer Node's native realpath resolver when canonicalizing existing paths
- ensure Windows short-path aliases like `RUNNER~1` are expanded before artifact workflow JSON emits file paths
- add regression coverage for the canonicalization helper

## Context
- follow-up to #971, which merged before this Windows-specific fix was added

## Testing
- pnpm run build
- pnpm exec vitest run test/utils/file-system.test.ts test/commands/artifact-workflow.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved file path resolution with native filesystem APIs and fallback mechanisms.

* **Tests**
  * Added test coverage for the enhanced path canonicalization functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->