### PR TITLE
fix: escape glob-special characters in directory paths

### DIFF
--- a/src/core/artifact-graph/outputs.ts
+++ b/src/core/artifact-graph/outputs.ts
@@ -11,23 +11,33 @@ export function isGlobPattern(pattern: string): boolean {
 }
 
 /**
+ * Escapes glob-special characters in a directory path so it is treated as a
+ * literal string by fast-glob.  Only parentheses and square brackets need
+ * escaping — curly braces and other extglob prefixes do not break matching
+ * when they appear in isolation inside a filesystem path.
+ */
+function escapeGlobPath(p: string): string {
+  return p.replace(/[()[\]]/g, '\\$&');
+}
+
+/**
  * Resolves an artifact's output path(s) to concrete files that currently exist.
  * Returns absolute file paths. Glob matches are sorted for deterministic output.
  */
 export function resolveArtifactOutputs(changeDir: string, generates: string): string[] {
-  const fullPattern = path.join(changeDir, generates);
-
   if (!isGlobPattern(generates)) {
+    const fullPath = path.join(changeDir, generates);
     try {
-      return fs.statSync(fullPattern).isFile()
-        ? [FileSystemUtils.canonicalizeExistingPath(fullPattern)]
+      return fs.statSync(fullPath).isFile()
+        ? [FileSystemUtils.canonicalizeExistingPath(fullPath)]
         : [];
     } catch {
       return [];
     }
   }
 
-  const normalizedPattern = FileSystemUtils.toPosixPath(fullPattern);
+  const escapedDir = escapeGlobPath(FileSystemUtils.toPosixPath(changeDir));
+  const normalizedPattern = escapedDir + '/' + FileSystemUtils.toPosixPath(generates);
   const matches = fg
     .sync(normalizedPattern, { onlyFiles: true })
     .map((match) => FileSystemUtils.canonicalizeExistingPath(path.normalize(match)));

--- a/src/core/artifact-graph/outputs.ts
+++ b/src/core/artifact-graph/outputs.ts
@@ -11,16 +11,6 @@ export function isGlobPattern(pattern: string): boolean {
 }
 
 /**
- * Escapes glob-special characters in a directory path so it is treated as a
- * literal string by fast-glob.  Only parentheses and square brackets need
- * escaping — curly braces and other extglob prefixes do not break matching
- * when they appear in isolation inside a filesystem path.
- */
-function escapeGlobPath(p: string): string {
-  return p.replace(/[()[\]]/g, '\\$&');
-}
-
-/**
  * Resolves an artifact's output path(s) to concrete files that currently exist.
  * Returns absolute file paths. Glob matches are sorted for deterministic output.
  */
@@ -36,10 +26,9 @@ export function resolveArtifactOutputs(changeDir: string, generates: string): st
     }
   }
 
-  const escapedDir = escapeGlobPath(FileSystemUtils.toPosixPath(changeDir));
-  const normalizedPattern = escapedDir + '/' + FileSystemUtils.toPosixPath(generates);
+  const normalizedPattern = FileSystemUtils.toPosixPath(generates);
   const matches = fg
-    .sync(normalizedPattern, { onlyFiles: true })
+    .sync(normalizedPattern, { cwd: changeDir, onlyFiles: true, absolute: true })
     .map((match) => FileSystemUtils.canonicalizeExistingPath(path.normalize(match)));
 
   return Array.from(new Set(matches)).sort();

--- a/test/core/artifact-graph/outputs.test.ts
+++ b/test/core/artifact-graph/outputs.test.ts
@@ -106,4 +106,57 @@ describe('artifact-graph/outputs', () => {
     expect(resolveArtifactOutputs(tempDir, 'specs/*/spec.md')).toEqual([]);
     expect(artifactOutputExists(tempDir, 'specs/*/spec.md')).toBe(false);
   });
+
+  describe('glob-special characters in directory paths', () => {
+    it('resolves glob patterns when directory contains parentheses', () => {
+      const dirWithParens = path.join(tempDir, 'project (work)');
+      const specDir = path.join(dirWithParens, 'specs', 'cap-a');
+      const specFile = path.join(specDir, 'spec.md');
+      fs.mkdirSync(specDir, { recursive: true });
+      fs.writeFileSync(specFile, 'content');
+
+      expect(resolveArtifactOutputs(dirWithParens, 'specs/*/spec.md')).toEqual([
+        canonical(specFile),
+      ]);
+      expect(artifactOutputExists(dirWithParens, 'specs/*/spec.md')).toBe(true);
+    });
+
+    it('resolves glob patterns when directory contains square brackets', () => {
+      const dirWithBrackets = path.join(tempDir, '[projects]');
+      const specDir = path.join(dirWithBrackets, 'specs', 'cap-a');
+      const specFile = path.join(specDir, 'spec.md');
+      fs.mkdirSync(specDir, { recursive: true });
+      fs.writeFileSync(specFile, 'content');
+
+      expect(resolveArtifactOutputs(dirWithBrackets, 'specs/*/spec.md')).toEqual([
+        canonical(specFile),
+      ]);
+      expect(artifactOutputExists(dirWithBrackets, 'specs/*/spec.md')).toBe(true);
+    });
+
+    it('resolves glob patterns when directory contains curly braces', () => {
+      const dirWithBraces = path.join(tempDir, '{workspace}');
+      const specDir = path.join(dirWithBraces, 'specs', 'cap-a');
+      const specFile = path.join(specDir, 'spec.md');
+      fs.mkdirSync(specDir, { recursive: true });
+      fs.writeFileSync(specFile, 'content');
+
+      expect(resolveArtifactOutputs(dirWithBraces, 'specs/*/spec.md')).toEqual([
+        canonical(specFile),
+      ]);
+      expect(artifactOutputExists(dirWithBraces, 'specs/*/spec.md')).toBe(true);
+    });
+
+    it('resolves non-glob generates when directory contains special characters', () => {
+      const dirWithParens = path.join(tempDir, 'project (work)');
+      const proposalFile = path.join(dirWithParens, 'proposal.md');
+      fs.mkdirSync(dirWithParens, { recursive: true });
+      fs.writeFileSync(proposalFile, 'content');
+
+      expect(resolveArtifactOutputs(dirWithParens, 'proposal.md')).toEqual([
+        canonical(proposalFile),
+      ]);
+      expect(artifactOutputExists(dirWithParens, 'proposal.md')).toBe(true);
+    });
+  });
 });

--- a/test/core/artifact-graph/outputs.test.ts
+++ b/test/core/artifact-graph/outputs.test.ts
@@ -147,6 +147,19 @@ describe('artifact-graph/outputs', () => {
       expect(artifactOutputExists(dirWithBraces, 'specs/*/spec.md')).toBe(true);
     });
 
+    it('resolves glob patterns when directory contains brace expansion syntax', () => {
+      const dirWithBraceExpansion = path.join(tempDir, 'project {a,b}');
+      const specDir = path.join(dirWithBraceExpansion, 'specs', 'cap-a');
+      const specFile = path.join(specDir, 'spec.md');
+      fs.mkdirSync(specDir, { recursive: true });
+      fs.writeFileSync(specFile, 'content');
+
+      expect(resolveArtifactOutputs(dirWithBraceExpansion, 'specs/*/spec.md')).toEqual([
+        canonical(specFile),
+      ]);
+      expect(artifactOutputExists(dirWithBraceExpansion, 'specs/*/spec.md')).toBe(true);
+    });
+
     it('resolves non-glob generates when directory contains special characters', () => {
       const dirWithParens = path.join(tempDir, 'project (work)');
       const proposalFile = path.join(dirWithParens, 'proposal.md');


### PR DESCRIPTION
## Summary
- Escape parentheses and square brackets in the directory portion of glob patterns before passing to `fast-glob`, so they are treated as literal path characters instead of extglob syntax
- Add `escapeGlobPath()` helper that targets only `()` and `[]` — characters proven to break `fast-glob`/`picomatch` matching in filesystem paths
- Add 4 test cases covering parentheses, square brackets, curly braces, and non-glob generates with special-character directories

## Test plan
- [x] All 12 existing + new tests pass (`vitest run test/core/artifact-graph/outputs.test.ts`)
- [x] Verified glob patterns resolve correctly when directory contains `()`, `[]`, `{}`
- [x] Verified non-glob `generates` (e.g. `proposal.md`) still works via `fs.statSync` path

Closes #974

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Artifact output resolution correctly handles directory names containing glob-special characters (parentheses, brackets, braces).
  * Glob pattern matching and file existence checks now succeed for artifacts in directories with those naming patterns.
  * Resolved behavior for literal (non-glob) outputs in such directories so canonical files are found.

* **Tests**
  * Added test coverage for directories with glob-special characters to ensure correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->