### PR TITLE
fix: handle XDG_CONFIG_HOME and %APPDATA% in telemetry config path

### DIFF
--- a/src/telemetry/config.ts
+++ b/src/telemetry/config.ts
@@ -5,10 +5,15 @@
 import { promises as fs } from 'fs';
 import path from 'path';
 import os from 'os';
+import {
+  GLOBAL_CONFIG_DIR_NAME,
+  GLOBAL_CONFIG_FILE_NAME,
+  getGlobalConfigDir,
+} from '../core/global-config.js';
 
 // Constants
-export const CONFIG_DIR_NAME = 'openspec';
-export const CONFIG_FILE_NAME = 'config.json';
+export const CONFIG_DIR_NAME = GLOBAL_CONFIG_DIR_NAME;
+export const CONFIG_FILE_NAME = GLOBAL_CONFIG_FILE_NAME;
 
 export interface TelemetryConfig {
   anonymousId?: string;
@@ -21,26 +26,87 @@ export interface GlobalConfig {
 }
 
 function getConfigDir(): string {
-  // XDG_CONFIG_HOME takes precedence on all platforms when explicitly set
-  const xdgConfigHome = process.env.XDG_CONFIG_HOME;
-  if (xdgConfigHome) {
-    return path.join(xdgConfigHome, CONFIG_DIR_NAME);
-  }
+  return getGlobalConfigDir();
+}
 
-  const platform = os.platform();
+function getLegacyConfigPath(): string {
+  return path.join(os.homedir(), '.config', CONFIG_DIR_NAME, CONFIG_FILE_NAME);
+}
 
-  if (platform === 'win32') {
-    // Windows: use %APPDATA%
-    const appData = process.env.APPDATA;
-    if (appData) {
-      return path.join(appData, CONFIG_DIR_NAME);
+async function readConfigFile(configPath: string): Promise<GlobalConfig | undefined> {
+  try {
+    const content = await fs.readFile(configPath, 'utf-8');
+    return JSON.parse(content) as GlobalConfig;
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return undefined;
     }
-    // Fallback for Windows if APPDATA is not set
-    return path.join(os.homedir(), 'AppData', 'Roaming', CONFIG_DIR_NAME);
+    // If parse fails or another read error occurs, ignore the file.
+    return {};
+  }
+}
+
+async function writeConfigFile(configPath: string, config: GlobalConfig): Promise<void> {
+  await fs.mkdir(path.dirname(configPath), { recursive: true });
+  await fs.writeFile(configPath, JSON.stringify(config, null, 2) + '\n');
+}
+
+function hasMissingTelemetryFields(config: GlobalConfig): boolean {
+  const telemetry = config.telemetry;
+  return (
+    !telemetry ||
+    telemetry.anonymousId === undefined ||
+    telemetry.noticeSeen === undefined
+  );
+}
+
+function mergeLegacyTelemetry(config: GlobalConfig, legacyConfig: GlobalConfig): GlobalConfig | undefined {
+  const legacyTelemetry = legacyConfig.telemetry;
+  if (!legacyTelemetry) {
+    return undefined;
   }
 
-  // Unix/macOS fallback: ~/.config
-  return path.join(os.homedir(), '.config', CONFIG_DIR_NAME);
+  const currentTelemetry = config.telemetry ?? {};
+  const shouldMigrate =
+    (currentTelemetry.anonymousId === undefined && legacyTelemetry.anonymousId !== undefined) ||
+    (currentTelemetry.noticeSeen === undefined && legacyTelemetry.noticeSeen !== undefined);
+
+  if (!shouldMigrate) {
+    return undefined;
+  }
+
+  return {
+    ...config,
+    telemetry: {
+      ...legacyTelemetry,
+      ...currentTelemetry,
+    },
+  };
+}
+
+async function migrateLegacyTelemetryConfig(configPath: string, config: GlobalConfig): Promise<GlobalConfig> {
+  const legacyConfigPath = getLegacyConfigPath();
+  if (path.resolve(configPath) === path.resolve(legacyConfigPath) || !hasMissingTelemetryFields(config)) {
+    return config;
+  }
+
+  const legacyConfig = await readConfigFile(legacyConfigPath);
+  if (!legacyConfig) {
+    return config;
+  }
+
+  const migrated = mergeLegacyTelemetry(config, legacyConfig);
+  if (!migrated) {
+    return config;
+  }
+
+  try {
+    await writeConfigFile(configPath, migrated);
+  } catch {
+    // Preserve telemetry for this run even if the one-time migration cannot be persisted.
+  }
+
+  return migrated;
 }
 
 /**
@@ -62,16 +128,8 @@ export function getConfigPath(): string {
  */
 export async function readConfig(): Promise<GlobalConfig> {
   const configPath = getConfigPath();
-  try {
-    const content = await fs.readFile(configPath, 'utf-8');
-    return JSON.parse(content) as GlobalConfig;
-  } catch (error: unknown) {
-    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      return {};
-    }
-    // If parse fails or other error, return empty config
-    return {};
-  }
+  const config = (await readConfigFile(configPath)) ?? {};
+  return migrateLegacyTelemetryConfig(configPath, config);
 }
 
 /**
@@ -80,10 +138,6 @@ export async function readConfig(): Promise<GlobalConfig> {
  */
 export async function writeConfig(updates: Partial<GlobalConfig>): Promise<void> {
   const configPath = getConfigPath();
-  const configDir = path.dirname(configPath);
-
-  // Ensure directory exists
-  await fs.mkdir(configDir, { recursive: true });
 
   // Read existing config and merge
   const existing = await readConfig();
@@ -94,7 +148,7 @@ export async function writeConfig(updates: Partial<GlobalConfig>): Promise<void>
     merged.telemetry = { ...existing.telemetry, ...updates.telemetry };
   }
 
-  await fs.writeFile(configPath, JSON.stringify(merged, null, 2) + '\n');
+  await writeConfigFile(configPath, merged);
 }
 
 /**

--- a/src/telemetry/config.ts
+++ b/src/telemetry/config.ts
@@ -1,10 +1,14 @@
 /**
  * Global configuration for telemetry state.
- * Stores anonymous ID and notice-seen flag in ~/.config/openspec/config.json
+ * Stores anonymous ID and notice-seen flag in the platform-appropriate config directory.
  */
 import { promises as fs } from 'fs';
 import path from 'path';
 import os from 'os';
+
+// Constants
+export const CONFIG_DIR_NAME = 'openspec';
+export const CONFIG_FILE_NAME = 'config.json';
 
 export interface TelemetryConfig {
   anonymousId?: string;
@@ -16,13 +20,40 @@ export interface GlobalConfig {
   [key: string]: unknown; // Preserve other fields
 }
 
+function getConfigDir(): string {
+  // XDG_CONFIG_HOME takes precedence on all platforms when explicitly set
+  const xdgConfigHome = process.env.XDG_CONFIG_HOME;
+  if (xdgConfigHome) {
+    return path.join(xdgConfigHome, CONFIG_DIR_NAME);
+  }
+
+  const platform = os.platform();
+
+  if (platform === 'win32') {
+    // Windows: use %APPDATA%
+    const appData = process.env.APPDATA;
+    if (appData) {
+      return path.join(appData, CONFIG_DIR_NAME);
+    }
+    // Fallback for Windows if APPDATA is not set
+    return path.join(os.homedir(), 'AppData', 'Roaming', CONFIG_DIR_NAME);
+  }
+
+  // Unix/macOS fallback: ~/.config
+  return path.join(os.homedir(), '.config', CONFIG_DIR_NAME);
+}
+
 /**
  * Get the path to the global config file.
- * Uses ~/.config/openspec/config.json on all platforms.
+ * Follows XDG Base Directory Specification and platform conventions.
+ *
+ * - All platforms: $XDG_CONFIG_HOME/openspec/ if XDG_CONFIG_HOME is set
+ * - Unix/macOS fallback: ~/.config/openspec/
+ * - Windows fallback: %APPDATA%/openspec/
  */
 export function getConfigPath(): string {
-  const configDir = path.join(os.homedir(), '.config', 'openspec');
-  return path.join(configDir, 'config.json');
+  const configDir = getConfigDir();
+  return path.join(configDir, CONFIG_FILE_NAME);
 }
 
 /**

--- a/src/telemetry/config.ts
+++ b/src/telemetry/config.ts
@@ -25,6 +25,11 @@ export interface GlobalConfig {
   [key: string]: unknown; // Preserve other fields
 }
 
+type ConfigReadResult =
+  | { status: 'missing' }
+  | { status: 'ok'; config: GlobalConfig }
+  | { status: 'invalid'; config: GlobalConfig };
+
 function getConfigDir(): string {
   return getGlobalConfigDir();
 }
@@ -33,16 +38,16 @@ function getLegacyConfigPath(): string {
   return path.join(os.homedir(), '.config', CONFIG_DIR_NAME, CONFIG_FILE_NAME);
 }
 
-async function readConfigFile(configPath: string): Promise<GlobalConfig | undefined> {
+async function readConfigFile(configPath: string): Promise<ConfigReadResult> {
   try {
     const content = await fs.readFile(configPath, 'utf-8');
-    return JSON.parse(content) as GlobalConfig;
+    return { status: 'ok', config: JSON.parse(content) as GlobalConfig };
   } catch (error: unknown) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-      return undefined;
+      return { status: 'missing' };
     }
     // If parse fails or another read error occurs, ignore the file.
-    return {};
+    return { status: 'invalid', config: {} };
   }
 }
 
@@ -84,26 +89,32 @@ function mergeLegacyTelemetry(config: GlobalConfig, legacyConfig: GlobalConfig):
   };
 }
 
-async function migrateLegacyTelemetryConfig(configPath: string, config: GlobalConfig): Promise<GlobalConfig> {
+async function migrateLegacyTelemetryConfig(
+  configPath: string,
+  config: GlobalConfig,
+  persist: boolean,
+): Promise<GlobalConfig> {
   const legacyConfigPath = getLegacyConfigPath();
   if (path.resolve(configPath) === path.resolve(legacyConfigPath) || !hasMissingTelemetryFields(config)) {
     return config;
   }
 
-  const legacyConfig = await readConfigFile(legacyConfigPath);
-  if (!legacyConfig) {
+  const legacyRead = await readConfigFile(legacyConfigPath);
+  if (legacyRead.status !== 'ok') {
     return config;
   }
 
-  const migrated = mergeLegacyTelemetry(config, legacyConfig);
+  const migrated = mergeLegacyTelemetry(config, legacyRead.config);
   if (!migrated) {
     return config;
   }
 
-  try {
-    await writeConfigFile(configPath, migrated);
-  } catch {
-    // Preserve telemetry for this run even if the one-time migration cannot be persisted.
+  if (persist) {
+    try {
+      await writeConfigFile(configPath, migrated);
+    } catch {
+      // Preserve telemetry for this run even if the one-time migration cannot be persisted.
+    }
   }
 
   return migrated;
@@ -128,8 +139,9 @@ export function getConfigPath(): string {
  */
 export async function readConfig(): Promise<GlobalConfig> {
   const configPath = getConfigPath();
-  const config = (await readConfigFile(configPath)) ?? {};
-  return migrateLegacyTelemetryConfig(configPath, config);
+  const read = await readConfigFile(configPath);
+  const config = read.status === 'ok' ? read.config : {};
+  return migrateLegacyTelemetryConfig(configPath, config, read.status !== 'invalid');
 }
 
 /**

--- a/test/telemetry/config.test.ts
+++ b/test/telemetry/config.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
+import { randomUUID } from 'node:crypto';
 
 import {
   getConfigPath,
@@ -13,26 +14,32 @@ import {
 
 describe('telemetry/config', () => {
   let tempDir: string;
-  let originalHome: string | undefined;
-  let originalUserProfile: string | undefined;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  function restoreEnv(env: NodeJS.ProcessEnv): void {
+    for (const key of Object.keys(process.env)) {
+      delete process.env[key];
+    }
+    Object.assign(process.env, env);
+  }
 
   beforeEach(() => {
     // Create temp directory for tests
-    tempDir = path.join(os.tmpdir(), `openspec-telemetry-test-${Date.now()}`);
+    tempDir = path.join(os.tmpdir(), `openspec-telemetry-test-${randomUUID()}`);
     fs.mkdirSync(tempDir, { recursive: true });
 
     // Mock HOME/USERPROFILE to point to temp dir
     // On POSIX, os.homedir() uses HOME; on Windows it uses USERPROFILE
-    originalHome = process.env.HOME;
-    originalUserProfile = process.env.USERPROFILE;
+    originalEnv = { ...process.env };
+    delete process.env.XDG_CONFIG_HOME;
+    delete process.env.APPDATA;
     process.env.HOME = tempDir;
     process.env.USERPROFILE = tempDir;
   });
 
   afterEach(() => {
-    // Restore HOME/USERPROFILE
-    process.env.HOME = originalHome;
-    process.env.USERPROFILE = originalUserProfile;
+    // Restore environment
+    restoreEnv(originalEnv);
 
     // Clean up temp directory
     fs.rmSync(tempDir, { recursive: true, force: true });
@@ -42,6 +49,15 @@ describe('telemetry/config', () => {
     it('should return path to config.json in .config/openspec', () => {
       const result = getConfigPath();
       expect(result).toBe(path.join(tempDir, '.config', 'openspec', 'config.json'));
+    });
+
+    it('should use XDG_CONFIG_HOME when set', () => {
+      const xdgConfigHome = path.join(tempDir, 'xdg-config');
+      process.env.XDG_CONFIG_HOME = xdgConfigHome;
+
+      const result = getConfigPath();
+
+      expect(result).toBe(path.join(xdgConfigHome, 'openspec', 'config.json'));
     });
   });
 
@@ -74,6 +90,58 @@ describe('telemetry/config', () => {
       const config = await readConfig();
       expect(config).toEqual({});
     });
+
+    it('should migrate telemetry from legacy path when XDG_CONFIG_HOME is set', async () => {
+      const xdgConfigHome = path.join(tempDir, 'xdg-config');
+      const legacyConfigDir = path.join(tempDir, '.config', 'openspec');
+      const legacyConfigPath = path.join(legacyConfigDir, 'config.json');
+      const newConfigPath = path.join(xdgConfigHome, 'openspec', 'config.json');
+      process.env.XDG_CONFIG_HOME = xdgConfigHome;
+
+      fs.mkdirSync(legacyConfigDir, { recursive: true });
+      fs.writeFileSync(legacyConfigPath, JSON.stringify({
+        telemetry: { anonymousId: 'legacy-id', noticeSeen: true },
+      }));
+
+      const config = await readConfig();
+
+      expect(config.telemetry).toEqual({ anonymousId: 'legacy-id', noticeSeen: true });
+      expect(JSON.parse(fs.readFileSync(newConfigPath, 'utf-8')).telemetry).toEqual({
+        anonymousId: 'legacy-id',
+        noticeSeen: true,
+      });
+    });
+
+    it('should fill only missing telemetry fields from legacy config', async () => {
+      const xdgConfigHome = path.join(tempDir, 'xdg-config');
+      const legacyConfigDir = path.join(tempDir, '.config', 'openspec');
+      const legacyConfigPath = path.join(legacyConfigDir, 'config.json');
+      const newConfigDir = path.join(xdgConfigHome, 'openspec');
+      const newConfigPath = path.join(newConfigDir, 'config.json');
+      process.env.XDG_CONFIG_HOME = xdgConfigHome;
+
+      fs.mkdirSync(legacyConfigDir, { recursive: true });
+      fs.writeFileSync(legacyConfigPath, JSON.stringify({
+        telemetry: { anonymousId: 'legacy-id', noticeSeen: true },
+        legacyOnly: 'ignored',
+      }));
+
+      fs.mkdirSync(newConfigDir, { recursive: true });
+      fs.writeFileSync(newConfigPath, JSON.stringify({
+        featureFlags: { existing: true },
+        telemetry: { anonymousId: 'new-id' },
+      }));
+
+      const config = await readConfig();
+
+      expect(config.featureFlags).toEqual({ existing: true });
+      expect(config.telemetry).toEqual({ anonymousId: 'new-id', noticeSeen: true });
+      expect((config as Record<string, unknown>).legacyOnly).toBeUndefined();
+      expect(JSON.parse(fs.readFileSync(newConfigPath, 'utf-8')).telemetry).toEqual({
+        anonymousId: 'new-id',
+        noticeSeen: true,
+      });
+    });
   });
 
   describe('writeConfig', () => {
@@ -87,6 +155,18 @@ describe('telemetry/config', () => {
 
     it('should write config to file', async () => {
       const configPath = path.join(tempDir, '.config', 'openspec', 'config.json');
+
+      await writeConfig({ telemetry: { anonymousId: 'test-123' } });
+
+      const content = fs.readFileSync(configPath, 'utf-8');
+      const parsed = JSON.parse(content);
+      expect(parsed.telemetry.anonymousId).toBe('test-123');
+    });
+
+    it('should write config to XDG_CONFIG_HOME when set', async () => {
+      const xdgConfigHome = path.join(tempDir, 'xdg-config');
+      const configPath = path.join(xdgConfigHome, 'openspec', 'config.json');
+      process.env.XDG_CONFIG_HOME = xdgConfigHome;
 
       await writeConfig({ telemetry: { anonymousId: 'test-123' } });
 

--- a/test/telemetry/config.test.ts
+++ b/test/telemetry/config.test.ts
@@ -23,6 +23,16 @@ describe('telemetry/config', () => {
     Object.assign(process.env, env);
   }
 
+  function defaultConfigDir(): string {
+    return os.platform() === 'win32'
+      ? path.join(tempDir, 'appdata', 'openspec')
+      : path.join(tempDir, '.config', 'openspec');
+  }
+
+  function defaultConfigPath(): string {
+    return path.join(defaultConfigDir(), 'config.json');
+  }
+
   beforeEach(() => {
     // Create temp directory for tests
     tempDir = path.join(os.tmpdir(), `openspec-telemetry-test-${randomUUID()}`);
@@ -32,7 +42,7 @@ describe('telemetry/config', () => {
     // On POSIX, os.homedir() uses HOME; on Windows it uses USERPROFILE
     originalEnv = { ...process.env };
     delete process.env.XDG_CONFIG_HOME;
-    delete process.env.APPDATA;
+    process.env.APPDATA = path.join(tempDir, 'appdata');
     process.env.HOME = tempDir;
     process.env.USERPROFILE = tempDir;
   });
@@ -46,9 +56,9 @@ describe('telemetry/config', () => {
   });
 
   describe('getConfigPath', () => {
-    it('should return path to config.json in .config/openspec', () => {
+    it('should return path to config.json in the default config directory', () => {
       const result = getConfigPath();
-      expect(result).toBe(path.join(tempDir, '.config', 'openspec', 'config.json'));
+      expect(result).toBe(defaultConfigPath());
     });
 
     it('should use XDG_CONFIG_HOME when set', () => {
@@ -68,8 +78,8 @@ describe('telemetry/config', () => {
     });
 
     it('should load valid config from file', async () => {
-      const configDir = path.join(tempDir, '.config', 'openspec');
-      const configPath = path.join(configDir, 'config.json');
+      const configDir = defaultConfigDir();
+      const configPath = defaultConfigPath();
 
       fs.mkdirSync(configDir, { recursive: true });
       fs.writeFileSync(configPath, JSON.stringify({
@@ -81,8 +91,8 @@ describe('telemetry/config', () => {
     });
 
     it('should return empty object for invalid JSON', async () => {
-      const configDir = path.join(tempDir, '.config', 'openspec');
-      const configPath = path.join(configDir, 'config.json');
+      const configDir = defaultConfigDir();
+      const configPath = defaultConfigPath();
 
       fs.mkdirSync(configDir, { recursive: true });
       fs.writeFileSync(configPath, '{ invalid json }');
@@ -110,6 +120,29 @@ describe('telemetry/config', () => {
         anonymousId: 'legacy-id',
         noticeSeen: true,
       });
+    });
+
+    it('should not overwrite invalid new config during legacy migration', async () => {
+      const xdgConfigHome = path.join(tempDir, 'xdg-config');
+      const legacyConfigDir = path.join(tempDir, '.config', 'openspec');
+      const legacyConfigPath = path.join(legacyConfigDir, 'config.json');
+      const newConfigDir = path.join(xdgConfigHome, 'openspec');
+      const newConfigPath = path.join(newConfigDir, 'config.json');
+      const invalidJson = '{ invalid json }';
+      process.env.XDG_CONFIG_HOME = xdgConfigHome;
+
+      fs.mkdirSync(legacyConfigDir, { recursive: true });
+      fs.writeFileSync(legacyConfigPath, JSON.stringify({
+        telemetry: { anonymousId: 'legacy-id', noticeSeen: true },
+      }));
+
+      fs.mkdirSync(newConfigDir, { recursive: true });
+      fs.writeFileSync(newConfigPath, invalidJson);
+
+      const config = await readConfig();
+
+      expect(config.telemetry).toEqual({ anonymousId: 'legacy-id', noticeSeen: true });
+      expect(fs.readFileSync(newConfigPath, 'utf-8')).toBe(invalidJson);
     });
 
     it('should fill only missing telemetry fields from legacy config', async () => {
@@ -146,7 +179,7 @@ describe('telemetry/config', () => {
 
   describe('writeConfig', () => {
     it('should create directory if it does not exist', async () => {
-      const configDir = path.join(tempDir, '.config', 'openspec');
+      const configDir = defaultConfigDir();
 
       await writeConfig({ telemetry: { noticeSeen: true } });
 
@@ -154,7 +187,7 @@ describe('telemetry/config', () => {
     });
 
     it('should write config to file', async () => {
-      const configPath = path.join(tempDir, '.config', 'openspec', 'config.json');
+      const configPath = defaultConfigPath();
 
       await writeConfig({ telemetry: { anonymousId: 'test-123' } });
 
@@ -176,8 +209,8 @@ describe('telemetry/config', () => {
     });
 
     it('should preserve existing fields when updating', async () => {
-      const configDir = path.join(tempDir, '.config', 'openspec');
-      const configPath = path.join(configDir, 'config.json');
+      const configDir = defaultConfigDir();
+      const configPath = defaultConfigPath();
 
       // Create initial config with other fields
       fs.mkdirSync(configDir, { recursive: true });
@@ -196,8 +229,8 @@ describe('telemetry/config', () => {
     });
 
     it('should deep merge telemetry fields', async () => {
-      const configDir = path.join(tempDir, '.config', 'openspec');
-      const configPath = path.join(configDir, 'config.json');
+      const configDir = defaultConfigDir();
+      const configPath = defaultConfigPath();
 
       // Create initial config
       fs.mkdirSync(configDir, { recursive: true });
@@ -222,8 +255,8 @@ describe('telemetry/config', () => {
     });
 
     it('should return telemetry section from config', async () => {
-      const configDir = path.join(tempDir, '.config', 'openspec');
-      const configPath = path.join(configDir, 'config.json');
+      const configDir = defaultConfigDir();
+      const configPath = defaultConfigPath();
 
       fs.mkdirSync(configDir, { recursive: true });
       fs.writeFileSync(configPath, JSON.stringify({
@@ -239,15 +272,15 @@ describe('telemetry/config', () => {
     it('should create telemetry config when none exists', async () => {
       await updateTelemetryConfig({ anonymousId: 'new-id' });
 
-      const configPath = path.join(tempDir, '.config', 'openspec', 'config.json');
+      const configPath = defaultConfigPath();
       const content = fs.readFileSync(configPath, 'utf-8');
       const parsed = JSON.parse(content);
       expect(parsed.telemetry.anonymousId).toBe('new-id');
     });
 
     it('should merge with existing telemetry config', async () => {
-      const configDir = path.join(tempDir, '.config', 'openspec');
-      const configPath = path.join(configDir, 'config.json');
+      const configDir = defaultConfigDir();
+      const configPath = defaultConfigPath();
 
       fs.mkdirSync(configDir, { recursive: true });
       fs.writeFileSync(configPath, JSON.stringify({


### PR DESCRIPTION
`src/telemetry/config.ts` hardcodes the config path to `~/.config/openspec/config.json`, ignoring `XDG_CONFIG_HOME` and Windows `%APPDATA%`, unlike `src/core/global-config.ts` which handles both.

This causes telemetry state (anonymous ID, notice-seen flag) to be written to a different directory than global config when `XDG_CONFIG_HOME` is set or on Windows, leading to repeated telemetry notices and regenerated anonymous IDs.

This PR adds the same XDG/platform-aware resolution to the telemetry config path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Telemetry config now uses platform-appropriate system directories and standardized names for consistent behavior across Windows, macOS, and Linux.
* **Bug Fixes**
  * One-time migration merges missing telemetry fields from legacy locations while preserving existing config and avoiding overwriting invalid configs.
  * Reading/writing of config is more robust (clearer statuses, ensures parent directories, safer JSON handling).
* **Tests**
  * Expanded and hardened tests for platform resolution, migration scenarios, and read/write correctness with improved environment isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->