### PR TITLE
docs: remove teams Slack mention from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,6 @@ Our philosophy:
   Follow <a href="https://x.com/0xTab">@0xTab on X</a> for updates · Join the <a href="https://discord.gg/YctCnvvshC">OpenSpec Discord</a> for help and questions.
 </p>
 
-### Teams
-
-Using OpenSpec in a team? [Email here](mailto:teams@openspec.dev) for access to our Slack channel.
-
 <!-- TODO: Add GIF demo of /opsx:propose → /opsx:archive workflow -->
 
 ## See it in action


### PR DESCRIPTION
## Summary
- Remove the Teams section that mentioned Slack channel access from the README

## Testing
- Verified README no longer contains Slack, teams@openspec, or the Teams heading

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the Teams section and team access call-to-action from README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->