### PR TITLE
chore: add changeset for v1.3.1 patch fixes

### DIFF
--- a/.changeset/v1-3-1-patch-fixes.md
+++ b/.changeset/v1-3-1-patch-fixes.md
@@ -1,0 +1,11 @@
+---
+"@fission-ai/openspec": patch
+---
+
+### Bug Fixes
+
+- **Canonical artifact paths** — Workflow artifact paths are now resolved via the native `realpath`, so symlinks and case-insensitive filesystems no longer cause path mismatches during apply and archive.
+- **Glob apply instructions** — Apply instructions with glob artifact outputs now resolve correctly, and literal artifact outputs are enforced to be file paths.
+- **Hidden main spec requirements** — Requirements nested inside fenced code blocks or otherwise hidden in main specs are now detected during validation.
+- **Clean `--json` output** — Spinner progress text no longer leaks into stderr when `--json` is passed, so AI agents that combine stdout and stderr can parse the JSON reliably.
+- **Silent telemetry in firewalled environments** — PostHog network errors are now swallowed with a 1s timeout and retries/remote config disabled, so OpenSpec no longer surfaces `PostHogFetchNetworkError` in locked-down networks. Telemetry opt-out is documented earlier in the README, installation guide, and CLI reference.


### PR DESCRIPTION
## Summary

Patch release (1.3.0 → 1.3.1) bundling the bug fixes merged to `main` since v1.3.0. All user-facing changes are fixes; docs-only and test-only commits are excluded per changeset guidelines.

### Bug Fixes included

- **Canonical artifact paths** (#971, #972) — Workflow artifact paths resolved via native `realpath`.
- **Glob apply instructions** (#967) — Glob artifact outputs resolve correctly; literal outputs enforced as file paths.
- **Hidden main spec requirements** (#966) — Requirements inside fenced code blocks are now detected.
- **Clean `--json` output** (#960) — Spinners no longer leak into stderr when `--json` is passed.
- **Silent telemetry in firewalled environments** (#959) — PostHog network errors are swallowed; telemetry opt-out docs surfaced earlier.

## Test plan

- [ ] CI green on this branch
- [ ] Confirm changeset file parses correctly and the follow-up Version Packages PR bumps to `1.3.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed artifact path resolution issues across different filesystems and configurations
  * Fixed apply instruction handling for file pattern matching
  * Fixed spec validation for nested code block requirements
  * Fixed CLI JSON output formatting

* **Documentation**
  * Updated telemetry opt-out documentation in README and CLI guides

<!-- end of auto-generated comment: release notes by coderabbit.ai -->