### PR TITLE
feat: add LLM Wiki integration for knowledge management

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,22 @@ If you want the expanded workflow (`/opsx:new`, `/opsx:continue`, `/opsx:ff`, `/
 → **[Multi-Language](docs/multi-language.md)**: multi-language support<br>
 → **[Customization](docs/customization.md)**: make it yours
 
+## Integrations
+
+### LLM Wiki
+
+OpenSpec supports integration with LLM Wiki for knowledge management, creating a complete knowledge loop:
+
+**Query** (before work) → **Explore/Propose** → **Apply** → **Archive** → **Ingest** (after completion)
+
+Benefits:
+- Avoid duplicate discussions of solved problems
+- Leverage existing features and design decisions
+- Automatically accumulate knowledge over time
+- Maintain context across team members and sessions
+
+See [docs/guides/llm-wiki-integration.md](docs/guides/llm-wiki-integration.md) for setup instructions and examples.
+
 
 ## Why OpenSpec?
 

--- a/docs/guides/llm-wiki-integration.md
+++ b/docs/guides/llm-wiki-integration.md
@@ -1,0 +1,468 @@
+# LLM Wiki Integration Guide
+
+> Complete knowledge management workflow for OpenSpec projects
+
+## Overview
+
+OpenSpec + LLM Wiki integration provides a complete knowledge loop:
+
+**Query** (before work) → **Explore/Propose** → **Apply** → **Archive** → **Ingest** (after completion)
+
+This integration solves common knowledge management challenges:
+- Avoids duplicate discussions of solved problems
+- Leverages existing features and design decisions
+- Automatically accumulates knowledge over time
+- Maintains context across team members and sessions
+
+## Quick Start
+
+### 1. Install Skills
+
+Copy the example skills to your project's AI tool directory:
+
+```bash
+# For Claude Code
+cp examples/wiki-integration/skills/openspec-wiki-query .claude/skills/
+cp examples/wiki-integration/skills/openspec-wiki-ingest .claude/skills/
+
+# For other tools, adjust path accordingly
+# Cursor: .cursor/skills/
+# Windsurf: .windsurf/skills/
+# etc.
+```
+
+### 2. Initialize Wiki Structure
+
+Create the recommended directory structure in your `openspec/` folder:
+
+```bash
+mkdir -p openspec/docs/wiki/features
+mkdir -p openspec/docs/wiki/components
+mkdir -p openspec/docs/wiki/guides
+mkdir -p openspec/docs/wiki/api
+mkdir -p openspec/docs/raw/00-meta
+mkdir -p openspec/docs/raw/00-uncategorized
+mkdir -p openspec/docs/raw/05-configurations
+mkdir -p openspec/docs/schema
+```
+
+**Directory Structure**:
+```
+openspec/
+├── docs/
+│   ├── wiki/              # Knowledge base pages
+│   │   ├── index.md       # Main index of all pages
+│   │   ├── log.md         # Change log for wiki updates
+│   │   ├── features/      # Feature documentation
+│   │   ├── components/    # Component documentation
+│   │   ├── guides/        # How-to guides
+│   │   └── api/           # API documentation
+│   ├── raw/               # Raw source documents
+│   │   ├── 00-meta/       # Meta-documents (not ingested)
+│   │   ├── 00-uncategorized/ # Uncategorized docs (organize first)
+│   │   └── 05-configurations/ # Reference docs (not ingested)
+│   └── schema/            # Schema definitions
+│       └── CLAUDE.md      # Wiki structure specifications
+```
+
+### 3. Create Initial Files
+
+Create `openspec/docs/wiki/index.md`:
+
+```markdown
+# Project Wiki Index
+
+## Features
+- [[feature-name]] - Brief description
+
+## Components
+- [[component-name]] - Brief description
+
+## Guides
+- [[guide-name]] - Brief description
+
+## Statistics
+- Total Pages: 0
+- Last Updated: YYYY-MM-DD
+```
+
+Create `openspec/docs/wiki/log.md`:
+
+```markdown
+# Wiki Change Log
+
+## [YYYY-MM-DD] init | manual
+**Operation**: initialize
+**Summary**: Initial wiki setup
+```
+
+Create `openspec/docs/schema/CLAUDE.md` (customize for your project):
+
+```markdown
+# Wiki Schema Specifications
+
+## Page Types
+
+### Feature Pages
+Location: `openspec/docs/wiki/features/{name}.md`
+Template: See below
+
+### Component Pages
+Location: `openspec/docs/wiki/components/{name}.md`
+
+## Exclusion Rules
+
+Do NOT ingest:
+- `openspec/docs/raw/00-meta/` - Meta-documents about the documentation system
+- `openspec/docs/raw/05-configurations/` - Reference configuration manuals
+
+Organize First:
+- `openspec/docs/raw/00-uncategorized/` - Must be categorized before ingestion
+
+## Page Template
+
+Feature pages should include:
+- YAML frontmatter with title, type, source, last_updated, tags
+- Overview section
+- Implementation details
+- Technical decisions
+- Related links using `[[page-name]]` format
+```
+
+### 4. Configure Hooks
+
+Add hooks to your AI tool's configuration file. Example for Claude Code (`settings.json`):
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Skill",
+        "if": "Skill(openspec-explore) || Skill(openspec-propose)",
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "Before starting, query the Wiki for relevant background information and existing features to avoid duplicate work and leverage existing design decisions: Read openspec/docs/wiki/index.md and openspec/docs/wiki/log.md, then search for relevant pages based on user intent."
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Skill",
+        "if": "Skill(openspec-archive-change)",
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "/openspec-wiki-ingest"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Note**: Hook configuration varies by IDE/tool. See the [Supported Tools](#supported-tools) section for details.
+
+### 5. Restart Your IDE
+
+Restart your AI-powered IDE for the new skills and hooks to take effect.
+
+## Configuration
+
+### PreToolUse Hook
+
+Automatically queries the wiki before starting exploration or proposal work.
+
+**When it triggers**:
+- Before running `/openspec-explore`
+- Before running `/openspec-propose`
+
+**What it does**:
+- Reads `openspec/docs/wiki/index.md` to understand available knowledge
+- Reads `openspec/docs/wiki/log.md` to see recent changes
+- Searches for relevant pages based on user's topic
+- Provides context to avoid duplicate work
+
+### PostToolUse Hook
+
+Automatically ingests completed changes into the wiki after archiving.
+
+**When it triggers**:
+- After running `/openspec-archive-change`
+
+**What it does**:
+- Scans `openspec/changes/archive/` for unprocessed changes
+- Reads proposal, design, and task documents
+- Creates or updates wiki feature pages
+- Updates cross-references and index
+- Records changes in the log
+
+### Customizing Wiki Structure
+
+You can customize the wiki structure by modifying `openspec/docs/schema/CLAUDE.md`:
+
+**Page Types**: Add custom types beyond features/components/guides/api
+
+**Exclusion Rules**: Define which raw documents should not be ingested
+
+**Templates**: Customize page templates for your project's needs
+
+**Language**: Specify language requirements (English, Chinese, etc.)
+
+## Usage Examples
+
+### Example 1: Starting a New Feature
+
+```bash
+# User runs: /openspec-propose "Add user authentication"
+
+# PreToolUse hook automatically triggers:
+# 1. Queries wiki for existing auth-related features
+# 2. Finds [[user-login]] and [[session-management]]
+# 3. Provides context: "Project already has login and session features"
+
+# AI uses this context to propose complementary features
+# rather than duplicating existing work
+```
+
+### Example 2: Completing a Change
+
+```bash
+# User completes work and runs: /openspec-archive-change
+
+# PostToolUse hook automatically triggers:
+# 1. Reads proposal.md, design.md, tasks.md from archive
+# 2. Creates openspec/docs/wiki/features/user-authentication.md
+# 3. Updates index.md with new feature link
+# 4. Appends entry to log.md
+# 5. Adds cross-references to related features
+
+# Next time someone queries the wiki, they'll find this feature
+```
+
+### Example 3: Manual Query
+
+```bash
+# Manually query wiki for specific topic
+/openspec-wiki-query "database migration"
+
+# Returns:
+# - [[database-schema-evolution]] - Previous migration strategy
+# - [[backup-procedures]] - Related backup documentation
+# - Design decisions about migration approach
+```
+
+### Example 4: Manual Ingest
+
+```bash
+# Ingest specific archived change
+/openspec-wiki-ingest openspec/changes/archive/add-payment-gateway
+
+# Or ingest uncategorized documentation
+/openspec-wiki-ingest openspec/docs/raw/00-uncategorized/api-notes.md
+```
+
+## Best Practices
+
+### 1. Keep Wiki Updated
+
+- Archive changes promptly after completion
+- Review auto-generated wiki pages for accuracy
+- Add missing cross-references manually if needed
+
+### 2. Organize Raw Documents
+
+- Regularly categorize documents in `00-uncategorized/`
+- Move meta-documents to `00-meta/` (won't be ingested)
+- Keep reference docs in `05-configurations/` (won't be ingested)
+
+### 3. Write Good Proposals
+
+The quality of wiki pages depends on proposal and design documents:
+
+- **proposal.md**: Clear overview of what and why
+- **design.md**: Detailed technical decisions and rationale
+- **tasks.md**: Implementation steps (helps with completeness)
+
+### 4. Review Auto-Generated Content
+
+After automatic ingestion:
+- Verify extracted information is accurate
+- Add any missing context or examples
+- Update cross-references to related features
+
+### 5. Use Consistent Naming
+
+- Use kebab-case for page names: `user-authentication.md`
+- Match page names to change names when possible
+- Be consistent with terminology across pages
+
+### 6. Maintain Cross-References
+
+Good cross-references make the wiki navigable:
+- Link to related features in "Related Links" sections
+- Link to component pages from feature pages
+- Update old pages when new related features are added
+
+## Troubleshooting
+
+### Issue: Skills Not Found
+
+**Symptom**: `/openspec-wiki-query` or `/openspec-wiki-ingest` commands not recognized
+
+**Solution**:
+1. Verify skills are in correct directory (e.g., `.claude/skills/`)
+2. Check skill file has valid YAML frontmatter
+3. Restart your IDE
+4. Check IDE logs for skill loading errors
+
+### Issue: Hooks Not Triggering
+
+**Symptom**: Wiki query/ingest doesn't happen automatically
+
+**Solution**:
+1. Verify hooks configuration syntax is correct
+2. Check hook conditions match skill names exactly
+3. Ensure settings file is in correct location for your IDE
+4. Test hooks manually by running skills directly
+
+### Issue: Wiki Structure Not Found
+
+**Symptom**: Skills report "Wiki structure not initialized"
+
+**Solution**:
+1. Verify `openspec/docs/wiki/index.md` exists
+2. Check directory structure matches expected layout
+3. Run initialization steps from Quick Start section
+4. Verify paths in skill files match your actual structure
+
+### Issue: Ingestion Fails
+
+**Symptom**: `/openspec-wiki-ingest` reports errors
+
+**Solution**:
+1. Check input source path is correct
+2. Verify schema file exists at `openspec/docs/schema/CLAUDE.md`
+3. Ensure input source is not in exclusion list
+4. Check file permissions for write access to wiki directory
+
+### Issue: Duplicate Pages
+
+**Symptom**: Multiple pages for same feature
+
+**Solution**:
+1. Check if change was already ingested (look in log.md)
+2. Verify change name matches existing wiki page
+3. Manually merge duplicate pages if needed
+4. Update source field to prevent future duplicates
+
+## Supported Tools
+
+### Claude Code ✅ Verified
+
+**Configuration File**: `settings.json` in project root or home directory
+
+**Hook Support**: Full support for PreToolUse and PostToolUse hooks
+
+**Example**: See `examples/wiki-integration/claude-settings.json`
+
+### Other AI Tools
+
+Different tools have different hook mechanisms:
+
+- **Cursor**: May use different configuration format
+- **Windsurf**: Check Windsurf documentation for hooks
+- **GitHub Copilot**: Limited hook support
+- **Custom Tools**: Implement similar pre/post execution logic
+
+**Recommendation**: Start with Claude Code as reference implementation, adapt for other tools as needed.
+
+## Advanced Topics
+
+### Customizing Ingestion Logic
+
+You can modify the ingestion behavior by:
+
+1. **Editing skill files**: Adjust templates and workflows
+2. **Modifying schema**: Change page types and rules
+3. **Adding filters**: Exclude specific changes or patterns
+4. **Custom transformations**: Format content differently
+
+### Batch Processing
+
+For large backlogs of archived changes:
+
+```bash
+# Ingest all unprocessed changes at once
+/openspec-wiki-ingest
+
+# The skill will:
+# 1. Scan all archived changes
+# 2. Compare with existing wiki pages
+# 3. Process only un-ingested changes
+# 4. Provide summary report
+```
+
+### Multi-Project Setup
+
+If working across multiple projects:
+
+1. Copy skills to each project's AI tool directory
+2. Initialize wiki structure in each project
+3. Configure hooks per project
+4. Each project maintains its own wiki independently
+
+### Team Collaboration
+
+For team environments:
+
+1. Commit wiki structure to version control
+2. Document wiki conventions in team guidelines
+3. Review auto-generated pages as part of code review
+4. Encourage team members to query wiki before proposing changes
+
+## Migration Guide
+
+### From No Wiki to Wiki Integration
+
+1. Set up wiki structure (Quick Start Step 2)
+2. Create initial index and log files
+3. Install skills and configure hooks
+4. Backfill existing changes:
+   ```bash
+   # Manually ingest past archived changes
+   /openspec-wiki-ingest openspec/changes/archive/{old-change-1}
+   /openspec-wiki-ingest openspec/changes/archive/{old-change-2}
+   # ... repeat for important historical changes
+   ```
+
+### From Manual Documentation to Automated
+
+1. Move existing docs to `openspec/docs/raw/`
+2. Categorize appropriately (meta, uncategorized, configurations)
+3. Run ingestion on organized documents
+4. Review and refine generated pages
+
+## Related Resources
+
+- [OpenSpec Documentation](https://github.com/Fission-AI/OpenSpec)
+- [Agent Skills Specification](https://skills.sh/)
+- [LLM Wiki Pattern](https://llm-wiki-pattern.example.com) *(replace with actual resource)*
+
+## Contributing
+
+Found issues or have improvements? Please contribute:
+
+1. Report bugs via GitHub Issues
+2. Suggest enhancements to skill workflows
+3. Share best practices from your experience
+4. Improve documentation with real-world examples
+
+---
+
+**Version**: 1.0  
+**Last Updated**: 2026-04-22  
+**Maintained By**: OpenSpec Community

--- a/examples/wiki-integration/README.md
+++ b/examples/wiki-integration/README.md
@@ -1,0 +1,73 @@
+# LLM Wiki Integration Examples
+
+This directory contains example configurations and skills for integrating OpenSpec with LLM Wiki for knowledge management.
+
+## Contents
+
+### `skills/`
+Example skill files that can be copied to your project's AI tool directory:
+
+- **`openspec-wiki-query/`** - Skill for querying the wiki before starting work
+- **`openspec-wiki-ingest/`** - Skill for ingesting completed changes into the wiki
+
+### `claude-settings.json`
+Example hook configuration for Claude Code that automatically triggers wiki query and ingest operations.
+
+## Quick Setup
+
+1. Copy skills to your AI tool directory:
+   ```bash
+   # For Claude Code
+   cp -r skills/openspec-wiki-query .claude/skills/
+   cp -r skills/openspec-wiki-ingest .claude/skills/
+   ```
+
+2. Configure hooks (see `claude-settings.json` for example)
+
+3. Initialize wiki structure in your project:
+   ```bash
+   mkdir -p openspec/docs/wiki/features
+   mkdir -p openspec/docs/raw/00-uncategorized
+   mkdir -p openspec/docs/schema
+   ```
+
+4. Restart your IDE
+
+For detailed instructions, see [docs/guides/llm-wiki-integration.md](../../docs/guides/llm-wiki-integration.md).
+
+## Directory Structure
+
+The recommended wiki structure uses `openspec/docs/` as the base:
+
+```
+openspec/
+├── docs/
+│   ├── wiki/              # Knowledge base
+│   │   ├── index.md
+│   │   ├── log.md
+│   │   ├── features/
+│   │   ├── components/
+│   │   └── ...
+│   ├── raw/               # Source documents
+│   │   ├── 00-meta/
+│   │   ├── 00-uncategorized/
+│   │   └── 05-configurations/
+│   └── schema/            # Schema definitions
+│       └── CLAUDE.md
+```
+
+## Customization
+
+These examples are generic and should be customized for your project:
+
+- Adjust wiki paths if using different structure
+- Modify exclusion rules in schema file
+- Customize page templates
+- Adapt hook configuration for your IDE
+
+## Notes
+
+- Skills use `openspec/docs/` as the default wiki location
+- Hooks are configured for Claude Code; adapt for other tools
+- All content is in English for international compatibility
+- Skills read from actual files, not hardcoded content

--- a/examples/wiki-integration/claude-settings.json
+++ b/examples/wiki-integration/claude-settings.json
@@ -1,0 +1,28 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Skill",
+        "if": "Skill(openspec-explore) || Skill(openspec-propose)",
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "Before starting, query the Wiki for relevant background information and existing features to avoid duplicate work and leverage existing design decisions: Read openspec/docs/wiki/index.md and openspec/docs/wiki/log.md, then search for relevant pages based on user intent."
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Skill",
+        "if": "Skill(openspec-archive-change)",
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "/openspec-wiki-ingest"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/examples/wiki-integration/skills/openspec-wiki-ingest/skill.md
+++ b/examples/wiki-integration/skills/openspec-wiki-ingest/skill.md
@@ -1,0 +1,394 @@
+---
+name: openspec-wiki-ingest
+description: Ingest documentation into LLM Wiki, automatically maintaining the knowledge base
+license: MIT
+compatibility: Works with any project using OpenSpec + LLM Wiki integration
+metadata:
+  author: openspec-community
+  version: "1.0"
+---
+
+# OpenSpec Wiki Ingest Skill
+
+Ingest documentation into the LLM Wiki to automatically maintain the knowledge base.
+
+## Usage
+
+```bash
+# Auto-detect mode (batch ingest all unprocessed OpenSpec changes)
+/openspec-wiki-ingest
+
+# Ingest specific OpenSpec archived change
+/openspec-wiki-ingest openspec/changes/archive/{change-name}
+
+# Ingest other documentation
+/openspec-wiki-ingest openspec/docs/raw/{category}/{document-name}.md
+
+# Ingest entire directory
+/openspec-wiki-ingest openspec/docs/raw/{category}/{directory}/
+```
+
+## Supported Input Sources
+
+### 1. OpenSpec Archived Changes
+
+**Path**: `openspec/changes/archive/{change-name}/`
+
+**Read Files**:
+- `proposal.md` - Change overview
+- `design.md` - Design decisions
+- `tasks.md` - Task list (if exists)
+
+**Generate Page**:
+- `openspec/docs/wiki/features/{kebab-case-name}.md` - Feature page
+
+### 2. Other Documentation
+
+**Path**: `openspec/docs/raw/{category}/{document-name}.md`
+
+**Read Files**:
+- Directly read document content
+
+**Generate Page**:
+- Generate corresponding page according to `openspec/docs/schema/CLAUDE.md` rules
+
+**⚠️ Exclusion Rules** (from `openspec/docs/schema/CLAUDE.md`):
+- ❌ **Do not ingest** `openspec/docs/raw/00-meta/` (meta-documents: documents about the documentation system)
+- ❌ **Do not ingest** `openspec/docs/raw/05-configurations/` (reference documents: configuration operation manuals)
+- ⚠️ **Organize first** `openspec/docs/raw/00-uncategorized/` (uncategorized documents)
+
+**Important**: Specific exclusion rules and categories are defined by the project's `openspec/docs/schema/CLAUDE.md`.
+
+## Working Modes
+
+### Mode 1: Auto-Detection (Recommended for OpenSpec)
+
+**Trigger**: Call `/openspec-wiki-ingest` without arguments
+
+**Workflow**:
+1. Scan `openspec/changes/archive/` directory
+2. Read `openspec/docs/wiki/features/*.md`, extract existing pages
+3. Cross-compare to find un-ingested changes:
+   - Check `source` field in Wiki pages
+   - Check filename matching
+   - Check `last_updated` timestamp
+4. Batch ingest unprocessed changes
+5. Output summary report
+
+**Output Example**:
+```
+Detecting OpenSpec changes...
+
+Found {N} archived changes:
+  ✓ {existing-change-1}
+  ✓ {existing-change-2}
+  ⚡ {new-change} (NEW)
+
+Detecting Wiki status...
+  Existing: {M} feature pages
+  To ingest: {K} changes
+
+Ingesting: {new-change}
+  - Reading proposal.md: ✓
+  - Reading design.md: ✓
+  - Reading tasks.md: ✓
+  - Creating Wiki page: ✓
+  - Updating index: ✓
+  - Recording log: ✓
+
+Done! Successfully ingested {K} changes.
+```
+
+### Mode 2: Specified Path
+
+**Trigger**: Call with path argument `/openspec-wiki-ingest <path>`
+
+**Supported Paths**:
+- OpenSpec archive: `openspec/changes/archive/{change-name}/`
+- Other docs: `openspec/docs/raw/{category}/{document-name}.md`
+- Directory: `openspec/docs/raw/{category}/{directory}/`
+
+**Workflow**: Execute according to "Standard Workflow" below
+
+## Standard Workflow
+
+### 0. ⭐ Pre-check (Must Execute)
+
+```bash
+# ⚠️ First step: Read Wiki maintenance specifications
+READ openspec/docs/schema/CLAUDE.md
+
+# Confirm exclusion rules (read from schema file)
+# Check uncategorized documents
+CHECK openspec/docs/raw/00-uncategorized/
+# If files exist, remind user to organize first
+```
+
+**If does not comply with specifications, refuse to ingest and prompt user**:
+```
+Error: Input source is in exclusion list
+
+Reason: According to openspec/docs/schema/CLAUDE.md, this input source should not be ingested
+
+View specifications: openspec/docs/schema/CLAUDE.md
+```
+
+### 1. Read Specifications and Status
+
+```bash
+# Read Wiki maintenance specifications
+READ openspec/docs/schema/CLAUDE.md
+
+# Read existing page index
+READ openspec/docs/wiki/index.md
+
+# Read change log
+READ openspec/docs/wiki/log.md
+```
+
+### 2. Analyze Input Source
+
+Based on input source type:
+- **OpenSpec**: Read change documents, extract key information
+- **Other docs**: Read content, analyze topic and type
+
+**Key**: Extract information from actually read files, do not fabricate or assume content.
+
+### 3. Determine Page Type
+
+Determine page type based on document content and `openspec/docs/schema/CLAUDE.md`:
+- `feature` - Feature page
+- `component` - Component page
+- `guide` - Guide page
+- `api` - API page
+- `overview` - Project overview (only one, in wiki root)
+
+**Note**: Page types and categories are defined by the project's schema file and may vary by project.
+
+### 4. Create/Update Page
+
+Create or update wiki page according to page type:
+
+#### Feature Page Template (Example)
+
+```markdown
+---
+title: {Feature Name}
+type: feature
+source: openspec/changes/archive/{change-name}
+last_updated: {YYYY-MM-DD}
+tags: [{tags extracted from document}]
+---
+
+# {Feature Name}
+
+## Overview
+{Extracted from proposal.md}
+
+## Implementation Details
+{Extracted from implementation.md}
+
+## Technical Decisions
+{Extracted from design.md}
+
+## Related Links
+- [[{related-feature-1}]]
+- [[{related-feature-2}]]
+```
+
+**Important**:
+- All content extracted from actually read files
+- Do not fabricate feature names, descriptions, or examples
+- Template structure defined by project's schema file
+
+#### Other Page Types
+
+Refer to page type definitions in `openspec/docs/schema/CLAUDE.md`.
+
+### 5. Update Cross-References
+
+1. Check related pages (based on tags, keywords)
+2. Add cross-references `[[page-name]]`
+3. Update "Related Links" section in related pages
+
+### 6. Update Index
+
+Update `openspec/docs/wiki/index.md`:
+- Add new page link under appropriate category
+- Update statistics
+
+### 7. Record Log
+
+Append to `openspec/docs/wiki/log.md`:
+
+```markdown
+## [{YYYY-MM-DD}] ingest | {source}
+
+**Operation**: ingest
+**Source**: {source-path}
+**Affected Pages**:
+- Created: openspec/docs/wiki/{type}/{name}.md
+- Updated: openspec/docs/wiki/index.md
+- Updated: openspec/docs/wiki/{related-page}.md
+
+**Summary**: {brief description}
+**Conflicts**: None / X conflicts
+**Outdated Content**: None / X outdated pages
+```
+
+## Considerations
+
+### 1. Prioritize Reading Existing Pages
+
+Before creating new pages, check if they already exist:
+- If exists, update existing page
+- If not exists, create new page
+
+### 2. Check Conflicts
+
+If new content conflicts with existing pages:
+- Add `⚠️ **Conflict**` marker
+- Record conflict count in log
+
+### 3. Mark Outdated Content
+
+If new content makes old content obsolete:
+- Add `⚠️ **Outdated**` marker to old page
+- Add link to new page
+
+### 4. Maintain Consistent Format
+
+- Use format defined in `openspec/docs/schema/CLAUDE.md`
+- YAML frontmatter must be complete
+- Cross-references use `[[page-name]]` format
+
+### 5. Language Standards
+
+- Follow project's language standards
+- Preserve original technical terms
+- Code comments follow project conventions
+
+## Examples
+
+### Ingest OpenSpec Change
+
+```bash
+/openspec-wiki-ingest openspec/changes/archive/{change-name}
+```
+
+**Output**:
+```
+Ingesting: openspec/changes/archive/{change-name}
+
+Reading specifications: ✓
+Reading index: ✓ ({N} existing pages)
+
+Analyzing input source: ✓
+  - proposal.md: ✓
+  - design.md: ✓
+  - tasks.md: ✓
+
+Determining page type: feature
+
+Creating page:
+  openspec/docs/wiki/features/{name}.md: ✓
+
+Updating cross-references:
+  - [[{related-page-1}]]: ✓
+  - [[{related-page-2}]]: ✓
+
+Updating index:
+  openspec/docs/wiki/index.md: ✓
+
+Recording log:
+  openspec/docs/wiki/log.md: ✓
+
+Done! Affected {M} pages, no conflicts, no outdated content
+```
+
+### Ingest Other Documentation
+
+```bash
+/openspec-wiki-ingest openspec/docs/raw/{category}/{document-name}.md
+```
+
+**Output**:
+```
+Ingesting: openspec/docs/raw/{category}/{document-name}.md
+
+Reading specifications: ✓
+Reading index: ✓ ({N} existing pages)
+
+Analyzing input source: ✓
+
+Determining page type: {type}
+
+Creating page:
+  openspec/docs/wiki/{type}/{name}.md: ✓
+
+Updating cross-references:
+  - [[{related-page}]]: ✓
+
+Updating index:
+  openspec/docs/wiki/index.md: ✓
+
+Recording log:
+  openspec/docs/wiki/log.md: ✓
+
+Done! Affected {M} pages, no conflicts, no outdated content
+```
+
+## Error Handling
+
+### Input Source Not Found
+
+```
+Error: Cannot find input source
+Path: {path}
+Please check if path is correct
+```
+
+### Wiki Structure Not Initialized
+
+```
+Error: Wiki structure not initialized
+Please refer to project documentation to initialize Wiki
+```
+
+### Schema File Missing
+
+```
+Error: Schema file missing
+Path: openspec/docs/schema/CLAUDE.md
+Please refer to project documentation to create schema file
+```
+
+### In Exclusion List
+
+```
+Error: Input source is in exclusion list
+
+Reason: According to openspec/docs/schema/CLAUDE.md, this input source should not be ingested
+
+View specifications: openspec/docs/schema/CLAUDE.md
+```
+
+## Related Skills
+
+- `/openspec-wiki-query` - Query Wiki skill
+- `/openspec-archive-change` - Archive OpenSpec change (automatically triggers this skill)
+
+## Project-Specific Configuration
+
+This skill is generic, but projects need configuration:
+
+1. **Wiki Path**: Default `openspec/docs/wiki/`
+2. **Schema File**: Default `openspec/docs/schema/CLAUDE.md`, defines Wiki structure specifications
+3. **Exclusion Rules**: Defined in schema file for what should not be ingested
+4. **Page Types**: features, components, guides, api, etc., defined in schema
+5. **Template Format**: Template structure for each page type, defined in schema
+
+**Important**:
+- Do not hardcode project-specific examples in skill file
+- All content should be obtained from actually read files
+- Different projects can have different schemas, paths, and rules

--- a/examples/wiki-integration/skills/openspec-wiki-ingest/skill.yaml
+++ b/examples/wiki-integration/skills/openspec-wiki-ingest/skill.yaml
@@ -1,0 +1,9 @@
+---
+name: openspec-wiki-ingest
+description: Ingest documentation into LLM Wiki, automatically maintaining the knowledge base
+license: MIT
+compatibility: Works with any project using OpenSpec + LLM Wiki integration
+metadata:
+  author: openspec-community
+  version: "1.0"
+---

--- a/examples/wiki-integration/skills/openspec-wiki-query/skill.md
+++ b/examples/wiki-integration/skills/openspec-wiki-query/skill.md
@@ -1,0 +1,243 @@
+---
+name: openspec-wiki-query
+description: Query LLM Wiki for relevant information, context, and background knowledge before starting work
+license: MIT
+compatibility: Works with any project using OpenSpec + LLM Wiki integration
+metadata:
+  author: openspec-community
+  version: "1.0"
+---
+
+# OpenSpec Wiki Query Skill
+
+Query the LLM Wiki knowledge base to retrieve relevant background information, context, and existing features.
+
+## Usage
+
+```bash
+# Automatic mode (query based on current context)
+/openspec-wiki-query
+
+# Query specific topic
+/openspec-wiki-query {search keywords}
+```
+
+## Workflow
+
+### Step 1: Read Wiki Structure
+
+```bash
+# Read main index to understand overall knowledge base structure
+READ openspec/docs/wiki/index.md
+
+# Read change log to understand recent work
+READ openspec/docs/wiki/log.md
+```
+
+### Step 2: Intelligent Search
+
+Based on user's topic or current context, search for relevant pages:
+
+#### Search Strategy
+
+1. **Keyword Matching**
+   - Search for relevant titles and descriptions in index.md
+   - Extract related features, components, guides, API pages
+
+2. **Context Inference**
+   - Infer related topics from query keywords
+   - Find related features, components, architecture documentation
+
+3. **Cross-References**
+   - Check "Related Links" sections in relevant pages
+   - Look for dependencies and impact scope
+
+### Step 3: Read Relevant Pages
+
+For found relevant pages, read their content:
+
+```bash
+# Read specific page content
+READ openspec/docs/wiki/features/{feature-name}.md
+READ openspec/docs/wiki/guides/{guide-name}.md
+READ openspec/docs/wiki/components/{component-name}.md
+```
+
+**Key**: Extract information from actually read files, do not fabricate or assume content.
+
+### Step 4: Return Structured Summary
+
+Based on search results and actually read content, return the following information:
+
+```markdown
+## 📚 Wiki Query Results
+
+### Related {Page Type}
+- [[{page-name}]] - {brief description extracted from page}
+
+### Related Design Decisions
+- {decision content extracted from page}
+
+### Related {Other Page Type}
+- [[{page-name}]] - {usage description extracted from page}
+
+### Related Links
+- [[{related-page-1}]]
+- [[{related-page-2}]]
+```
+
+**Important**: All descriptions and links must be based on actually read file content.
+
+## Output Format
+
+### Scenario 1: Found Relevant Content
+
+```markdown
+## 📚 Wiki Query Results
+
+### ✅ Found Related {Page Type}
+
+**{Feature Name}** (openspec/docs/wiki/{type}/{name}.md)
+- **Overview**: {overview extracted from page}
+- **Key Decisions**: {decisions extracted from page}
+- **Implementation Points**:
+  - {point 1 extracted from page}
+  - {point 2 extracted from page}
+
+### 📋 Related Documentation
+
+- [[{related-page-1}]] - {description extracted from page}
+- [[{related-page-2}]] - {description extracted from page}
+
+### ⚠️ Notes
+
+- {notes extracted from page}
+
+### 🔗 Related Links
+
+- [[{related-page-3}]]
+```
+
+### Scenario 2: No Direct Match Found
+
+```markdown
+## 📚 Wiki Query Results
+
+### ❌ No Direct Match Found
+
+**Search Keywords**: {user-provided keywords}
+
+**Closest Matches**:
+- [[{possibly-related-page-1}]] - {reason for relevance}
+- [[{possibly-related-page-2}]] - {reason for relevance}
+
+**Suggestions**:
+- Check if keywords are accurate
+- View openspec/docs/wiki/index.md for complete content list
+- View openspec/docs/wiki/log.md for recent changes
+
+**Current Wiki Coverage**:
+- {statistics extracted from index.md}
+```
+
+### Scenario 3: Multiple Related Results (Potential Conflicts or Duplicates)
+
+```markdown
+## 📚 Wiki Query Results
+
+### ⚠️ Multiple Related {Page Type} Found
+
+**Scenario**: Possible feature duplication or evolution
+
+**Related {Page Type}**:
+1. [[{page-name-1}]] - {description extracted from page}
+2. [[{page-name-2}]] - {description extracted from page}
+
+**Analysis**:
+- {relationship analysis based on page content}
+
+**Recommendations**:
+- {recommendations based on page content}
+```
+
+## Query Optimization
+
+### Performance Considerations
+
+- Only read necessary files (index.md, log.md, relevant pages)
+- Avoid recursively reading all Wiki pages
+- Use keyword matching instead of full-text search
+
+### Accuracy Guarantees
+
+- **Results must be based on actually read file content**
+- Do not fabricate information or assume project-specific content
+- If unsure about relevance, list potentially related pages for user judgment
+- Clearly distinguish "directly related" from "potentially related"
+
+### Extensibility
+
+- Supports Wiki structure changes (dynamically adapts by reading index.md)
+- Supports new page types (features, components, guides, api, etc.)
+- Applicable to any project using LLM Wiki
+
+## Integration with Hooks
+
+This skill is designed to be called by PreToolUse hook:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Skill",
+        "if": "Skill(openspec-explore) || Skill(openspec-propose)",
+        "hooks": [
+          {
+            "type": "prompt",
+            "prompt": "Before starting, query the wiki for relevant background: Read openspec/docs/wiki/index.md and openspec/docs/wiki/log.md, then search for relevant pages based on user intent."
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Effect**:
+- During `openspec-explore`: Provides exploration context, avoids duplicate discussions
+- During `openspec-propose`: Checks for duplicate features, leverages existing design decisions
+
+## Error Handling
+
+### Wiki Not Initialized
+
+```
+Error: Wiki structure not found
+Please check if openspec/docs/wiki/index.md exists
+If Wiki is not initialized, refer to project documentation
+```
+
+### Index File Corrupted
+
+```
+Error: Cannot read Wiki index
+Please check if openspec/docs/wiki/index.md format is correct
+Refer to project's openspec/docs/schema/CLAUDE.md
+```
+
+## Related Skills
+
+- `/openspec-wiki-ingest` - Write documentation to Wiki
+- `/openspec-explore` - Explore mode (calls this skill)
+- `/openspec-propose` - Proposal mode (calls this skill)
+
+## Project-Specific Configuration
+
+This skill is generic, but projects may need configuration:
+
+1. **Wiki Path**: Default `openspec/docs/wiki/`, can be modified in project config
+2. **Schema File**: Default `openspec/docs/schema/CLAUDE.md`, defines Wiki structure specifications
+3. **Page Types**: features, components, guides, api, etc., customizable in schema
+
+**Important**: Do not hardcode project-specific feature names, architecture names, or examples in the skill file. All content should be read from actual files.

--- a/examples/wiki-integration/skills/openspec-wiki-query/skill.yaml
+++ b/examples/wiki-integration/skills/openspec-wiki-query/skill.yaml
@@ -1,0 +1,9 @@
+---
+name: openspec-wiki-query
+description: Query LLM Wiki for relevant information, context, and background knowledge before starting work
+license: MIT
+compatibility: Works with any project using OpenSpec + LLM Wiki integration
+metadata:
+  author: openspec-community
+  version: "1.0"
+---


### PR DESCRIPTION
This PR adds complete LLM Wiki integration examples and documentation to OpenSpec:

Features:
- Add openspec-wiki-query skill for querying wiki before changes
- Add openspec-wiki-ingest skill for ingesting changes after archive
- Add PreToolUse hook example to auto-query wiki on explore/propose
- Add PostToolUse hook example to auto-ingest on archive
- Add comprehensive documentation and setup guide
- Update README with integration section

Benefits:
- Complete knowledge loop: Query → Develop → Archive → Ingest
- Avoid duplicate work by querying existing knowledge
- Automatic knowledge accumulation over time
- Works with any project using OpenSpec + LLM Wiki

The implementation is provided as examples and documentation, making it easy for users to adopt without modifying OpenSpec core. Skills use openspec/docs/ directory structure and read from actual files rather than hardcoding project-specific content.

Example configurations include Claude Code hooks (settings.json). Users can adapt the pattern for other AI tools as needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added LLM Wiki integration for AI-driven knowledge management with automated query and ingest capabilities

**Documentation**
- Added comprehensive integration guide with step-by-step setup instructions, examples, and best practices
- Added example configuration and templates for LLM Wiki workflows
- Updated README with new Integrations section

<!-- end of auto-generated comment: release notes by coderabbit.ai -->