### PR TITLE
feat(schema): add extends field for single-level schema inheritance

### DIFF
--- a/src/core/artifact-graph/resolver.ts
+++ b/src/core/artifact-graph/resolver.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { getGlobalDataDir } from '../global-config.js';
-import { parseSchema, SchemaValidationError } from './schema.js';
+import { parseSchema, SchemaValidationError, validateNoCycles } from './schema.js';
 import type { SchemaYaml } from './types.js';
 
 /**
@@ -133,8 +133,9 @@ export function resolveSchema(name: string, projectRoot?: string): SchemaYaml {
     );
   }
 
+  let schema: SchemaYaml;
   try {
-    return parseSchema(content);
+    schema = parseSchema(content);
   } catch (err) {
     if (err instanceof SchemaValidationError) {
       throw new SchemaLoadError(
@@ -150,6 +151,137 @@ export function resolveSchema(name: string, projectRoot?: string): SchemaYaml {
       parseError
     );
   }
+
+  // Resolve inheritance if extends is set
+  if (schema.extends) {
+    schema = mergeWithParent(schema, projectRoot, schemaPath);
+  }
+
+  return schema;
+}
+
+/**
+ * Merges a child schema with its parent, applying single-level inheritance.
+ *
+ * Merge rules:
+ * - Child artifacts override matching parent artifacts by ID (field-level merge,
+ *   child fields take precedence).
+ * - Child artifacts with IDs not in the parent are appended after inherited ones.
+ * - The child's `apply` section (if present) replaces the parent's entirely.
+ * - Only one level of inheritance is supported; the parent must not also extend.
+ *
+ * @param child - The parsed child schema (with extends set)
+ * @param projectRoot - Project root for schema resolution
+ * @param childPath - Path to child schema file (for error messages)
+ */
+function mergeWithParent(
+  child: SchemaYaml,
+  projectRoot: string | undefined,
+  childPath: string
+): SchemaYaml {
+  const parentName = child.extends!;
+
+  // Load the raw parent schema file to check for transitive extends BEFORE merging.
+  // We can't use resolveSchema() here because it flattens extends away — reading
+  // the raw file is the only way to catch grandparent chains.
+  const parentDir = getSchemaDir(parentName, projectRoot);
+  if (!parentDir) {
+    const availableSchemas = listSchemas(projectRoot);
+    throw new SchemaLoadError(
+      `Schema '${child.name}' extends '${parentName}', but '${parentName}' was not found. ` +
+        `Available schemas: ${availableSchemas.join(', ')}`,
+      childPath
+    );
+  }
+
+  const parentSchemaPath = path.join(parentDir, 'schema.yaml');
+  let rawParentContent: string;
+  try {
+    rawParentContent = fs.readFileSync(parentSchemaPath, 'utf-8');
+  } catch (err) {
+    const ioError = err instanceof Error ? err : new Error(String(err));
+    throw new SchemaLoadError(
+      `Failed to read parent schema at '${parentSchemaPath}': ${ioError.message}`,
+      childPath,
+      ioError
+    );
+  }
+
+  // Parse raw parent without inheritance resolution to detect transitive extends
+  let rawParent: SchemaYaml;
+  try {
+    rawParent = parseSchema(rawParentContent);
+  } catch (err) {
+    const parseError = err instanceof Error ? err : new Error(String(err));
+    throw new SchemaLoadError(
+      `Parent schema '${parentName}' is invalid: ${parseError.message}`,
+      parentSchemaPath,
+      parseError
+    );
+  }
+
+  if (rawParent.extends) {
+    throw new SchemaLoadError(
+      `Schema '${child.name}' extends '${parentName}', but '${parentName}' also uses extends. ` +
+        `Only one level of inheritance is supported.`,
+      childPath
+    );
+  }
+
+  // Merge artifacts: parent as base, child overrides by ID.
+  // Child-only artifact IDs are validated against the merged set after this point.
+  const mergedArtifacts = rawParent.artifacts.map(parentArtifact => {
+    const override = child.artifacts.find(a => a.id === parentArtifact.id);
+    // Field-level merge: start with parent, apply only the fields the child explicitly set
+    return override ? { ...parentArtifact, ...override } : parentArtifact;
+  });
+
+  // Append artifacts defined in child but not present in parent
+  const newArtifacts = child.artifacts.filter(
+    a => !rawParent.artifacts.find(p => p.id === a.id)
+  );
+
+  const merged: SchemaYaml = {
+    // Parent fields as base
+    ...rawParent,
+    // Child top-level fields override (name, version, description)
+    ...child,
+    // extends is flattened out — the merged result has no extends
+    extends: undefined,
+    artifacts: [...mergedArtifacts, ...newArtifacts],
+    // Child's apply section fully replaces parent's if present
+    apply: child.apply ?? rawParent.apply,
+  };
+
+  // Re-validate requires references against the full merged artifact set.
+  // This is necessary because child artifacts may reference parent-provided IDs.
+  const allIds = new Set(merged.artifacts.map(a => a.id));
+  for (const artifact of merged.artifacts) {
+    for (const req of artifact.requires) {
+      if (!allIds.has(req)) {
+        throw new SchemaLoadError(
+          `Schema '${child.name}': artifact '${artifact.id}' requires '${req}', ` +
+            `which does not exist in the merged schema.`,
+          childPath
+        );
+      }
+    }
+  }
+
+  // Validate there are no cycles in the merged artifact set.
+  // Child overrides may change requires, potentially introducing cycles.
+  try {
+    validateNoCycles(merged.artifacts);
+  } catch (err) {
+    const cycleError = err instanceof Error ? err : new Error(String(err));
+    throw new SchemaLoadError(
+      `Schema '${child.name}' (extends '${parentName}'): ${cycleError.message}`,
+      childPath,
+      cycleError
+    );
+  }
+
+  return merged;
 }
 
 /**

--- a/src/core/artifact-graph/schema.ts
+++ b/src/core/artifact-graph/schema.ts
@@ -35,11 +35,16 @@ export function parseSchema(yamlContent: string): SchemaYaml {
   // Check for duplicate artifact IDs
   validateNoDuplicateIds(schema.artifacts);
 
-  // Check that all requires references are valid
-  validateRequiresReferences(schema.artifacts);
+  // When a schema uses `extends`, child artifacts may reference IDs provided by the
+  // parent. Skip cross-boundary requires validation here — it runs post-merge in
+  // resolver.ts after the full artifact set is assembled.
+  if (!schema.extends) {
+    // Check that all requires references are valid
+    validateRequiresReferences(schema.artifacts);
 
-  // Check for cycles
-  validateNoCycles(schema.artifacts);
+    // Check for cycles
+    validateNoCycles(schema.artifacts);
+  }
 
   return schema;
 }
@@ -77,8 +82,9 @@ function validateRequiresReferences(artifacts: Artifact[]): void {
 /**
  * Validates that there are no cyclic dependencies.
  * Uses DFS to detect cycles and reports the full cycle path.
+ * Exported for use after schema merging in the resolver.
  */
-function validateNoCycles(artifacts: Artifact[]): void {
+export function validateNoCycles(artifacts: Artifact[]): void {
   const artifactMap = new Map(artifacts.map(a => [a.id, a]));
   const visited = new Set<string>();
   const inStack = new Set<string>();

--- a/src/core/artifact-graph/types.ts
+++ b/src/core/artifact-graph/types.ts
@@ -25,6 +25,9 @@ export const SchemaYamlSchema = z.object({
   name: z.string().min(1, { error: 'Schema name is required' }),
   version: z.number().int().positive({ error: 'Version must be a positive integer' }),
   description: z.string().optional(),
+  // Optional: inherit artifacts and apply config from another schema.
+  // Only one level of inheritance is supported (the parent cannot also extend).
+  extends: z.string().optional(),
   artifacts: z.array(ArtifactSchema).min(1, { error: 'At least one artifact required' }),
   // Optional apply phase configuration (for schema-aware apply instructions)
   apply: ApplyPhaseSchema.optional(),

--- a/test/core/artifact-graph/schema.test.ts
+++ b/test/core/artifact-graph/schema.test.ts
@@ -203,5 +203,34 @@ artifacts:
       const schema = parseSchema(yaml);
       expect(schema.artifacts[0].requires).toEqual([]);
     });
+
+    it('should parse extends field when present', () => {
+      const yaml = `
+name: child-schema
+version: 1
+extends: some-parent
+artifacts:
+  - id: root
+    generates: root.md
+    description: Root artifact
+    template: templates/root.md
+`;
+      const schema = parseSchema(yaml);
+      expect(schema.extends).toBe('some-parent');
+    });
+
+    it('should leave extends undefined when not set', () => {
+      const yaml = `
+name: test
+version: 1
+artifacts:
+  - id: root
+    generates: root.md
+    description: Root artifact
+    template: templates/root.md
+`;
+      const schema = parseSchema(yaml);
+      expect(schema.extends).toBeUndefined();
+    });
   });
 });


### PR DESCRIPTION
Closes #778

## Problem

`openspec schema fork` copies a schema flat — no link back to the original. If you want to change one artifact or add an extra step, you still have to duplicate the entire file. With multiple platform schemas (iOS, Android, HarmonyOS, etc.) sharing 80% of the same artifacts, this creates real maintenance pain: fix a typo in one, repeat it in all the others.

## Solution

Add an optional `extends` field. A child schema names its parent and only declares what it wants to override or add.

```yaml
name: ios-dev
version: 1
extends: spec-driven

artifacts:
  - id: proposal
    generates: proposal.md
    description: iOS proposal
    template: proposal.md
    instruction: |
      Custom iOS-specific guidance here.
      Everything else (design, tasks, specs) is inherited from spec-driven.

  - id: ui-review          # new artifact not in the parent
    generates: ui-review.md
    description: UI design review
    template: ui-review.md
    requires: [design]
```

## Merge rules

- Parent artifacts are the base.
- Child artifact with matching ID → field-level merge (child fields win, rest fall back to parent).
- Child artifact with new ID → appended after the inherited set.
- Child `apply` block (if present) replaces the parent's; otherwise parent's is inherited.
- `extends` is flattened away — callers get a normal `SchemaYaml` with no `extends` field.

## Constraints

- **Single-level only.** If the parent also has `extends`, resolution throws `SchemaLoadError`. Keeping it shallow makes behavior easy to reason about.
- Child artifacts can reference parent-provided IDs in `requires` — validation runs post-merge against the full artifact set.
- Cycle detection also runs on the merged set.
- All existing schemas without `extends` are completely unaffected.

## Changes

- `types.ts` — add optional `extends: string` to `SchemaYamlSchema`
- `schema.ts` — export `validateNoCycles`; skip cross-boundary `requires` validation when `extends` is present (deferred to post-merge)
- `resolver.ts` — resolve inheritance in `resolveSchema` via `mergeWithParent`
- `resolver.test.ts` — 9 new test cases covering inherit, override, append, apply fallback, missing parent, and two-level rejection
- `schema.test.ts` — 2 new test cases for `extends` field parsing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Schemas can now inherit artifacts and configuration from parent schemas using a single-level inheritance model, enabling better reusability and reducing duplication.

* **Tests**
  * Added test coverage for schema inheritance validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->