### PR TITLE
docs: add workspace reimplementation proposal slices

### DIFF
--- a/WORKSPACE_REIMPLEMENTATION_DIRECTION.md
+++ b/WORKSPACE_REIMPLEMENTATION_DIRECTION.md
@@ -1,0 +1,454 @@
+# Workspace Reimplementation Direction
+
+Date: 2026-04-30
+
+This document captures the intended direction for reimplementing OpenSpec workspace support from scratch, based on what we learned from the workspace POC.
+
+The reimplementation should be ordered around the path a real user takes through OpenSpec:
+
+```text
+create workspace
+  -> add repos
+  -> open workspace
+  -> explore across repos
+  -> create proposal
+  -> apply one repo slice
+  -> verify
+  -> archive
+```
+
+The goal is not to rebuild every POC mechanism. The goal is to get one user-facing capability working at a time, in the same order a user would naturally create, implement, verify, and archive a change.
+
+## North Star
+
+A user should think:
+
+```text
+I have a multi-repo product goal.
+I create an OpenSpec workspace.
+I open it with my agent.
+The agent can see the registered repos.
+We explore until the scope is clear.
+Then we create a proposal.
+Then we implement one repo slice at a time.
+```
+
+They should not think:
+
+```text
+I need to create a change so repos become visible.
+I need to materialize repo-local artifacts.
+I need to understand workspace overlays.
+I need to manage target metadata separately from proposal files.
+```
+
+The core product rule is:
+
+```text
+Repository visibility is not change commitment.
+```
+
+Registered repos are the workspace working set. Creating a change is a planning commitment. Applying a change is an implementation workflow.
+
+## Build Order
+
+### 1. Workspace Creation
+
+First make workspace creation boring and solid.
+
+User goal:
+
+```text
+Create a place where cross-repo planning lives.
+```
+
+Expected surface:
+
+```bash
+openspec workspace create my-workspace
+openspec workspace add-repo openspec /path/to/openspec
+openspec workspace add-repo landing /path/to/openspec-landing
+```
+
+Expected outcome:
+
+```text
+workspace/
+  AGENTS.md
+  changes/
+  .openspec-workspace/
+```
+
+Product decisions:
+
+- Use `.openspec-workspace/`, not `.openspec/`, for workspace metadata.
+- Keep `changes/` visible at the workspace root.
+- Treat registered repos as the workspace working set.
+- Make `doctor` show human-readable repo names and resolved paths.
+
+Defer:
+
+- Branches.
+- Worktrees.
+- Apply.
+- Archive.
+- Complex target lifecycle.
+
+Done when a user can create a workspace, register repos, and run `doctor` to see exactly what OpenSpec knows.
+
+### 2. Workspace Open
+
+Next make the workspace openable in the way users expect.
+
+User goal:
+
+```text
+Open this multi-repo working set with my coding agent.
+```
+
+Expected surface:
+
+```bash
+openspec workspace open
+openspec workspace open --agent codex
+openspec workspace open --agent github-copilot
+```
+
+Product behavior:
+
+- `workspace open` opens the coordination workspace plus registered repos.
+- Repo visibility is default.
+- Change selection is optional focus, not the mechanism for repo access.
+- `--agent` should be a one-session override by default. Persisting the preferred agent should require an explicit preference-setting action.
+
+For GitHub Copilot, generate or open a `.code-workspace` file with:
+
+```text
+workspace root
+registered repo A
+registered repo B
+```
+
+For Claude and Codex, attach the registered repo directories through the agent's supported mechanism.
+
+Defer:
+
+- `workspace open --change`.
+- In-session upgrade flows.
+- Per-change attachment restrictions.
+
+Done when opening a workspace gives the agent visibility into the coordination root and all registered repos.
+
+### 3. Agent Guidance And Explore
+
+Then make exploration work.
+
+User goal:
+
+```text
+Tell the agent a rough product goal and have it inspect the repos before creating a proposal.
+```
+
+Expected user prompt:
+
+```text
+Explore how we should make the OpenSpec docs available on the landing page.
+Look across the registered repos, but do not implement yet.
+```
+
+Agent behavior:
+
+- Understand it is in workspace mode.
+- Inspect registered repos.
+- Explain likely affected repos.
+- Ask for clarification only when needed.
+- Avoid implementation edits during explore.
+
+Build:
+
+- Workspace-level `AGENTS.md` guidance.
+- Normal OpenSpec skills and commands in workspace sessions.
+- Workspace-specific guidance layered on top of normal `/explore`, not replacing it.
+
+Defer:
+
+- Proposal artifact generation.
+- Target confirmation commands.
+- Apply context providers.
+
+Done when a user can open a workspace and run a useful cross-repo exploration without creating a dummy change.
+
+### 4. Proposal Creation
+
+Only after explore works, build proposal creation.
+
+User goal:
+
+```text
+Now that we understand the scope, capture the plan.
+```
+
+Expected user prompt:
+
+```text
+Create a proposal for this change.
+Target the repos that are actually affected.
+```
+
+Preferred artifact shape:
+
+```text
+changes/integrate-docs/
+  proposal.md
+  design.md
+  tasks.md
+  specs/
+    openspec/
+      docs-conventions/spec.md
+    landing/
+      docs-routing/spec.md
+```
+
+Key workflow rule:
+
+```text
+/explore may leave targets unknown.
+/propose may discover targets.
+/propose must confirm targets before saying ready for apply.
+```
+
+Targets should be represented by the proposal artifacts themselves where possible. If there is `specs/landing/...`, then `landing` is in scope. Avoid a separate required `targets: [...]` metadata list as the active source of truth.
+
+Defer:
+
+- Repo-local materialization.
+- Worktree selection.
+- Multi-repo implementation.
+- Archive.
+
+Done when a user can explore, then create a workspace proposal with repo-scoped specs and tasks.
+
+### 5. Status
+
+Before implementation, make status excellent.
+
+User goal:
+
+```text
+Where are we, what repos are involved, and is this ready to implement?
+```
+
+Expected surface:
+
+```bash
+openspec status
+openspec status --change integrate-docs
+```
+
+Human output should answer:
+
+```text
+Change: integrate-docs
+Scope: openspec, landing
+Proposal: present
+Design: present
+Tasks: present
+Ready for apply: yes/no
+```
+
+Status should also catch structural mistakes:
+
+- Unknown repo folder under `specs/`.
+- Missing tasks.
+- No confirmed affected repo.
+- Registered repo path missing.
+
+Done when the agent and user can trust status before applying.
+
+### 6. Apply One Repo Slice
+
+Only now build `/apply`.
+
+User goal:
+
+```text
+Implement the planned slice for one repo.
+```
+
+Expected user prompt:
+
+```text
+/apply integrate-docs for landing
+```
+
+Product contract:
+
+```text
+/apply means implement.
+```
+
+It does not mean:
+
+```text
+copy planning files
+materialize repo-local OpenSpec state
+create the proposal files for the first time
+```
+
+Agent behavior:
+
+1. Ask OpenSpec for apply context.
+2. Read proposal, design, tasks, and relevant specs.
+3. Confirm the target repo checkout.
+4. Edit only that repo.
+5. Update workspace tasks.
+6. Run relevant checks.
+
+This likely wants a normalized context command internally, but that is supporting machinery:
+
+```json
+{
+  "mode": "workspace",
+  "change": "integrate-docs",
+  "target": "landing",
+  "implementationRoot": "/repos/openspec-landing",
+  "contextFiles": [
+    "changes/integrate-docs/proposal.md",
+    "changes/integrate-docs/design.md",
+    "changes/integrate-docs/tasks.md",
+    "changes/integrate-docs/specs/landing/docs-routing/spec.md"
+  ],
+  "allowedEditRoots": [
+    "/repos/openspec-landing"
+  ],
+  "tasksFile": "changes/integrate-docs/tasks.md"
+}
+```
+
+Defer:
+
+- Applying multiple repos at once.
+- Automatic branch creation.
+- Worktree management.
+- Repo-local OpenSpec mirroring.
+
+Done when one repo slice can be implemented from the central workspace plan.
+
+### 7. Verify
+
+Then build verification.
+
+User goal:
+
+```text
+Check whether the implemented repo slice satisfies the plan.
+```
+
+Expected prompt:
+
+```text
+/verify integrate-docs for landing
+```
+
+Behavior:
+
+- Read the same normalized context as `/apply`.
+- Inspect the implementation checkout.
+- Check tasks and specs for that repo.
+- Run repo validation.
+- Report gaps clearly.
+
+Default behavior should verify one repo slice. Whole-workspace verification can come later.
+
+Done when a user can verify one implemented repo slice against the central workspace plan.
+
+### 8. Archive
+
+Archive comes last in the first complete loop.
+
+User goal:
+
+```text
+The change is done. Move it out of active planning.
+```
+
+Expected prompt:
+
+```text
+/archive integrate-docs
+```
+
+Behavior:
+
+- Require all targeted repo slices to be complete or explicitly accepted.
+- Archive the workspace change.
+- Do not require repo-local planning copies unless OpenSpec later decides that repo-local archival matters.
+
+Done when a user can complete the full lifecycle:
+
+```text
+workspace create
+  -> open
+  -> explore
+  -> propose
+  -> apply repo A
+  -> apply repo B
+  -> verify
+  -> archive
+```
+
+## Implementation Discipline
+
+Build only the next user-visible step.
+
+The sequence should stay grounded in these questions:
+
+```text
+1. Can I create the workspace?
+2. Can I see my repos?
+3. Can my agent explore them?
+4. Can we capture a proposal?
+5. Can status tell us if it is ready?
+6. Can the agent implement one repo slice?
+7. Can we verify it?
+8. Can we archive it?
+```
+
+Avoid starting with internal abstractions unless they are required for the next user-visible capability.
+
+Do not start with:
+
+- Target metadata machinery.
+- Materialization.
+- Adapter abstractions.
+- Branch orchestration.
+- Worktree orchestration.
+- Multi-repo apply.
+
+Those may matter later, but they should not define the first reimplementation path.
+
+## Product Shape
+
+The workspace should feel like OpenSpec's normal workflow stretched across multiple repos, not a second product with its own lifecycle.
+
+The durable product model is:
+
+```text
+workspace = central planning source of truth
+registered repos = visible working set
+proposal = scoped planning commitment
+repo target = one affected repo in the plan
+branch/worktree = implementation checkout
+/apply = implement one selected repo slice
+```
+
+Keep the user journey simple:
+
+```text
+Open the workspace.
+Ask the agent to explore.
+Create the proposal when scope is clear.
+Implement one repo slice at a time.
+Verify.
+Archive.
+```

--- a/WORKSPACE_REIMPLEMENTATION_DIRECTION.md
+++ b/WORKSPACE_REIMPLEMENTATION_DIRECTION.md
@@ -2,6 +2,8 @@
 
 Date: 2026-04-30
 
+Fresh-agent entry point: read `WORKSPACE_REIMPLEMENTATION_START_HERE.md` first, then return to this document for the full product direction.
+
 This document captures the intended direction for reimplementing OpenSpec workspace support from scratch, based on what we learned from the workspace POC.
 
 The reimplementation should be ordered around the path a real user takes through OpenSpec:

--- a/WORKSPACE_REIMPLEMENTATION_START_HERE.md
+++ b/WORKSPACE_REIMPLEMENTATION_START_HERE.md
@@ -1,0 +1,67 @@
+# Workspace Reimplementation Start Here
+
+This is the grep-friendly entry point for agents working on the workspace reimplementation.
+
+Useful search terms:
+
+```text
+workspace reimplementation
+workspace poc
+workspace-poc
+workspace reference guide
+workspace roadmap
+fresh agent
+start here
+```
+
+## Start Here
+
+Read these files in order:
+
+1. `WORKSPACE_REIMPLEMENTATION_DIRECTION.md`
+2. `openspec/changes/workspace-reimplementation-roadmap/README.md`
+3. `openspec/changes/workspace-reimplementation-roadmap/POC_REFERENCE_GUIDE.md`
+4. The proposal for the next implementation slice
+
+The POC reference commit is:
+
+```text
+workspace-poc @ 79a45ac043f414e63d13e08b9da83b135cb20a39
+```
+
+Use the POC as research material. Do not merge it into an implementation branch. Do not preserve its architecture unless a slice proposal or design explicitly decides to do so.
+
+## Implementation Order
+
+Implement these flat OpenSpec changes in order:
+
+1. `workspace-foundation`
+2. `workspace-create-and-register-repos`
+3. `workspace-open-agent-context`
+4. `workspace-change-planning`
+5. `workspace-apply-repo-slice`
+6. `workspace-verify-and-archive`
+
+`workspace-reimplementation-roadmap` is the continuity and reference container for the plan.
+
+## Before Editing
+
+For the slice you are about to implement, inspect the pinned POC commit using `POC_REFERENCE_GUIDE.md`, then write down:
+
+```text
+POC findings for <slice>:
+
+User behavior to preserve:
+- ...
+
+Tests or examples worth translating:
+- ...
+
+Implementation shortcuts to avoid:
+- ...
+
+Open design questions:
+- ...
+```
+
+Capture durable findings in the relevant OpenSpec artifact so future sessions do not depend on chat history.

--- a/openspec/changes/workspace-apply-repo-slice/proposal.md
+++ b/openspec/changes/workspace-apply-repo-slice/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+After a workspace proposal exists, users need a practical way to implement one repo slice at a time.
+
+In the proper workspace model, apply means implementation:
+
+```text
+Take the selected workspace change.
+Take the selected repo slice.
+Open or use the right checkout.
+Implement that slice while preserving the workspace plan.
+```
+
+It should not mean copying or materializing planning files into every repo as a user-facing workflow.
+
+## What Changes
+
+Add the repo-slice apply workflow for workspace changes:
+
+- select a workspace change
+- select one target repo alias
+- resolve the local checkout for that alias
+- provide the agent with the workspace plan and repo-specific implementation context
+- track progress without making the workspace lose ownership of the plan
+
+The workflow should support implementation across separate branches or sessions while keeping the workspace proposal as the continuity layer.
+
+Planning dependency:
+
+- Depends on `workspace-change-planning`.
+
+## Capabilities
+
+### New Capabilities
+
+- `workspace-repo-slice-apply`: Applies one repo slice of a workspace change as an implementation workflow.
+
+### Modified Capabilities
+
+- `cli-artifact-workflow`: Defines workspace apply as implementation rather than materialization.
+- `context-injection`: Supplies repo-specific implementation context from a workspace change.
+
+## Impact
+
+- Workspace apply command behavior.
+- Agent handoff text for repo-slice implementation.
+- Local checkout resolution and branch/worktree assumptions.
+- Tests that apply operates on one target repo slice and does not require copying workspace planning artifacts as the primary user contract.

--- a/openspec/changes/workspace-change-planning/proposal.md
+++ b/openspec/changes/workspace-change-planning/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+Once repos are visible and the agent has workspace context, the user should be able to plan a cross-repo change without immediately materializing repo-local artifacts.
+
+The user goal is:
+
+```text
+Explore the product goal across repos.
+Decide the scope.
+Create one workspace-level proposal that identifies the repo slices.
+```
+
+Planning should be the commitment point. Repo visibility alone should remain lightweight.
+
+## What Changes
+
+Add workspace-level change planning:
+
+- create a workspace change from the coordination root
+- capture the product goal once
+- identify target repos by registered alias
+- let the agent explore before committing to implementation slices
+- keep the workspace as the planning source of truth
+
+This slice should avoid rebuilding the POC's materialization-first behavior. Repo-local artifacts should not be created merely because a workspace change exists.
+
+Planning dependency:
+
+- Depends on `workspace-open-agent-context`.
+
+## Capabilities
+
+### New Capabilities
+
+- `workspace-change-planning`: Creates and manages workspace-level proposals for cross-repo goals.
+
+### Modified Capabilities
+
+- `change-creation`: Adds workspace-aware change creation semantics and target repo selection.
+- `openspec-conventions`: Defines the relationship between workspace-level planning and repo-local implementation work.
+
+## Impact
+
+- Workspace change creation.
+- Target repo metadata and validation.
+- Agent instructions for proposing cross-repo changes.
+- Tests that registered repos are visible before change creation and that creating a change does not imply repo-local materialization.

--- a/openspec/changes/workspace-create-and-register-repos/proposal.md
+++ b/openspec/changes/workspace-create-and-register-repos/proposal.md
@@ -1,0 +1,52 @@
+## Why
+
+Users start workspace work by collecting the repos involved in a product goal. They should not have to create a change before the system can see those repos.
+
+The product rule is:
+
+```text
+Repository visibility is not change commitment.
+```
+
+A registered repo is part of the workspace working set. A change is a later planning commitment.
+
+## What Changes
+
+Add the user-facing flow for creating a workspace and registering repos:
+
+```text
+Create a workspace.
+Add repos by stable aliases.
+See which repos are available to the workspace.
+```
+
+Expected user surface:
+
+```bash
+openspec workspace create my-workspace
+openspec workspace add-repo openspec /path/to/openspec
+openspec workspace add-repo landing /path/to/openspec-landing
+```
+
+The system should store committed repo guidance separately from local checkout paths so a workspace can be shared without committing machine-specific state.
+
+Planning dependency:
+
+- Depends on `workspace-foundation`.
+
+## Capabilities
+
+### New Capabilities
+
+- `workspace-repo-registry`: Lets users create a workspace and register repos as the working set for future cross-repo planning.
+
+### Modified Capabilities
+
+- `cli-artifact-workflow`: Introduces workspace setup commands that happen before change creation.
+
+## Impact
+
+- `openspec workspace create`
+- `openspec workspace add-repo`
+- Workspace metadata and local overlay files.
+- Docs and generated agent guidance that explain registered repos as visibility, not implementation commitment.

--- a/openspec/changes/workspace-foundation/proposal.md
+++ b/openspec/changes/workspace-foundation/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+Users need a workspace to feel like a durable place for cross-repo planning, not like a special command mode that appears only after implementation work has started.
+
+The foundation should establish the workspace mental model before any higher-level workflow depends on it:
+
+```text
+I have a multi-repo product goal.
+I create an OpenSpec workspace.
+That workspace has its own planning surface and local repo registry.
+```
+
+The POC proved that workspace state is useful, but the reimplementation should make the core model boring, explicit, and easy for agents to explain.
+
+## What Changes
+
+Define the foundational workspace model:
+
+- workspace root detection
+- workspace metadata directory naming
+- committed planning surface versus local-only machine state
+- stable repo aliases as the durable identity for registered repos
+- compatibility expectations between repo-local OpenSpec projects and coordination workspaces
+
+This slice should settle whether the workspace metadata directory is `.openspec-workspace/` or another name before other changes build on the storage contract.
+
+Planning dependency:
+
+- None. This is the first implementation slice.
+
+## Capabilities
+
+### New Capabilities
+
+- `workspace-foundation`: Defines the durable workspace root, metadata, and local-state model used by later workspace workflows.
+
+### Modified Capabilities
+
+- `openspec-conventions`: Adds conventions for distinguishing repo-local OpenSpec projects from coordination workspaces.
+
+## Impact
+
+- Workspace root and metadata helpers.
+- Workspace configuration parsing and validation.
+- Documentation and agent guidance for the workspace mental model.
+- No repo registration, agent launch, change planning, apply, verify, or archive behavior should depend on hidden assumptions outside this foundation.

--- a/openspec/changes/workspace-open-agent-context/proposal.md
+++ b/openspec/changes/workspace-open-agent-context/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+After a user creates a workspace and registers repos, they need to open that workspace with an agent and have the agent understand the working set immediately.
+
+The user should not need to explain where every repo lives, which aliases matter, or whether they are currently planning versus implementing. The workspace should provide that context.
+
+## What Changes
+
+Add the workspace-open experience:
+
+```text
+Open this workspace with my agent.
+The agent sees the workspace root, registered repos, current changes, and relevant instructions.
+```
+
+The launch context should separate stable guidance from dynamic runtime scope:
+
+- stable behavior belongs in workspace-level agent guidance where possible
+- dynamic scope belongs in the launch prompt or equivalent runtime context
+- registered repos should be visible even when no change is active
+- change-scoped sessions should include the selected change and target repo context
+
+Planning dependency:
+
+- Depends on `workspace-create-and-register-repos`.
+
+## Capabilities
+
+### New Capabilities
+
+- `workspace-agent-context`: Opens a workspace session with enough dynamic context for an agent to reason across registered repos.
+
+### Modified Capabilities
+
+- `context-injection`: Extends context construction to include workspace root, repo registry, active workspace changes, and selected change scope.
+
+## Impact
+
+- `openspec workspace open`
+- Workspace prompt and agent-launch context.
+- Generated or committed agent guidance for workspace mode.
+- Tests for opening outside a workspace, opening a workspace by name, and opening change-scoped workspace sessions.

--- a/openspec/changes/workspace-reimplementation-roadmap/POC_REFERENCE_GUIDE.md
+++ b/openspec/changes/workspace-reimplementation-roadmap/POC_REFERENCE_GUIDE.md
@@ -2,6 +2,8 @@
 
 This guide is for a fresh agent starting a new session with no prior context about the workspace POC.
 
+Root entry point: `WORKSPACE_REIMPLEMENTATION_START_HERE.md`.
+
 The goal is not to continue the POC. The goal is to use it as research material before reimplementing workspace support cleanly from the current base.
 
 ## Reference Point

--- a/openspec/changes/workspace-reimplementation-roadmap/POC_REFERENCE_GUIDE.md
+++ b/openspec/changes/workspace-reimplementation-roadmap/POC_REFERENCE_GUIDE.md
@@ -1,0 +1,255 @@
+# Workspace POC Reference Guide
+
+This guide is for a fresh agent starting a new session with no prior context about the workspace POC.
+
+The goal is not to continue the POC. The goal is to use it as research material before reimplementing workspace support cleanly from the current base.
+
+## Reference Point
+
+Use this exact commit as the stable reference:
+
+```text
+workspace-poc @ 79a45ac043f414e63d13e08b9da83b135cb20a39
+```
+
+Do not rely only on the moving branch name. Do not merge this commit into the implementation branch. Do not cherry-pick from it unless a later proposal explicitly decides that a small piece should be preserved.
+
+## What The POC Was Trying To Prove
+
+Start from the user journey:
+
+```text
+create workspace
+  -> add repos
+  -> open workspace with an agent
+  -> explore across repos
+  -> create a proposal
+  -> apply one repo slice
+  -> verify
+  -> archive
+```
+
+The POC is useful if it helps answer:
+
+- What did the user experience feel like when workspace mode worked?
+- Which CLI surfaces made the workflow easier to understand?
+- Which tests captured real product expectations?
+- Which implementation choices were shortcuts that should not survive?
+- Which terminology became misleading once the desired product shape was clearer?
+
+## First Files To Read
+
+Read these from the POC commit before implementation:
+
+```text
+WORKSPACE_REIMPLEMENTATION_DIRECTION.md
+WORKSPACE_POC_FOLLOWUP_NOTES.md
+docs/workspace.md
+docs/workspace-demo.md
+docs/cli.md
+src/commands/workspace.ts
+src/core/workspace/open.ts
+test/commands/workspace/open.test.ts
+test/core/workspace/open.test.ts
+test/cli-e2e/workspace/workspace-open-cli.test.ts
+```
+
+Optional deeper context:
+
+```text
+workspace-poc-explorer.html
+workspace-poc-phase-playground.html
+copilot-session-d4e9c61e-readable.md
+copilot-session-d4e9c61e-timeline.md
+```
+
+The optional files are historical research aids. Use them to understand how the POC evolved, not as implementation requirements.
+
+## How To Inspect The POC Safely
+
+Preferred approach: use a separate worktree or read files directly from the pinned commit.
+
+Example direct reads:
+
+```bash
+git show 79a45ac043f414e63d13e08b9da83b135cb20a39:WORKSPACE_REIMPLEMENTATION_DIRECTION.md
+git show 79a45ac043f414e63d13e08b9da83b135cb20a39:src/commands/workspace.ts
+git diff origin/main...79a45ac043f414e63d13e08b9da83b135cb20a39 --stat
+```
+
+Example separate worktree:
+
+```bash
+git worktree add ../openspec-workspace-poc 79a45ac043f414e63d13e08b9da83b135cb20a39
+```
+
+Keep the implementation branch based on the current target branch. The POC worktree is for reading and running tests only.
+
+## What To Bring Back
+
+Before implementing a slice, come back with a short POC findings note:
+
+```text
+POC findings for <slice>:
+
+User behavior to preserve:
+- ...
+
+Tests or examples worth translating:
+- ...
+
+Implementation shortcuts to avoid:
+- ...
+
+Open design questions:
+- ...
+```
+
+Put durable findings in the relevant OpenSpec proposal or design artifact. Do not leave important decisions only in chat.
+
+## Slice-Specific Reading
+
+### `workspace-foundation`
+
+Focus on:
+
+- workspace root shape
+- metadata directory naming
+- local versus committed state
+- repo alias semantics
+
+Read:
+
+```text
+WORKSPACE_REIMPLEMENTATION_DIRECTION.md
+WORKSPACE_POC_FOLLOWUP_NOTES.md
+docs/workspace.md
+src/commands/workspace.ts
+```
+
+Bring back:
+
+- the storage model worth keeping
+- the metadata naming decision
+- any compatibility risks with repo-local `openspec/`
+
+### `workspace-create-and-register-repos`
+
+Focus on:
+
+- how a user creates a workspace
+- how repo aliases are registered
+- what `doctor` or equivalent status output should explain
+
+Read:
+
+```text
+docs/workspace.md
+docs/workspace-demo.md
+src/commands/workspace.ts
+test/commands/workspace/setup.test.ts
+```
+
+Bring back:
+
+- expected commands
+- expected files
+- validation behavior for bad paths, duplicate aliases, and missing repos
+
+### `workspace-open-agent-context`
+
+Focus on:
+
+- what context the agent receives
+- how registered repos become visible
+- how one-session agent selection should work
+- what should be stable guidance versus dynamic launch context
+
+Read:
+
+```text
+WORKSPACE_POC_FOLLOWUP_NOTES.md
+src/commands/workspace.ts
+src/core/workspace/open.ts
+test/commands/workspace/open.test.ts
+test/core/workspace/open.test.ts
+test/cli-e2e/workspace/workspace-open-cli.test.ts
+```
+
+Bring back:
+
+- launch-context requirements
+- agent-specific behavior to preserve
+- prompt or guidance text that should become stable instructions
+
+### `workspace-change-planning`
+
+Focus on:
+
+- when repo scope becomes a planning commitment
+- whether targets should be inferred from artifacts
+- how proposal, design, tasks, and specs should be arranged
+
+Read:
+
+```text
+WORKSPACE_REIMPLEMENTATION_DIRECTION.md
+docs/workspace.md
+docs/workspace-demo.md
+```
+
+Bring back:
+
+- the artifact shape to use
+- how targets should be confirmed
+- which POC target metadata ideas should be avoided or deferred
+
+### `workspace-apply-repo-slice`
+
+Focus on:
+
+- the terminology decision that apply means implementation
+- what context the agent needs to implement one repo slice
+- why materialization should not be the user-facing contract
+
+Read:
+
+```text
+WORKSPACE_REIMPLEMENTATION_DIRECTION.md
+WORKSPACE_POC_FOLLOWUP_NOTES.md
+```
+
+Bring back:
+
+- the normalized apply context shape
+- the user-facing apply contract
+- any POC materialization behavior that should be explicitly rejected
+
+### `workspace-verify-and-archive`
+
+Focus on:
+
+- partial repo completion versus full workspace completion
+- how verification should report gaps
+- how archive should avoid forcing repo-local planning copies
+
+Read:
+
+```text
+WORKSPACE_REIMPLEMENTATION_DIRECTION.md
+docs/workspace-demo.md
+```
+
+Bring back:
+
+- the minimum useful verify behavior
+- the archive preconditions
+- the distinction between repo-slice completion and workspace hard-done state
+
+## Ground Rules
+
+- Treat the POC as evidence, not inheritance.
+- Preserve user-visible lessons before preserving code.
+- Prefer current repo patterns over POC-only abstractions.
+- Implement one user-visible step at a time.
+- Update this roadmap when a POC lesson changes a later slice.

--- a/openspec/changes/workspace-reimplementation-roadmap/README.md
+++ b/openspec/changes/workspace-reimplementation-roadmap/README.md
@@ -19,7 +19,9 @@ The POC branch is reference material only:
 workspace-poc @ 79a45ac043f414e63d13e08b9da83b135cb20a39
 ```
 
-Use it to understand behavior, tests, and lessons learned. Do not merge it or preserve its architecture by default.
+Use it to understand behavior, tests, and lessons learned. Do not merge it or preserve its architecture by default. The full source direction document from that branch is copied at the repository root as `WORKSPACE_REIMPLEMENTATION_DIRECTION.md`.
+
+Fresh agents should read `POC_REFERENCE_GUIDE.md` before implementing any slice. That guide explains how to inspect the pinned POC commit, which files to read for each slice, and what findings to bring back into the OpenSpec artifacts.
 
 ## Change Order
 
@@ -54,10 +56,12 @@ Use this prompt at the start of future implementation sessions:
 
 ```text
 Continue the workspace reimplementation roadmap. Read
-openspec/changes/workspace-reimplementation-roadmap/README.md first, then
-pick up the next unfinished flat sibling change in order. Use workspace-poc
-at 79a45ac043f414e63d13e08b9da83b135cb20a39 as reference material only.
-Preserve intended behavior, but reimplement cleanly from the current base.
+openspec/changes/workspace-reimplementation-roadmap/README.md and
+openspec/changes/workspace-reimplementation-roadmap/POC_REFERENCE_GUIDE.md
+first, then pick up the next unfinished flat sibling change in order. Use
+workspace-poc at 79a45ac043f414e63d13e08b9da83b135cb20a39 as reference
+material only. Preserve intended behavior, but reimplement cleanly from the
+current base. Before editing, summarize the POC findings for the slice.
 ```
 
 ## Branching Guidance

--- a/openspec/changes/workspace-reimplementation-roadmap/README.md
+++ b/openspec/changes/workspace-reimplementation-roadmap/README.md
@@ -2,6 +2,8 @@
 
 This change is the continuity layer for reimplementing workspace support across multiple sessions and branches.
 
+Root entry point for fresh agents: `WORKSPACE_REIMPLEMENTATION_START_HERE.md`.
+
 The user journey we are implementing is:
 
 ```text

--- a/openspec/changes/workspace-reimplementation-roadmap/README.md
+++ b/openspec/changes/workspace-reimplementation-roadmap/README.md
@@ -1,0 +1,65 @@
+# Workspace Reimplementation Roadmap
+
+This change is the continuity layer for reimplementing workspace support across multiple sessions and branches.
+
+The user journey we are implementing is:
+
+```text
+create workspace
+  -> add repos
+  -> open workspace with agent context
+  -> plan a cross-repo change
+  -> implement one repo slice
+  -> verify and archive
+```
+
+The POC branch is reference material only:
+
+```text
+workspace-poc @ 79a45ac043f414e63d13e08b9da83b135cb20a39
+```
+
+Use it to understand behavior, tests, and lessons learned. Do not merge it or preserve its architecture by default.
+
+## Change Order
+
+Implement the flat sibling changes in this order:
+
+1. `workspace-foundation`
+2. `workspace-create-and-register-repos`
+3. `workspace-open-agent-context`
+4. `workspace-change-planning`
+5. `workspace-apply-repo-slice`
+6. `workspace-verify-and-archive`
+
+OpenSpec currently discovers active changes as immediate directories under `openspec/changes/`, and change names are kebab-case identifiers. Keep these changes as flat siblings until formal change-stacking metadata is available.
+
+## Dependency Notes
+
+`workspace-foundation` establishes the storage, root detection, and naming model. Every later slice should build on that model instead of redefining workspace metadata.
+
+`workspace-create-and-register-repos` makes registered repos visible before a change exists. This preserves the product rule that repository visibility is not change commitment.
+
+`workspace-open-agent-context` gives the agent the workspace root, registered repos, active changes, and selected change scope.
+
+`workspace-change-planning` creates the workspace-level planning commitment and identifies target repo slices.
+
+`workspace-apply-repo-slice` treats apply as implementation of one selected repo slice, not materialization of workspace planning files.
+
+`workspace-verify-and-archive` makes cross-repo progress visible and separates partial repo completion from final workspace completion.
+
+## Session Handoff Prompt
+
+Use this prompt at the start of future implementation sessions:
+
+```text
+Continue the workspace reimplementation roadmap. Read
+openspec/changes/workspace-reimplementation-roadmap/README.md first, then
+pick up the next unfinished flat sibling change in order. Use workspace-poc
+at 79a45ac043f414e63d13e08b9da83b135cb20a39 as reference material only.
+Preserve intended behavior, but reimplement cleanly from the current base.
+```
+
+## Branching Guidance
+
+Each sibling change may be implemented on its own branch or PR. Keep decisions that affect later slices in this README or in the relevant proposal so future sessions do not depend on chat history.

--- a/openspec/changes/workspace-reimplementation-roadmap/proposal.md
+++ b/openspec/changes/workspace-reimplementation-roadmap/proposal.md
@@ -1,0 +1,53 @@
+## Why
+
+Workspace support needs to be reimplemented as a user-facing workflow, not carried forward as a direct port of the proof of concept.
+
+A user should be able to say they have a multi-repo product goal, create a workspace, add the relevant repos, open that workspace with an agent, plan the change, implement one repo slice at a time, verify it, and archive it. The POC branch captured useful behavior and discovery, but its implementation should remain reference material rather than the base architecture.
+
+This roadmap also needs to survive multiple sessions and branches. Current OpenSpec change discovery treats active changes as flat immediate directories under `openspec/changes/`, and change names are kebab-case identifiers rather than nested paths. This change is therefore a flat planning container with sibling proposal changes instead of nested child changes.
+
+Reference material:
+
+- `workspace-poc` at `79a45ac043f414e63d13e08b9da83b135cb20a39`
+- `WORKSPACE_REIMPLEMENTATION_DIRECTION.md` on that branch
+- `WORKSPACE_POC_FOLLOWUP_NOTES.md` on that branch
+
+## What Changes
+
+Add a lightweight roadmap for reimplementing workspace support as a stack of flat sibling OpenSpec changes:
+
+- `workspace-foundation`
+- `workspace-create-and-register-repos`
+- `workspace-open-agent-context`
+- `workspace-change-planning`
+- `workspace-apply-repo-slice`
+- `workspace-verify-and-archive`
+
+Each sibling change owns one step in the lived user journey. Dependencies are documented in proposal prose for now. When change stacking metadata lands, this roadmap can be migrated to explicit `parent` and `dependsOn` metadata.
+
+The intended order is:
+
+```text
+workspace-foundation
+  -> workspace-create-and-register-repos
+  -> workspace-open-agent-context
+  -> workspace-change-planning
+  -> workspace-apply-repo-slice
+  -> workspace-verify-and-archive
+```
+
+## Capabilities
+
+### New Capabilities
+
+- `workspace-reimplementation-roadmap`: Coordinates the workspace reimplementation plan across multiple flat OpenSpec changes.
+
+### Modified Capabilities
+
+- `openspec-conventions`: Clarifies that this workspace effort uses flat sibling changes until nested or stacked change metadata is supported.
+
+## Impact
+
+- Planning only in this PR.
+- Future changes will affect workspace metadata, workspace CLI flows, agent context construction, workspace change planning, repo-slice application, verification, and archive behavior.
+- No runtime behavior changes are introduced by this roadmap proposal.

--- a/openspec/changes/workspace-verify-and-archive/proposal.md
+++ b/openspec/changes/workspace-verify-and-archive/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+Users need to know whether a cross-repo workspace change is complete without flattening all repo progress into one ambiguous done state.
+
+The desired lifecycle is:
+
+```text
+Verify each repo slice.
+See which slices are complete or still open.
+Archive repo-local results when appropriate.
+Archive the workspace change when the cross-repo goal is done.
+```
+
+Verification and archive should make the user's cross-repo status clearer, not force them to reason about internal artifact placement.
+
+## What Changes
+
+Add workspace-aware verify and archive behavior:
+
+- verify workspace-level change structure and target repo status
+- show per-repo slice progress
+- support repo-local archive work where needed
+- support explicit workspace-level archive when the coordinated goal is complete
+- avoid treating partial repo completion as full workspace completion
+
+Planning dependency:
+
+- Depends on `workspace-apply-repo-slice`.
+
+## Capabilities
+
+### New Capabilities
+
+- `workspace-verify-archive`: Verifies and archives workspace changes with per-repo progress visibility.
+
+### Modified Capabilities
+
+- `cli-archive`: Adds workspace-aware archive semantics.
+- `opsx-verify-skill`: Adds workspace verification guidance.
+- `opsx-archive-skill`: Adds workspace archive guidance.
+
+## Impact
+
+- Workspace status, verify, and archive behavior.
+- Per-repo slice completion reporting.
+- Workspace-level hard-done marker or equivalent archive state.
+- Tests for partial completion, final workspace archive, and compatibility with standalone repo-local archive flows.


### PR DESCRIPTION
## Summary

Adds a lightweight OpenSpec planning layer for reimplementing workspace support without nesting changes under a parent directory.

This PR adds one roadmap proposal plus six flat sibling proposal changes:

- `workspace-reimplementation-roadmap`
- `workspace-foundation`
- `workspace-create-and-register-repos`
- `workspace-open-agent-context`
- `workspace-change-planning`
- `workspace-apply-repo-slice`
- `workspace-verify-and-archive`

It also adds the handoff/reference material a fresh agent needs before implementation:

- `WORKSPACE_REIMPLEMENTATION_START_HERE.md`: grep-friendly root entrypoint with search terms, reading order, implementation order, and before-editing checklist
- `WORKSPACE_REIMPLEMENTATION_DIRECTION.md`: full direction document copied from `workspace-poc` at `79a45ac043f414e63d13e08b9da83b135cb20a39`
- `openspec/changes/workspace-reimplementation-roadmap/README.md`: implementation order, dependency notes, branch/session handoff guidance
- `openspec/changes/workspace-reimplementation-roadmap/POC_REFERENCE_GUIDE.md`: how a new agent should inspect the POC, which files to read by slice, and what findings to bring back before editing

The roadmap records `workspace-poc @ 79a45ac043f414e63d13e08b9da83b135cb20a39` as reference material only. Dependencies are documented in proposal prose for now because current OpenSpec change discovery expects flat immediate directories under `openspec/changes/`, and formal change stacking metadata is not implemented yet.

## Verification

- `openspec list --json`
- `git hash-object WORKSPACE_REIMPLEMENTATION_DIRECTION.md`
- `git rev-parse 79a45ac043f414e63d13e08b9da83b135cb20a39:WORKSPACE_REIMPLEMENTATION_DIRECTION.md`
- `rg -n "workspace reimplementation|workspace poc|fresh agent|start here|workspace reference guide|workspace roadmap" WORKSPACE_REIMPLEMENTATION_START_HERE.md WORKSPACE_REIMPLEMENTATION_DIRECTION.md openspec/changes/workspace-reimplementation-roadmap`

Confirmed all seven proposal-only changes are discovered as flat active changes with `no-tasks` status. Confirmed the copied `WORKSPACE_REIMPLEMENTATION_DIRECTION.md` matches the pinned POC blob exactly. Confirmed obvious grep terms surface the root start-here guide and roadmap materials.

## Notes

- No runtime code changes.
- No nested change directories.
- `gh auth status` reports the local GitHub CLI token is invalid, so this PR was opened and updated with the GitHub connector.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive planning documentation for multi-repository workspace support, outlining the intended user workflow for creating workspaces, registering repositories, planning cross-repo changes, applying implementations to individual repositories, and verifying/archiving workspace completion.
  * Established the implementation roadmap and reference materials for workspace reimplementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->