### PR TITLE
fix: make requirement header parsing case-insensitive

### DIFF
--- a/src/core/parsers/requirement-blocks.ts
+++ b/src/core/parsers/requirement-blocks.ts
@@ -58,7 +58,7 @@ export function extractRequirementsSection(content: string): RequirementsSection
   let preambleLines: string[] = [];
 
   // Collect preamble lines until first requirement header
-  while (cursor < sectionBodyLines.length && !/^###\s+Requirement:/i.test(sectionBodyLines[cursor])) {
+  while (cursor < sectionBodyLines.length && !REQUIREMENT_HEADER_REGEX.test(sectionBodyLines[cursor])) {
     preambleLines.push(sectionBodyLines[cursor]);
     cursor++;
   }
@@ -76,7 +76,7 @@ export function extractRequirementsSection(content: string): RequirementsSection
     cursor++;
     // Gather lines until next requirement header or end of section
     const bodyLines: string[] = [headerLineCandidate];
-    while (cursor < sectionBodyLines.length && !/^###\s+Requirement:/i.test(sectionBodyLines[cursor]) && !/^##\s+/.test(sectionBodyLines[cursor])) {
+    while (cursor < sectionBodyLines.length && !REQUIREMENT_HEADER_REGEX.test(sectionBodyLines[cursor]) && !/^##\s+/.test(sectionBodyLines[cursor])) {
       bodyLines.push(sectionBodyLines[cursor]);
       cursor++;
     }
@@ -176,7 +176,7 @@ function parseRequirementBlocksFromSection(sectionBody: string): RequirementBloc
   let i = 0;
   while (i < lines.length) {
     // Seek next requirement header
-    while (i < lines.length && !/^###\s+Requirement:/i.test(lines[i])) i++;
+    while (i < lines.length && !REQUIREMENT_HEADER_REGEX.test(lines[i])) i++;
     if (i >= lines.length) break;
     const headerLine = lines[i];
     const m = headerLine.match(REQUIREMENT_HEADER_REGEX);
@@ -184,7 +184,7 @@ function parseRequirementBlocksFromSection(sectionBody: string): RequirementBloc
     const name = normalizeRequirementName(m[1]);
     const buf: string[] = [headerLine];
     i++;
-    while (i < lines.length && !/^###\s+Requirement:/i.test(lines[i]) && !/^##\s+/.test(lines[i])) {
+    while (i < lines.length && !REQUIREMENT_HEADER_REGEX.test(lines[i]) && !/^##\s+/.test(lines[i])) {
       buf.push(lines[i]);
       i++;
     }

--- a/src/core/parsers/requirement-blocks.ts
+++ b/src/core/parsers/requirement-blocks.ts
@@ -16,7 +16,7 @@ export function normalizeRequirementName(name: string): string {
   return name.trim();
 }
 
-const REQUIREMENT_HEADER_REGEX = /^###\s*Requirement:\s*(.+)\s*$/;
+const REQUIREMENT_HEADER_REGEX = /^###\s*Requirement:\s*(.+)\s*$/i;
 
 /**
  * Extracts the Requirements section from a spec file and parses requirement blocks.
@@ -58,7 +58,7 @@ export function extractRequirementsSection(content: string): RequirementsSection
   let preambleLines: string[] = [];
 
   // Collect preamble lines until first requirement header
-  while (cursor < sectionBodyLines.length && !/^###\s+Requirement:/.test(sectionBodyLines[cursor])) {
+  while (cursor < sectionBodyLines.length && !/^###\s+Requirement:/i.test(sectionBodyLines[cursor])) {
     preambleLines.push(sectionBodyLines[cursor]);
     cursor++;
   }
@@ -76,7 +76,7 @@ export function extractRequirementsSection(content: string): RequirementsSection
     cursor++;
     // Gather lines until next requirement header or end of section
     const bodyLines: string[] = [headerLineCandidate];
-    while (cursor < sectionBodyLines.length && !/^###\s+Requirement:/.test(sectionBodyLines[cursor]) && !/^##\s+/.test(sectionBodyLines[cursor])) {
+    while (cursor < sectionBodyLines.length && !/^###\s+Requirement:/i.test(sectionBodyLines[cursor]) && !/^##\s+/.test(sectionBodyLines[cursor])) {
       bodyLines.push(sectionBodyLines[cursor]);
       cursor++;
     }
@@ -176,7 +176,7 @@ function parseRequirementBlocksFromSection(sectionBody: string): RequirementBloc
   let i = 0;
   while (i < lines.length) {
     // Seek next requirement header
-    while (i < lines.length && !/^###\s+Requirement:/.test(lines[i])) i++;
+    while (i < lines.length && !/^###\s+Requirement:/i.test(lines[i])) i++;
     if (i >= lines.length) break;
     const headerLine = lines[i];
     const m = headerLine.match(REQUIREMENT_HEADER_REGEX);
@@ -184,7 +184,7 @@ function parseRequirementBlocksFromSection(sectionBody: string): RequirementBloc
     const name = normalizeRequirementName(m[1]);
     const buf: string[] = [headerLine];
     i++;
-    while (i < lines.length && !/^###\s+Requirement:/.test(lines[i]) && !/^##\s+/.test(lines[i])) {
+    while (i < lines.length && !/^###\s+Requirement:/i.test(lines[i]) && !/^##\s+/.test(lines[i])) {
       buf.push(lines[i]);
       i++;
     }

--- a/src/core/parsers/spec-structure.ts
+++ b/src/core/parsers/spec-structure.ts
@@ -1,7 +1,7 @@
 const REQUIREMENTS_SECTION_HEADER = /^##\s+Requirements\s*$/i;
 const TOP_LEVEL_SECTION_HEADER = /^##\s+/;
 const DELTA_HEADER = /^##\s+(ADDED|MODIFIED|REMOVED|RENAMED)\s+Requirements\s*$/i;
-const REQUIREMENT_HEADER = /^###\s+Requirement:\s*(.+)\s*$/;
+const REQUIREMENT_HEADER = /^###\s+Requirement:\s*(.+)\s*$/i;
 
 export interface MainSpecStructureIssue {
   kind: 'delta-header' | 'requirement-outside-requirements';

--- a/src/core/specs-apply.ts
+++ b/src/core/specs-apply.ts
@@ -287,7 +287,7 @@ export async function buildUpdatedSpec(
       throw new Error(`${specName} MODIFIED failed for header "### Requirement: ${mod.name}" - not found`);
     }
     // Replace block with provided raw (ensure header line matches key)
-    const modHeaderMatch = mod.raw.split('\n')[0].match(/^###\s*Requirement:\s*(.+)\s*$/);
+    const modHeaderMatch = mod.raw.split('\n')[0].match(/^###\s*Requirement:\s*(.+)\s*$/i);
     if (!modHeaderMatch || normalizeRequirementName(modHeaderMatch[1]) !== key) {
       throw new Error(
         `${specName} MODIFIED failed for header "### Requirement: ${mod.name}" - header mismatch in content`

--- a/test/core/parsers/requirement-blocks.test.ts
+++ b/test/core/parsers/requirement-blocks.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { extractRequirementsSection, parseDeltaSpec } from '../../../src/core/parsers/requirement-blocks.js';
+
+describe('extractRequirementsSection', () => {
+  it('parses canonical ### Requirement: headers', () => {
+    const result = extractRequirementsSection(`## Requirements\n### Requirement: Foo\nThe system SHALL foo.\n`);
+    expect(result.bodyBlocks.length).toBe(1);
+    expect(result.bodyBlocks[0].name).toBe('Foo');
+  });
+
+  it('regression: parses mixed-case ### requirement: headers without silently dropping them', () => {
+    const variants = [
+      '### requirement: Lowercase',
+      '### REQUIREMENT: Uppercase',
+      '### Requirement: Canonical',
+    ];
+    for (const header of variants) {
+      const result = extractRequirementsSection(`## Requirements\n${header}\nThe system SHALL foo.\n`);
+      expect(result.bodyBlocks.length).toBeGreaterThan(0);
+      expect(result.bodyBlocks[0].name).toBe(header.replace(/^###\s*requirement:\s*/i, ''));
+    }
+  });
+
+  it('regression: parses ###Requirement: header with no space after ### without silently dropping it', () => {
+    const result = extractRequirementsSection(`## Requirements\n###Requirement: NoSpace\nThe system SHALL foo.\n`);
+    expect(result.bodyBlocks.length).toBe(1);
+    expect(result.bodyBlocks[0].name).toBe('NoSpace');
+  });
+
+  it('regression: multiple blocks where first uses no-space header are all parsed', () => {
+    const content = `## Requirements\n###Requirement: First\nThe system SHALL first.\n\n### Requirement: Second\nThe system SHALL second.\n`;
+    const result = extractRequirementsSection(content);
+    expect(result.bodyBlocks.length).toBe(2);
+    expect(result.bodyBlocks[0].name).toBe('First');
+    expect(result.bodyBlocks[1].name).toBe('Second');
+  });
+});
+
+describe('parseDeltaSpec', () => {
+  it('regression: parses ###Requirement: header with no space in delta ADDED section', () => {
+    const content = `## ADDED Requirements\n###Requirement: NoSpace\nThe system SHALL foo.\n`;
+    const result = parseDeltaSpec(content);
+    expect(result.added.length).toBe(1);
+    expect(result.added[0].name).toBe('NoSpace');
+  });
+});


### PR DESCRIPTION
## Problem

`REQUIREMENT_HEADER_REGEX` and the inline seek/skip regexes use case-sensitive matching for `### Requirement:`, while the `## Requirements` section header is found case-insensitively (`/i`).

A user who writes `### requirement: Foo` gets a confusing validation error during archive — "no requirement entries parsed" — with no indication that header casing is the cause.

## Fix

Add the `i` flag to `REQUIREMENT_HEADER_REGEX` and all four inline regexes in `requirement-blocks.ts` that seek or skip `### Requirement:` headers.