### PR TITLE
[codex] Fix Windows workspace data dir paths

### DIFF
--- a/src/core/global-config.ts
+++ b/src/core/global-config.ts
@@ -69,30 +69,36 @@ export interface GlobalDataDirOptions {
   homedir?: string;
 }
 
+function joinGlobalDataPath(platform: NodeJS.Platform, ...segments: string[]): string {
+  return platform === 'win32'
+    ? path.win32.join(...segments)
+    : path.posix.join(...segments);
+}
+
 export function getGlobalDataDir(options: GlobalDataDirOptions = {}): string {
   const env = options.env ?? process.env;
+  const platform = options.platform ?? os.platform();
 
   // XDG_DATA_HOME takes precedence on all platforms when explicitly set
   const xdgDataHome = env.XDG_DATA_HOME;
   if (xdgDataHome) {
-    return path.join(xdgDataHome, GLOBAL_DATA_DIR_NAME);
+    return joinGlobalDataPath(platform, xdgDataHome, GLOBAL_DATA_DIR_NAME);
   }
 
-  const platform = options.platform ?? os.platform();
   const homedir = options.homedir ?? os.homedir();
 
   if (platform === 'win32') {
     // Windows: use %LOCALAPPDATA%
     const localAppData = env.LOCALAPPDATA;
     if (localAppData) {
-      return path.win32.join(localAppData, GLOBAL_DATA_DIR_NAME);
+      return joinGlobalDataPath(platform, localAppData, GLOBAL_DATA_DIR_NAME);
     }
     // Fallback for Windows if LOCALAPPDATA is not set
-    return path.win32.join(homedir, 'AppData', 'Local', GLOBAL_DATA_DIR_NAME);
+    return joinGlobalDataPath(platform, homedir, 'AppData', 'Local', GLOBAL_DATA_DIR_NAME);
   }
 
   // Unix/macOS fallback: ~/.local/share
-  return path.join(homedir, '.local', 'share', GLOBAL_DATA_DIR_NAME);
+  return joinGlobalDataPath(platform, homedir, '.local', 'share', GLOBAL_DATA_DIR_NAME);
 }
 
 /**

--- a/test/cli-e2e/basic.test.ts
+++ b/test/cli-e2e/basic.test.ts
@@ -134,7 +134,9 @@ describe('openspec CLI e2e basics', () => {
       const result = await runCLI(['init', '--tools', 'all'], {
         cwd: emptyProjectDir,
         env: { CODEX_HOME: codexHome },
+        timeoutMs: 20000,
       });
+      expect(result.timedOut).toBe(false);
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('OpenSpec Setup Complete');
 
@@ -143,7 +145,7 @@ describe('openspec CLI e2e basics', () => {
       const cursorSkillPath = path.join(emptyProjectDir, '.cursor/skills/openspec-explore/SKILL.md');
       expect(await fileExists(claudeSkillPath)).toBe(true);
       expect(await fileExists(cursorSkillPath)).toBe(true);
-    });
+    }, 25000);
 
     it('initializes with --tools list option', async () => {
       const projectDir = await prepareFixture('tmp-init');

--- a/test/core/global-config.test.ts
+++ b/test/core/global-config.test.ts
@@ -6,6 +6,7 @@ import * as os from 'node:os';
 import {
   getGlobalConfigDir,
   getGlobalConfigPath,
+  getGlobalDataDir,
   getGlobalConfig,
   saveGlobalConfig,
   GLOBAL_CONFIG_DIR_NAME,
@@ -92,6 +93,44 @@ describe('global-config', () => {
       const result = getGlobalConfigPath();
 
       expect(result).toBe(path.join(tempDir, 'openspec', 'config.json'));
+    });
+  });
+
+  describe('getGlobalDataDir', () => {
+    it('should use POSIX separators for Unix-like platform overrides', () => {
+      expect(
+        getGlobalDataDir({
+          env: {},
+          platform: 'linux',
+          homedir: '/home/tabish',
+        })
+      ).toBe('/home/tabish/.local/share/openspec');
+
+      expect(
+        getGlobalDataDir({
+          env: { XDG_DATA_HOME: '/var/data' },
+          platform: 'darwin',
+          homedir: '/Users/tabish',
+        })
+      ).toBe('/var/data/openspec');
+    });
+
+    it('should use Windows separators for native Windows platform overrides', () => {
+      expect(
+        getGlobalDataDir({
+          env: {},
+          platform: 'win32',
+          homedir: 'C:\\Users\\Tabish',
+        })
+      ).toBe('C:\\Users\\Tabish\\AppData\\Local\\openspec');
+
+      expect(
+        getGlobalDataDir({
+          env: { LOCALAPPDATA: 'D:\\Users\\Tabish\\AppData\\Local' },
+          platform: 'win32',
+          homedir: 'C:\\Users\\Tabish',
+        })
+      ).toBe('D:\\Users\\Tabish\\AppData\\Local\\openspec');
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes the Windows CI failure from the workspace foundation merge by making `getGlobalDataDir` honor the requested platform's path conventions when `platform`, `env`, or `homedir` overrides are passed.

## Root Cause

`getGlobalDataDir({ platform: 'linux', homedir: '/home/tabish' })` still used native `path.join`. On Windows CI that produced backslash paths like `\home\tabish\...`, so the workspace foundation test that simulated Linux fallback behavior failed after #1029 merged to `main`.

## Changes

- Added a small platform-aware join helper for global data paths.
- Added direct coverage for Linux/macOS-style and native Windows global data directory resolution.
- Gave the broad `init --tools all` e2e test an explicit timeout budget and timeout assertion, matching the slower Windows matrix behavior.

## Validation

- `pnpm run build`
- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run test/cli-e2e/basic.test.ts test/core/global-config.test.ts test/core/workspace/foundation.test.ts`
- `pnpm test` (`71 passed`, `1435 passed`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for global directory path resolution across different platforms.
  * Improved timeout handling in CLI end-to-end tests for enhanced stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->