### PR TITLE
docs: add Community Schemas section + README entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,13 @@ If you want the expanded workflow (`/opsx:new`, `/opsx:continue`, `/opsx:ff`, `/
 → **[Customization](docs/customization.md)**: make it yours
 
 
+## Community schemas
+
+Third-party schema bundles distributed via standalone repositories — these provide opinionated workflows that integrate OpenSpec with other tools, similar to how [github/spec-kit's community extension catalog](https://github.com/github/spec-kit/tree/main/extensions) handles tool integrations.
+
+→ **[Browse the catalog](docs/customization.md#community-schemas)** in the customization docs.
+
+
 ## Why OpenSpec?
 
 AI coding assistants are powerful but unpredictable when requirements live only in chat history. OpenSpec adds a lightweight spec layer so you agree on what to build before any code is written.

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -337,6 +337,20 @@ Then edit `schema.yaml` to add:
 
 ---
 
+## Community Schemas
+
+OpenSpec also supports community-maintained schemas distributed via standalone repositories. These provide opinionated workflows that integrate OpenSpec with other tools or systems, similar to how [github/spec-kit's community extension catalog](https://github.com/github/spec-kit/tree/main/extensions) works for spec-kit.
+
+Community schemas are not vendored into OpenSpec core — they live in their own repositories with their own release cadence. To use one, copy the schema bundle into your project's `openspec/schemas/<schema-name>/` directory (each repo's README has install instructions).
+
+| Schema | Maintainer | Repository | Description |
+|--------|-----------|-----------|-------------|
+| `superpowers-bridge` | @JiangWay | [JiangWay/openspec-schemas](https://github.com/JiangWay/openspec-schemas/tree/main/superpowers-bridge) | Integrates OpenSpec's artifact governance with [obra/superpowers](https://github.com/obra/superpowers) execution skills (brainstorming, writing-plans, TDD via subagents, code review, finishing). Adds an evidence-first `retrospective` artifact filling a gap Superpowers does not natively cover. |
+
+> Want to contribute a community schema? Open an issue with a link to your repository, or submit a PR adding a row to this table.
+
+---
+
 ## See Also
 
 - [CLI Reference: Schema Commands](cli.md#schema-commands) - Full command documentation


### PR DESCRIPTION
## Summary

Adds a "Community Schemas" section to `docs/customization.md` listing community-maintained OpenSpec schemas distributed via standalone repositories. Modeled after [github/spec-kit's community extension catalog](https://github.com/github/spec-kit/tree/main/extensions).

Also adds a brief 4-line "Community schemas" introductory section in `README.md` pointing to the new catalog.

The first catalog entry is `superpowers-bridge` — born from the proposal in #970 and now living at [JiangWay/openspec-schemas](https://github.com/JiangWay/openspec-schemas).

This PR adds documentation only; no code or schema changes. Each row in the catalog represents a separately-maintained external repository.

## Test plan
- [x] New section reads naturally between Examples and See Also in customization.md
- [x] README "Community schemas" section sits cleanly between Docs and Why OpenSpec
- [x] All linked repositories exist and resolve

## Maintainer note

Easy to partially accept — the README addition is a separate hunk from the `docs/customization.md` addition. If you'd prefer keeping the README focused (without a community-schemas entry), happy to revise to just the docs change.

Refs: #970

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Community Schemas" section explaining how to use third-party schema bundles distributed via standalone repositories.
  * Documented installation instructions for community-maintained schemas.
  * Provided reference to community catalog for schema discovery.
  * Included guidance for contributing new community schemas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->