### PR TITLE
[codex] Add workspace setup commands

### DIFF
--- a/WORKSPACE_REIMPLEMENTATION_DIRECTION.md
+++ b/WORKSPACE_REIMPLEMENTATION_DIRECTION.md
@@ -9,10 +9,10 @@ This document captures the intended direction for reimplementing OpenSpec worksp
 The reimplementation should be ordered around the path a real user takes through OpenSpec:
 
 ```text
-create workspace
-  -> add repos
+set up workspace
+  -> link repos or folders
   -> open workspace
-  -> explore across repos
+  -> explore across repos or folders
   -> create proposal
   -> apply one repo slice
   -> verify
@@ -27,9 +27,9 @@ A user should think:
 
 ```text
 I have a multi-repo product goal.
-I create an OpenSpec workspace.
+I set up an OpenSpec workspace.
 I open it with my agent.
-The agent can see the registered repos.
+The agent can see the linked repos or folders.
 We explore until the scope is clear.
 Then we create a proposal.
 Then we implement one repo slice at a time.
@@ -40,63 +40,76 @@ They should not think:
 ```text
 I need to create a change so repos become visible.
 I need to materialize repo-local artifacts.
-I need to understand workspace overlays.
+I need to understand implementation-specific workspace machinery.
 I need to manage target metadata separately from proposal files.
 ```
 
 The core product rule is:
 
 ```text
-Repository visibility is not change commitment.
+Workspace visibility is not change commitment.
 ```
 
-Registered repos are the workspace working set. Creating a change is a planning commitment. Applying a change is an implementation workflow.
+Linked repos or folders are planning context. Creating a change is a planning commitment. Applying a change is an implementation workflow.
 
 ## Build Order
 
-### 1. Workspace Creation
+### 1. Workspace Setup And Links
 
-First make workspace creation boring and solid.
+First make workspace setup boring and solid.
 
 User goal:
 
 ```text
-Create a place where cross-repo planning lives.
+Create a planning home and link the repos or folders OpenSpec should know about.
 ```
 
 Expected surface:
 
 ```bash
-openspec workspace create my-workspace
-openspec workspace add-repo openspec /path/to/openspec
-openspec workspace add-repo landing /path/to/openspec-landing
+openspec workspace setup
+openspec workspace setup --no-interactive --name platform --link /path/to/api --link web=/path/to/web
+openspec workspace list
+openspec workspace ls
+openspec workspace link /path/to/api
+openspec workspace link api-service /path/to/api
+openspec workspace relink api /new/path/to/api
+openspec workspace doctor
 ```
 
 Expected outcome:
 
 ```text
-workspace/
-  AGENTS.md
+workspace-root/
   changes/
   .openspec-workspace/
+    workspace.yaml
+    local.yaml
 ```
 
 Product decisions:
 
 - Use `.openspec-workspace/`, not `.openspec/`, for workspace metadata.
 - Keep `changes/` visible at the workspace root.
-- Treat registered repos as the workspace working set.
-- Make `doctor` show human-readable repo names and resolved paths.
+- Keep setup as the only public creation path for the first release; do not expose `workspace create`.
+- Use `workspace link` and `workspace relink`, not POC-era `add-repo` or `update-repo`.
+- Allow linked repos or folders without repo-local `openspec/` state.
+- Keep stable link names in shared workspace state and local paths in machine-local state.
+- Make `doctor` show link names, resolved paths, repo-local specs paths when present, and suggested fixes.
 
 Defer:
 
+- Agent launch and workspace open behavior.
+- Preferred-agent prompts.
+- Owner or handoff metadata.
+- Workspace change creation or target selection.
 - Branches.
 - Worktrees.
 - Apply.
 - Archive.
 - Complex target lifecycle.
 
-Done when a user can create a workspace, register repos, and run `doctor` to see exactly what OpenSpec knows.
+Done when a user can set up a workspace, link repos or folders, list known workspaces, relink local paths, and run `doctor` to see exactly what OpenSpec can resolve.
 
 ### 2. Workspace Open
 
@@ -105,7 +118,7 @@ Next make the workspace openable in the way users expect.
 User goal:
 
 ```text
-Open this multi-repo working set with my coding agent.
+Open this multi-repo planning context with my coding agent.
 ```
 
 Expected surface:
@@ -118,7 +131,7 @@ openspec workspace open --agent github-copilot
 
 Product behavior:
 
-- `workspace open` opens the coordination workspace plus registered repos.
+- `workspace open` opens the coordination workspace plus linked repos or folders.
 - Repo visibility is default.
 - Change selection is optional focus, not the mechanism for repo access.
 - `--agent` should be a one-session override by default. Persisting the preferred agent should require an explicit preference-setting action.
@@ -127,11 +140,11 @@ For GitHub Copilot, generate or open a `.code-workspace` file with:
 
 ```text
 workspace root
-registered repo A
-registered repo B
+linked repo or folder A
+linked repo or folder B
 ```
 
-For Claude and Codex, attach the registered repo directories through the agent's supported mechanism.
+For Claude and Codex, attach the linked repo or folder directories through the agent's supported mechanism.
 
 Defer:
 
@@ -139,7 +152,7 @@ Defer:
 - In-session upgrade flows.
 - Per-change attachment restrictions.
 
-Done when opening a workspace gives the agent visibility into the coordination root and all registered repos.
+Done when opening a workspace gives the agent visibility into the coordination root and all linked repos or folders.
 
 ### 3. Agent Guidance And Explore
 
@@ -155,13 +168,13 @@ Expected user prompt:
 
 ```text
 Explore how we should make the OpenSpec docs available on the landing page.
-Look across the registered repos, but do not implement yet.
+Look across the linked repos or folders, but do not implement yet.
 ```
 
 Agent behavior:
 
 - Understand it is in workspace mode.
-- Inspect registered repos.
+- Inspect linked repos or folders.
 - Explain likely affected repos.
 - Ask for clarification only when needed.
 - Avoid implementation edits during explore.
@@ -263,7 +276,7 @@ Status should also catch structural mistakes:
 - Unknown repo folder under `specs/`.
 - Missing tasks.
 - No confirmed affected repo.
-- Registered repo path missing.
+- Linked repo or folder path missing.
 
 Done when the agent and user can trust status before applying.
 
@@ -389,7 +402,8 @@ Behavior:
 Done when a user can complete the full lifecycle:
 
 ```text
-workspace create
+workspace setup
+  -> link repos or folders
   -> open
   -> explore
   -> propose
@@ -406,8 +420,8 @@ Build only the next user-visible step.
 The sequence should stay grounded in these questions:
 
 ```text
-1. Can I create the workspace?
-2. Can I see my repos?
+1. Can I set up the workspace?
+2. Can I see my linked repos or folders?
 3. Can my agent explore them?
 4. Can we capture a proposal?
 5. Can status tell us if it is ready?
@@ -436,10 +450,10 @@ The workspace should feel like OpenSpec's normal workflow stretched across multi
 The durable product model is:
 
 ```text
-workspace = central planning source of truth
-registered repos = visible working set
+workspace = durable planning home
+links = repos or folders visible for planning
 proposal = scoped planning commitment
-repo target = one affected repo in the plan
+repo slice = one affected repo or folder in the plan
 branch/worktree = implementation checkout
 /apply = implement one selected repo slice
 ```

--- a/WORKSPACE_REIMPLEMENTATION_DIRECTION.md
+++ b/WORKSPACE_REIMPLEMENTATION_DIRECTION.md
@@ -80,7 +80,7 @@ openspec workspace doctor
 Expected outcome:
 
 ```text
-workspace-root/
+workspace-folder/
   changes/
   .openspec-workspace/
     workspace.yaml
@@ -90,7 +90,7 @@ workspace-root/
 Product decisions:
 
 - Use `.openspec-workspace/`, not `.openspec/`, for workspace metadata.
-- Keep `changes/` visible at the workspace root.
+- Keep `changes/` visible in the workspace folder.
 - Keep setup as the only public creation path for the first release; do not expose `workspace create`.
 - Use `workspace link` and `workspace relink`, not POC-era `add-repo` or `update-repo`.
 - Allow linked repos or folders without repo-local `openspec/` state.
@@ -139,7 +139,7 @@ Product behavior:
 For GitHub Copilot, generate or open a `.code-workspace` file with:
 
 ```text
-workspace root
+workspace folder
 linked repo or folder A
 linked repo or folder B
 ```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -7,6 +7,7 @@ The OpenSpec CLI (`openspec`) provides terminal commands for project setup, vali
 | Category | Commands | Purpose |
 |----------|----------|---------|
 | **Setup** | `init`, `update` | Initialize and update OpenSpec in your project |
+| **Workspaces (beta)** | `workspace setup`, `workspace list`, `workspace ls`, `workspace link`, `workspace relink`, `workspace doctor` | Set up planning across linked repos or folders |
 | **Browsing** | `list`, `view`, `show` | Explore changes and specs |
 | **Validation** | `validate` | Check changes and specs for issues |
 | **Lifecycle** | `archive` | Finalize completed changes |
@@ -46,6 +47,11 @@ These commands support `--json` output for programmatic use by AI agents and scr
 | `openspec instructions` | Get next steps | `--json` for agent instructions |
 | `openspec templates` | Find template paths | `--json` for path resolution |
 | `openspec schemas` | List available schemas | `--json` for schema discovery |
+| `openspec workspace setup --no-interactive` | Create a workspace with explicit inputs | `--json` for structured setup output |
+| `openspec workspace list` | Browse known workspaces | `--json` for typed workspace objects |
+| `openspec workspace link` | Link a repo or folder | `--json` for structured link output |
+| `openspec workspace relink` | Repair a linked path | `--json` for structured link output |
+| `openspec workspace doctor` | Check one workspace | `--json` for structured status output |
 
 ---
 
@@ -156,6 +162,103 @@ openspec update [path] [options]
 npm update @fission-ai/openspec
 openspec update
 ```
+
+---
+
+## Workspace Commands
+
+Workspace commands are under active development and are not ready for use yet. Do not build external automation, integrations, or long-lived workflows on top of this command surface; command behavior, state files, and JSON output can change at any point.
+
+Coordination workspaces are planning homes for work that spans multiple repos or folders. Workspace visibility is not change commitment: link the repos or folders OpenSpec should know about, then create changes when you are ready to plan specific work.
+
+### `openspec workspace setup`
+
+Create a workspace in the standard OpenSpec workspace location and link at least one existing repo or folder.
+
+```
+openspec workspace setup [options]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--name <name>` | Workspace name. Names must be kebab-case |
+| `--link <path>` | Link an existing repo or folder and infer the link name from the folder name |
+| `--link <name>=<path>` | Link an existing repo or folder with an explicit link name |
+| `--no-interactive` | Disable prompts; requires `--name` and at least one `--link` |
+| `--json` | Output JSON; requires `--no-interactive` |
+
+**Examples:**
+
+```bash
+openspec workspace setup
+openspec workspace setup --no-interactive --name platform --link /repos/api --link web=/repos/web
+openspec workspace setup --no-interactive --json --name checkout --link /repos/platform/apps/checkout
+```
+
+Setup prints the workspace root, the planning path, linked repos or folders, and a workspace check. It does not ask for a preferred agent or open the workspace.
+
+### `openspec workspace list`
+
+List known OpenSpec workspaces from the local registry.
+
+```
+openspec workspace list [--json]
+openspec workspace ls [--json]
+```
+
+The list shows each workspace path and linked repos or folders. Stale registry records are reported but not changed.
+
+### `openspec workspace link`
+
+Record an existing repo or folder for one workspace.
+
+```
+openspec workspace link [name] <path> [options]
+```
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--workspace <name>` | Select a known workspace from the local registry |
+| `--json` | Output JSON |
+| `--no-interactive` | Disable workspace picker prompts |
+
+**Examples:**
+
+```bash
+openspec workspace link /repos/api
+openspec workspace link api-service /repos/api
+openspec workspace link --workspace platform /repos/platform/apps/checkout
+```
+
+The path must already exist. Relative paths are resolved against the command's current directory before OpenSpec stores the verified absolute path in machine-local workspace state. Linked paths can be full repos, packages, services, apps, or folders without repo-local `openspec/` state.
+
+### `openspec workspace relink`
+
+Repair or change the local path for an existing link.
+
+```
+openspec workspace relink <name> <path> [options]
+```
+
+The path must already exist. Relink updates only the machine-local path for the stable link name.
+
+### `openspec workspace doctor`
+
+Check what one workspace can resolve on the current machine.
+
+```
+openspec workspace doctor [options]
+```
+
+Doctor shows the workspace root, planning path, linked repos or folders, missing paths, repo-local specs paths when present, and suggested fixes. It reports issues only; it does not repair them automatically.
+
+Commands that need one workspace use the current workspace when run from inside a workspace root or subdirectory. From elsewhere, pass `--workspace <name>`, select from the picker in an interactive terminal, or rely on the only known workspace when exactly one exists. In `--json` or `--no-interactive` mode, ambiguous selection fails with a structured status error and suggests `--workspace <name>`.
+
+JSON responses use typed objects plus `status` arrays. Primary data lives in `workspace`, `workspaces`, or `link`; warnings and errors live in `status`.
 
 ---
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -175,7 +175,7 @@ Coordination workspaces are planning homes for work that spans multiple repos or
 
 Create a workspace in the standard OpenSpec workspace location and link at least one existing repo or folder.
 
-```
+```bash
 openspec workspace setup [options]
 ```
 
@@ -197,13 +197,13 @@ openspec workspace setup --no-interactive --name platform --link /repos/api --li
 openspec workspace setup --no-interactive --json --name checkout --link /repos/platform/apps/checkout
 ```
 
-Setup prints the workspace location, linked repos or folders, and a workspace check. It does not ask for a preferred agent or open the workspace.
+Setup prints the workspace location, planning path, linked repos or folders, and a workspace check. It does not ask for a preferred agent or open the workspace.
 
 ### `openspec workspace list`
 
 List known OpenSpec workspaces from the local registry.
 
-```
+```bash
 openspec workspace list [--json]
 openspec workspace ls [--json]
 ```
@@ -214,7 +214,7 @@ The list shows each workspace location and linked repos or folders. Stale regist
 
 Record an existing repo or folder for one workspace.
 
-```
+```bash
 openspec workspace link [name] <path> [options]
 ```
 
@@ -240,7 +240,7 @@ The path must already exist. Relative paths are resolved against the command's c
 
 Repair or change the local path for an existing link.
 
-```
+```bash
 openspec workspace relink <name> <path> [options]
 ```
 
@@ -250,7 +250,7 @@ The path must already exist. Relink updates only the machine-local path for the 
 
 Check what one workspace can resolve on the current machine.
 
-```
+```bash
 openspec workspace doctor [options]
 ```
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -197,7 +197,7 @@ openspec workspace setup --no-interactive --name platform --link /repos/api --li
 openspec workspace setup --no-interactive --json --name checkout --link /repos/platform/apps/checkout
 ```
 
-Setup prints the workspace root, the planning path, linked repos or folders, and a workspace check. It does not ask for a preferred agent or open the workspace.
+Setup prints the workspace location, linked repos or folders, and a workspace check. It does not ask for a preferred agent or open the workspace.
 
 ### `openspec workspace list`
 
@@ -208,7 +208,7 @@ openspec workspace list [--json]
 openspec workspace ls [--json]
 ```
 
-The list shows each workspace path and linked repos or folders. Stale registry records are reported but not changed.
+The list shows each workspace location and linked repos or folders. Stale registry records are reported but not changed.
 
 ### `openspec workspace link`
 
@@ -254,9 +254,9 @@ Check what one workspace can resolve on the current machine.
 openspec workspace doctor [options]
 ```
 
-Doctor shows the workspace root, planning path, linked repos or folders, missing paths, repo-local specs paths when present, and suggested fixes. It reports issues only; it does not repair them automatically.
+Doctor shows the workspace location, planning path, linked repos or folders, missing paths, repo-local specs paths when present, and suggested fixes. It reports issues only; it does not repair them automatically.
 
-Commands that need one workspace use the current workspace when run from inside a workspace root or subdirectory. From elsewhere, pass `--workspace <name>`, select from the picker in an interactive terminal, or rely on the only known workspace when exactly one exists. In `--json` or `--no-interactive` mode, ambiguous selection fails with a structured status error and suggests `--workspace <name>`.
+Commands that need one workspace use the current workspace when run from inside a workspace folder or subdirectory. From elsewhere, pass `--workspace <name>`, select from the picker in an interactive terminal, or rely on the only known workspace when exactly one exists. In `--json` or `--no-interactive` mode, ambiguous selection fails with a structured status error and suggests `--workspace <name>`.
 
 JSON responses use typed objects plus `status` arrays. Primary data lives in `workspace`, `workspaces`, or `link`; warnings and errors live in `status`.
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -51,7 +51,9 @@ This separation is key. You can work on multiple changes in parallel without con
 
 ## Coordination Workspaces
 
-Workspace support is in beta. The concepts below describe the direction and foundation currently being implemented; commands and workflows may change, and some workspace commands may not be available in the current stable release yet.
+Workspace support is under active development and is not ready for use yet. Do not build external automation, integrations, or long-lived workflows on top of workspace behavior; the commands, state files, and JSON output can change at any point.
+
+The commands below provide the first setup flow for planning across linked repos or folders.
 
 Repo-local OpenSpec projects are the right default when one repo owns the planning, implementation, and archive flow. Some work spans several repos or folders. For that case, an OpenSpec coordination workspace is the durable planning home.
 
@@ -131,9 +133,38 @@ OpenSpec also keeps a machine-local registry at:
 getGlobalDataDir()/workspaces/registry.yaml
 ```
 
-The registry maps workspace names to workspace roots so later global commands can list or select known workspaces from anywhere. It is only an index. Each workspace folder remains authoritative for its own `.openspec-workspace/workspace.yaml` and `.openspec-workspace/local.yaml`, so stale registry entries can be reported and repaired without redefining the workspace itself.
+The registry maps workspace names to workspace roots so later global commands can list or select known workspaces from anywhere. It is only an index. Each workspace folder remains authoritative for its own `.openspec-workspace/workspace.yaml` and `.openspec-workspace/local.yaml`, so stale registry records can be reported and repaired without redefining the workspace itself.
 
-This foundation intentionally stops before the full workspace workflow. Creation, link and relink commands, agent launch, workspace proposal creation, repo-slice apply, verify, and archive behavior are later slices built on this storage and naming contract.
+Workspace visibility is not change commitment. Set up a workspace when OpenSpec should know which repos or folders are relevant; create a change later when you are ready to plan a feature, fix, project, or other piece of work.
+
+Useful commands:
+
+```bash
+# Guided setup
+openspec workspace setup
+
+# Automation-friendly setup
+openspec workspace setup --no-interactive --name platform --link /repos/api --link web=/repos/web
+
+# See known workspaces from the local registry
+openspec workspace list
+openspec workspace ls
+
+# Add or repair links for the selected workspace
+openspec workspace link /repos/api
+openspec workspace link api-service /repos/api
+openspec workspace relink api-service /new/path/to/api
+
+# Check what this machine can resolve
+openspec workspace doctor
+openspec workspace doctor --workspace platform
+```
+
+`workspace setup` always creates the workspace in the standard workspace location, records it in the local registry, shows the workspace path, and requires at least one linked repo or folder. `workspace link` and `workspace relink` record existing folders only; they do not create, copy, move, initialize, or edit the linked repo or folder.
+
+Workspace commands that need one workspace can run from anywhere with `--workspace <name>`. If you run them inside a workspace root or subdirectory, OpenSpec uses that current workspace. If several known workspaces are available and you do not pass `--workspace <name>`, human commands show a picker; `--json` and `--no-interactive` fail with a structured status error instead of prompting.
+
+Direct workspace commands support JSON output for scripts. JSON responses keep primary data in `workspace`, `workspaces`, or `link` objects and report warnings or errors in `status` arrays. Healthy objects use `status: []`.
 
 ## Specs
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -68,7 +68,7 @@ change    = one feature, fix, project, or other planned piece of work
 A workspace has a different shape from a repo-local project:
 
 ```text
-workspace-root/
+workspace-folder/
 ├── changes/                       # Workspace-level planning
 └── .openspec-workspace/
     ├── workspace.yaml             # Shared workspace identity and link names
@@ -84,7 +84,7 @@ repo-root/
     └── changes/
 ```
 
-That distinction matters. The workspace root is a coordination surface for planning across linked repos or folders. Each repo's `openspec/` directory remains the home for repo-owned specs, repo-local changes, and implementation planning. Users do not need to run repo-local `openspec init` inside a workspace root.
+That distinction matters. The workspace folder is a coordination surface for planning across linked repos or folders. Each repo's `openspec/` directory remains the home for repo-owned specs, repo-local changes, and implementation planning. Users do not need to run repo-local `openspec init` inside a workspace folder.
 
 Stable link names are how workspace planning refers to repos and folders. The shared workspace state keeps names such as `api`, `web`, or `checkout`; each machine maps those names to its own local paths in `.openspec-workspace/local.yaml`.
 
@@ -133,7 +133,7 @@ OpenSpec also keeps a machine-local registry at:
 getGlobalDataDir()/workspaces/registry.yaml
 ```
 
-The registry maps workspace names to workspace roots so later global commands can list or select known workspaces from anywhere. It is only an index. Each workspace folder remains authoritative for its own `.openspec-workspace/workspace.yaml` and `.openspec-workspace/local.yaml`, so stale registry records can be reported and repaired without redefining the workspace itself.
+The registry maps workspace names to workspace locations so later global commands can list or select known workspaces from anywhere. It is only an index. Each workspace folder remains authoritative for its own `.openspec-workspace/workspace.yaml` and `.openspec-workspace/local.yaml`, so stale registry records can be reported and repaired without redefining the workspace itself.
 
 Workspace visibility is not change commitment. Set up a workspace when OpenSpec should know which repos or folders are relevant; create a change later when you are ready to plan a feature, fix, project, or other piece of work.
 
@@ -160,9 +160,9 @@ openspec workspace doctor
 openspec workspace doctor --workspace platform
 ```
 
-`workspace setup` always creates the workspace in the standard workspace location, records it in the local registry, shows the workspace path, and requires at least one linked repo or folder. `workspace link` and `workspace relink` record existing folders only; they do not create, copy, move, initialize, or edit the linked repo or folder.
+`workspace setup` always creates the workspace in the standard workspace location, records it in the local registry, shows the workspace location, and requires at least one linked repo or folder. `workspace link` and `workspace relink` record existing folders only; they do not create, copy, move, initialize, or edit the linked repo or folder.
 
-Workspace commands that need one workspace can run from anywhere with `--workspace <name>`. If you run them inside a workspace root or subdirectory, OpenSpec uses that current workspace. If several known workspaces are available and you do not pass `--workspace <name>`, human commands show a picker; `--json` and `--no-interactive` fail with a structured status error instead of prompting.
+Workspace commands that need one workspace can run from anywhere with `--workspace <name>`. If you run them inside a workspace folder or subdirectory, OpenSpec uses that current workspace. If several known workspaces are available and you do not pass `--workspace <name>`, human commands show a picker; `--json` and `--no-interactive` fail with a structured status error instead of prompting.
 
 Direct workspace commands support JSON output for scripts. JSON responses keep primary data in `workspace`, `workspaces`, or `link` objects and report warnings or errors in `status` arrays. Healthy objects use `status: []`.
 

--- a/openspec/changes/workspace-create-and-register-repos/design.md
+++ b/openspec/changes/workspace-create-and-register-repos/design.md
@@ -86,7 +86,7 @@ Guided onboarding:
 - let the user add more repos or folders with a simple repeated prompt
 - record the workspace in the local workspace registry
 - run `workspace doctor`
-- print the workspace root, planning path, linked repos or folders, and next useful commands
+- print the workspace location, planning path, linked repos or folders, and next useful commands
 
 This slice should not ask for preferred agent or open the workspace with an agent. Those belong to `workspace-open-agent-context`.
 
@@ -111,20 +111,20 @@ The output should answer what exists and what each workspace links to:
 ```yaml
 workspaces:
   - name: platform
-    root: /.../openspec/workspaces/platform
+    location: /.../openspec/workspaces/platform
     links:
       - name: api
         path: /repos/api
       - name: web
         path: /repos/web
   - name: checkout
-    root: /.../openspec/workspaces/checkout
+    location: /.../openspec/workspaces/checkout
     links:
       - name: app
         path: /repos/platform/apps/checkout
 ```
 
-List should keep deep validation for `workspace doctor`. It can still report obviously stale workspace registry entries if a known workspace path no longer exists. Stale registry entries are report-only in this slice: `workspace list` should not delete, rewrite, or repair registry entries, and this slice should not add a `workspace forget` command.
+List should keep deep validation for `workspace doctor`. It can still report obviously stale workspace registry entries if a known workspace location no longer exists. Stale registry entries are report-only in this slice: `workspace list` should not delete, rewrite, or repair registry entries, and this slice should not add a `workspace forget` command.
 
 For JSON output, list should use typed workspace objects with a structured `status` array for issues:
 
@@ -151,7 +151,7 @@ For JSON output, list should use typed workspace objects with a structured `stat
         {
           "severity": "error",
           "code": "workspace_root_missing",
-          "message": "Workspace root does not exist.",
+          "message": "Workspace location does not exist.",
           "fix": "Remove or repair the local registry entry."
         }
       ]
@@ -196,11 +196,11 @@ This slice should keep relink focused on path repair. It should not include owne
 
 ### `workspace doctor`
 
-Explain one selected workspace from the user's machine. If the command is run from a workspace root or subdirectory and `--workspace <name>` is not provided, doctor should use that current workspace. Otherwise it should follow the normal workspace-selection rules.
+Explain one selected workspace from the user's machine. If the command is run from a workspace folder or subdirectory and `--workspace <name>` is not provided, doctor should use that current workspace. Otherwise it should follow the normal workspace-selection rules.
 
 Doctor should inspect:
 
-- workspace root
+- workspace location
 - workspace planning path
 - linked repos and folders
 - whether each local path exists
@@ -214,7 +214,7 @@ Doctor should not scan every known workspace in the local registry by default. B
 
 Doctor should report issues and suggested fixes. It should not repair anything automatically.
 
-Registry cleanup remains out of scope. If doctor cannot inspect the selected workspace because the registry points at a missing or invalid workspace root, it should report that selected-workspace issue through status entries and stop before inspecting links. Other stale registry entries should be surfaced by `workspace list`, not by selected-workspace doctor.
+Registry cleanup remains out of scope. If doctor cannot inspect the selected workspace because the registry points at a missing or invalid workspace location, it should report that selected-workspace issue through status entries and stop before inspecting links. Other stale registry entries should be surfaced by `workspace list`, not by selected-workspace doctor.
 
 Human output should be readable by default: a short workspace summary, linked repo or folder rows, and a clear issues section when anything needs attention. It should not be raw JSON or a rigid YAML dump.
 
@@ -289,7 +289,7 @@ The current workspace wins even if it is not in the local workspace registry. Th
 }
 ```
 
-For human output, this should be a short warning rather than a blocking error. Successful mutating commands that use an unregistered current workspace, such as `workspace link` or `workspace relink`, should record the workspace name and root in the local registry after the mutation succeeds. Non-mutating commands such as `workspace doctor` should not write registry state; they should only report the warning. This slice should not add a standalone `workspace register` or `workspace join` command.
+For human output, this should be a short warning rather than a blocking error. Successful mutating commands that use an unregistered current workspace, such as `workspace link` or `workspace relink`, should record the workspace name and location in the local registry after the mutation succeeds. Non-mutating commands such as `workspace doctor` should not write registry state; they should only report the warning. This slice should not add a standalone `workspace register` or `workspace join` command.
 
 In non-interactive mode, commands that need one workspace should fail when selection is ambiguous and suggest `--workspace <name>`.
 

--- a/openspec/changes/workspace-create-and-register-repos/design.md
+++ b/openspec/changes/workspace-create-and-register-repos/design.md
@@ -30,6 +30,24 @@ The path may point at a full repo or a folder inside a large monorepo. It may po
 
 The product language should say "repos or folders". It should avoid "working set", "code area", "entry", "alias", and "local overlay" in user-facing output.
 
+Path handling should behave like a folder picker. The user may type a relative or absolute path, but OpenSpec should verify that it points to an existing folder, convert it to an absolute path relative to the command's current working directory when needed, and store that verified absolute path in local workspace state. OpenSpec should not store the raw string the user typed.
+
+Path conversion stays in the current runtime. Native Windows paths, WSL2 paths, and Unix paths should not be translated across runtimes. Where duplicate-path detection needs canonical comparisons, OpenSpec may compare canonical existing paths internally, but it should store and display the verified absolute path for the current runtime.
+
+## Names
+
+Workspace names should be kebab-case:
+
+```text
+platform
+checkout-web
+api2
+```
+
+Invalid workspace names include uppercase letters, underscores, dots, spaces, leading hyphens, trailing hyphens, empty names, dot names, and path separators. Interactive setup should explain the expected form and let the user retry. Non-interactive setup should fail with the same expectation in the error message.
+
+Link names should keep the folder-style validation from `workspace-foundation`: they must not be empty, must not be `.` or `..`, must not contain path separators, and must be unique inside the workspace. This lets inferred link names match existing folder basenames without forcing users to rename local folders for workspace planning.
+
 Link names are normally inferred from the folder basename:
 
 ```text
@@ -37,7 +55,23 @@ Link names are normally inferred from the folder basename:
 /repos/platform/apps/checkout      -> checkout
 ```
 
-If the inferred name conflicts, interactive flows should ask for a different name. Non-interactive flows should fail with a clear message.
+If the inferred name conflicts, interactive setup should show the conflicting name and the existing path it maps to, then ask for a different name. Non-interactive setup and direct `workspace link` should fail with a clear message instead of silently overwriting.
+
+Duplicate-name errors should be specific:
+
+```text
+Cannot use link name 'api' because another link already uses that name.
+Existing link:
+  api -> /repos/api
+
+Choose a different name:
+  openspec workspace link archived-api /archive/api
+
+If you meant to change the existing link path:
+  openspec workspace relink api /archive/api
+```
+
+This slice does not add a separate link-rename command. Renaming a link can be considered later if users need it, but v1 should keep the command model crisp: `link` adds a new link, and `relink` changes the local path for an existing link.
 
 ## Commands
 
@@ -50,9 +84,9 @@ Guided onboarding:
 - require at least one existing repo or folder path
 - infer link names from folder names
 - let the user add more repos or folders with a simple repeated prompt
-- register the workspace in the local workspace registry
+- record the workspace in the local workspace registry
 - run `workspace doctor`
-- print the workspace root, planning path, linked repos/folders, and next useful commands
+- print the workspace root, planning path, linked repos or folders, and next useful commands
 
 This slice should not ask for preferred agent or open the workspace with an agent. Those belong to `workspace-open-agent-context`.
 
@@ -90,7 +124,42 @@ workspaces:
         path: /repos/platform/apps/checkout
 ```
 
-List should keep deep validation for `workspace doctor`. It can still report obviously stale workspace registry entries if a registered workspace path no longer exists.
+List should keep deep validation for `workspace doctor`. It can still report obviously stale workspace registry entries if a known workspace path no longer exists. Stale registry entries are report-only in this slice: `workspace list` should not delete, rewrite, or repair registry entries, and this slice should not add a `workspace forget` command.
+
+For JSON output, list should use typed workspace objects with a structured `status` array for issues:
+
+```json
+{
+  "workspaces": [
+    {
+      "name": "platform",
+      "root": "/.../openspec/workspaces/platform",
+      "links": [
+        {
+          "name": "api",
+          "path": "/repos/api",
+          "status": []
+        }
+      ],
+      "status": []
+    },
+    {
+      "name": "old-platform",
+      "root": "/.../openspec/workspaces/old-platform",
+      "links": [],
+      "status": [
+        {
+          "severity": "error",
+          "code": "workspace_root_missing",
+          "message": "Workspace root does not exist.",
+          "fix": "Remove or repair the local registry entry."
+        }
+      ]
+    }
+  ],
+  "status": []
+}
+```
 
 ### `workspace link [name] <path>`
 
@@ -111,6 +180,8 @@ The path must exist. The command should accept:
 - monorepo folders such as packages, services, and apps
 - repos or folders without repo-local `openspec/`
 
+If the user passes a relative path, OpenSpec should resolve it against the command's current working directory before writing local state.
+
 If the path has repo-local OpenSpec state, OpenSpec can report the repo specs path in doctor output. If it does not, OpenSpec should still allow workspace planning.
 
 `workspace link` only records the link. It must not create, copy, move, initialize, or edit files in the linked repo or folder.
@@ -119,11 +190,15 @@ If the path has repo-local OpenSpec state, OpenSpec can report the repo specs pa
 
 Repair or change the local path for an existing link.
 
-This slice should keep relink focused on path repair. It should not include owner/handoff metadata; that language was too process-heavy in the POC and can be revisited later if users need contact or notes fields.
+Relink should use the same path handling as link: require an existing folder, resolve relative inputs to absolute runtime-local paths, and store the verified path.
+
+This slice should keep relink focused on path repair. It should not include owner or handoff metadata; that language was too process-heavy in the POC and can be revisited later if users need contact or notes fields.
 
 ### `workspace doctor`
 
-Explain the current workspace from the user's machine:
+Explain one selected workspace from the user's machine. If the command is run from a workspace root or subdirectory and `--workspace <name>` is not provided, doctor should use that current workspace. Otherwise it should follow the normal workspace-selection rules.
+
+Doctor should inspect:
 
 - workspace root
 - workspace planning path
@@ -133,38 +208,51 @@ Explain the current workspace from the user's machine:
 - missing local paths
 - local names that are not in shared workspace state
 - shared link names that are missing local paths
-- stale local registry entries
 - suggested fixes for each issue
+
+Doctor should not scan every known workspace in the local registry by default. Broad registry visibility belongs to `workspace list`. A future `workspace doctor --all` can be considered later if users need global workspace diagnostics.
 
 Doctor should report issues and suggested fixes. It should not repair anything automatically.
 
-Human output should be YAML-like with snake_case keys:
+Registry cleanup remains out of scope. If doctor cannot inspect the selected workspace because the registry points at a missing or invalid workspace root, it should report that selected-workspace issue through status entries and stop before inspecting links. Other stale registry entries should be surfaced by `workspace list`, not by selected-workspace doctor.
 
-```yaml
-workspace:
-  name: platform
-  root: /.../openspec/workspaces/platform
-  planning_path: /.../openspec/workspaces/platform/changes
+Human output should be readable by default: a short workspace summary, linked repo or folder rows, and a clear issues section when anything needs attention. It should not be raw JSON or a rigid YAML dump.
 
-links:
-  - name: api
-    path: /repos/api
-    path_status: exists
-    repo_specs_path: /repos/api/openspec/specs
+JSON output should follow the object/status pattern: primary data lives in typed objects, and diagnostics live in `status` arrays. A healthy object has `status: []`. Status entries should include `severity`, `code`, `message`, and optional `target` and `fix` fields.
 
-  - name: web
-    path: /old/path/web
-    path_status: missing
-    repo_specs_path: null
-    issue: linked_path_missing
-    fix: openspec workspace relink web /path/to/web
-
-summary:
-  status: needs_attention
-  issues: 1
+```json
+{
+  "workspace": {
+    "name": "platform",
+    "root": "/.../openspec/workspaces/platform",
+    "planning_path": "/.../openspec/workspaces/platform/changes",
+    "links": [
+      {
+        "name": "api",
+        "path": "/repos/api",
+        "repo_specs_path": "/repos/api/openspec/specs",
+        "status": []
+      },
+      {
+        "name": "web",
+        "path": "/old/path/web",
+        "repo_specs_path": null,
+        "status": [
+          {
+            "severity": "error",
+            "code": "linked_path_missing",
+            "message": "Linked path does not exist.",
+            "target": "links.web.path",
+            "fix": "openspec workspace relink web /path/to/web"
+          }
+        ]
+      }
+    ],
+    "status": []
+  },
+  "status": []
+}
 ```
-
-JSON output can keep the same structure using JSON syntax.
 
 ## Workspace Selection
 
@@ -189,7 +277,23 @@ If the current command needs one workspace and `--workspace <name>` is not provi
 - otherwise select the only known workspace
 - otherwise explain that no workspaces exist and suggest `openspec workspace setup`
 
+The current workspace wins even if it is not in the local workspace registry. This supports manually created or shared workspace folders. In that case commands should continue and include a non-fatal warning status:
+
+```json
+{
+  "severity": "warning",
+  "code": "workspace_not_in_local_registry",
+  "message": "This workspace is not recorded in the local workspace registry.",
+  "target": "workspace.root",
+  "fix": "Run a mutating workspace command from this workspace, such as workspace link or workspace relink, to record it locally."
+}
+```
+
+For human output, this should be a short warning rather than a blocking error. Successful mutating commands that use an unregistered current workspace, such as `workspace link` or `workspace relink`, should record the workspace name and root in the local registry after the mutation succeeds. Non-mutating commands such as `workspace doctor` should not write registry state; they should only report the warning. This slice should not add a standalone `workspace register` or `workspace join` command.
+
 In non-interactive mode, commands that need one workspace should fail when selection is ambiguous and suggest `--workspace <name>`.
+
+`--json` should also suppress prompting for commands that need one workspace. If a command would otherwise show a picker, JSON mode should fail with a structured status error and suggest `--workspace <name>`.
 
 ## Machine-Local Files
 
@@ -207,7 +311,7 @@ The local workspace registry should also be machine-local:
 <global-data-dir>/workspaces/registry.yaml
 ```
 
-Generated agent-open surfaces can be ignored by `workspace-open-agent-context` when that slice creates them.
+Generated agent launch surfaces can be ignored by `workspace-open-agent-context` when that slice creates them.
 
 ## JSON Output
 
@@ -218,6 +322,16 @@ Interactive setup does not need JSON output as its primary contract. Non-interac
 - `workspace link --json`
 - `workspace relink --json`
 - `workspace doctor --json`
+
+`workspace setup --json` should require `--no-interactive`. If a user runs `workspace setup --json` without `--no-interactive`, setup should fail clearly because an interactive wizard cannot produce clean JSON. Direct commands such as `workspace list --json`, `workspace link --json`, `workspace relink --json`, and `workspace doctor --json` do not require `--no-interactive`, but JSON mode should disable prompts and fail on ambiguous workspace selection.
+
+JSON output should use object/status structure across commands:
+
+- primary entities such as `workspace`, `workspaces`, or `link` carry the durable data
+- `status` arrays carry warnings, errors, and suggested fixes
+- status entries use stable `code` values plus human-readable `message` text
+- command-level `status` describes the whole response
+- object-level `status` describes that specific workspace or link
 
 ## POC Adjustments
 
@@ -235,8 +349,8 @@ Change:
 - do not require repo-local OpenSpec state to link a repo or folder
 - use `workspace link` instead of `workspace add-repo`
 - use `workspace relink` instead of `workspace update-repo`
-- do not save preferred agent during setup
+- do not save a preferred agent during setup
 - do not offer to open the workspace from setup
 - require setup to link at least one existing repo or folder
-- keep update behavior focused on path repair rather than owner/handoff metadata
+- keep relink behavior focused on path repair rather than owner or handoff metadata
 - do not use "working set", "code area", "entry", "alias", or "local overlay" in human-facing output

--- a/openspec/changes/workspace-create-and-register-repos/proposal.md
+++ b/openspec/changes/workspace-create-and-register-repos/proposal.md
@@ -1,5 +1,7 @@
 ## Why
 
+Note: the change id keeps the older "register repos" wording for continuity. User-facing product language in this slice is `workspace setup`, `workspace link`, `workspace relink`, and "linked repos or folders."
+
 Users start workspace work by creating a planning home and linking the repos or folders OpenSpec should know about.
 
 They should not have to create a change before OpenSpec can see the relevant repos, monorepo folders, packages, services, or apps.
@@ -38,17 +40,29 @@ openspec workspace doctor
 
 `workspace setup` is the creation path for users. It should ask for the workspace name first, create the workspace in the standard location, require at least one existing repo or folder path, infer link names from folder names, show the workspace path, and run a check at the end so the user knows what OpenSpec can see.
 
+Workspace names should be kebab-case so they are clean managed-folder names and stable registry identifiers. Link names should keep the folder-style validation from `workspace-foundation` because they are often inferred directly from existing repo or folder basenames.
+
 `workspace setup --no-interactive` is the automation path. It should require enough flags to create a useful workspace, including a workspace name and at least one link.
 
 `workspace list` shows known OpenSpec-managed workspaces from the local workspace registry, including each workspace path and linked repos or folders.
 
 `workspace link` records an existing local repo or folder path for the selected workspace. It should support a simple form that infers the link name from the folder name and an explicit-name form for conflicts or clarity. Linking does not create, copy, move, initialize, or edit files in the linked repo or folder.
 
+Linking should behave like selecting a folder from a picker: OpenSpec verifies the folder exists, resolves relative inputs to an absolute path in the current runtime, and stores that verified path instead of the raw input string.
+
+When a link name is already in use, OpenSpec should preserve the existing link and show the conflicting name with the existing path. The error should suggest choosing a different link name, or using `workspace relink <name> <path>` if the user intended to change the existing link's path.
+
 `workspace relink` lets users repair or change the local path for an existing link without recreating the workspace. It should not introduce owner or handoff metadata in this slice.
 
-`workspace doctor` explains what the current machine can resolve: the workspace root, the workspace planning path, linked repos or folders, missing paths, stale local registry entries, repo-local specs paths when present, and suggested fixes. It reports issues but does not repair them automatically.
+`workspace doctor` explains what the current machine can resolve for one selected workspace: the workspace root, the workspace planning path, linked repos or folders, missing paths, repo-local specs paths when present, and suggested fixes. It should infer the current workspace when run from inside a workspace. It reports issues but does not repair them automatically.
 
 Workspace commands should work globally. When a command needs one workspace and the user did not specify it, OpenSpec should use the local registry to show an interactive picker. In non-interactive mode, it should fail with a clear message and suggest `--workspace <name>`.
+
+When a command runs from inside a valid workspace that is not in the local registry, OpenSpec should still use that current workspace. It should surface a non-fatal warning status that the workspace is not known locally, and successful mutating commands such as `workspace link` or `workspace relink` should record that workspace in the local registry after they update workspace state.
+
+Machine-readable output should separate workspace or link objects from status entries. Status should be an array of structured issues instead of scattering fields such as `root_status`, `issue`, or `fix` through the primary object shape.
+
+Interactive behavior should be disabled whenever output must be script-safe. `--no-interactive` means no prompts, and `--json` should fail instead of prompting when selection or setup inputs are ambiguous. `workspace setup --json` should require `--no-interactive` so JSON setup always uses the explicit automation path.
 
 Planning dependency:
 
@@ -61,33 +75,35 @@ Behavior to preserve:
 - `workspace setup` was the friendly onboarding path.
 - `workspace list` made managed workspaces discoverable.
 - A direct automation path is still useful, but it should live under `workspace setup --no-interactive`.
-- Link repair is useful, but owner/handoff metadata should not carry forward in this slice.
+- Link repair is useful, but owner or handoff metadata should not carry forward in this slice.
 - `workspace doctor` was the right place to answer "what does OpenSpec know about this workspace?"
 - Shared workspace state and local paths were stored separately.
 - Setup failed cleanly when non-interactive inputs were incomplete.
-- Created workspaces ignored machine-local path state.
+- Created workspaces excluded machine-local path state from portable workspace state.
 
 Behavior to change:
 
-- The POC required registered repos to already contain repo-local `openspec/`. This should become an implementation-readiness signal, not a planning prerequisite.
+- The POC required linked repo paths to already contain repo-local `openspec/`. This should become an implementation-readiness signal, not a planning prerequisite.
 - The POC used repo-only language. This slice should use "repos or folders" for user-facing text.
 - The public command should be `workspace link`, not `workspace add-repo`.
 - The repair command should be `workspace relink`, not `workspace update-repo`.
 - Public `workspace create` should be removed for the first release. Setup should be the creation flow.
-- The POC's `setup` flow stored preferred agent/open behavior. Agent launch preferences belong to `workspace-open-agent-context`, not this slice.
+- The POC's `setup` flow stored preferred agent and open behavior. Agent launch preferences belong to `workspace-open-agent-context`, not this slice.
 - Human output should avoid implementation terms such as working set, code area, entry, alias, or local overlay.
 - `setup` should require at least one linked repo or folder so the created workspace is immediately useful.
 
 ## Non-Goals
 
 - No public `openspec workspace create` command in this first release.
-- No workspace-open agent launch behavior.
-- No preferred-agent prompts or saved agent preference.
+- No agent launch or workspace open behavior.
+- No preferred agent prompts or saved agent preference.
 - No owner or handoff metadata fields.
 - No workspace change creation or target selection.
 - No apply, verify, archive, branch, or worktree behavior.
 - No requirement that linked repos or folders have repo-local OpenSpec state.
 - No automatic repair behavior in `workspace doctor`.
+- No registry cleanup command such as `workspace forget`; stale registry entries are report-only in this slice.
+- No standalone `workspace register` or `workspace join` command; unregistered current workspaces are usable, and mutating workspace commands can record them locally.
 
 ## Capabilities
 
@@ -98,6 +114,7 @@ Behavior to change:
 ### Modified Capabilities
 
 - `cli-artifact-workflow`: Introduces workspace setup commands that happen before change creation.
+- `workspace-foundation`: Tightens workspace names to kebab-case while keeping folder-style link names.
 
 ## Impact
 
@@ -108,4 +125,4 @@ Behavior to change:
 - `openspec workspace relink`
 - `openspec workspace doctor`
 - Local workspace registry usage from `workspace-foundation`.
-- Docs and generated guidance that explain linked repos/folders as planning context, not implementation commitment.
+- Docs and generated guidance that explain linked repos or folders as planning context, not implementation commitment.

--- a/openspec/changes/workspace-create-and-register-repos/proposal.md
+++ b/openspec/changes/workspace-create-and-register-repos/proposal.md
@@ -38,13 +38,13 @@ openspec workspace relink api /new/path/to/api
 openspec workspace doctor
 ```
 
-`workspace setup` is the creation path for users. It should ask for the workspace name first, create the workspace in the standard location, require at least one existing repo or folder path, infer link names from folder names, show the workspace path, and run a check at the end so the user knows what OpenSpec can see.
+`workspace setup` is the creation path for users. It should ask for the workspace name first, create the workspace in the standard location, require at least one existing repo or folder path, infer link names from folder names, show the workspace location, and run a check at the end so the user knows what OpenSpec can see.
 
 Workspace names should be kebab-case so they are clean managed-folder names and stable registry identifiers. Link names should keep the folder-style validation from `workspace-foundation` because they are often inferred directly from existing repo or folder basenames.
 
 `workspace setup --no-interactive` is the automation path. It should require enough flags to create a useful workspace, including a workspace name and at least one link.
 
-`workspace list` shows known OpenSpec-managed workspaces from the local workspace registry, including each workspace path and linked repos or folders.
+`workspace list` shows known OpenSpec-managed workspaces from the local workspace registry, including each workspace location and linked repos or folders.
 
 `workspace link` records an existing local repo or folder path for the selected workspace. It should support a simple form that infers the link name from the folder name and an explicit-name form for conflicts or clarity. Linking does not create, copy, move, initialize, or edit files in the linked repo or folder.
 
@@ -54,7 +54,7 @@ When a link name is already in use, OpenSpec should preserve the existing link a
 
 `workspace relink` lets users repair or change the local path for an existing link without recreating the workspace. It should not introduce owner or handoff metadata in this slice.
 
-`workspace doctor` explains what the current machine can resolve for one selected workspace: the workspace root, the workspace planning path, linked repos or folders, missing paths, repo-local specs paths when present, and suggested fixes. It should infer the current workspace when run from inside a workspace. It reports issues but does not repair them automatically.
+`workspace doctor` explains what the current machine can resolve for one selected workspace: the workspace location, the workspace planning path, linked repos or folders, missing paths, repo-local specs paths when present, and suggested fixes. It should infer the current workspace when run from inside a workspace. It reports issues but does not repair them automatically.
 
 Workspace commands should work globally. When a command needs one workspace and the user did not specify it, OpenSpec should use the local registry to show an interactive picker. In non-interactive mode, it should fail with a clear message and suggest `--workspace <name>`.
 

--- a/openspec/changes/workspace-create-and-register-repos/specs/cli-artifact-workflow/spec.md
+++ b/openspec/changes/workspace-create-and-register-repos/specs/cli-artifact-workflow/spec.md
@@ -15,7 +15,7 @@ The CLI artifact workflow SHALL expose workspace setup commands before change cr
 
 #### Scenario: Keeping setup separate from agent launch
 - **WHEN** a user completes workspace setup
-- **THEN** the setup workflow SHALL leave agent launch and workspace-open behavior to a later workflow
+- **THEN** the setup workflow SHALL leave agent launch and workspace open behavior to a later workflow
 - **AND** setup SHALL not require a preferred agent choice
 
 #### Scenario: Avoiding public direct creation

--- a/openspec/changes/workspace-create-and-register-repos/specs/workspace-foundation/spec.md
+++ b/openspec/changes/workspace-create-and-register-repos/specs/workspace-foundation/spec.md
@@ -1,0 +1,35 @@
+## MODIFIED Requirements
+
+### Requirement: Stable Workspace Name
+OpenSpec SHALL use one kebab-case workspace name across workspace identity, managed storage, and the local registry.
+
+#### Scenario: Using one workspace name
+- **WHEN** OpenSpec creates or records a managed workspace
+- **THEN** the workspace name SHALL be stored in `.openspec-workspace/workspace.yaml`
+- **AND** the same name SHALL be used as the default managed workspace folder name
+- **AND** the same name SHALL be used as the local registry name
+
+#### Scenario: Rejecting invalid workspace names
+- **WHEN** OpenSpec accepts a workspace name
+- **THEN** it SHALL require kebab-case names using lowercase letters, numbers, and single hyphen separators
+- **AND** it SHALL reject empty names, dot names, names with leading or trailing hyphens, names with repeated hyphens, uppercase letters, spaces, underscores, dots, and path separators
+- **AND** setup flows SHALL report OS-level folder creation failures clearly
+
+### Requirement: Stable Link Names
+OpenSpec SHALL use stable folder-style link names to refer to repos and folders in workspace planning.
+
+#### Scenario: Referring to a repo or folder in workspace planning
+- **WHEN** workspace state or later workspace planning artifacts refer to a linked repo or folder
+- **THEN** they SHALL use the stable link name
+- **AND** the same link name SHALL remain valid even when local checkout paths differ
+
+#### Scenario: Reusing link names across machines
+- **WHEN** a workspace is used on another machine
+- **THEN** link names SHALL remain stable
+- **AND** local checkout paths MAY differ on that machine
+
+#### Scenario: Rejecting invalid link names
+- **WHEN** OpenSpec accepts a workspace link name
+- **THEN** it SHALL reject empty names, `.` or `..`, and names containing path separators
+- **AND** link names SHALL be unique within the workspace
+- **AND** link names SHALL not be required to use workspace-name kebab-case

--- a/openspec/changes/workspace-create-and-register-repos/specs/workspace-links/spec.md
+++ b/openspec/changes/workspace-create-and-register-repos/specs/workspace-links/spec.md
@@ -74,7 +74,7 @@ OpenSpec SHALL provide a guided setup flow for users starting workspace planning
 
 #### Scenario: Finishing setup
 - **WHEN** setup finishes
-- **THEN** OpenSpec SHALL show the workspace root, planning path, and linked repos or folders
+- **THEN** OpenSpec SHALL show the workspace location, planning path, and linked repos or folders
 - **AND** it SHALL check what the current machine can resolve
 
 #### Scenario: Recording created workspaces locally
@@ -94,7 +94,7 @@ OpenSpec SHALL let users see the OpenSpec-managed workspaces available on the cu
 #### Scenario: Listing workspaces
 - **WHEN** a user runs `openspec workspace list`
 - **THEN** OpenSpec SHALL list known managed workspaces
-- **AND** each workspace SHALL include the workspace name, workspace path, and linked repos or folders
+- **AND** each workspace SHALL include the workspace name, workspace location, and linked repos or folders
 
 #### Scenario: Using the short list command
 - **WHEN** a user runs `openspec workspace ls`
@@ -107,7 +107,7 @@ OpenSpec SHALL let users see the OpenSpec-managed workspaces available on the cu
 - **AND** it SHALL show the user how to create one
 
 #### Scenario: Listing stale registry entries
-- **WHEN** the local registry contains a workspace path that no longer exists
+- **WHEN** the local registry contains a workspace location that no longer exists
 - **THEN** `workspace list` SHALL report the stale workspace entry
 - **AND** it SHALL avoid silently deleting registry state
 - **AND** it SHALL avoid rewriting or repairing registry state automatically
@@ -126,12 +126,12 @@ OpenSpec SHALL let workspace commands run from outside workspace directories.
 - **AND** it SHALL fail clearly if the workspace name is unknown
 
 #### Scenario: Using the current workspace
-- **GIVEN** the command runs from a workspace root or subdirectory
+- **GIVEN** the command runs from a workspace folder or subdirectory
 - **WHEN** the command needs one workspace and no `--workspace` flag is provided
 - **THEN** OpenSpec SHALL use the current workspace
 
 #### Scenario: Using an unregistered current workspace
-- **GIVEN** the command runs from a valid workspace root or subdirectory
+- **GIVEN** the command runs from a valid workspace folder or subdirectory
 - **AND** that workspace is not recorded in the local workspace registry
 - **WHEN** the command needs one workspace and no `--workspace <name>` flag is provided
 - **THEN** OpenSpec SHALL use the current workspace
@@ -141,7 +141,7 @@ OpenSpec SHALL let workspace commands run from outside workspace directories.
 #### Scenario: Recording an unregistered current workspace after mutation
 - **GIVEN** a mutating workspace command uses a valid current workspace that is not recorded in the local workspace registry
 - **WHEN** `workspace link` or `workspace relink` succeeds
-- **THEN** OpenSpec SHALL record the workspace name and root in the local workspace registry
+- **THEN** OpenSpec SHALL record the workspace name and location in the local workspace registry
 
 #### Scenario: Doctor does not register current workspaces
 - **GIVEN** `workspace doctor` uses a valid current workspace that is not recorded in the local workspace registry
@@ -170,7 +170,7 @@ OpenSpec SHALL let workspace commands run from outside workspace directories.
 
 #### Scenario: No known workspaces for a command that needs one
 - **GIVEN** no known workspaces exist in the local registry
-- **AND** the command is not running from a workspace root or subdirectory
+- **AND** the command is not running from a workspace folder or subdirectory
 - **WHEN** `workspace link`, `workspace relink`, `workspace doctor`, or another command that needs one workspace runs without `--workspace <name>`
 - **THEN** OpenSpec SHALL fail without showing a picker regardless of interactive mode
 - **AND** it SHALL print `No known OpenSpec workspaces. Run 'openspec workspace setup' first.`
@@ -274,18 +274,18 @@ OpenSpec SHALL explain what the current machine can resolve for a workspace.
 - **AND** it SHALL not scan every known workspace in the local registry by default
 
 #### Scenario: Doctor infers the current workspace
-- **GIVEN** the command runs from a workspace root or subdirectory
+- **GIVEN** the command runs from a workspace folder or subdirectory
 - **WHEN** the user runs `openspec workspace doctor` without `--workspace <name>`
 - **THEN** OpenSpec SHALL inspect the current workspace
 
 #### Scenario: Checking a healthy workspace
 - **WHEN** a user runs `openspec workspace doctor`
-- **THEN** OpenSpec SHALL show the workspace root and workspace planning path
+- **THEN** OpenSpec SHALL show the workspace location and workspace planning path
 - **AND** it SHALL show linked repos or folders and which paths resolve on the current machine
 
-#### Scenario: Selected workspace root is missing
+#### Scenario: Selected workspace location is missing
 - **GIVEN** the selected workspace comes from the local registry
-- **AND** the registered workspace root is missing or invalid
+- **AND** the registered workspace location is missing or invalid
 - **WHEN** a user runs `openspec workspace doctor`
 - **THEN** OpenSpec SHALL report a selected-workspace status error
 - **AND** it SHALL not attempt to inspect links for that workspace

--- a/openspec/changes/workspace-create-and-register-repos/specs/workspace-links/spec.md
+++ b/openspec/changes/workspace-create-and-register-repos/specs/workspace-links/spec.md
@@ -11,7 +11,12 @@ OpenSpec SHALL provide a guided setup flow for users starting workspace planning
 #### Scenario: Asking for the workspace name first
 - **WHEN** interactive setup starts
 - **THEN** OpenSpec SHALL ask for the workspace name before asking for repos or folders
-- **AND** workspace names SHALL use lowercase letters, numbers, and hyphens
+- **AND** workspace names SHALL use kebab-case with lowercase letters, numbers, and hyphens
+
+#### Scenario: Retrying an invalid workspace name during setup
+- **WHEN** an interactive user enters an invalid workspace name
+- **THEN** OpenSpec SHALL explain that workspace names must be kebab-case
+- **AND** it SHALL let the user enter another workspace name before continuing setup
 
 #### Scenario: Linking a required first repo or folder
 - **WHEN** setup asks for repos or folders
@@ -23,15 +28,44 @@ OpenSpec SHALL provide a guided setup flow for users starting workspace planning
 - **THEN** OpenSpec SHALL infer the link name from the folder basename
 - **AND** it SHALL ask for a different name only when the inferred name conflicts
 
+#### Scenario: Handling inferred link name conflicts during setup
+- **GIVEN** setup infers a link name that already exists in the workspace
+- **WHEN** setup is interactive
+- **THEN** OpenSpec SHALL show the conflicting link name and the existing path for that link
+- **AND** it SHALL ask the user for a different link name before continuing
+
+#### Scenario: Preserving folder-style link names
+- **WHEN** OpenSpec accepts a workspace link name
+- **THEN** it SHALL allow folder-style names that are valid under the workspace foundation link-name rules
+- **AND** it SHALL not require link names to use the stricter workspace-name kebab-case rule
+
 #### Scenario: Adding multiple repos or folders during setup
 - **WHEN** setup links a repo or folder
 - **THEN** OpenSpec SHALL let the user add another repo or folder with a simple repeated prompt
 - **AND** each linked path SHALL be recorded without editing the target repo or folder
 
+#### Scenario: Storing verified absolute paths during setup
+- **WHEN** setup links a repo or folder path
+- **THEN** OpenSpec SHALL verify that the path resolves to an existing folder
+- **AND** it SHALL store an absolute runtime-local path in machine-local state instead of the raw user input
+- **AND** relative inputs SHALL be resolved against the command's current working directory
+
+#### Scenario: Preserving equals signs in setup link paths
+- **WHEN** non-interactive setup receives a `--link` value that resolves to an existing folder and contains `=`
+- **THEN** OpenSpec SHALL treat the full value as the path
+- **AND** it SHALL infer the link name from the folder basename
+- **AND** explicit `--link <name>=<path>` inputs SHALL preserve `=` characters inside `<path>`
+
 #### Scenario: Running setup with non-interactive inputs
 - **WHEN** `openspec workspace setup --no-interactive` receives a workspace name and at least one valid link
 - **THEN** OpenSpec SHALL create the workspace without prompts
 - **AND** it SHALL support repeated `--link` values
+
+#### Scenario: Non-interactive setup duplicate link names
+- **WHEN** `openspec workspace setup --no-interactive` receives two links with the same inferred or explicit name
+- **THEN** OpenSpec SHALL fail with a clear duplicate link-name error
+- **AND** the error SHALL show the conflicting link name and the first path using that name
+- **AND** it SHALL suggest using explicit `--link <name>=<path>` values with different names
 
 #### Scenario: Missing non-interactive setup inputs
 - **WHEN** `openspec workspace setup --no-interactive` is missing a workspace name or link
@@ -43,7 +77,7 @@ OpenSpec SHALL provide a guided setup flow for users starting workspace planning
 - **THEN** OpenSpec SHALL show the workspace root, planning path, and linked repos or folders
 - **AND** it SHALL check what the current machine can resolve
 
-#### Scenario: Registering created workspaces locally
+#### Scenario: Recording created workspaces locally
 - **WHEN** setup creates a workspace
 - **THEN** OpenSpec SHALL record it in the local workspace registry
 - **AND** the workspace folder SHALL remain the source of truth for workspace state
@@ -76,6 +110,12 @@ OpenSpec SHALL let users see the OpenSpec-managed workspaces available on the cu
 - **WHEN** the local registry contains a workspace path that no longer exists
 - **THEN** `workspace list` SHALL report the stale workspace entry
 - **AND** it SHALL avoid silently deleting registry state
+- **AND** it SHALL avoid rewriting or repairing registry state automatically
+
+#### Scenario: Avoiding registry cleanup commands
+- **WHEN** users inspect stale workspace registry entries in this slice
+- **THEN** OpenSpec SHALL treat stale entries as report-only diagnostics
+- **AND** it SHALL not expose a registry cleanup command such as `workspace forget`
 
 ### Requirement: Global Workspace Commands
 OpenSpec SHALL let workspace commands run from outside workspace directories.
@@ -90,6 +130,25 @@ OpenSpec SHALL let workspace commands run from outside workspace directories.
 - **WHEN** the command needs one workspace and no `--workspace` flag is provided
 - **THEN** OpenSpec SHALL use the current workspace
 
+#### Scenario: Using an unregistered current workspace
+- **GIVEN** the command runs from a valid workspace root or subdirectory
+- **AND** that workspace is not recorded in the local workspace registry
+- **WHEN** the command needs one workspace and no `--workspace <name>` flag is provided
+- **THEN** OpenSpec SHALL use the current workspace
+- **AND** it SHALL include a non-fatal warning status with code `workspace_not_in_local_registry`
+- **AND** the warning SHALL explain how the user can get the workspace recorded locally
+
+#### Scenario: Recording an unregistered current workspace after mutation
+- **GIVEN** a mutating workspace command uses a valid current workspace that is not recorded in the local workspace registry
+- **WHEN** `workspace link` or `workspace relink` succeeds
+- **THEN** OpenSpec SHALL record the workspace name and root in the local workspace registry
+
+#### Scenario: Doctor does not register current workspaces
+- **GIVEN** `workspace doctor` uses a valid current workspace that is not recorded in the local workspace registry
+- **WHEN** doctor finishes
+- **THEN** OpenSpec SHALL report the non-fatal registry warning
+- **AND** it SHALL not write registry state
+
 #### Scenario: Picking from multiple workspaces
 - **GIVEN** multiple known workspaces exist
 - **WHEN** an interactive command needs one workspace and none is specified
@@ -102,13 +161,20 @@ OpenSpec SHALL let workspace commands run from outside workspace directories.
 - **THEN** OpenSpec SHALL fail with a clear message
 - **AND** it SHALL suggest passing `--workspace <name>`
 
+#### Scenario: Ambiguous JSON workspace selection
+- **GIVEN** multiple known workspaces exist
+- **WHEN** a command running with `--json` needs one workspace and none is specified
+- **THEN** OpenSpec SHALL fail without showing a picker
+- **AND** it SHALL emit a structured status error
+- **AND** it SHALL suggest passing `--workspace <name>`
+
 #### Scenario: No known workspaces for a command that needs one
 - **GIVEN** no known workspaces exist in the local registry
 - **AND** the command is not running from a workspace root or subdirectory
 - **WHEN** `workspace link`, `workspace relink`, `workspace doctor`, or another command that needs one workspace runs without `--workspace <name>`
 - **THEN** OpenSpec SHALL fail without showing a picker regardless of interactive mode
 - **AND** it SHALL print `No known OpenSpec workspaces. Run 'openspec workspace setup' first.`
-- **AND** it SHALL explain that `--workspace <name>` can be used after at least one workspace is registered
+- **AND** it SHALL explain that `--workspace <name>` can be used after at least one workspace is known locally
 
 ### Requirement: Workspace Links
 OpenSpec SHALL let users link existing repos or folders to a workspace before creating a change.
@@ -116,17 +182,23 @@ OpenSpec SHALL let users link existing repos or folders to a workspace before cr
 #### Scenario: Linking with an inferred name
 - **WHEN** a user runs `openspec workspace link <path>`
 - **THEN** OpenSpec SHALL infer the link name from the folder basename
-- **AND** it SHALL store the local path as machine-local state
+- **AND** it SHALL store the verified absolute local path as machine-local state
 
 #### Scenario: Linking with an explicit name
 - **WHEN** a user runs `openspec workspace link <name> <path>`
 - **THEN** OpenSpec SHALL use the explicit link name for planning
-- **AND** it SHALL store the local path as machine-local state
+- **AND** it SHALL store the verified absolute local path as machine-local state
 
 #### Scenario: Requiring an existing path
 - **WHEN** a user links a repo or folder path
 - **THEN** the path SHALL exist on the current machine
 - **AND** OpenSpec SHALL reject missing paths with a clear message
+
+#### Scenario: Resolving linked paths before storage
+- **WHEN** a user links a repo or folder path
+- **THEN** OpenSpec SHALL store the verified absolute path for the current runtime
+- **AND** relative inputs SHALL be resolved against the command's current working directory
+- **AND** OpenSpec SHALL not translate paths between native Windows, WSL2, and Unix runtimes
 
 #### Scenario: Linking a monorepo folder
 - **WHEN** a user links a package, service, app, or directory inside a monorepo
@@ -143,10 +215,19 @@ OpenSpec SHALL let users link existing repos or folders to a workspace before cr
 - **THEN** OpenSpec SHALL record workspace state and local path state
 - **AND** it SHALL not create, copy, move, initialize, or edit files in the linked repo or folder
 
+#### Scenario: Blocking link when local state is invalid
+- **GIVEN** the workspace machine-local state file exists but cannot be parsed or validated
+- **WHEN** a user runs `openspec workspace link`
+- **THEN** OpenSpec SHALL fail with status code `workspace_local_state_invalid`
+- **AND** it SHALL not rewrite shared workspace state or machine-local path state
+
 #### Scenario: Reusing a link name
 - **GIVEN** a workspace already has a link with a given name
 - **WHEN** a user tries to link another path with the same name
-- **THEN** OpenSpec SHALL explain that the link name is already in use
+- **THEN** OpenSpec SHALL explain that the link name is already in use by another link
+- **AND** it SHALL show the existing link name and existing path
+- **AND** it SHALL suggest choosing a different link name
+- **AND** it SHALL suggest `workspace relink <name> <path>` when the user intended to change the existing link path
 - **AND** it SHALL preserve the existing link unless the user explicitly relinks it
 
 ### Requirement: Workspace Relinks
@@ -156,12 +237,23 @@ OpenSpec SHALL let users update existing link paths without recreating the works
 - **GIVEN** a workspace has a link
 - **WHEN** a user runs `openspec workspace relink <name> <path>`
 - **THEN** OpenSpec SHALL keep the stable link name
-- **AND** it SHALL update the machine-local path for the current machine
+- **AND** it SHALL update the machine-local path for the current machine to the verified absolute path
 
 #### Scenario: Requiring an existing relink path
 - **WHEN** a user relinks to a new path
 - **THEN** the new path SHALL exist on the current machine
 - **AND** OpenSpec SHALL reject missing paths with a clear message
+
+#### Scenario: Resolving relink paths before storage
+- **WHEN** a user relinks to a new path
+- **THEN** OpenSpec SHALL store the verified absolute path for the current runtime
+- **AND** relative inputs SHALL be resolved against the command's current working directory
+
+#### Scenario: Blocking relink when local state is invalid
+- **GIVEN** the workspace machine-local state file exists but cannot be parsed or validated
+- **WHEN** a user runs `openspec workspace relink`
+- **THEN** OpenSpec SHALL fail with status code `workspace_local_state_invalid`
+- **AND** it SHALL not rewrite machine-local path state
 
 #### Scenario: Updating an unknown link
 - **WHEN** a user tries to relink a link that does not exist
@@ -176,10 +268,27 @@ OpenSpec SHALL let users update existing link paths without recreating the works
 ### Requirement: Workspace Health Check
 OpenSpec SHALL explain what the current machine can resolve for a workspace.
 
+#### Scenario: Doctor checks one selected workspace
+- **WHEN** a user runs `openspec workspace doctor`
+- **THEN** OpenSpec SHALL inspect one selected workspace
+- **AND** it SHALL not scan every known workspace in the local registry by default
+
+#### Scenario: Doctor infers the current workspace
+- **GIVEN** the command runs from a workspace root or subdirectory
+- **WHEN** the user runs `openspec workspace doctor` without `--workspace <name>`
+- **THEN** OpenSpec SHALL inspect the current workspace
+
 #### Scenario: Checking a healthy workspace
 - **WHEN** a user runs `openspec workspace doctor`
 - **THEN** OpenSpec SHALL show the workspace root and workspace planning path
 - **AND** it SHALL show linked repos or folders and which paths resolve on the current machine
+
+#### Scenario: Selected workspace root is missing
+- **GIVEN** the selected workspace comes from the local registry
+- **AND** the registered workspace root is missing or invalid
+- **WHEN** a user runs `openspec workspace doctor`
+- **THEN** OpenSpec SHALL report a selected-workspace status error
+- **AND** it SHALL not attempt to inspect links for that workspace
 
 #### Scenario: Reporting repo-local specs paths
 - **WHEN** a linked repo or folder resolves
@@ -196,15 +305,21 @@ OpenSpec SHALL explain what the current machine can resolve for a workspace.
 - **THEN** doctor SHALL explain which link names are affected
 - **AND** it SHALL distinguish shared workspace links from local-only paths
 
+#### Scenario: Reporting invalid local state
+- **WHEN** list or doctor reads a workspace whose machine-local state file cannot be parsed or validated
+- **THEN** OpenSpec SHALL report status code `workspace_local_state_invalid`
+- **AND** it SHALL avoid treating the invalid local state as an empty path map for mutation or repair suggestions
+- **AND** it SHALL not rewrite workspace registry state or machine-local path state
+
 #### Scenario: Reporting without auto-repair
 - **WHEN** doctor finds issues
 - **THEN** it SHALL report all issues it can find
 - **AND** it SHALL not automatically repair workspace state
 
-#### Scenario: Using YAML-like human output
+#### Scenario: Using readable human output
 - **WHEN** doctor prints human output
-- **THEN** it SHALL use YAML-like structure with snake_case keys
-- **AND** it SHALL include a summary status and issue count
+- **THEN** it SHALL show a readable workspace summary, linked repos or folders, and issues when present
+- **AND** it SHALL avoid printing raw JSON or relying on a rigid YAML dump as the default human experience
 
 ### Requirement: Scriptable Workspace Setup Commands
 OpenSpec SHALL provide JSON output for direct workspace setup commands.
@@ -213,6 +328,28 @@ OpenSpec SHALL provide JSON output for direct workspace setup commands.
 - **WHEN** a user passes `--json` to direct workspace setup commands
 - **THEN** OpenSpec SHALL print machine-readable output
 - **AND** the output SHALL avoid extra human-readable text
+- **AND** the output SHALL separate primary objects from structured `status` entries
+
+#### Scenario: Setup JSON requires non-interactive setup
+- **WHEN** a user runs `openspec workspace setup --json` without `--no-interactive`
+- **THEN** OpenSpec SHALL fail clearly
+- **AND** it SHALL explain that `workspace setup --json` requires `--no-interactive`
+
+#### Scenario: JSON output disables prompts
+- **WHEN** a direct workspace setup command runs with `--json`
+- **THEN** OpenSpec SHALL avoid interactive prompts
+- **AND** it SHALL fail with structured status output when required choices are ambiguous
+
+#### Scenario: JSON status entry shape
+- **WHEN** a direct workspace setup command reports warnings, errors, or suggested fixes in JSON output
+- **THEN** each status entry SHALL include a stable `code`, a `severity`, and a human-readable `message`
+- **AND** status entries MAY include `target` and `fix` fields when a specific object field or suggested command is useful
+
+#### Scenario: JSON object status shape
+- **WHEN** a direct workspace setup command emits JSON for workspace, link, or list objects
+- **THEN** each object MAY include a `status` array for object-specific warnings or errors
+- **AND** the top-level response SHALL include a `status` array for command-level warnings or errors
+- **AND** healthy objects and healthy responses SHALL use an empty `status` array
 
 #### Scenario: Commands with JSON output
 - **WHEN** users run `workspace setup --no-interactive`, `workspace list`, `workspace link`, `workspace relink`, or `workspace doctor`

--- a/openspec/changes/workspace-create-and-register-repos/tasks.md
+++ b/openspec/changes/workspace-create-and-register-repos/tasks.md
@@ -16,7 +16,7 @@
 - [x] 2.5 Infer link names from folder basenames during setup
 - [x] 2.6 Let users add more repos or folders with a simple repeated prompt
 - [x] 2.7 Run `workspace doctor` after setup and show a readable summary
-- [x] 2.8 Print the workspace root, planning path, linked repos or folders, and next useful commands
+- [x] 2.8 Print the workspace location, planning path, linked repos or folders, and next useful commands
 - [x] 2.9 Keep preferred agent prompts and workspace opening out of this slice
 - [x] 2.10 Add `.gitignore` handling for machine-local workspace state
 - [x] 2.11 Record created workspaces in the local workspace registry
@@ -40,7 +40,7 @@
 - [x] 4.2 Add `workspace ls` as an alias for `workspace list`
 - [x] 4.3 List known OpenSpec-managed workspaces from the local workspace registry
 - [x] 4.4 Handle the no-workspaces case with a clear next step
-- [x] 4.5 Show each workspace path and linked repos or folders
+- [x] 4.5 Show each workspace location and linked repos or folders
 - [x] 4.6 Report stale registry entries with status entries without deleting, rewriting, or repairing registry state
 - [x] 4.7 Add JSON output with typed workspace objects and structured status arrays
 
@@ -85,9 +85,9 @@
 ## 8. Workspace Doctor
 
 - [x] 8.1 Implement `openspec workspace doctor` for one selected workspace only
-- [x] 8.2 Show the workspace root and workspace planning path
+- [x] 8.2 Show the workspace location and workspace planning path
 - [x] 8.3 Show linked repos or folders in readable human output with a clear issues section
-- [x] 8.4 Report missing local paths, missing filesystem paths, local-only names, and selected-workspace root problems
+- [x] 8.4 Report missing local paths, missing filesystem paths, local-only names, and selected-workspace location problems
 - [x] 8.5 Report `repo_specs_path` when repo-local `openspec/specs` exists and `null` otherwise
 - [x] 8.6 Include suggested fixes for each issue
 - [x] 8.7 Avoid automatic repair behavior
@@ -102,7 +102,7 @@
 - [x] 9.4 Avoid "working set", "code area", "entry", "alias", and "local overlay" in human-facing docs
 - [x] 9.5 Document JSON output support and the object/status response pattern for non-interactive/direct commands
 - [x] 9.6 Document global command behavior, workspace picker behavior, and `--workspace <name>`
-- [x] 9.7 Document that setup controls workspace storage and always shows the workspace path
+- [x] 9.7 Document that setup controls workspace storage and always shows the workspace location
 
 ## 10. Verification
 

--- a/openspec/changes/workspace-create-and-register-repos/tasks.md
+++ b/openspec/changes/workspace-create-and-register-repos/tasks.md
@@ -1,104 +1,121 @@
 ## 1. POC Findings And Scope
 
 - [x] 1.1 Confirm `setup`, `list`, and `doctor` belong to this slice
-- [x] 1.2 Capture that setup should not own preferred-agent or workspace-open behavior
-- [x] 1.3 Capture that linked repos/folders and monorepo paths are allowed without repo-local OpenSpec state
+- [x] 1.2 Capture that setup should not own preferred agent or workspace open behavior
+- [x] 1.3 Capture that linked repos or folders and monorepo paths are allowed without repo-local OpenSpec state
 - [x] 1.4 Capture decisions for JSON output, `ls`, `.gitignore`, non-interactive setup, required first link, and relink behavior
 - [x] 1.5 Capture that public `workspace create` is out of scope for the first release
 - [x] 1.6 Capture `link`/`relink` as the user-facing commands
 
 ## 2. Workspace Setup
 
-- [ ] 2.1 Implement `openspec workspace setup` as the only public creation path
-- [ ] 2.2 Prompt for workspace name first in interactive setup
-- [ ] 2.3 Validate workspace names with lowercase letters, numbers, and hyphens
-- [ ] 2.4 Require at least one existing repo or folder path during setup
-- [ ] 2.5 Infer link names from folder basenames during setup
-- [ ] 2.6 Let users add more repos/folders with a simple repeated prompt
-- [ ] 2.7 Run `workspace doctor` after setup and show a readable summary
-- [ ] 2.8 Print the workspace root, planning path, linked repos/folders, and next useful commands
-- [ ] 2.9 Keep preferred-agent prompts and workspace opening out of this slice
-- [ ] 2.10 Add `.gitignore` handling for machine-local workspace state
-- [ ] 2.11 Register created workspaces in the local workspace registry
-- [ ] 2.12 Add tests for native Windows/PowerShell and WSL2-compatible path construction where practical
+- [x] 2.1 Implement `openspec workspace setup` as the only public creation path
+- [x] 2.2 Prompt for workspace name first in interactive setup
+- [x] 2.3 Validate workspace names as kebab-case and let interactive users retry invalid names
+- [x] 2.4 Require at least one existing repo or folder path during setup
+- [x] 2.5 Infer link names from folder basenames during setup
+- [x] 2.6 Let users add more repos or folders with a simple repeated prompt
+- [x] 2.7 Run `workspace doctor` after setup and show a readable summary
+- [x] 2.8 Print the workspace root, planning path, linked repos or folders, and next useful commands
+- [x] 2.9 Keep preferred agent prompts and workspace opening out of this slice
+- [x] 2.10 Add `.gitignore` handling for machine-local workspace state
+- [x] 2.11 Record created workspaces in the local workspace registry
+- [x] 2.12 Add tests for native Windows/PowerShell and WSL2-compatible path construction where practical
 
 ## 3. Non-Interactive Setup
 
-- [ ] 3.1 Add `workspace setup --no-interactive --name <name> --link <path>` support
-- [ ] 3.2 Support repeated `--link` values
-- [ ] 3.3 Support `--link <path>` with inferred names
-- [ ] 3.4 Support `--link <name>=<path>` with explicit names
-- [ ] 3.5 Fail cleanly when non-interactive setup is missing a name or at least one link
-- [ ] 3.6 Add `--json` output for non-interactive setup
-- [ ] 3.7 Preserve the interactive setup UX when `--no-interactive` is not passed
+- [x] 3.1 Add `workspace setup --no-interactive --name <name> --link <path>` support
+- [x] 3.2 Support repeated `--link` values
+- [x] 3.3 Support `--link <path>` with inferred names
+- [x] 3.4 Support `--link <name>=<path>` with explicit names
+- [x] 3.5 Fail cleanly when non-interactive setup is missing a name or at least one link
+- [x] 3.6 Resolve relative link paths to verified absolute runtime-local paths before storing local state
+- [x] 3.7 Require `--no-interactive` when `workspace setup --json` is used
+- [x] 3.8 Add `--json` output for non-interactive setup
+- [x] 3.9 Preserve the interactive setup UX when `--no-interactive` is not passed
 
 ## 4. Workspace Listing
 
-- [ ] 4.1 Implement `openspec workspace list`
-- [ ] 4.2 Add `workspace ls` as an alias for `workspace list`
-- [ ] 4.3 List known OpenSpec-managed workspaces from the local workspace registry
-- [ ] 4.4 Handle the no-workspaces case with a clear next step
-- [ ] 4.5 Show each workspace path and linked repos/folders
-- [ ] 4.6 Report stale registry entries without doing deep doctor validation
-- [ ] 4.7 Add JSON output for scripts
+- [x] 4.1 Implement `openspec workspace list`
+- [x] 4.2 Add `workspace ls` as an alias for `workspace list`
+- [x] 4.3 List known OpenSpec-managed workspaces from the local workspace registry
+- [x] 4.4 Handle the no-workspaces case with a clear next step
+- [x] 4.5 Show each workspace path and linked repos or folders
+- [x] 4.6 Report stale registry entries with status entries without deleting, rewriting, or repairing registry state
+- [x] 4.7 Add JSON output with typed workspace objects and structured status arrays
 
 ## 5. Workspace Selection
 
-- [ ] 5.1 Make workspace commands work from outside workspace directories
-- [ ] 5.2 Add `--workspace <name>` to commands that need one workspace
-- [ ] 5.3 Use the current workspace when running from inside a workspace
-- [ ] 5.4 Show an interactive picker when multiple known workspaces exist and no workspace is specified
-- [ ] 5.5 Select the only known workspace automatically when there is exactly one
-- [ ] 5.6 Fail clearly in non-interactive mode when workspace selection is ambiguous
-- [ ] 5.7 Use the local workspace registry for workspace lookup
+- [x] 5.1 Make workspace commands work from outside workspace directories
+- [x] 5.2 Add `--workspace <name>` to commands that need one workspace
+- [x] 5.3 Use the current workspace when running from inside a workspace
+- [x] 5.4 Use unregistered current workspaces with a non-fatal warning status
+- [x] 5.5 Record unregistered current workspaces in the local registry after successful `workspace link` or `workspace relink`
+- [x] 5.6 Keep `workspace doctor` diagnostic-only when the current workspace is unregistered
+- [x] 5.7 Show an interactive picker when multiple known workspaces exist and no workspace is specified
+- [x] 5.8 Select the only known workspace automatically when there is exactly one
+- [x] 5.9 Fail clearly in non-interactive mode when workspace selection is ambiguous
+- [x] 5.10 Fail with structured status output instead of prompting when `--json` workspace selection is ambiguous
+- [x] 5.11 Use the local workspace registry for workspace lookup
 
 ## 6. Workspace Links
 
-- [ ] 6.1 Implement `openspec workspace link <path>` with inferred link names
-- [ ] 6.2 Implement `openspec workspace link <name> <path>` with explicit link names
-- [ ] 6.3 Accept full repo roots and monorepo package/service/app folder paths
-- [ ] 6.4 Require linked paths to exist
-- [ ] 6.5 Allow links without repo-local `openspec/`
-- [ ] 6.6 Store stable link names in shared state and local paths in machine-local state
-- [ ] 6.7 Detect duplicate link names with a clear error or interactive rename prompt
-- [ ] 6.8 Preserve native Windows and WSL2-style paths as local path values
-- [ ] 6.9 Ensure link only records state and does not edit the linked repo/folder
-- [ ] 6.10 Add `--json` output for `workspace link`
+- [x] 6.1 Implement `openspec workspace link <path>` with inferred link names
+- [x] 6.2 Implement `openspec workspace link <name> <path>` with explicit link names
+- [x] 6.3 Accept full repo roots and monorepo package/service/app folder paths
+- [x] 6.4 Require linked paths to exist
+- [x] 6.5 Allow links without repo-local `openspec/`
+- [x] 6.6 Store stable link names in shared state and local paths in machine-local state
+- [x] 6.7 Keep link names folder-style, and detect duplicate link names with a specific error that shows the existing link path and suggests a different name or `workspace relink`
+- [x] 6.8 Resolve relative linked paths to verified absolute runtime-local paths before storing local state
+- [x] 6.9 Preserve native Windows and WSL2-style paths as local path values without cross-runtime translation
+- [x] 6.10 Ensure link only records state and does not edit the linked repo/folder
+- [x] 6.11 Add `--json` output for `workspace link`
 
 ## 7. Workspace Relinks
 
-- [ ] 7.1 Implement `openspec workspace relink <name> <path>`
-- [ ] 7.2 Let users repair or change the local path for an existing link
-- [ ] 7.3 Require relink paths to exist
-- [ ] 7.4 Keep owner/handoff metadata out of this slice
-- [ ] 7.5 Add `--json` output for `workspace relink`
-- [ ] 7.6 Return a clear error for unknown link names
+- [x] 7.1 Implement `openspec workspace relink <name> <path>`
+- [x] 7.2 Let users repair or change the local path for an existing link
+- [x] 7.3 Require relink paths to exist
+- [x] 7.4 Resolve relative relink paths to verified absolute runtime-local paths before storing local state
+- [x] 7.5 Keep owner or handoff metadata out of this slice
+- [x] 7.6 Add `--json` output for `workspace relink`
+- [x] 7.7 Return a clear error for unknown link names
 
 ## 8. Workspace Doctor
 
-- [ ] 8.1 Implement `openspec workspace doctor`
-- [ ] 8.2 Show the workspace root and workspace planning path
-- [ ] 8.3 Show linked repos/folders in YAML-like human output with snake_case keys
-- [ ] 8.4 Report missing local paths, missing filesystem paths, local-only names, and stale registry entries
-- [ ] 8.5 Report `repo_specs_path` when repo-local `openspec/specs` exists and `null` otherwise
-- [ ] 8.6 Include suggested fixes for each issue
-- [ ] 8.7 Avoid automatic repair behavior
-- [ ] 8.8 Add JSON output for scripts
+- [x] 8.1 Implement `openspec workspace doctor` for one selected workspace only
+- [x] 8.2 Show the workspace root and workspace planning path
+- [x] 8.3 Show linked repos or folders in readable human output with a clear issues section
+- [x] 8.4 Report missing local paths, missing filesystem paths, local-only names, and selected-workspace root problems
+- [x] 8.5 Report `repo_specs_path` when repo-local `openspec/specs` exists and `null` otherwise
+- [x] 8.6 Include suggested fixes for each issue
+- [x] 8.7 Avoid automatic repair behavior
+- [x] 8.8 Add JSON output with typed workspace/link objects and structured status arrays
+- [x] 8.9 Keep stale registry cleanup commands such as `workspace forget` out of this slice
 
 ## 9. Documentation And Guidance
 
-- [ ] 9.1 Document setup/list/link/relink/doctor in user-facing product language
-- [ ] 9.2 Document linked repos/folders and large-monorepo folder links
-- [ ] 9.3 Document that workspace visibility is not change commitment
-- [ ] 9.4 Avoid "working set", "code area", "entry", "alias", and "local overlay" in human-facing docs
-- [ ] 9.5 Document JSON output support for non-interactive/direct commands
-- [ ] 9.6 Document global command behavior, workspace picker behavior, and `--workspace <name>`
-- [ ] 9.7 Document that setup controls workspace storage and always shows the workspace path
+- [x] 9.1 Document setup/list/link/relink/doctor in user-facing product language
+- [x] 9.2 Document linked repos or folders and large-monorepo folder links
+- [x] 9.3 Document that workspace visibility is not change commitment
+- [x] 9.4 Avoid "working set", "code area", "entry", "alias", and "local overlay" in human-facing docs
+- [x] 9.5 Document JSON output support and the object/status response pattern for non-interactive/direct commands
+- [x] 9.6 Document global command behavior, workspace picker behavior, and `--workspace <name>`
+- [x] 9.7 Document that setup controls workspace storage and always shows the workspace path
 
 ## 10. Verification
 
-- [ ] 10.1 Run `openspec validate workspace-create-and-register-repos --strict`
-- [ ] 10.2 Run targeted command tests for workspace setup/list/link/relink/doctor
-- [ ] 10.3 Run targeted tests for links without repo-local OpenSpec and monorepo folder links
-- [ ] 10.4 Run targeted tests for JSON output, `ls`, `.gitignore`, non-interactive setup, and required first link
-- [ ] 10.5 Run targeted tests for global command selection and local workspace registry behavior
+- [x] 10.1 Run `openspec validate workspace-create-and-register-repos --strict`
+- [x] 10.2 Run targeted command tests for workspace setup/list/link/relink/doctor, including doctor inferring the current workspace
+- [x] 10.3 Run targeted tests for links without repo-local OpenSpec and monorepo folder links
+- [x] 10.4 Run targeted tests for JSON output, `ls`, `.gitignore`, non-interactive setup, required first link, verified absolute path storage, and JSON/no-interactive prompt suppression
+- [x] 10.5 Run targeted tests for global command selection, unregistered current workspace handling, and local workspace registry behavior
+
+## 11. Review Fixes
+
+- [x] 11.1 Preserve `=` characters in inferred setup link paths while keeping explicit `--link <name>=<path>` support
+- [x] 11.2 Add reusable core helpers for optional local state reads and setup link input parsing
+- [x] 11.3 Fail `workspace link` and `workspace relink` before mutation when local state is invalid
+- [x] 11.4 Report invalid local state distinctly in `workspace list` and `workspace doctor`
+- [x] 11.5 Add regression tests for equals-sign setup paths and malformed local state behavior

--- a/openspec/changes/workspace-open-agent-context/proposal.md
+++ b/openspec/changes/workspace-open-agent-context/proposal.md
@@ -1,6 +1,6 @@
 ## Why
 
-After a user creates a workspace and registers repos, they need to open that workspace with an agent and have the agent understand the working set immediately.
+After a user creates a workspace and links repos or folders, they need to open that workspace with an agent and have the agent understand the working set immediately.
 
 The user should not need to explain where every repo lives, which aliases matter, or whether they are currently planning versus implementing. The workspace should provide that context.
 
@@ -10,14 +10,16 @@ Add the workspace-open experience:
 
 ```text
 Open this workspace with my agent.
-The agent sees the workspace location, registered repos, current changes, and relevant instructions.
+The agent sees the workspace location, linked repos or folders, current changes, and relevant instructions.
 ```
+
+Links are the planning context. The local registry is only a workspace-discovery index for finding known workspaces on the current machine.
 
 The launch context should separate stable guidance from dynamic runtime scope:
 
 - stable behavior belongs in workspace-level agent guidance where possible
 - dynamic scope belongs in the launch prompt or equivalent runtime context
-- registered repos should be visible even when no change is active
+- linked repos or folders should be visible even when no change is active
 - change-scoped sessions should include the selected change and target repo context
 
 Planning dependency:
@@ -28,11 +30,11 @@ Planning dependency:
 
 ### New Capabilities
 
-- `workspace-agent-context`: Opens a workspace session with enough dynamic context for an agent to reason across registered repos.
+- `workspace-agent-context`: Opens a workspace session with enough dynamic context for an agent to reason across linked repos or folders.
 
 ### Modified Capabilities
 
-- `context-injection`: Extends context construction to include workspace location, repo registry, active workspace changes, and selected change scope.
+- `context-injection`: Extends context construction to include workspace location, workspace links, active workspace changes, and selected change scope.
 
 ## Impact
 

--- a/openspec/changes/workspace-open-agent-context/proposal.md
+++ b/openspec/changes/workspace-open-agent-context/proposal.md
@@ -10,7 +10,7 @@ Add the workspace-open experience:
 
 ```text
 Open this workspace with my agent.
-The agent sees the workspace root, registered repos, current changes, and relevant instructions.
+The agent sees the workspace location, registered repos, current changes, and relevant instructions.
 ```
 
 The launch context should separate stable guidance from dynamic runtime scope:
@@ -32,7 +32,7 @@ Planning dependency:
 
 ### Modified Capabilities
 
-- `context-injection`: Extends context construction to include workspace root, repo registry, active workspace changes, and selected change scope.
+- `context-injection`: Extends context construction to include workspace location, repo registry, active workspace changes, and selected change scope.
 
 ## Impact
 

--- a/openspec/changes/workspace-reimplementation-roadmap/POC_REFERENCE_GUIDE.md
+++ b/openspec/changes/workspace-reimplementation-roadmap/POC_REFERENCE_GUIDE.md
@@ -115,7 +115,7 @@ Put durable findings in the relevant OpenSpec proposal or design artifact. Do no
 
 Focus on:
 
-- workspace root shape
+- workspace folder shape
 - metadata directory naming
 - local versus committed state
 - stable workspace name semantics

--- a/openspec/changes/workspace-reimplementation-roadmap/README.md
+++ b/openspec/changes/workspace-reimplementation-roadmap/README.md
@@ -44,7 +44,7 @@ OpenSpec currently discovers active changes as immediate directories under `open
 
 `workspace-create-and-register-repos` creates the workspace and makes linked repos or folders visible before a change exists. Linked items may be full repos, monorepo modules, or planning-only folders. This preserves the product rule that workspace visibility is not change commitment.
 
-`workspace-open-agent-context` gives the agent the workspace root, linked repos or folders, active changes, and selected change scope.
+`workspace-open-agent-context` gives the agent the workspace location, linked repos or folders, active changes, and selected change scope.
 
 `workspace-change-planning` creates the workspace-level planning commitment and identifies target repo slices.
 

--- a/openspec/changes/workspace-reimplementation-roadmap/README.md
+++ b/openspec/changes/workspace-reimplementation-roadmap/README.md
@@ -42,7 +42,7 @@ OpenSpec currently discovers active changes as immediate directories under `open
 
 `workspace-foundation` establishes the storage, root detection, and naming model. Every later slice should build on that model instead of redefining workspace metadata.
 
-`workspace-create-and-register-repos` creates the workspace and makes linked repos or folders visible before a change exists. Linked items may be full repos, monorepo modules, or planning-only code areas. This preserves the product rule that workspace visibility is not change commitment.
+`workspace-create-and-register-repos` creates the workspace and makes linked repos or folders visible before a change exists. Linked items may be full repos, monorepo modules, or planning-only folders. This preserves the product rule that workspace visibility is not change commitment.
 
 `workspace-open-agent-context` gives the agent the workspace root, linked repos or folders, active changes, and selected change scope.
 

--- a/openspec/explorations/workspace-architecture.md
+++ b/openspec/explorations/workspace-architecture.md
@@ -77,7 +77,7 @@ We researched how similar tools handle config layering:
 | **ESLint (flat)** | Single root config | *Deliberately killed cascading* - "complexity exploded exponentially" |
 | **Turborepo** | Root + package extends | Per-package `turbo.json` with `extends: ["//"]` for overrides |
 | **Nx** | Integrated vs Package-based | Two modes - shared root OR per-package. Hard to migrate from integrated. |
-| **pnpm** | Workspace root defines scope | `pnpm-workspace.yaml` at root. Dependencies can be shared or per-package |
+| **pnpm** | Workspace file defines package scope | `pnpm-workspace.yaml` at the package-set root. Dependencies can be shared or per-package |
 | **Claude Code** | Global + Project | `~/.claude/` for global, `.claude/` per-project. No workspace tracking. |
 | **Kiro** | Distributed per-root | Each folder has `.kiro/`. Aggregated display, no inheritance. |
 

--- a/openspec/specs/openspec-conventions/spec.md
+++ b/openspec/specs/openspec-conventions/spec.md
@@ -265,7 +265,7 @@ OpenSpec conventions SHALL describe coordination workspaces in user-facing produ
 
 #### Scenario: Distinguishing workspace and repo-local surfaces
 - **WHEN** OpenSpec documentation compares workspace and repo-local flows
-- **THEN** it SHALL explain that workspace planning lives in the workspace root
+- **THEN** it SHALL explain that workspace planning lives in the workspace folder
 - **AND** it SHALL explain that repo-local specs and changes continue to live under each repo's `openspec/` directory
 
 #### Scenario: Sequencing the workspace roadmap

--- a/openspec/specs/workspace-foundation/spec.md
+++ b/openspec/specs/workspace-foundation/spec.md
@@ -15,10 +15,10 @@ OpenSpec SHALL give users and agents a recognizable workspace home for cross-rep
 - **AND** the workspace SHALL be able to hold multiple changes over time
 
 #### Scenario: Working from inside a workspace
-- **GIVEN** a user runs OpenSpec from a workspace root or one of its subdirectories
+- **GIVEN** a user runs OpenSpec from a workspace folder or one of its subdirectories
 - **WHEN** OpenSpec resolves the current workspace
-- **THEN** it SHALL identify the workspace root
-- **AND** it SHALL use the workspace root's `changes/` directory as the workspace planning area
+- **THEN** it SHALL identify the workspace location
+- **AND** it SHALL use the workspace location's `changes/` directory as the workspace planning area
 
 #### Scenario: Avoiding accidental workspace mode
 - **GIVEN** a directory has `changes/` but is not an OpenSpec workspace
@@ -51,12 +51,12 @@ OpenSpec SHALL distinguish a coordination workspace from a repo-local OpenSpec p
 - **GIVEN** a repo-local OpenSpec project uses `openspec/`
 - **WHEN** that repo is linked to a workspace
 - **THEN** OpenSpec SHALL continue treating `openspec/` as that repo's local OpenSpec directory
-- **AND** workspace planning SHALL remain anchored in the workspace root
+- **AND** workspace planning SHALL remain anchored in the workspace folder
 
-#### Scenario: Avoiding repo-local initialization in the workspace root
-- **WHEN** a user is working from an OpenSpec workspace root
-- **THEN** OpenSpec SHALL treat that root as a workspace coordination surface
-- **AND** users SHALL not need to initialize a repo-local `openspec/` project inside the workspace root
+#### Scenario: Avoiding repo-local initialization in the workspace folder
+- **WHEN** a user is working from an OpenSpec workspace folder
+- **THEN** OpenSpec SHALL treat that folder as a workspace coordination surface
+- **AND** users SHALL not need to initialize a repo-local `openspec/` project inside the workspace folder
 
 ### Requirement: Safe Workspace Sharing
 OpenSpec SHALL keep shared workspace information separate from local machine paths.
@@ -72,7 +72,7 @@ OpenSpec SHALL keep shared workspace information separate from local machine pat
 - **AND** another machine MAY map the same link names to different local paths
 
 #### Scenario: Preserving runtime-local paths
-- **WHEN** OpenSpec reads or writes local workspace paths
+- **WHEN** OpenSpec reads or writes machine-local path state
 - **THEN** it SHALL preserve path strings valid for the current runtime
 - **AND** it SHALL support native Windows paths and WSL2/Linux paths as local state values
 
@@ -110,13 +110,13 @@ OpenSpec SHALL use a standard location for OpenSpec-managed workspaces without a
 - **THEN** it SHALL use the resolved workspace location by default
 - **AND** users SHALL be able to follow the normal workspace flow without choosing a storage location
 
-#### Scenario: Showing the workspace path
+#### Scenario: Showing the workspace location
 - **WHEN** OpenSpec creates a workspace in the standard workspace location
-- **THEN** it SHALL report the workspace path to the user
+- **THEN** it SHALL report the workspace location to the user
 - **AND** it SHALL not hide where planning files were created
 
 #### Scenario: Staying in the current runtime
-- **WHEN** OpenSpec resolves workspace paths or local repo paths
+- **WHEN** OpenSpec resolves workspace locations or local repo paths
 - **THEN** it SHALL interpret paths for the runtime running OpenSpec
 - **AND** Windows, UNC WSL, and WSL mount paths SHALL remain explicit user-provided paths
 
@@ -125,13 +125,13 @@ OpenSpec SHALL keep a lightweight local registry of known workspaces on the curr
 
 #### Scenario: Recording known workspaces
 - **WHEN** OpenSpec creates or learns about a managed workspace
-- **THEN** it SHALL be able to record the workspace name and path in a local registry
+- **THEN** it SHALL be able to record the workspace name and location in a local registry
 - **AND** the registry SHALL be machine-local state
 
 #### Scenario: Keeping workspace folders authoritative
 - **WHEN** OpenSpec reads workspace details
 - **THEN** each workspace folder's `.openspec-workspace/workspace.yaml` SHALL remain the source of truth for that workspace
-- **AND** the local registry SHALL act only as an index of known workspace paths
+- **AND** the local registry SHALL act only as an index of known workspace locations
 
 #### Scenario: Finding workspaces from anywhere
 - **WHEN** a later workspace command runs outside a workspace directory

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -16,6 +16,7 @@ import { CompletionCommand } from '../commands/completion.js';
 import { FeedbackCommand } from '../commands/feedback.js';
 import { registerConfigCommand } from '../commands/config.js';
 import { registerSchemaCommand } from '../commands/schema.js';
+import { registerWorkspaceCommand } from '../commands/workspace.js';
 import {
   statusCommand,
   instructionsCommand,
@@ -285,6 +286,7 @@ program
 registerSpecCommand(program);
 registerConfigCommand(program);
 registerSchemaCommand(program);
+registerWorkspaceCommand(program);
 
 // Top-level validate command
 program

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -279,6 +279,13 @@ export class CompletionCommand {
           }
           break;
         }
+        case 'schemas': {
+          const schemaNames = await this.completionProvider.getSchemaNames();
+          for (const name of schemaNames) {
+            console.log(`${name}\tschema`);
+          }
+          break;
+        }
         case 'archived-changes': {
           const archivedIds = await getArchivedChangeIds();
           for (const id of archivedIds) {

--- a/src/commands/workspace.ts
+++ b/src/commands/workspace.ts
@@ -104,7 +104,11 @@ async function promptSetupLinks(): Promise<Record<string, string>> {
     );
     let linkName = inferLinkName(resolvedPath);
 
-    validateLinkNameForCommand(linkName);
+    try {
+      validateLinkNameForCommand(linkName);
+    } catch {
+      linkName = await promptLinkName(links);
+    }
 
     if (links[linkName]) {
       console.log(`Link name '${linkName}' is already linked to ${links[linkName]}.`);
@@ -306,7 +310,6 @@ class WorkspaceCommand {
               console.log(`    Fix: ${status.fix}`);
             }
           }
-          continue;
         }
         console.log('    Linked repos or folders:');
         if (workspace.links.length === 0) {

--- a/src/commands/workspace.ts
+++ b/src/commands/workspace.ts
@@ -1,0 +1,498 @@
+import { Command } from 'commander';
+import * as nodeFs from 'node:fs';
+import * as path from 'node:path';
+
+import { listWorkspaceRegistryEntries } from '../core/workspace/index.js';
+import { isInteractive, resolveNoInteractive } from '../utils/interactive.js';
+import {
+  addWorkspaceLink,
+  createManagedWorkspace,
+  inferLinkName,
+  loadWorkspaceForDoctor,
+  loadWorkspaceForList,
+  parseSetupLinks,
+  readRegistry,
+  resolveExistingDirectory,
+  updateWorkspaceLink,
+  validateLinkNameForCommand,
+  validateWorkspaceNameForSetup,
+} from './workspace/operations.js';
+import { selectWorkspaceForCommand } from './workspace/selection.js';
+import {
+  WorkspaceCliError,
+  WorkspaceLinkMutationPayload,
+  WorkspaceLinkOptions,
+  WorkspaceListOptions,
+  WorkspaceOutput,
+  WorkspaceSetupOptions,
+  WorkspaceStatus,
+  appendStatus,
+  asErrorMessage,
+  asStatus,
+} from './workspace/types.js';
+
+function printJson(payload: unknown): void {
+  console.log(JSON.stringify(payload, null, 2));
+}
+
+async function promptWorkspaceName(initialName?: string): Promise<string> {
+  if (initialName) {
+    return validateWorkspaceNameForSetup(initialName);
+  }
+
+  const { input } = await import('@inquirer/prompts');
+
+  return input({
+    message: 'Workspace name:',
+    validate(value: string) {
+      try {
+        validateWorkspaceNameForSetup(value);
+        return true;
+      } catch {
+        return 'Workspace names must be kebab-case with lowercase letters, numbers, and single hyphen separators.';
+      }
+    },
+  });
+}
+
+async function promptExistingPath(message: string): Promise<string> {
+  const { input } = await import('@inquirer/prompts');
+
+  const pathInput = await input({
+    message,
+    validate(value: string) {
+      const resolvedPath = path.isAbsolute(value)
+        ? path.resolve(value)
+        : path.resolve(process.cwd(), value);
+      return nodeFs.existsSync(resolvedPath) && nodeFs.statSync(resolvedPath).isDirectory()
+        ? true
+        : 'Enter an existing repo or folder path.';
+    },
+  });
+
+  return resolveExistingDirectory(pathInput);
+}
+
+async function promptLinkName(existingLinks: Record<string, string>): Promise<string> {
+  const { input } = await import('@inquirer/prompts');
+
+  return input({
+    message: 'Link name:',
+    validate(value: string) {
+      try {
+        validateLinkNameForCommand(value);
+      } catch (error) {
+        return asErrorMessage(error);
+      }
+
+      if (existingLinks[value]) {
+        return `Link name '${value}' is already linked to ${existingLinks[value]}.`;
+      }
+
+      return true;
+    },
+  });
+}
+
+async function promptSetupLinks(): Promise<Record<string, string>> {
+  const { confirm } = await import('@inquirer/prompts');
+  const links: Record<string, string> = {};
+
+  while (true) {
+    const resolvedPath = await promptExistingPath(
+      Object.keys(links).length === 0 ? 'Repo or folder path:' : 'Another repo or folder path:'
+    );
+    let linkName = inferLinkName(resolvedPath);
+
+    validateLinkNameForCommand(linkName);
+
+    if (links[linkName]) {
+      console.log(`Link name '${linkName}' is already linked to ${links[linkName]}.`);
+      linkName = await promptLinkName(links);
+    }
+
+    links[linkName] = resolvedPath;
+
+    const addAnother = await confirm({
+      message: 'Add another repo or folder?',
+      default: false,
+    });
+
+    if (!addAnother) {
+      return links;
+    }
+  }
+}
+
+function printStatusLines(statuses: WorkspaceStatus[]): void {
+  for (const status of statuses) {
+    const label = status.severity === 'warning' ? 'Warning' : 'Issue';
+    console.log(`${label}: ${status.message}`);
+    if (status.fix) {
+      console.log(`Fix: ${status.fix}`);
+    }
+  }
+}
+
+function printLinksHuman(links: WorkspaceOutput['links']): void {
+  if (links.length === 0) {
+    console.log('  (no linked repos or folders)');
+    return;
+  }
+
+  for (const link of links) {
+    const suffix = link.status.some((status) => status.severity === 'error') ? ' [issue]' : '';
+    console.log(`  ${link.name} -> ${link.path ?? '(no local path recorded)'}${suffix}`);
+    if (link.repo_specs_path) {
+      console.log(`    repo specs: ${link.repo_specs_path}`);
+    }
+  }
+}
+
+function printDoctorHuman(result: { workspace: WorkspaceOutput; status: WorkspaceStatus[] }): void {
+  console.log(`Workspace: ${result.workspace.name}`);
+  console.log(`Root: ${result.workspace.root}`);
+  console.log(`Planning path: ${result.workspace.planning_path}`);
+  console.log('');
+  printStatusLines(result.status);
+  if (result.status.length > 0) {
+    console.log('');
+  }
+  console.log('Linked repos or folders:');
+  printLinksHuman(result.workspace.links);
+
+  const issues = [
+    ...result.workspace.status,
+    ...result.workspace.links.flatMap((link) => link.status),
+  ];
+
+  if (issues.length === 0) {
+    console.log('');
+    console.log('No workspace issues found.');
+    return;
+  }
+
+  console.log('');
+  console.log('Issues:');
+  for (const issue of issues) {
+    console.log(`  - ${issue.message}`);
+    if (issue.target) {
+      console.log(`    Target: ${issue.target}`);
+    }
+    if (issue.fix) {
+      console.log(`    Fix: ${issue.fix}`);
+    }
+  }
+}
+
+function printWorkspaceSummaryHuman(workspace: WorkspaceOutput): void {
+  console.log(`Workspace: ${workspace.name}`);
+  console.log(`Root: ${workspace.root}`);
+  console.log(`Planning path: ${workspace.planning_path}`);
+  console.log('');
+  console.log('Linked repos or folders:');
+  printLinksHuman(workspace.links);
+}
+
+function printLinkMutationHuman(
+  heading: string,
+  payload: WorkspaceLinkMutationPayload
+): void {
+  printStatusLines(payload.status);
+  console.log(heading);
+  console.log(`  ${payload.link.name} -> ${payload.link.path}`);
+  console.log(`Workspace: ${payload.workspace.name}`);
+}
+
+class WorkspaceCommand {
+  async setup(options: WorkspaceSetupOptions = {}): Promise<void> {
+    try {
+      const noInteractive = resolveNoInteractive(options);
+
+      if (options.json && !noInteractive) {
+        throw new WorkspaceCliError(
+          'workspace setup --json requires --no-interactive.',
+          'setup_json_requires_no_interactive',
+          {
+            fix: 'openspec workspace setup --no-interactive --json --name <name> --link <path>',
+          }
+        );
+      }
+
+      const interactive = !noInteractive && isInteractive(options);
+      if (!interactive && (!options.name || (options.link ?? []).length === 0)) {
+        throw new WorkspaceCliError(
+          'workspace setup --no-interactive requires --name <name> and at least one --link <path>.',
+          'missing_setup_inputs',
+          {
+            fix: 'openspec workspace setup --no-interactive --name platform --link /path/to/repo',
+          }
+        );
+      }
+
+      const workspaceName = interactive
+        ? await promptWorkspaceName(options.name)
+        : validateWorkspaceNameForSetup(options.name ?? '');
+      const links = interactive ? await promptSetupLinks() : await parseSetupLinks(options.link);
+
+      if (Object.keys(links).length === 0) {
+        throw new WorkspaceCliError(
+          'workspace setup --no-interactive requires --name <name> and at least one --link <path>.',
+          'missing_setup_inputs',
+          {
+            fix: 'openspec workspace setup --no-interactive --name platform --link /path/to/repo',
+          }
+        );
+      }
+
+      const workspace = await createManagedWorkspace(workspaceName, links);
+      const doctorResult = await loadWorkspaceForDoctor({
+        name: workspace.name,
+        root: workspace.root,
+        status: [],
+        unregisteredCurrentWorkspace: false,
+      });
+
+      if (options.json) {
+        printJson({
+          workspace: doctorResult.workspace,
+          status: doctorResult.status,
+        });
+        return;
+      }
+
+      console.log('Workspace setup complete');
+      console.log('');
+      printWorkspaceSummaryHuman(workspace);
+      console.log('');
+      console.log('Workspace check:');
+      printDoctorHuman(doctorResult);
+      console.log('');
+      console.log('Next useful commands:');
+      console.log(`  openspec workspace doctor --workspace ${workspace.name}`);
+      console.log('  openspec workspace list');
+    } catch (error) {
+      this.handleFailure(options.json, { workspace: null, status: [] }, error);
+    }
+  }
+
+  async list(options: WorkspaceListOptions = {}): Promise<void> {
+    try {
+      const registry = await readRegistry();
+      const entries = listWorkspaceRegistryEntries(registry);
+      const workspaces = await Promise.all(entries.map((entry) => loadWorkspaceForList(entry)));
+      const payload = { workspaces, status: [] as WorkspaceStatus[] };
+
+      if (options.json) {
+        printJson(payload);
+        return;
+      }
+
+      if (workspaces.length === 0) {
+        console.log("No OpenSpec workspaces found. Run 'openspec workspace setup' first.");
+        return;
+      }
+
+      console.log('Known OpenSpec workspaces:');
+      for (const workspace of workspaces) {
+        console.log(`  ${workspace.name}`);
+        console.log(`    Root: ${workspace.root}`);
+        if (workspace.status.length > 0) {
+          for (const status of workspace.status) {
+            console.log(
+              `    ${status.severity === 'warning' ? 'Warning' : 'Issue'}: ${status.message}`
+            );
+            if (status.fix) {
+              console.log(`    Fix: ${status.fix}`);
+            }
+          }
+          continue;
+        }
+        console.log('    Linked repos or folders:');
+        if (workspace.links.length === 0) {
+          console.log('      (none)');
+        } else {
+          for (const link of workspace.links) {
+            console.log(`      ${link.name} -> ${link.path ?? '(no local path recorded)'}`);
+          }
+        }
+      }
+    } catch (error) {
+      this.handleFailure(options.json, { workspaces: [], status: [] }, error);
+    }
+  }
+
+  async link(
+    nameOrPath: string | undefined,
+    linkPath: string | undefined,
+    options: WorkspaceLinkOptions = {}
+  ): Promise<void> {
+    try {
+      if (!nameOrPath) {
+        throw new WorkspaceCliError(
+          'workspace link requires a repo or folder path.',
+          'missing_link_path',
+          {
+            fix: 'openspec workspace link /path/to/repo',
+          }
+        );
+      }
+
+      const selected = await selectWorkspaceForCommand(options, 'link');
+      const payload = await addWorkspaceLink(selected, nameOrPath, linkPath);
+
+      if (options.json) {
+        printJson(payload);
+        return;
+      }
+
+      printLinkMutationHuman('Linked repo or folder:', payload);
+    } catch (error) {
+      this.handleFailure(options.json, { workspace: null, link: null, status: [] }, error);
+    }
+  }
+
+  async relink(
+    linkNameInput: string | undefined,
+    linkPath: string | undefined,
+    options: WorkspaceLinkOptions = {}
+  ): Promise<void> {
+    try {
+      if (!linkNameInput || !linkPath) {
+        throw new WorkspaceCliError(
+          'workspace relink requires a link name and repo or folder path.',
+          'missing_relink_arguments',
+          {
+            fix: 'openspec workspace relink <name> /path/to/repo',
+          }
+        );
+      }
+
+      const selected = await selectWorkspaceForCommand(options, 'relink');
+      const payload = await updateWorkspaceLink(selected, linkNameInput, linkPath);
+
+      if (options.json) {
+        printJson(payload);
+        return;
+      }
+
+      printLinkMutationHuman('Relinked repo or folder:', payload);
+    } catch (error) {
+      this.handleFailure(options.json, { workspace: null, link: null, status: [] }, error);
+    }
+  }
+
+  async doctor(options: WorkspaceLinkOptions = {}): Promise<void> {
+    try {
+      const selected = await selectWorkspaceForCommand(options, 'doctor');
+      const result = await loadWorkspaceForDoctor(selected);
+
+      if (options.json) {
+        printJson(result);
+        return;
+      }
+
+      printDoctorHuman(result);
+    } catch (error) {
+      this.handleFailure(options.json, { workspace: null, status: [] }, error);
+    }
+  }
+
+  private handleFailure<T extends { status: WorkspaceStatus[] }>(
+    json: boolean | undefined,
+    payload: T,
+    error: unknown
+  ): void {
+    if (json) {
+      printJson(appendStatus(payload, asStatus(error)));
+      process.exitCode = 1;
+      return;
+    }
+
+    const status = asStatus(error);
+    console.error(`Error: ${status.message}`);
+    if (status.fix) {
+      console.error(`Fix: ${status.fix}`);
+    }
+    process.exitCode = 1;
+  }
+}
+
+function collectOption(value: string, previous: string[]): string[] {
+  return [...previous, value];
+}
+
+function addWorkspaceSelectionOptions(command: Command): Command {
+  return command
+    .option('--workspace <name>', 'Workspace name from the local workspace registry')
+    .option('--json', 'Output as JSON')
+    .option('--no-interactive', 'Disable prompts');
+}
+
+export function registerWorkspaceCommand(program: Command): void {
+  const workspaceCommand = new WorkspaceCommand();
+  const workspace = program
+    .command('workspace')
+    .description('Set up and inspect coordination workspaces');
+
+  workspace
+    .command('setup')
+    .description('Set up a workspace and link existing repos or folders')
+    .option('--name <name>', 'Workspace name')
+    .option('--link <link>', 'Repo or folder link. Use <path> or <name>=<path>.', collectOption, [])
+    .option('--json', 'Output as JSON')
+    .option('--no-interactive', 'Disable prompts')
+    .action(async (options: WorkspaceSetupOptions) => {
+      await workspaceCommand.setup(options);
+    });
+
+  workspace
+    .command('list')
+    .description('List known OpenSpec workspaces')
+    .option('--json', 'Output as JSON')
+    .action(async (options: WorkspaceListOptions) => {
+      await workspaceCommand.list(options);
+    });
+
+  workspace
+    .command('ls')
+    .description('List known OpenSpec workspaces')
+    .option('--json', 'Output as JSON')
+    .action(async (options: WorkspaceListOptions) => {
+      await workspaceCommand.list(options);
+    });
+
+  addWorkspaceSelectionOptions(
+    workspace
+      .command('link [nameOrPath] [path]')
+      .description('Link an existing repo or folder to a workspace')
+  ).action(async (
+    nameOrPath: string | undefined,
+    linkPath: string | undefined,
+    options: WorkspaceLinkOptions
+  ) => {
+    await workspaceCommand.link(nameOrPath, linkPath, options);
+  });
+
+  addWorkspaceSelectionOptions(
+    workspace
+      .command('relink <name> <path>')
+      .description('Update the local path for an existing workspace link')
+  ).action(async (
+    linkName: string | undefined,
+    linkPath: string | undefined,
+    options: WorkspaceLinkOptions
+  ) => {
+    await workspaceCommand.relink(linkName, linkPath, options);
+  });
+
+  addWorkspaceSelectionOptions(
+    workspace
+      .command('doctor')
+      .description('Check what a workspace can resolve on this machine')
+  ).action(async (options: WorkspaceLinkOptions) => {
+    await workspaceCommand.doctor(options);
+  });
+
+  // Intentionally no public `workspace create` command in this slice.
+}

--- a/src/commands/workspace.ts
+++ b/src/commands/workspace.ts
@@ -404,6 +404,8 @@ class WorkspaceCommand {
       console.log('');
       printWorkspaceListHuman([doctorResult.workspace]);
       console.log('');
+      console.log(`Planning path: ${doctorResult.workspace.planning_path}`);
+      console.log('');
       console.log('Workspace check:');
       printWorkspaceCheckSummaryHuman(doctorResult);
       console.log('');

--- a/src/commands/workspace.ts
+++ b/src/commands/workspace.ts
@@ -1,4 +1,5 @@
 import { Command } from 'commander';
+import chalk from 'chalk';
 import * as nodeFs from 'node:fs';
 import * as path from 'node:path';
 
@@ -21,6 +22,7 @@ import { selectWorkspaceForCommand } from './workspace/selection.js';
 import {
   WorkspaceCliError,
   WorkspaceLinkMutationPayload,
+  WorkspaceListOutput,
   WorkspaceLinkOptions,
   WorkspaceListOptions,
   WorkspaceOutput,
@@ -35,6 +37,43 @@ function printJson(payload: unknown): void {
   console.log(JSON.stringify(payload, null, 2));
 }
 
+const workspacePromptTheme = {
+  prefix: '',
+  style: {
+    answer: (text: string) => chalk.cyan(text),
+    defaultAnswer: (text: string) => chalk.dim(text),
+    error: (text: string) => chalk.red(text),
+    help: (text: string) => chalk.dim(text),
+    highlight: (text: string) => chalk.cyan(text),
+    key: (text: string) => chalk.cyan(text),
+    message: (text: string) => chalk.bold(text),
+  },
+};
+
+const workspaceSelectTheme = {
+  ...workspacePromptTheme,
+  icon: {
+    cursor: chalk.cyan('>'),
+  },
+  style: {
+    ...workspacePromptTheme.style,
+    keysHelpTip: (keys: [key: string, action: string][]) =>
+      chalk.dim(keys.map(([key, action]) => `${key}: ${action}`).join(' | ')),
+  },
+};
+
+function printWorkspaceSetupIntro(): void {
+  console.log(chalk.bold('Workspace setup'));
+  console.log('');
+}
+
+function isPromptCancellationError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.name === 'ExitPromptError' || error.message.includes('force closed the prompt with SIGINT'))
+  );
+}
+
 async function promptWorkspaceName(initialName?: string): Promise<string> {
   if (initialName) {
     return validateWorkspaceNameForSetup(initialName);
@@ -42,8 +81,14 @@ async function promptWorkspaceName(initialName?: string): Promise<string> {
 
   const { input } = await import('@inquirer/prompts');
 
+  console.log(chalk.bold('[1/3] Name the workspace'));
+  console.log(chalk.dim('Use a stable name for the repo group, e.g. platform.'));
+  console.log('');
+
   return input({
     message: 'Workspace name:',
+    required: true,
+    theme: workspacePromptTheme,
     validate(value: string) {
       try {
         validateWorkspaceNameForSetup(value);
@@ -55,11 +100,15 @@ async function promptWorkspaceName(initialName?: string): Promise<string> {
   });
 }
 
-async function promptExistingPath(message: string): Promise<string> {
+async function promptExistingPath(message: string, defaultPath?: string): Promise<string> {
   const { input } = await import('@inquirer/prompts');
 
   const pathInput = await input({
     message,
+    default: defaultPath,
+    prefill: defaultPath ? 'editable' : undefined,
+    required: true,
+    theme: workspacePromptTheme,
     validate(value: string) {
       const resolvedPath = path.isAbsolute(value)
         ? path.resolve(value)
@@ -78,6 +127,8 @@ async function promptLinkName(existingLinks: Record<string, string>): Promise<st
 
   return input({
     message: 'Link name:',
+    required: true,
+    theme: workspacePromptTheme,
     validate(value: string) {
       try {
         validateLinkNameForCommand(value);
@@ -95,12 +146,19 @@ async function promptLinkName(existingLinks: Record<string, string>): Promise<st
 }
 
 async function promptSetupLinks(): Promise<Record<string, string>> {
-  const { confirm } = await import('@inquirer/prompts');
+  const { select } = await import('@inquirer/prompts');
   const links: Record<string, string> = {};
 
+  console.log('');
+  console.log(chalk.bold('[2/3] Link repos or folders'));
+  console.log(chalk.dim('Start with the current directory, or enter another repo path.'));
+  console.log('');
+
   while (true) {
+    const linkCount = Object.keys(links).length;
     const resolvedPath = await promptExistingPath(
-      Object.keys(links).length === 0 ? 'Repo or folder path:' : 'Another repo or folder path:'
+      linkCount === 0 ? 'Repo or folder path:' : 'Another repo or folder path:',
+      linkCount === 0 ? '.' : undefined
     );
     let linkName = inferLinkName(resolvedPath);
 
@@ -116,13 +174,30 @@ async function promptSetupLinks(): Promise<Record<string, string>> {
     }
 
     links[linkName] = resolvedPath;
+    console.log(chalk.green(`Added link '${linkName}'`));
+    console.log(chalk.dim(`  ${resolvedPath}`));
 
-    const addAnother = await confirm({
-      message: 'Add another repo or folder?',
-      default: false,
+    const nextAction = await select({
+      message: 'Continue',
+      default: 'finish',
+      choices: [
+        {
+          name: 'Create workspace files',
+          short: 'Create workspace files',
+          value: 'finish',
+          description: 'Run a workspace check after setup',
+        },
+        {
+          name: 'Add another repo or folder',
+          short: 'Add another',
+          value: 'add',
+          description: 'Include another local directory in this workspace',
+        },
+      ],
+      theme: workspaceSelectTheme,
     });
 
-    if (!addAnother) {
+    if (nextAction === 'finish') {
       return links;
     }
   }
@@ -153,9 +228,16 @@ function printLinksHuman(links: WorkspaceOutput['links']): void {
   }
 }
 
+function collectWorkspaceIssues(workspace: WorkspaceListOutput): WorkspaceStatus[] {
+  return [
+    ...workspace.status,
+    ...workspace.links.flatMap((link) => link.status),
+  ];
+}
+
 function printDoctorHuman(result: { workspace: WorkspaceOutput; status: WorkspaceStatus[] }): void {
   console.log(`Workspace: ${result.workspace.name}`);
-  console.log(`Root: ${result.workspace.root}`);
+  console.log(`Location: ${result.workspace.root}`);
   console.log(`Planning path: ${result.workspace.planning_path}`);
   console.log('');
   printStatusLines(result.status);
@@ -165,10 +247,7 @@ function printDoctorHuman(result: { workspace: WorkspaceOutput; status: Workspac
   console.log('Linked repos or folders:');
   printLinksHuman(result.workspace.links);
 
-  const issues = [
-    ...result.workspace.status,
-    ...result.workspace.links.flatMap((link) => link.status),
-  ];
+  const issues = collectWorkspaceIssues(result.workspace);
 
   if (issues.length === 0) {
     console.log('');
@@ -189,13 +268,60 @@ function printDoctorHuman(result: { workspace: WorkspaceOutput; status: Workspac
   }
 }
 
-function printWorkspaceSummaryHuman(workspace: WorkspaceOutput): void {
-  console.log(`Workspace: ${workspace.name}`);
-  console.log(`Root: ${workspace.root}`);
-  console.log(`Planning path: ${workspace.planning_path}`);
-  console.log('');
-  console.log('Linked repos or folders:');
-  printLinksHuman(workspace.links);
+function printWorkspaceListHuman(workspaces: WorkspaceListOutput[]): void {
+  console.log(chalk.bold(`OpenSpec workspaces (${workspaces.length})`));
+
+  for (const workspace of workspaces) {
+    console.log('');
+    console.log(chalk.bold(workspace.name));
+    console.log(`  Location: ${workspace.root}`);
+
+    if (workspace.status.length > 0) {
+      console.log('  Status:');
+      for (const status of workspace.status) {
+        const statusLabel = status.severity === 'warning' ? chalk.yellow('Warning') : chalk.red('Issue');
+        console.log(`    ${statusLabel}: ${status.message}`);
+        if (status.fix) {
+          console.log(`    Fix: ${status.fix}`);
+        }
+      }
+    }
+
+    console.log(`  Linked repos or folders (${workspace.links.length}):`);
+    if (workspace.links.length === 0) {
+      console.log(chalk.dim('    (none)'));
+      continue;
+    }
+
+    for (const link of workspace.links) {
+      const suffix = link.status.some((status) => status.severity === 'error') ? chalk.red(' [issue]') : '';
+      console.log(`    ${link.name} -> ${link.path ?? '(no local path recorded)'}${suffix}`);
+      if (link.repo_specs_path) {
+        console.log(chalk.dim(`      repo specs: ${link.repo_specs_path}`));
+      }
+    }
+  }
+}
+
+function printWorkspaceCheckSummaryHuman(result: { workspace: WorkspaceOutput; status: WorkspaceStatus[] }): void {
+  printStatusLines(result.status);
+  const issues = collectWorkspaceIssues(result.workspace);
+
+  if (issues.length === 0) {
+    console.log('  No workspace issues found.');
+    return;
+  }
+
+  console.log('  Issues:');
+  for (const issue of issues) {
+    console.log(`    - ${issue.message}`);
+    if (issue.target) {
+      console.log(`      Target: ${issue.target}`);
+    }
+    if (issue.fix) {
+      console.log(`      Fix: ${issue.fix}`);
+    }
+  }
 }
 
 function printLinkMutationHuman(
@@ -224,6 +350,10 @@ class WorkspaceCommand {
       }
 
       const interactive = !noInteractive && isInteractive(options);
+      if (interactive) {
+        printWorkspaceSetupIntro();
+      }
+
       if (!interactive && (!options.name || (options.link ?? []).length === 0)) {
         throw new WorkspaceCliError(
           'workspace setup --no-interactive requires --name <name> and at least one --link <path>.',
@@ -249,6 +379,11 @@ class WorkspaceCommand {
         );
       }
 
+      if (interactive) {
+        console.log('');
+        console.log(chalk.bold('[3/3] Create workspace files'));
+      }
+
       const workspace = await createManagedWorkspace(workspaceName, links);
       const doctorResult = await loadWorkspaceForDoctor({
         name: workspace.name,
@@ -265,12 +400,12 @@ class WorkspaceCommand {
         return;
       }
 
-      console.log('Workspace setup complete');
+      console.log(chalk.green('Workspace setup complete'));
       console.log('');
-      printWorkspaceSummaryHuman(workspace);
+      printWorkspaceListHuman([doctorResult.workspace]);
       console.log('');
       console.log('Workspace check:');
-      printDoctorHuman(doctorResult);
+      printWorkspaceCheckSummaryHuman(doctorResult);
       console.log('');
       console.log('Next useful commands:');
       console.log(`  openspec workspace doctor --workspace ${workspace.name}`);
@@ -297,29 +432,7 @@ class WorkspaceCommand {
         return;
       }
 
-      console.log('Known OpenSpec workspaces:');
-      for (const workspace of workspaces) {
-        console.log(`  ${workspace.name}`);
-        console.log(`    Root: ${workspace.root}`);
-        if (workspace.status.length > 0) {
-          for (const status of workspace.status) {
-            console.log(
-              `    ${status.severity === 'warning' ? 'Warning' : 'Issue'}: ${status.message}`
-            );
-            if (status.fix) {
-              console.log(`    Fix: ${status.fix}`);
-            }
-          }
-        }
-        console.log('    Linked repos or folders:');
-        if (workspace.links.length === 0) {
-          console.log('      (none)');
-        } else {
-          for (const link of workspace.links) {
-            console.log(`      ${link.name} -> ${link.path ?? '(no local path recorded)'}`);
-          }
-        }
-      }
+      printWorkspaceListHuman(workspaces);
     } catch (error) {
       this.handleFailure(options.json, { workspaces: [], status: [] }, error);
     }
@@ -406,6 +519,12 @@ class WorkspaceCommand {
     payload: T,
     error: unknown
   ): void {
+    if (!json && isPromptCancellationError(error)) {
+      console.error('Cancelled.');
+      process.exitCode = 130;
+      return;
+    }
+
     if (json) {
       printJson(appendStatus(payload, asStatus(error)));
       process.exitCode = 1;

--- a/src/commands/workspace/operations.ts
+++ b/src/commands/workspace/operations.ts
@@ -202,7 +202,7 @@ function localStateInvalidStatus(error: unknown): WorkspaceStatus {
   return makeStatus(
     'error',
     'workspace_local_state_invalid',
-    `Machine-local workspace paths could not be read: ${asErrorMessage(error)}`,
+    `Machine-local paths could not be read: ${asErrorMessage(error)}`,
     {
       target: 'workspace.local_state',
       fix: 'Repair or remove .openspec-workspace/local.yaml, then run openspec workspace relink <name> <path> for affected links.',
@@ -355,7 +355,7 @@ export async function loadWorkspaceForList(
       root: entry.workspaceRoot,
       links: [],
       status: [
-        makeStatus('error', 'workspace_root_missing', 'Workspace root does not exist.', {
+        makeStatus('error', 'workspace_root_missing', 'Workspace location does not exist.', {
           target: 'workspace.root',
           fix: 'Remove or repair the local registry record.',
         }),
@@ -419,7 +419,7 @@ export async function loadWorkspaceForDoctor(
           makeStatus(
             'error',
             'selected_workspace_root_missing',
-            'Selected workspace root does not exist or is not a valid workspace.',
+            'Selected workspace location does not exist or is not a valid workspace.',
             {
               target: 'workspace.root',
               fix: 'Repair the local workspace registry record or choose another workspace.',
@@ -469,7 +469,7 @@ export async function loadWorkspaceForDoctor(
         makeStatus(
           'warning',
           'workspace_local_state_missing',
-          'Machine-local workspace paths are not recorded yet.',
+          'Machine-local paths are not recorded yet.',
           {
             target: 'workspace.local_state',
             fix: 'Run openspec workspace relink <name> <path> for each linked repo or folder on this machine.',
@@ -576,7 +576,7 @@ async function readWorkspaceForMutation(
 ): Promise<{ sharedState: WorkspaceSharedState; localState: WorkspaceLocalState }> {
   if (!(await directoryExists(selected.root)) || !(await isWorkspaceRoot(selected.root))) {
     throw new WorkspaceCliError(
-      `Workspace root does not exist for '${selected.name}': ${selected.root}`,
+      `Workspace location does not exist for '${selected.name}': ${selected.root}`,
       'selected_workspace_root_missing',
       {
         target: 'workspace.root',

--- a/src/commands/workspace/operations.ts
+++ b/src/commands/workspace/operations.ts
@@ -273,9 +273,12 @@ export async function createManagedWorkspace(
     );
   }
 
+  let createdWorkspaceRoot = false;
+
   try {
     await FileSystemUtils.createDirectory(path.dirname(workspaceRoot));
     await fs.mkdir(workspaceRoot);
+    createdWorkspaceRoot = true;
     await FileSystemUtils.createDirectory(getWorkspaceChangesDir(workspaceRoot));
     await writeWorkspaceSharedState(workspaceRoot, {
       version: 1,
@@ -289,6 +292,14 @@ export async function createManagedWorkspace(
     await ensureWorkspaceGitignore(workspaceRoot);
     await recordWorkspaceInRegistry(workspaceName, workspaceRoot);
   } catch (error) {
+    if (createdWorkspaceRoot) {
+      try {
+        await fs.rm(workspaceRoot, { recursive: true, force: true });
+      } catch {
+        // Preserve the original creation failure; callers can retry or inspect the path.
+      }
+    }
+
     throw new WorkspaceCliError(
       `Could not create workspace '${workspaceName}': ${asErrorMessage(error)}`,
       'workspace_create_failed',

--- a/src/commands/workspace/operations.ts
+++ b/src/commands/workspace/operations.ts
@@ -1,0 +1,684 @@
+import * as nodeFs from 'node:fs';
+import * as path from 'node:path';
+
+import {
+  WorkspaceLocalState,
+  WorkspaceRegistryEntry,
+  WorkspaceRegistryState,
+  WorkspaceSharedState,
+  getManagedWorkspaceRoot,
+  getWorkspaceChangesDir,
+  getWorkspacePortableIgnorePatterns,
+  isWorkspaceRoot,
+  parseWorkspaceSetupLinkInput,
+  readOptionalWorkspaceLocalState,
+  readWorkspaceRegistryState,
+  readWorkspaceSharedState,
+  validateWorkspaceLinkName,
+  validateWorkspaceName,
+  writeWorkspaceLocalState,
+  writeWorkspaceRegistryState,
+  writeWorkspaceSharedState,
+} from '../../core/workspace/index.js';
+import { FileSystemUtils } from '../../utils/file-system.js';
+import {
+  SelectedWorkspace,
+  WorkspaceCliError,
+  WorkspaceLinkMutationPayload,
+  WorkspaceLinkOutput,
+  WorkspaceListOutput,
+  WorkspaceOutput,
+  WorkspaceStatus,
+  asErrorMessage,
+  makeStatus,
+} from './types.js';
+
+const fs = nodeFs.promises;
+
+function emptyRegistry(): WorkspaceRegistryState {
+  return { version: 1, workspaces: {} };
+}
+
+function emptyLocalState(): WorkspaceLocalState {
+  return { version: 1, paths: {} };
+}
+
+export async function readRegistry(): Promise<WorkspaceRegistryState> {
+  return (await readWorkspaceRegistryState()) ?? emptyRegistry();
+}
+
+async function recordWorkspaceInRegistry(name: string, workspaceRoot: string): Promise<void> {
+  const registry = await readRegistry();
+  await writeWorkspaceRegistryState({
+    version: 1,
+    workspaces: {
+      ...registry.workspaces,
+      [name]: workspaceRoot,
+    },
+  });
+}
+
+export async function directoryExists(dirPath: string): Promise<boolean> {
+  try {
+    return (await fs.stat(dirPath)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    return (await fs.stat(filePath)).isFile();
+  } catch {
+    return false;
+  }
+}
+
+export async function resolveExistingDirectory(
+  inputPath: string,
+  cwd = process.cwd()
+): Promise<string> {
+  if (inputPath.length === 0) {
+    throw new WorkspaceCliError('Repo or folder path must not be empty.', 'linked_path_empty', {
+      target: 'link.path',
+      fix: 'Choose an existing repo or folder path.',
+    });
+  }
+
+  const resolvedPath = path.isAbsolute(inputPath)
+    ? path.resolve(inputPath)
+    : path.resolve(cwd, inputPath);
+
+  if (!(await directoryExists(resolvedPath))) {
+    throw new WorkspaceCliError(
+      `Path '${inputPath}' is not an existing folder.`,
+      'linked_path_missing',
+      {
+        target: 'link.path',
+        fix: 'Choose an existing repo or folder path.',
+      }
+    );
+  }
+
+  return resolvedPath;
+}
+
+export function inferLinkName(absolutePath: string): string {
+  return path.basename(absolutePath);
+}
+
+function normalizeLinksForOutput(
+  sharedState: WorkspaceSharedState,
+  localState: WorkspaceLocalState | null
+): WorkspaceLinkOutput[] {
+  return Object.keys(sharedState.links)
+    .sort((a, b) => a.localeCompare(b))
+    .map((name) => ({
+      name,
+      path: localState?.paths[name] ?? null,
+      status: [],
+    }));
+}
+
+function formatDuplicateLinkMessage(
+  linkName: string,
+  existingPath: string | null,
+  replacementPath: string
+): string {
+  return [
+    `Cannot use link name '${linkName}' because another link already uses that name.`,
+    'Existing link:',
+    `  ${linkName} -> ${existingPath ?? '(no local path recorded)'}`,
+    '',
+    'Choose a different link name:',
+    `  openspec workspace link archived-${linkName} ${replacementPath}`,
+    '',
+    'If you meant to change the existing link path:',
+    `  openspec workspace relink ${linkName} ${replacementPath}`,
+  ].join('\n');
+}
+
+function duplicateLinkError(
+  linkName: string,
+  existingPath: string | null,
+  replacementPath: string
+): WorkspaceCliError {
+  return new WorkspaceCliError(
+    formatDuplicateLinkMessage(linkName, existingPath, replacementPath),
+    'duplicate_link_name',
+    {
+      target: `links.${linkName}`,
+      fix: `Choose a different link name or run 'openspec workspace relink ${linkName} ${replacementPath}'.`,
+    }
+  );
+}
+
+function duplicateSetupLinkError(
+  linkName: string,
+  existingPath: string,
+  replacementPath: string
+): WorkspaceCliError {
+  return new WorkspaceCliError(
+    [
+      `Cannot use link name '${linkName}' because another setup link already uses that name.`,
+      'Existing link:',
+      `  ${linkName} -> ${existingPath}`,
+      '',
+      'Use explicit --link <name>=<path> values with different names.',
+    ].join('\n'),
+    'duplicate_link_name',
+    {
+      target: `links.${linkName}`,
+      fix: `Use explicit --link ${linkName}-alt=${replacementPath} with a different link name.`,
+    }
+  );
+}
+
+export function validateWorkspaceNameForSetup(name: string): string {
+  try {
+    return validateWorkspaceName(name);
+  } catch {
+    throw new WorkspaceCliError(
+      'Workspace name must be kebab-case with lowercase letters, numbers, and single hyphen separators.',
+      'invalid_workspace_name',
+      {
+        target: 'workspace.name',
+      }
+    );
+  }
+}
+
+export function validateLinkNameForCommand(name: string): string {
+  try {
+    return validateWorkspaceLinkName(name);
+  } catch (error) {
+    throw new WorkspaceCliError(asErrorMessage(error), 'invalid_link_name', {
+      target: 'link.name',
+    });
+  }
+}
+
+function localStateInvalidStatus(error: unknown): WorkspaceStatus {
+  return makeStatus(
+    'error',
+    'workspace_local_state_invalid',
+    `Machine-local workspace paths could not be read: ${asErrorMessage(error)}`,
+    {
+      target: 'workspace.local_state',
+      fix: 'Repair or remove .openspec-workspace/local.yaml, then run openspec workspace relink <name> <path> for affected links.',
+    }
+  );
+}
+
+async function readLocalStateForMutation(workspaceRoot: string): Promise<WorkspaceLocalState> {
+  try {
+    return (await readOptionalWorkspaceLocalState(workspaceRoot)) ?? emptyLocalState();
+  } catch (error) {
+    const status = localStateInvalidStatus(error);
+    throw new WorkspaceCliError(status.message, status.code, {
+      target: status.target,
+      fix: status.fix,
+    });
+  }
+}
+
+async function ensureWorkspaceGitignore(workspaceRoot: string): Promise<void> {
+  const gitignorePath = path.join(workspaceRoot, '.gitignore');
+  const patterns = getWorkspacePortableIgnorePatterns();
+  const existingContent = (await fileExists(gitignorePath))
+    ? await fs.readFile(gitignorePath, 'utf-8')
+    : '';
+  const existingLines = new Set(
+    existingContent
+      .split(/\r?\n/u)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+  );
+  const missingPatterns = patterns.filter((pattern) => !existingLines.has(pattern));
+
+  if (missingPatterns.length === 0) {
+    return;
+  }
+
+  const prefix = existingContent.length > 0 && !existingContent.endsWith('\n') ? '\n' : '';
+  const content = `${existingContent}${prefix}${missingPatterns.join('\n')}\n`;
+  await fs.writeFile(gitignorePath, content, 'utf-8');
+}
+
+export async function createManagedWorkspace(
+  name: string,
+  links: Record<string, string>
+): Promise<WorkspaceOutput> {
+  const workspaceName = validateWorkspaceNameForSetup(name);
+  const workspaceRoot = getManagedWorkspaceRoot(workspaceName);
+  const registry = await readRegistry();
+
+  if (registry.workspaces[workspaceName]) {
+    throw new WorkspaceCliError(
+      `Workspace '${workspaceName}' is already recorded in the local workspace registry at ${registry.workspaces[workspaceName]}.`,
+      'workspace_already_exists',
+      {
+        target: 'workspace.name',
+      }
+    );
+  }
+
+  if (await directoryExists(workspaceRoot)) {
+    throw new WorkspaceCliError(
+      `Workspace '${workspaceName}' already exists at ${workspaceRoot}.`,
+      'workspace_already_exists',
+      {
+        target: 'workspace.root',
+      }
+    );
+  }
+
+  try {
+    await FileSystemUtils.createDirectory(path.dirname(workspaceRoot));
+    await fs.mkdir(workspaceRoot);
+    await FileSystemUtils.createDirectory(getWorkspaceChangesDir(workspaceRoot));
+    await writeWorkspaceSharedState(workspaceRoot, {
+      version: 1,
+      name: workspaceName,
+      links: Object.fromEntries(Object.keys(links).map((linkName) => [linkName, {}])),
+    });
+    await writeWorkspaceLocalState(workspaceRoot, {
+      version: 1,
+      paths: links,
+    });
+    await ensureWorkspaceGitignore(workspaceRoot);
+    await recordWorkspaceInRegistry(workspaceName, workspaceRoot);
+  } catch (error) {
+    throw new WorkspaceCliError(
+      `Could not create workspace '${workspaceName}': ${asErrorMessage(error)}`,
+      'workspace_create_failed',
+      {
+        target: 'workspace.root',
+      }
+    );
+  }
+
+  return {
+    name: workspaceName,
+    root: workspaceRoot,
+    planning_path: getWorkspaceChangesDir(workspaceRoot),
+    links: Object.entries(links)
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([linkName, linkPath]) => ({
+        name: linkName,
+        path: linkPath,
+        status: [],
+      })),
+    status: [],
+  };
+}
+
+export async function parseSetupLinks(
+  linkInputs: string[] | undefined
+): Promise<Record<string, string>> {
+  const links: Record<string, string> = {};
+
+  for (const rawLink of linkInputs ?? []) {
+    const parsed = await parseWorkspaceSetupLinkInput(rawLink);
+    const resolvedPath = await resolveExistingDirectory(parsed.pathInput);
+    const linkName = validateLinkNameForCommand(parsed.name ?? inferLinkName(resolvedPath));
+
+    if (links[linkName]) {
+      throw duplicateSetupLinkError(linkName, links[linkName], resolvedPath);
+    }
+
+    links[linkName] = resolvedPath;
+  }
+
+  return links;
+}
+
+export async function loadWorkspaceForList(
+  entry: WorkspaceRegistryEntry
+): Promise<WorkspaceListOutput> {
+  const workspaceStatus: WorkspaceStatus[] = [];
+
+  if (!(await directoryExists(entry.workspaceRoot)) || !(await isWorkspaceRoot(entry.workspaceRoot))) {
+    return {
+      name: entry.name,
+      root: entry.workspaceRoot,
+      links: [],
+      status: [
+        makeStatus('error', 'workspace_root_missing', 'Workspace root does not exist.', {
+          target: 'workspace.root',
+          fix: 'Remove or repair the local registry record.',
+        }),
+      ],
+    };
+  }
+
+  let sharedState: WorkspaceSharedState;
+  let localState: WorkspaceLocalState | null = null;
+
+  try {
+    sharedState = await readWorkspaceSharedState(entry.workspaceRoot);
+  } catch (error) {
+    return {
+      name: entry.name,
+      root: entry.workspaceRoot,
+      links: [],
+      status: [
+        makeStatus(
+          'error',
+          'workspace_state_invalid',
+          `Workspace state could not be read: ${asErrorMessage(error)}`,
+          {
+            target: 'workspace.root',
+            fix: 'Repair the workspace state files before using this workspace.',
+          }
+        ),
+      ],
+    };
+  }
+
+  try {
+    localState = await readOptionalWorkspaceLocalState(entry.workspaceRoot);
+  } catch (error) {
+    workspaceStatus.push(localStateInvalidStatus(error));
+  }
+
+  return {
+    name: sharedState.name,
+    root: entry.workspaceRoot,
+    links: normalizeLinksForOutput(sharedState, localState),
+    status: workspaceStatus,
+  };
+}
+
+export async function loadWorkspaceForDoctor(
+  selected: SelectedWorkspace
+): Promise<{ workspace: WorkspaceOutput; status: WorkspaceStatus[] }> {
+  const commandStatus = [...selected.status];
+  const workspaceStatus: WorkspaceStatus[] = [];
+  const planningPath = getWorkspaceChangesDir(selected.root);
+
+  if (!(await directoryExists(selected.root)) || !(await isWorkspaceRoot(selected.root))) {
+    return {
+      workspace: {
+        name: selected.name,
+        root: selected.root,
+        planning_path: planningPath,
+        links: [],
+        status: [
+          makeStatus(
+            'error',
+            'selected_workspace_root_missing',
+            'Selected workspace root does not exist or is not a valid workspace.',
+            {
+              target: 'workspace.root',
+              fix: 'Repair the local workspace registry record or choose another workspace.',
+            }
+          ),
+        ],
+      },
+      status: commandStatus,
+    };
+  }
+
+  let sharedState: WorkspaceSharedState;
+  let localState: WorkspaceLocalState;
+  let localStateInvalid = false;
+
+  try {
+    sharedState = await readWorkspaceSharedState(selected.root);
+  } catch (error) {
+    return {
+      workspace: {
+        name: selected.name,
+        root: selected.root,
+        planning_path: planningPath,
+        links: [],
+        status: [
+          makeStatus(
+            'error',
+            'workspace_state_invalid',
+            `Workspace state could not be read: ${asErrorMessage(error)}`,
+            {
+              target: 'workspace.root',
+              fix: 'Repair .openspec-workspace/workspace.yaml before using this workspace.',
+            }
+          ),
+        ],
+      },
+      status: commandStatus,
+    };
+  }
+
+  try {
+    const optionalLocalState = await readOptionalWorkspaceLocalState(selected.root);
+    localState = optionalLocalState ?? emptyLocalState();
+
+    if (!optionalLocalState) {
+      workspaceStatus.push(
+        makeStatus(
+          'warning',
+          'workspace_local_state_missing',
+          'Machine-local workspace paths are not recorded yet.',
+          {
+            target: 'workspace.local_state',
+            fix: 'Run openspec workspace relink <name> <path> for each linked repo or folder on this machine.',
+          }
+        )
+      );
+    }
+  } catch (error) {
+    localState = emptyLocalState();
+    localStateInvalid = true;
+    workspaceStatus.push(localStateInvalidStatus(error));
+  }
+
+  if (!(await directoryExists(planningPath))) {
+    workspaceStatus.push(
+      makeStatus(
+        'error',
+        'workspace_planning_path_missing',
+        'Workspace planning path does not exist.',
+        {
+          target: 'workspace.planning_path',
+          fix: `Create ${planningPath} or recreate the workspace with openspec workspace setup.`,
+        }
+      )
+    );
+  }
+
+  const sharedNames = new Set(Object.keys(sharedState.links));
+  const localNames = new Set(Object.keys(localState.paths));
+  const linkNames = [...new Set([...sharedNames, ...localNames])].sort((a, b) =>
+    a.localeCompare(b)
+  );
+  const links: WorkspaceLinkOutput[] = [];
+
+  for (const linkName of linkNames) {
+    const linkStatus: WorkspaceStatus[] = [];
+    const localPath = localState.paths[linkName] ?? null;
+    let repoSpecsPath: string | null = null;
+
+    if (!sharedNames.has(linkName)) {
+      linkStatus.push(
+        makeStatus(
+          'warning',
+          'local_path_without_shared_link',
+          'Local path is recorded without a shared workspace link.',
+          {
+            target: `links.${linkName}`,
+            fix: `Add a shared link with openspec workspace link ${linkName} ${localPath ?? '/path/to/folder'} or remove the local-only path from .openspec-workspace/local.yaml.`,
+          }
+        )
+      );
+    }
+
+    if (sharedNames.has(linkName) && !localPath && !localStateInvalid) {
+      linkStatus.push(
+        makeStatus(
+          'error',
+          'linked_path_missing_from_local_state',
+          'Shared link does not have a local path on this machine.',
+          {
+            target: `links.${linkName}.path`,
+            fix: `openspec workspace relink ${linkName} /path/to/${linkName}`,
+          }
+        )
+      );
+    }
+
+    if (localPath) {
+      if (await directoryExists(localPath)) {
+        const candidateSpecsPath = path.join(localPath, 'openspec', 'specs');
+        repoSpecsPath = (await directoryExists(candidateSpecsPath)) ? candidateSpecsPath : null;
+      } else {
+        linkStatus.push(
+          makeStatus('error', 'linked_path_missing', 'Linked path does not exist.', {
+            target: `links.${linkName}.path`,
+            fix: `openspec workspace relink ${linkName} /path/to/${linkName}`,
+          })
+        );
+      }
+    }
+
+    links.push({
+      name: linkName,
+      path: localPath,
+      repo_specs_path: repoSpecsPath,
+      status: linkStatus,
+    });
+  }
+
+  return {
+    workspace: {
+      name: sharedState.name,
+      root: selected.root,
+      planning_path: planningPath,
+      links,
+      status: workspaceStatus,
+    },
+    status: commandStatus,
+  };
+}
+
+async function readWorkspaceForMutation(
+  selected: SelectedWorkspace
+): Promise<{ sharedState: WorkspaceSharedState; localState: WorkspaceLocalState }> {
+  if (!(await directoryExists(selected.root)) || !(await isWorkspaceRoot(selected.root))) {
+    throw new WorkspaceCliError(
+      `Workspace root does not exist for '${selected.name}': ${selected.root}`,
+      'selected_workspace_root_missing',
+      {
+        target: 'workspace.root',
+        fix: 'Run openspec workspace list to inspect known workspaces.',
+      }
+    );
+  }
+
+  return {
+    sharedState: await readWorkspaceSharedState(selected.root),
+    localState: await readLocalStateForMutation(selected.root),
+  };
+}
+
+async function recordSelectedWorkspaceAfterMutation(selected: SelectedWorkspace): Promise<void> {
+  if (selected.unregisteredCurrentWorkspace) {
+    await recordWorkspaceInRegistry(selected.name, selected.root);
+  }
+}
+
+function buildLinkMutationPayload(
+  selected: SelectedWorkspace,
+  sharedState: WorkspaceSharedState,
+  localState: WorkspaceLocalState,
+  linkName: string,
+  linkPath: string
+): WorkspaceLinkMutationPayload {
+  return {
+    workspace: {
+      name: sharedState.name,
+      root: selected.root,
+      planning_path: getWorkspaceChangesDir(selected.root),
+      links: normalizeLinksForOutput(sharedState, localState),
+      status: [],
+    },
+    link: {
+      name: linkName,
+      path: linkPath,
+      status: [],
+    },
+    status: selected.status,
+  };
+}
+
+export async function addWorkspaceLink(
+  selected: SelectedWorkspace,
+  nameOrPath: string,
+  linkPath?: string
+): Promise<WorkspaceLinkMutationPayload> {
+  const explicitName = linkPath ? nameOrPath : undefined;
+  const pathInput = linkPath ?? nameOrPath;
+  const resolvedPath = await resolveExistingDirectory(pathInput);
+  const linkName = validateLinkNameForCommand(explicitName ?? inferLinkName(resolvedPath));
+  const { sharedState, localState } = await readWorkspaceForMutation(selected);
+
+  if (sharedState.links[linkName]) {
+    throw duplicateLinkError(linkName, localState.paths[linkName] ?? null, resolvedPath);
+  }
+
+  const updatedSharedState: WorkspaceSharedState = {
+    ...sharedState,
+    links: {
+      ...sharedState.links,
+      [linkName]: {},
+    },
+  };
+  const updatedLocalState: WorkspaceLocalState = {
+    version: 1,
+    paths: {
+      ...localState.paths,
+      [linkName]: resolvedPath,
+    },
+  };
+
+  await writeWorkspaceSharedState(selected.root, updatedSharedState);
+  await writeWorkspaceLocalState(selected.root, updatedLocalState);
+  await recordSelectedWorkspaceAfterMutation(selected);
+
+  return buildLinkMutationPayload(
+    selected,
+    updatedSharedState,
+    updatedLocalState,
+    linkName,
+    resolvedPath
+  );
+}
+
+export async function updateWorkspaceLink(
+  selected: SelectedWorkspace,
+  linkNameInput: string,
+  linkPath: string
+): Promise<WorkspaceLinkMutationPayload> {
+  const linkName = validateLinkNameForCommand(linkNameInput);
+  const resolvedPath = await resolveExistingDirectory(linkPath);
+  const { sharedState, localState } = await readWorkspaceForMutation(selected);
+
+  if (!sharedState.links[linkName]) {
+    throw new WorkspaceCliError(`Unknown workspace link '${linkName}'.`, 'unknown_link_name', {
+      target: `links.${linkName}`,
+      fix: 'Run openspec workspace doctor to see linked repos or folders.',
+    });
+  }
+
+  const updatedLocalState: WorkspaceLocalState = {
+    version: 1,
+    paths: {
+      ...localState.paths,
+      [linkName]: resolvedPath,
+    },
+  };
+
+  await writeWorkspaceLocalState(selected.root, updatedLocalState);
+  await recordSelectedWorkspaceAfterMutation(selected);
+
+  return buildLinkMutationPayload(selected, sharedState, updatedLocalState, linkName, resolvedPath);
+}

--- a/src/commands/workspace/selection.ts
+++ b/src/commands/workspace/selection.ts
@@ -1,0 +1,118 @@
+import {
+  findWorkspaceRoot,
+  listWorkspaceRegistryEntries,
+  readWorkspaceSharedState,
+} from '../../core/workspace/index.js';
+import { isInteractive, resolveNoInteractive } from '../../utils/interactive.js';
+import { readRegistry, validateWorkspaceNameForSetup } from './operations.js';
+import {
+  SelectedWorkspace,
+  WorkspaceCliError,
+  WorkspaceSelectionOptions,
+  makeStatus,
+} from './types.js';
+
+export async function selectWorkspaceForCommand(
+  options: WorkspaceSelectionOptions,
+  commandName: string
+): Promise<SelectedWorkspace> {
+  const registry = await readRegistry();
+
+  if (options.workspace) {
+    const workspaceName = validateWorkspaceNameForSetup(options.workspace);
+    const registryRoot = registry.workspaces[workspaceName];
+
+    if (!registryRoot) {
+      throw new WorkspaceCliError(
+        `Unknown OpenSpec workspace '${workspaceName}'.`,
+        'workspace_not_found',
+        {
+          target: 'workspace.name',
+          fix: 'Run openspec workspace list to see known workspaces.',
+        }
+      );
+    }
+
+    return {
+      name: workspaceName,
+      root: registryRoot,
+      status: [],
+      unregisteredCurrentWorkspace: false,
+    };
+  }
+
+  const currentWorkspaceRoot = await findWorkspaceRoot(process.cwd());
+
+  if (currentWorkspaceRoot) {
+    const sharedState = await readWorkspaceSharedState(currentWorkspaceRoot);
+    const registeredRoot = registry.workspaces[sharedState.name];
+    const isRegistered = registeredRoot === currentWorkspaceRoot;
+    const warning = makeStatus(
+      'warning',
+      'workspace_not_in_local_registry',
+      'This workspace is not recorded in the local workspace registry.',
+      {
+        target: 'workspace.root',
+        fix: 'Run a mutating workspace command from this workspace, such as workspace link or workspace relink, to record it locally.',
+      }
+    );
+
+    return {
+      name: sharedState.name,
+      root: currentWorkspaceRoot,
+      status: isRegistered ? [] : [warning],
+      unregisteredCurrentWorkspace: !isRegistered,
+    };
+  }
+
+  const entries = listWorkspaceRegistryEntries(registry);
+
+  if (entries.length === 0) {
+    throw new WorkspaceCliError(
+      "No known OpenSpec workspaces. Run 'openspec workspace setup' first.\nAfter at least one workspace is known locally, you can also pass --workspace <name>.",
+      'no_known_workspaces',
+      {
+        target: 'workspace.name',
+        fix: 'openspec workspace setup',
+      }
+    );
+  }
+
+  if (entries.length === 1) {
+    const [entry] = entries;
+
+    return {
+      name: entry.name,
+      root: entry.workspaceRoot,
+      status: [],
+      unregisteredCurrentWorkspace: false,
+    };
+  }
+
+  if (options.json || resolveNoInteractive(options) || !isInteractive(options)) {
+    throw new WorkspaceCliError(
+      'Multiple OpenSpec workspaces are known. Pass --workspace <name>.',
+      'workspace_selection_ambiguous',
+      {
+        target: 'workspace.name',
+        fix: `openspec workspace ${commandName} --workspace <name>`,
+      }
+    );
+  }
+
+  const { select } = await import('@inquirer/prompts');
+  const selectedName = await select({
+    message: 'Select workspace:',
+    choices: entries.map((entry) => ({
+      name: `${entry.name} (${entry.workspaceRoot})`,
+      value: entry.name,
+    })),
+  });
+
+  return {
+    name: selectedName,
+    root: registry.workspaces[selectedName],
+    status: [],
+    unregisteredCurrentWorkspace: false,
+  };
+}

--- a/src/commands/workspace/types.ts
+++ b/src/commands/workspace/types.ts
@@ -1,0 +1,119 @@
+export type StatusSeverity = 'error' | 'warning';
+
+export interface WorkspaceStatus {
+  severity: StatusSeverity;
+  code: string;
+  message: string;
+  target?: string;
+  fix?: string;
+}
+
+export interface WorkspaceLinkOutput {
+  name: string;
+  path: string | null;
+  repo_specs_path?: string | null;
+  status: WorkspaceStatus[];
+}
+
+export interface WorkspaceOutput {
+  name: string;
+  root: string;
+  planning_path: string;
+  links: WorkspaceLinkOutput[];
+  status: WorkspaceStatus[];
+}
+
+export interface WorkspaceListOutput {
+  name: string;
+  root: string;
+  links: WorkspaceLinkOutput[];
+  status: WorkspaceStatus[];
+}
+
+export interface WorkspaceSetupOptions {
+  name?: string;
+  link?: string[];
+  json?: boolean;
+  noInteractive?: boolean;
+  interactive?: boolean;
+}
+
+export interface WorkspaceSelectionOptions {
+  workspace?: string;
+  json?: boolean;
+  noInteractive?: boolean;
+  interactive?: boolean;
+}
+
+export type WorkspaceLinkOptions = WorkspaceSelectionOptions;
+
+export interface WorkspaceListOptions {
+  json?: boolean;
+}
+
+export interface SelectedWorkspace {
+  name: string;
+  root: string;
+  status: WorkspaceStatus[];
+  unregisteredCurrentWorkspace: boolean;
+}
+
+export interface WorkspaceLinkMutationPayload {
+  workspace: WorkspaceOutput;
+  link: {
+    name: string;
+    path: string;
+    status: WorkspaceStatus[];
+  };
+  status: WorkspaceStatus[];
+}
+
+export class WorkspaceCliError extends Error {
+  readonly status: WorkspaceStatus;
+
+  constructor(message: string, code: string, options: { target?: string; fix?: string } = {}) {
+    super(message);
+    this.status = {
+      severity: 'error',
+      code,
+      message,
+      ...options,
+    };
+  }
+}
+
+export function makeStatus(
+  severity: StatusSeverity,
+  code: string,
+  message: string,
+  options: { target?: string; fix?: string } = {}
+): WorkspaceStatus {
+  return {
+    severity,
+    code,
+    message,
+    ...options,
+  };
+}
+
+export function asErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function asStatus(error: unknown): WorkspaceStatus {
+  if (error instanceof WorkspaceCliError) {
+    return error.status;
+  }
+
+  return makeStatus('error', 'workspace_error', asErrorMessage(error));
+}
+
+export function appendStatus<T extends { status: WorkspaceStatus[] }>(
+  payload: T,
+  status: WorkspaceStatus
+): T {
+  return {
+    ...payload,
+    status: [...payload.status, status],
+  };
+}

--- a/src/core/completions/command-registry.ts
+++ b/src/core/completions/command-registry.ts
@@ -196,7 +196,17 @@ export const COMMAND_REGISTRY: CommandDefinition[] = [
         name: 'link',
         description: 'Link an existing repo or folder to a workspace',
         acceptsPositional: true,
-        positionalType: 'path',
+        positionals: [
+          {
+            name: 'name-or-path',
+            type: 'path',
+            optional: true,
+          },
+          {
+            name: 'path',
+            type: 'path',
+          },
+        ],
         flags: [
           {
             name: 'workspace',
@@ -211,7 +221,15 @@ export const COMMAND_REGISTRY: CommandDefinition[] = [
         name: 'relink',
         description: 'Update the local path for an existing workspace link',
         acceptsPositional: true,
-        positionalType: 'path',
+        positionals: [
+          {
+            name: 'name',
+          },
+          {
+            name: 'path',
+            type: 'path',
+          },
+        ],
         flags: [
           {
             name: 'workspace',

--- a/src/core/completions/command-registry.ts
+++ b/src/core/completions/command-registry.ts
@@ -156,6 +156,88 @@ export const COMMAND_REGISTRY: CommandDefinition[] = [
     ],
   },
   {
+    name: 'workspace',
+    description: 'Set up and inspect coordination workspaces',
+    flags: [],
+    subcommands: [
+      {
+        name: 'setup',
+        description: 'Set up a workspace and link existing repos or folders',
+        flags: [
+          {
+            name: 'name',
+            description: 'Workspace name',
+            takesValue: true,
+          },
+          {
+            name: 'link',
+            description: 'Repo or folder link. Use <path> or <name>=<path>',
+            takesValue: true,
+          },
+          COMMON_FLAGS.json,
+          COMMON_FLAGS.noInteractive,
+        ],
+      },
+      {
+        name: 'list',
+        description: 'List known OpenSpec workspaces',
+        flags: [
+          COMMON_FLAGS.json,
+        ],
+      },
+      {
+        name: 'ls',
+        description: 'List known OpenSpec workspaces',
+        flags: [
+          COMMON_FLAGS.json,
+        ],
+      },
+      {
+        name: 'link',
+        description: 'Link an existing repo or folder to a workspace',
+        acceptsPositional: true,
+        positionalType: 'path',
+        flags: [
+          {
+            name: 'workspace',
+            description: 'Workspace name from the local workspace registry',
+            takesValue: true,
+          },
+          COMMON_FLAGS.json,
+          COMMON_FLAGS.noInteractive,
+        ],
+      },
+      {
+        name: 'relink',
+        description: 'Update the local path for an existing workspace link',
+        acceptsPositional: true,
+        positionalType: 'path',
+        flags: [
+          {
+            name: 'workspace',
+            description: 'Workspace name from the local workspace registry',
+            takesValue: true,
+          },
+          COMMON_FLAGS.json,
+          COMMON_FLAGS.noInteractive,
+        ],
+      },
+      {
+        name: 'doctor',
+        description: 'Check what a workspace can resolve on this machine',
+        flags: [
+          {
+            name: 'workspace',
+            description: 'Workspace name from the local workspace registry',
+            takesValue: true,
+          },
+          COMMON_FLAGS.json,
+          COMMON_FLAGS.noInteractive,
+        ],
+      },
+    ],
+  },
+  {
     name: 'feedback',
     description: 'Submit feedback about OpenSpec',
     acceptsPositional: true,

--- a/src/core/completions/completion-provider.ts
+++ b/src/core/completions/completion-provider.ts
@@ -1,4 +1,5 @@
 import { getActiveChangeIds, getSpecIds } from '../../utils/item-discovery.js';
+import { listSchemas } from '../artifact-graph/index.js';
 
 /**
  * Cache entry for completion data
@@ -17,6 +18,7 @@ export class CompletionProvider {
   private readonly cacheTTL: number;
   private changeCache: CacheEntry<string[]> | null = null;
   private specCache: CacheEntry<string[]> | null = null;
+  private schemaCache: CacheEntry<string[]> | null = null;
 
   /**
    * Creates a new completion provider
@@ -82,6 +84,31 @@ export class CompletionProvider {
   }
 
   /**
+   * Get all schema names for completion
+   *
+   * @returns Array of schema names
+   */
+  async getSchemaNames(): Promise<string[]> {
+    const now = Date.now();
+
+    // Check if cache is valid
+    if (this.schemaCache && now - this.schemaCache.timestamp < this.cacheTTL) {
+      return this.schemaCache.data;
+    }
+
+    // Fetch fresh data
+    const schemaNames = listSchemas(this.projectRoot);
+
+    // Update cache
+    this.schemaCache = {
+      data: schemaNames,
+      timestamp: now,
+    };
+
+    return schemaNames;
+  }
+
+  /**
    * Get both change and spec IDs for completion
    *
    * @returns Object with changeIds and specIds arrays
@@ -101,6 +128,7 @@ export class CompletionProvider {
   clearCache(): void {
     this.changeCache = null;
     this.specCache = null;
+    this.schemaCache = null;
   }
 
   /**
@@ -111,6 +139,7 @@ export class CompletionProvider {
   getCacheStats(): {
     changeCache: { valid: boolean; age?: number };
     specCache: { valid: boolean; age?: number };
+    schemaCache: { valid: boolean; age?: number };
   } {
     const now = Date.now();
 
@@ -122,6 +151,10 @@ export class CompletionProvider {
       specCache: {
         valid: this.specCache !== null && now - this.specCache.timestamp < this.cacheTTL,
         age: this.specCache ? now - this.specCache.timestamp : undefined,
+      },
+      schemaCache: {
+        valid: this.schemaCache !== null && now - this.schemaCache.timestamp < this.cacheTTL,
+        age: this.schemaCache ? now - this.schemaCache.timestamp : undefined,
       },
     };
   }

--- a/src/core/completions/generators/bash-generator.ts
+++ b/src/core/completions/generators/bash-generator.ts
@@ -184,6 +184,9 @@ complete -F _openspec_completion openspec
       case 'change-or-spec-id':
         lines.push(`${indent}_openspec_complete_items`);
         break;
+      case 'schema-name':
+        lines.push(`${indent}_openspec_complete_schemas`);
+        break;
       case 'shell':
         lines.push(`${indent}local shells="zsh bash fish powershell"`);
         lines.push(`${indent}COMPREPLY=($(compgen -W "$shells" -- "$cur"))`);

--- a/src/core/completions/generators/bash-generator.ts
+++ b/src/core/completions/generators/bash-generator.ts
@@ -1,4 +1,9 @@
-import { CompletionGenerator, CommandDefinition, FlagDefinition } from '../types.js';
+import {
+  CompletionGenerator,
+  CommandDefinition,
+  FlagDefinition,
+  PositionalDefinition,
+} from '../types.js';
 import { BASH_DYNAMIC_HELPERS } from '../templates/bash-templates.js';
 
 /**
@@ -109,14 +114,14 @@ complete -F _openspec_completion openspec
 
       for (const subcmd of cmd.subcommands) {
         lines.push(`${indent}  ${subcmd.name})`);
-        lines.push(...this.generateArgumentCompletion(subcmd, indent + '    '));
+        lines.push(...this.generateArgumentCompletion(subcmd, indent + '    ', 3));
         lines.push(`${indent}    ;;`);
       }
 
       lines.push(`${indent}esac`);
     } else {
       // No subcommands, just complete arguments
-      lines.push(...this.generateArgumentCompletion(cmd, indent));
+      lines.push(...this.generateArgumentCompletion(cmd, indent, 2));
     }
 
     return lines;
@@ -125,7 +130,11 @@ complete -F _openspec_completion openspec
   /**
    * Generate argument completion (flags and positional arguments)
    */
-  private generateArgumentCompletion(cmd: CommandDefinition, indent: string): string[] {
+  private generateArgumentCompletion(
+    cmd: CommandDefinition,
+    indent: string,
+    firstPositionalWordIndex: number
+  ): string[] {
     const lines: string[] = [];
 
     // Check for flag completion
@@ -145,7 +154,14 @@ complete -F _openspec_completion openspec
     }
 
     // Handle positional completions
-    if (cmd.acceptsPositional) {
+    if (cmd.positionals && cmd.positionals.length > 0) {
+      lines.push(...this.generateIndexedPositionalCompletion(
+        cmd.positionals,
+        cmd.flags,
+        firstPositionalWordIndex,
+        indent
+      ));
+    } else if (cmd.acceptsPositional) {
       lines.push(...this.generatePositionalCompletion(cmd.positionalType, indent));
     }
 
@@ -178,6 +194,73 @@ complete -F _openspec_completion openspec
     }
 
     return lines;
+  }
+
+  private generateIndexedPositionalCompletion(
+    positionals: PositionalDefinition[],
+    flags: FlagDefinition[],
+    firstPositionalWordIndex: number,
+    indent: string
+  ): string[] {
+    const lines: string[] = [];
+    const valueFlagCases = this.generateValueFlagCases(flags);
+
+    if (valueFlagCases.length > 0) {
+      lines.push(`${indent}case "$prev" in`);
+      lines.push(`${indent}  ${valueFlagCases.join('|')}) return 0 ;;`);
+      lines.push(`${indent}esac`);
+      lines.push('');
+    }
+
+    lines.push(`${indent}local positional_index=0`);
+    lines.push(`${indent}local skip_next=0`);
+    lines.push(`${indent}local i`);
+    lines.push(`${indent}for ((i = ${firstPositionalWordIndex}; i < cword; i++)); do`);
+    lines.push(`${indent}  if [[ $skip_next -eq 1 ]]; then`);
+    lines.push(`${indent}    skip_next=0`);
+    lines.push(`${indent}    continue`);
+    lines.push(`${indent}  fi`);
+    lines.push(`${indent}  case "\${words[i]}" in`);
+
+    if (valueFlagCases.length > 0) {
+      lines.push(`${indent}    ${valueFlagCases.join('|')}) skip_next=1 ;;`);
+      lines.push(`${indent}    ${valueFlagCases.map((flag) => `${flag}=*`).join('|')}) ;;`);
+    }
+
+    lines.push(`${indent}    -*) ;;`);
+    lines.push(`${indent}    *) ((positional_index++)) ;;`);
+    lines.push(`${indent}  esac`);
+    lines.push(`${indent}done`);
+    lines.push('');
+    lines.push(`${indent}case "$positional_index" in`);
+
+    for (const [index, positional] of positionals.entries()) {
+      const completion = this.generateIndexedPositionalCase(positional, indent + '  ');
+      if (completion.length === 0) continue;
+      lines.push(`${indent}  ${index})`);
+      lines.push(...completion);
+      lines.push(`${indent}    ;;`);
+    }
+
+    lines.push(`${indent}esac`);
+
+    return lines;
+  }
+
+  private generateValueFlagCases(flags: FlagDefinition[]): string[] {
+    return flags
+      .filter((flag) => flag.takesValue)
+      .flatMap((flag) => [
+        `--${flag.name}`,
+        ...(flag.short ? [`-${flag.short}`] : []),
+      ]);
+  }
+
+  private generateIndexedPositionalCase(
+    positional: PositionalDefinition,
+    indent: string
+  ): string[] {
+    return this.generatePositionalCompletion(positional.type, indent);
   }
 
 

--- a/src/core/completions/generators/fish-generator.ts
+++ b/src/core/completions/generators/fish-generator.ts
@@ -163,6 +163,9 @@ ${commandCompletions}`;
       case 'change-or-spec-id':
         lines.push(`complete -c openspec -n '${condition}' -a '(__fish_openspec_items)' -f`);
         break;
+      case 'schema-name':
+        lines.push(`complete -c openspec -n '${condition}' -a '(__fish_openspec_schemas)' -f`);
+        break;
       case 'shell':
         lines.push(`complete -c openspec -n '${condition}' -a 'zsh bash fish powershell' -f`);
         break;

--- a/src/core/completions/generators/powershell-generator.ts
+++ b/src/core/completions/generators/powershell-generator.ts
@@ -1,4 +1,9 @@
-import { CompletionGenerator, CommandDefinition, FlagDefinition } from '../types.js';
+import {
+  CompletionGenerator,
+  CommandDefinition,
+  FlagDefinition,
+  PositionalDefinition,
+} from '../types.js';
 import { POWERSHELL_DYNAMIC_HELPERS } from '../templates/powershell-templates.js';
 
 /**
@@ -123,14 +128,14 @@ Register-ArgumentCompleter -CommandName openspec -ScriptBlock $openspecCompleter
 
       for (const subcmd of cmd.subcommands) {
         lines.push(`${indent}    "${subcmd.name}" {`);
-        lines.push(...this.generateArgumentCompletion(subcmd, indent + '        '));
+        lines.push(...this.generateArgumentCompletion(subcmd, indent + '        ', 3));
         lines.push(`${indent}    }`);
       }
 
       lines.push(`${indent}}`);
     } else {
       // No subcommands
-      lines.push(...this.generateArgumentCompletion(cmd, indent));
+      lines.push(...this.generateArgumentCompletion(cmd, indent, 2));
     }
 
     return lines;
@@ -139,7 +144,11 @@ Register-ArgumentCompleter -CommandName openspec -ScriptBlock $openspecCompleter
   /**
    * Generate argument completion (flags and positional)
    */
-  private generateArgumentCompletion(cmd: CommandDefinition, indent: string): string[] {
+  private generateArgumentCompletion(
+    cmd: CommandDefinition,
+    indent: string,
+    firstPositionalTokenIndex: number
+  ): string[] {
     const lines: string[] = [];
 
     // Flag completion
@@ -167,11 +176,83 @@ Register-ArgumentCompleter -CommandName openspec -ScriptBlock $openspecCompleter
     }
 
     // Positional completion
-    if (cmd.acceptsPositional) {
+    if (cmd.positionals && cmd.positionals.length > 0) {
+      lines.push(...this.generateIndexedPositionalCompletion(
+        cmd.positionals,
+        cmd.flags,
+        firstPositionalTokenIndex,
+        indent
+      ));
+    } else if (cmd.acceptsPositional) {
       lines.push(...this.generatePositionalCompletion(cmd.positionalType, indent));
     }
 
     return lines;
+  }
+
+  private generateIndexedPositionalCompletion(
+    positionals: PositionalDefinition[],
+    flags: FlagDefinition[],
+    firstPositionalTokenIndex: number,
+    indent: string
+  ): string[] {
+    const lines: string[] = [];
+    const valueFlags = this.generateValueFlags(flags);
+
+    if (valueFlags.length > 0) {
+      const flagList = valueFlags.map((flag) => `"${flag}"`).join(', ');
+      lines.push(`${indent}if (@(${flagList}) -contains $tokens[$commandCount - 2]) { return }`);
+      lines.push('');
+    }
+
+    lines.push(`${indent}$positionalIndex = 0`);
+    lines.push(`${indent}$skipNext = $false`);
+    lines.push(`${indent}for ($i = ${firstPositionalTokenIndex}; $i -lt ($commandCount - 1); $i++) {`);
+    lines.push(`${indent}    if ($skipNext) {`);
+    lines.push(`${indent}        $skipNext = $false`);
+    lines.push(`${indent}        continue`);
+    lines.push(`${indent}    }`);
+    lines.push(`${indent}    $token = $tokens[$i]`);
+
+    if (valueFlags.length > 0) {
+      const flagList = valueFlags.map((flag) => `"${flag}"`).join(', ');
+      lines.push(`${indent}    if (@(${flagList}) -contains $token) {`);
+      lines.push(`${indent}        $skipNext = $true`);
+      lines.push(`${indent}        continue`);
+      lines.push(`${indent}    }`);
+      lines.push(`${indent}    if ($token -match "^(${valueFlags.map((flag) => this.escapeRegex(flag)).join('|')})=.*") { continue }`);
+    }
+
+    lines.push(`${indent}    if ($token -like "-*") { continue }`);
+    lines.push(`${indent}    $positionalIndex++`);
+    lines.push(`${indent}}`);
+    lines.push('');
+    lines.push(`${indent}switch ($positionalIndex) {`);
+
+    for (const [index, positional] of positionals.entries()) {
+      const completion = this.generatePositionalCompletion(positional.type, indent + '    ');
+      if (completion.length === 0) continue;
+      lines.push(`${indent}    ${index} {`);
+      lines.push(...completion);
+      lines.push(`${indent}    }`);
+    }
+
+    lines.push(`${indent}}`);
+
+    return lines;
+  }
+
+  private generateValueFlags(flags: FlagDefinition[]): string[] {
+    return flags
+      .filter((flag) => flag.takesValue)
+      .flatMap((flag) => [
+        `--${flag.name}`,
+        ...(flag.short ? [`-${flag.short}`] : []),
+      ]);
+  }
+
+  private escapeRegex(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   }
 
   /**

--- a/src/core/completions/generators/powershell-generator.ts
+++ b/src/core/completions/generators/powershell-generator.ts
@@ -278,6 +278,11 @@ Register-ArgumentCompleter -CommandName openspec -ScriptBlock $openspecCompleter
         lines.push(`${indent}    [System.Management.Automation.CompletionResult]::new($_, $_, "ParameterValue", $_)`);
         lines.push(`${indent}}`);
         break;
+      case 'schema-name':
+        lines.push(`${indent}Get-OpenSpecSchemas | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {`);
+        lines.push(`${indent}    [System.Management.Automation.CompletionResult]::new($_, $_, "ParameterValue", "Schema: $_")`);
+        lines.push(`${indent}}`);
+        break;
       case 'shell':
         lines.push(`${indent}$shells = @("zsh", "bash", "fish", "powershell")`);
         lines.push(`${indent}$shells | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {`);

--- a/src/core/completions/generators/zsh-generator.ts
+++ b/src/core/completions/generators/zsh-generator.ts
@@ -228,6 +228,8 @@ compdef _openspec openspec
         return "'*: :_openspec_complete_specs'";
       case 'change-or-spec-id':
         return "'*: :_openspec_complete_items'";
+      case 'schema-name':
+        return "'*: :_openspec_complete_schemas'";
       case 'path':
         return "'*:path:_files'";
       case 'shell':
@@ -272,20 +274,23 @@ compdef _openspec openspec
     index: number
   ): string {
     const name = this.escapeDescription(positional.name);
+    const separator = positional.optional ? '::' : ':';
 
     switch (positional.type) {
       case 'change-id':
-        return `'${index}:${name}:_openspec_complete_changes'`;
+        return `'${index}${separator}${name}:_openspec_complete_changes'`;
       case 'spec-id':
-        return `'${index}:${name}:_openspec_complete_specs'`;
+        return `'${index}${separator}${name}:_openspec_complete_specs'`;
       case 'change-or-spec-id':
-        return `'${index}:${name}:_openspec_complete_items'`;
+        return `'${index}${separator}${name}:_openspec_complete_items'`;
+      case 'schema-name':
+        return `'${index}${separator}${name}:_openspec_complete_schemas'`;
       case 'path':
-        return `'${index}:${name}:_files'`;
+        return `'${index}${separator}${name}:_files'`;
       case 'shell':
-        return `'${index}:${name}:(zsh bash fish powershell)'`;
+        return `'${index}${separator}${name}:(zsh bash fish powershell)'`;
       default:
-        return `'${index}:${name}:'`;
+        return `'${index}${separator}${name}:'`;
     }
   }
 

--- a/src/core/completions/generators/zsh-generator.ts
+++ b/src/core/completions/generators/zsh-generator.ts
@@ -1,4 +1,9 @@
-import { CompletionGenerator, CommandDefinition, FlagDefinition } from '../types.js';
+import {
+  CompletionGenerator,
+  CommandDefinition,
+  FlagDefinition,
+  PositionalDefinition,
+} from '../types.js';
 import { ZSH_DYNAMIC_HELPERS } from '../templates/zsh-templates.js';
 
 /**
@@ -139,16 +144,7 @@ compdef _openspec openspec
         lines.push('    ' + this.generateFlagSpec(flag) + ' \\');
       }
 
-      // Add positional argument completion
-      if (cmd.acceptsPositional) {
-        const positionalSpec = this.generatePositionalSpec(cmd.positionalType);
-        lines.push('    ' + positionalSpec);
-      } else {
-        // Remove trailing backslash from last flag
-        if (lines[lines.length - 1].endsWith(' \\')) {
-          lines[lines.length - 1] = lines[lines.length - 1].slice(0, -2);
-        }
-      }
+      this.appendPositionalSpecs(lines, cmd);
     }
 
     lines.push('}');
@@ -179,16 +175,7 @@ compdef _openspec openspec
       lines.push('    ' + this.generateFlagSpec(flag) + ' \\');
     }
 
-    // Add positional argument completion
-    if (subcmd.acceptsPositional) {
-      const positionalSpec = this.generatePositionalSpec(subcmd.positionalType);
-      lines.push('    ' + positionalSpec);
-    } else {
-      // Remove trailing backslash from last flag
-      if (lines[lines.length - 1].endsWith(' \\')) {
-        lines[lines.length - 1] = lines[lines.length - 1].slice(0, -2);
-      }
-    }
+    this.appendPositionalSpecs(lines, subcmd);
 
     lines.push('}');
 
@@ -247,6 +234,58 @@ compdef _openspec openspec
         return "'*:shell:(zsh bash fish powershell)'";
       default:
         return "'*: :_default'";
+    }
+  }
+
+  private appendPositionalSpecs(lines: string[], cmd: CommandDefinition): void {
+    const positionalSpecs = this.generatePositionalSpecs(cmd);
+
+    if (positionalSpecs.length === 0) {
+      if (lines[lines.length - 1].endsWith(' \\')) {
+        lines[lines.length - 1] = lines[lines.length - 1].slice(0, -2);
+      }
+      return;
+    }
+
+    for (const [index, spec] of positionalSpecs.entries()) {
+      const suffix = index === positionalSpecs.length - 1 ? '' : ' \\';
+      lines.push('    ' + spec + suffix);
+    }
+  }
+
+  private generatePositionalSpecs(cmd: CommandDefinition): string[] {
+    if (cmd.positionals && cmd.positionals.length > 0) {
+      return cmd.positionals.map((positional, index) =>
+        this.generateIndexedPositionalSpec(positional, index + 1)
+      );
+    }
+
+    if (cmd.acceptsPositional) {
+      return [this.generatePositionalSpec(cmd.positionalType)];
+    }
+
+    return [];
+  }
+
+  private generateIndexedPositionalSpec(
+    positional: PositionalDefinition,
+    index: number
+  ): string {
+    const name = this.escapeDescription(positional.name);
+
+    switch (positional.type) {
+      case 'change-id':
+        return `'${index}:${name}:_openspec_complete_changes'`;
+      case 'spec-id':
+        return `'${index}:${name}:_openspec_complete_specs'`;
+      case 'change-or-spec-id':
+        return `'${index}:${name}:_openspec_complete_items'`;
+      case 'path':
+        return `'${index}:${name}:_files'`;
+      case 'shell':
+        return `'${index}:${name}:(zsh bash fish powershell)'`;
+      default:
+        return `'${index}:${name}:'`;
     }
   }
 

--- a/src/core/completions/templates/bash-templates.ts
+++ b/src/core/completions/templates/bash-templates.ts
@@ -21,4 +21,10 @@ _openspec_complete_items() {
   local items
   items=$(openspec __complete changes 2>/dev/null | cut -f1; openspec __complete specs 2>/dev/null | cut -f1)
   COMPREPLY=($(compgen -W "$items" -- "$cur"))
+}
+
+_openspec_complete_schemas() {
+  local schemas
+  schemas=$(openspec __complete schemas 2>/dev/null | cut -f1)
+  COMPREPLY=($(compgen -W "$schemas" -- "$cur"))
 }`;

--- a/src/core/completions/templates/fish-templates.ts
+++ b/src/core/completions/templates/fish-templates.ts
@@ -37,4 +37,10 @@ end
 function __fish_openspec_items
     __fish_openspec_changes
     __fish_openspec_specs
+end
+
+function __fish_openspec_schemas
+    openspec __complete schemas 2>/dev/null | while read -l id desc
+        printf '%s\\t%s\\n' "$id" "$desc"
+    end
 end`;

--- a/src/core/completions/templates/powershell-templates.ts
+++ b/src/core/completions/templates/powershell-templates.ts
@@ -22,4 +22,13 @@ function Get-OpenSpecSpecs {
         }
     }
 }
+
+function Get-OpenSpecSchemas {
+    $output = openspec __complete schemas 2>$null
+    if ($output) {
+        $output | ForEach-Object {
+            ($_ -split "\\t")[0]
+        }
+    }
+}
 `;

--- a/src/core/completions/templates/zsh-templates.ts
+++ b/src/core/completions/templates/zsh-templates.ts
@@ -33,4 +33,13 @@ _openspec_complete_items() {
     items+=("$id:$desc")
   done < <(openspec __complete specs 2>/dev/null)
   _describe "item" items
+}
+
+# Use openspec __complete to get available schemas
+_openspec_complete_schemas() {
+  local -a schemas
+  while IFS=$'\\t' read -r id desc; do
+    schemas+=("$id:$desc")
+  done < <(openspec __complete schemas 2>/dev/null)
+  _describe "schema" schemas
 }`;

--- a/src/core/completions/types.ts
+++ b/src/core/completions/types.ts
@@ -30,6 +30,34 @@ export interface FlagDefinition {
   values?: string[];
 }
 
+export type PositionalType =
+  | 'change-id'
+  | 'spec-id'
+  | 'change-or-spec-id'
+  | 'path'
+  | 'shell'
+  | 'schema-name';
+
+/**
+ * Definition of a positional argument.
+ */
+export interface PositionalDefinition {
+  /**
+   * Positional name used in generated shell metadata.
+   */
+  name: string;
+
+  /**
+   * Type of positional argument for dynamic completion.
+   */
+  type?: PositionalType;
+
+  /**
+   * Whether this positional is optional in the CLI syntax.
+   */
+  optional?: boolean;
+}
+
 /**
  * Definition of a CLI command
  */
@@ -69,7 +97,12 @@ export interface CommandDefinition {
    * - 'schema-name': Complete with available schema names
    * - undefined: No specific completion
    */
-  positionalType?: 'change-id' | 'spec-id' | 'change-or-spec-id' | 'path' | 'shell' | 'schema-name';
+  positionalType?: PositionalType;
+
+  /**
+   * Ordered positional arguments when a command accepts more than one.
+   */
+  positionals?: PositionalDefinition[];
 }
 
 /**

--- a/src/core/workspace/foundation.ts
+++ b/src/core/workspace/foundation.ts
@@ -106,7 +106,15 @@ function validateFolderStyleName(name: string, label: string): string {
 }
 
 export function validateWorkspaceName(name: string): string {
-  return validateFolderStyleName(name, 'Workspace name');
+  validateFolderStyleName(name, 'Workspace name');
+
+  if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/u.test(name)) {
+    throw new Error(
+      'Workspace name must be kebab-case with lowercase letters, numbers, and single hyphen separators'
+    );
+  }
+
+  return name;
 }
 
 export function validateWorkspaceLinkName(name: string): string {
@@ -371,6 +379,29 @@ export async function readWorkspaceLocalState(workspaceRoot: string): Promise<Wo
   return parseWorkspaceLocalState(
     await fs.readFile(getWorkspaceLocalStatePath(workspaceRoot), 'utf-8')
   );
+}
+
+function isFileNotFoundError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as NodeJS.ErrnoException).code === 'ENOENT'
+  );
+}
+
+export async function readOptionalWorkspaceLocalState(
+  workspaceRoot: string
+): Promise<WorkspaceLocalState | null> {
+  try {
+    return await readWorkspaceLocalState(workspaceRoot);
+  } catch (error) {
+    if (isFileNotFoundError(error)) {
+      return null;
+    }
+
+    throw error;
+  }
 }
 
 export async function writeWorkspaceSharedState(

--- a/src/core/workspace/index.ts
+++ b/src/core/workspace/index.ts
@@ -1,1 +1,2 @@
 export * from './foundation.js';
+export * from './link-input.js';

--- a/src/core/workspace/link-input.ts
+++ b/src/core/workspace/link-input.ts
@@ -1,0 +1,51 @@
+import * as nodeFs from 'node:fs';
+import * as path from 'node:path';
+
+const fs = nodeFs.promises;
+
+export interface WorkspaceParsedLinkInput {
+  name?: string;
+  pathInput: string;
+}
+
+export interface WorkspaceLinkInputParseOptions {
+  cwd?: string;
+}
+
+async function directoryExists(inputPath: string, cwd: string): Promise<boolean> {
+  if (inputPath.length === 0) {
+    return false;
+  }
+
+  const resolvedPath = path.isAbsolute(inputPath)
+    ? path.resolve(inputPath)
+    : path.resolve(cwd, inputPath);
+
+  try {
+    return (await fs.stat(resolvedPath)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+export async function parseWorkspaceSetupLinkInput(
+  value: string,
+  options: WorkspaceLinkInputParseOptions = {}
+): Promise<WorkspaceParsedLinkInput> {
+  const cwd = options.cwd ?? process.cwd();
+
+  if (await directoryExists(value, cwd)) {
+    return { pathInput: value };
+  }
+
+  const separatorIndex = value.indexOf('=');
+
+  if (separatorIndex === -1) {
+    return { pathInput: value };
+  }
+
+  return {
+    name: value.slice(0, separatorIndex),
+    pathInput: value.slice(separatorIndex + 1),
+  };
+}

--- a/test/commands/completion.test.ts
+++ b/test/commands/completion.test.ts
@@ -244,6 +244,15 @@ describe('CompletionCommand', () => {
     });
   });
 
+  describe('dynamic completion data', () => {
+    it('should output schema names for shell completion', async () => {
+      await command.complete({ type: 'schemas' });
+
+      expect(consoleLogSpy).toHaveBeenCalledWith('spec-driven\tschema');
+      expect(process.exitCode).toBe(0);
+    });
+  });
+
   describe('shell detection integration', () => {
     it('should show appropriate error when detected shell is unsupported', async () => {
       vi.mocked(shellDetection.detectShell).mockReturnValue({ shell: undefined, detected: 'tcsh' });

--- a/test/commands/workspace.interactive.test.ts
+++ b/test/commands/workspace.interactive.test.ts
@@ -179,6 +179,42 @@ describe('workspace command interactive flows', () => {
     });
   });
 
+  it('asks for a link name when the inferred basename is invalid', async () => {
+    const linkedRoot = path.parse(tempDir).root;
+    const { input, confirm } = await getPromptMocks();
+
+    input.mockImplementation(async (options: { message: string; validate?: (value: string) => true | string }) => {
+      if (options.message === 'Workspace name:') {
+        return 'platform';
+      }
+
+      if (options.message === 'Repo or folder path:') {
+        return linkedRoot;
+      }
+
+      if (options.message === 'Link name:') {
+        expect(options.validate?.('')).toBe('Workspace link name must not be empty');
+        expect(options.validate?.('root')).toBe(true);
+        return 'root';
+      }
+
+      throw new Error(`Unexpected input prompt: ${options.message}`);
+    });
+    confirm.mockResolvedValueOnce(false);
+
+    await runWorkspaceCommand(['setup']);
+
+    expect(process.exitCode).toBeUndefined();
+    expect(input.mock.calls.map((call) => call[0].message)).toEqual([
+      'Workspace name:',
+      'Repo or folder path:',
+      'Link name:',
+    ]);
+    expect(readLocalState('platform').paths).toEqual({
+      root: linkedRoot,
+    });
+  });
+
   it('shows an interactive workspace picker when multiple workspaces are known', async () => {
     const api = mkdir('repos/api');
     const web = mkdir('repos/web');

--- a/test/commands/workspace.interactive.test.ts
+++ b/test/commands/workspace.interactive.test.ts
@@ -114,7 +114,7 @@ describe('workspace command interactive flows', () => {
 
       throw new Error(`Unexpected input prompt: ${options.message}`);
     });
-    confirm.mockResolvedValueOnce(false);
+    select.mockResolvedValueOnce('finish');
 
     await runWorkspaceCommand(['setup']);
 
@@ -123,20 +123,44 @@ describe('workspace command interactive flows', () => {
       'Workspace name:',
       'Repo or folder path:',
     ]);
-    expect(confirm.mock.calls[0][0]).toEqual(
+    expect(input.mock.calls[0][0]).toEqual(
       expect.objectContaining({
-        message: 'Add another repo or folder?',
-        default: false,
+        theme: expect.objectContaining({ prefix: '' }),
       })
     );
-    expect(select).not.toHaveBeenCalled();
+    expect(confirm).not.toHaveBeenCalled();
+    expect(select.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        message: 'Continue',
+        default: 'finish',
+        choices: expect.arrayContaining([
+          expect.objectContaining({ value: 'finish' }),
+          expect.objectContaining({ value: 'add' }),
+        ]),
+      })
+    );
     expect(readLocalState('platform').paths).toEqual({ api });
+  });
+
+  it('handles prompt cancellation without printing the raw SIGINT error', async () => {
+    const { input } = await getPromptMocks();
+    const cancellationError = new Error('User force closed the prompt with SIGINT');
+    cancellationError.name = 'ExitPromptError';
+    input.mockRejectedValueOnce(cancellationError);
+
+    await runWorkspaceCommand(['setup']);
+
+    expect(process.exitCode).toBe(130);
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Cancelled.');
+    expect(consoleErrorSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('User force closed the prompt with SIGINT')
+    );
   });
 
   it('lets users add another path and rename an inferred link-name conflict', async () => {
     const firstApi = mkdir('repos/current/api');
     const secondApi = mkdir('repos/archive/api');
-    const { input, confirm } = await getPromptMocks();
+    const { input, confirm, select } = await getPromptMocks();
 
     input.mockImplementation(async (options: { message: string; validate?: (value: string) => true | string }) => {
       if (options.message === 'Workspace name:') {
@@ -159,7 +183,7 @@ describe('workspace command interactive flows', () => {
 
       throw new Error(`Unexpected input prompt: ${options.message}`);
     });
-    confirm.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    select.mockResolvedValueOnce('add').mockResolvedValueOnce('finish');
 
     await runWorkspaceCommand(['setup']);
 
@@ -170,6 +194,7 @@ describe('workspace command interactive flows', () => {
       'Another repo or folder path:',
       'Link name:',
     ]);
+    expect(confirm).not.toHaveBeenCalled();
     expect(consoleLogSpy).toHaveBeenCalledWith(
       `Link name 'api' is already linked to ${firstApi}.`
     );
@@ -181,7 +206,7 @@ describe('workspace command interactive flows', () => {
 
   it('asks for a link name when the inferred basename is invalid', async () => {
     const linkedRoot = path.parse(tempDir).root;
-    const { input, confirm } = await getPromptMocks();
+    const { input, confirm, select } = await getPromptMocks();
 
     input.mockImplementation(async (options: { message: string; validate?: (value: string) => true | string }) => {
       if (options.message === 'Workspace name:') {
@@ -200,7 +225,7 @@ describe('workspace command interactive flows', () => {
 
       throw new Error(`Unexpected input prompt: ${options.message}`);
     });
-    confirm.mockResolvedValueOnce(false);
+    select.mockResolvedValueOnce('finish');
 
     await runWorkspaceCommand(['setup']);
 
@@ -210,6 +235,7 @@ describe('workspace command interactive flows', () => {
       'Repo or folder path:',
       'Link name:',
     ]);
+    expect(confirm).not.toHaveBeenCalled();
     expect(readLocalState('platform').paths).toEqual({
       root: linkedRoot,
     });

--- a/test/commands/workspace.interactive.test.ts
+++ b/test/commands/workspace.interactive.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Command } from 'commander';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+  getManagedWorkspaceRoot,
+  getWorkspaceLocalStatePath,
+  parseWorkspaceLocalState,
+} from '../../src/core/workspace/index.js';
+
+vi.mock('@inquirer/prompts', () => ({
+  input: vi.fn(),
+  confirm: vi.fn(),
+  select: vi.fn(),
+}));
+
+async function runWorkspaceCommand(args: string[]): Promise<void> {
+  const { registerWorkspaceCommand } = await import('../../src/commands/workspace.js');
+  const program = new Command();
+  registerWorkspaceCommand(program);
+  await program.parseAsync(['node', 'openspec', 'workspace', ...args]);
+}
+
+async function getPromptMocks(): Promise<{
+  input: ReturnType<typeof vi.fn>;
+  confirm: ReturnType<typeof vi.fn>;
+  select: ReturnType<typeof vi.fn>;
+}> {
+  const prompts = await import('@inquirer/prompts');
+  return {
+    input: prompts.input as unknown as ReturnType<typeof vi.fn>,
+    confirm: prompts.confirm as unknown as ReturnType<typeof vi.fn>,
+    select: prompts.select as unknown as ReturnType<typeof vi.fn>,
+  };
+}
+
+describe('workspace command interactive flows', () => {
+  let tempDir: string;
+  let dataHome: string;
+  let originalEnv: NodeJS.ProcessEnv;
+  let originalCwd: string;
+  let originalStdinTTY: boolean | undefined;
+  let originalExitCode: string | number | undefined;
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openspec-workspace-interactive-'));
+    dataHome = path.join(tempDir, 'data');
+    originalEnv = { ...process.env };
+    originalCwd = process.cwd();
+    originalStdinTTY = (process.stdin as NodeJS.ReadStream & { isTTY?: boolean }).isTTY;
+    originalExitCode = process.exitCode;
+
+    process.env = {
+      ...process.env,
+      XDG_DATA_HOME: dataHome,
+      OPENSPEC_TELEMETRY: '0',
+    };
+    delete process.env.CI;
+    delete process.env.OPEN_SPEC_INTERACTIVE;
+    process.chdir(tempDir);
+    (process.stdin as NodeJS.ReadStream & { isTTY?: boolean }).isTTY = true;
+    process.exitCode = undefined;
+
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    process.chdir(originalCwd);
+    (process.stdin as NodeJS.ReadStream & { isTTY?: boolean }).isTTY = originalStdinTTY;
+    process.exitCode = originalExitCode;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  function mkdir(relativePath: string): string {
+    const dir = path.join(tempDir, relativePath);
+    fs.mkdirSync(dir, { recursive: true });
+    return dir;
+  }
+
+  function readLocalState(workspaceName: string) {
+    const workspaceRoot = getManagedWorkspaceRoot(workspaceName);
+    return parseWorkspaceLocalState(
+      fs.readFileSync(getWorkspaceLocalStatePath(workspaceRoot), 'utf-8')
+    );
+  }
+
+  it('asks for the workspace name first and validates kebab-case before asking for links', async () => {
+    const api = mkdir('repos/api');
+    const { input, confirm, select } = await getPromptMocks();
+
+    input.mockImplementation(async (options: { message: string; validate?: (value: string) => true | string }) => {
+      if (options.message === 'Workspace name:') {
+        expect(options.validate?.('Bad_Name')).toBe(
+          'Workspace names must be kebab-case with lowercase letters, numbers, and single hyphen separators.'
+        );
+        return 'platform';
+      }
+
+      if (options.message === 'Repo or folder path:') {
+        expect(options.validate?.('missing-api')).toBe('Enter an existing repo or folder path.');
+        return api;
+      }
+
+      throw new Error(`Unexpected input prompt: ${options.message}`);
+    });
+    confirm.mockResolvedValueOnce(false);
+
+    await runWorkspaceCommand(['setup']);
+
+    expect(process.exitCode).toBeUndefined();
+    expect(input.mock.calls.map((call) => call[0].message)).toEqual([
+      'Workspace name:',
+      'Repo or folder path:',
+    ]);
+    expect(confirm.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        message: 'Add another repo or folder?',
+        default: false,
+      })
+    );
+    expect(select).not.toHaveBeenCalled();
+    expect(readLocalState('platform').paths).toEqual({ api });
+  });
+
+  it('lets users add another path and rename an inferred link-name conflict', async () => {
+    const firstApi = mkdir('repos/current/api');
+    const secondApi = mkdir('repos/archive/api');
+    const { input, confirm } = await getPromptMocks();
+
+    input.mockImplementation(async (options: { message: string; validate?: (value: string) => true | string }) => {
+      if (options.message === 'Workspace name:') {
+        return 'platform';
+      }
+
+      if (options.message === 'Repo or folder path:') {
+        return firstApi;
+      }
+
+      if (options.message === 'Another repo or folder path:') {
+        return secondApi;
+      }
+
+      if (options.message === 'Link name:') {
+        expect(options.validate?.('api')).toBe(`Link name 'api' is already linked to ${firstApi}.`);
+        expect(options.validate?.('api-archive')).toBe(true);
+        return 'api-archive';
+      }
+
+      throw new Error(`Unexpected input prompt: ${options.message}`);
+    });
+    confirm.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+
+    await runWorkspaceCommand(['setup']);
+
+    expect(process.exitCode).toBeUndefined();
+    expect(input.mock.calls.map((call) => call[0].message)).toEqual([
+      'Workspace name:',
+      'Repo or folder path:',
+      'Another repo or folder path:',
+      'Link name:',
+    ]);
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      `Link name 'api' is already linked to ${firstApi}.`
+    );
+    expect(readLocalState('platform').paths).toEqual({
+      api: firstApi,
+      'api-archive': secondApi,
+    });
+  });
+
+  it('shows an interactive workspace picker when multiple workspaces are known', async () => {
+    const api = mkdir('repos/api');
+    const web = mkdir('repos/web');
+    const { select } = await getPromptMocks();
+
+    await runWorkspaceCommand(['setup', '--no-interactive', '--name', 'platform', '--link', `api=${api}`]);
+    await runWorkspaceCommand(['setup', '--no-interactive', '--name', 'checkout-web', '--link', `web=${web}`]);
+    consoleLogSpy.mockClear();
+
+    select.mockResolvedValueOnce('checkout-web');
+
+    await runWorkspaceCommand(['doctor']);
+
+    expect(process.exitCode).toBeUndefined();
+    expect(select).toHaveBeenCalledTimes(1);
+    expect(select.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        message: 'Select workspace:',
+        choices: expect.arrayContaining([
+          expect.objectContaining({
+            name: expect.stringContaining('platform'),
+            value: 'platform',
+          }),
+          expect.objectContaining({
+            name: expect.stringContaining('checkout-web'),
+            value: 'checkout-web',
+          }),
+        ]),
+      })
+    );
+    expect(consoleLogSpy).toHaveBeenCalledWith('Workspace: checkout-web');
+  });
+});

--- a/test/commands/workspace.test.ts
+++ b/test/commands/workspace.test.ts
@@ -827,6 +827,7 @@ paths:
     expect(setup.stdout).not.toContain('Root:');
     expect(setup.stdout).toContain('Linked repos or folders (1):');
     expect(setup.stdout).toContain(`api -> ${api}`);
+    expect(setup.stdout).toContain('Planning path:');
     expect(setup.stdout).toContain('Workspace check:');
     expect(setup.stdout).toContain('No workspace issues found.');
     expect(setup.stdout).toContain('Next useful commands:');

--- a/test/commands/workspace.test.ts
+++ b/test/commands/workspace.test.ts
@@ -1,0 +1,832 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { COMMAND_REGISTRY } from '../../src/core/completions/command-registry.js';
+import {
+  WORKSPACE_CHANGES_DIR_NAME,
+  WORKSPACE_LOCAL_STATE_FILE_NAME,
+  WORKSPACE_LOCAL_STATE_IGNORE_PATTERN,
+  WORKSPACE_METADATA_DIR_NAME,
+  WORKSPACE_SHARED_STATE_FILE_NAME,
+  getWorkspaceLocalStatePath,
+  getWorkspaceRegistryPath,
+  getWorkspaceSharedStatePath,
+  parseWorkspaceLocalState,
+  parseWorkspaceRegistryState,
+  parseWorkspaceSharedState,
+} from '../../src/core/workspace/index.js';
+import { runCLI, type RunCLIResult } from '../helpers/run-cli.js';
+
+describe('workspace command', () => {
+  let tempDir: string;
+  let dataHome: string;
+  let env: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openspec-workspace-command-'));
+    dataHome = path.join(tempDir, 'data');
+    env = {
+      XDG_DATA_HOME: dataHome,
+      OPEN_SPEC_INTERACTIVE: '0',
+      OPENSPEC_TELEMETRY: '0',
+    };
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function mkdir(relativePath: string): string {
+    const dir = path.join(tempDir, relativePath);
+    fs.mkdirSync(dir, { recursive: true });
+    return dir;
+  }
+
+  function parseJson(result: RunCLIResult): any {
+    try {
+      return JSON.parse(result.stdout);
+    } catch (error) {
+      throw new Error(
+        `Could not parse JSON.\nCommand: ${result.command}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}\n${String(error)}`
+      );
+    }
+  }
+
+  async function setupWorkspace(name = 'platform', links: string[] = []): Promise<any> {
+    const result = await runCLI(
+      ['workspace', 'setup', '--no-interactive', '--json', '--name', name, ...links.flatMap((link) => ['--link', link])],
+      { cwd: tempDir, env }
+    );
+    expect(result.exitCode).toBe(0);
+    return parseJson(result);
+  }
+
+  function readLocalState(workspaceRoot: string) {
+    return parseWorkspaceLocalState(
+      fs.readFileSync(getWorkspaceLocalStatePath(workspaceRoot), 'utf-8')
+    );
+  }
+
+  function readSharedState(workspaceRoot: string) {
+    return parseWorkspaceSharedState(
+      fs.readFileSync(getWorkspaceSharedStatePath(workspaceRoot), 'utf-8')
+    );
+  }
+
+  it('sets up a workspace with required links, records local state, and lists it through ls', async () => {
+    const api = mkdir('repos/api');
+    mkdir('repos/api/openspec/specs');
+    const checkout = mkdir('repos/platform/apps/checkout');
+
+    const setup = await setupWorkspace('platform', [`api=${api}`, checkout]);
+
+    expect(setup.status).toEqual([]);
+    expect(setup.workspace.name).toBe('platform');
+    expect(setup.workspace.links).toEqual([
+      expect.objectContaining({
+        name: 'api',
+        path: api,
+        repo_specs_path: path.join(api, 'openspec', 'specs'),
+        status: [],
+      }),
+      expect.objectContaining({
+        name: 'checkout',
+        path: checkout,
+        repo_specs_path: null,
+        status: [],
+      }),
+    ]);
+
+    const workspaceRoot = setup.workspace.root;
+    const sharedState = parseWorkspaceSharedState(
+      fs.readFileSync(getWorkspaceSharedStatePath(workspaceRoot), 'utf-8')
+    );
+    const localState = parseWorkspaceLocalState(
+      fs.readFileSync(getWorkspaceLocalStatePath(workspaceRoot), 'utf-8')
+    );
+    const registry = parseWorkspaceRegistryState(
+      fs.readFileSync(
+        getWorkspaceRegistryPath({ globalDataDir: path.join(dataHome, 'openspec') }),
+        'utf-8'
+      )
+    );
+
+    expect(sharedState).toEqual({
+      version: 1,
+      name: 'platform',
+      links: {
+        api: {},
+        checkout: {},
+      },
+    });
+    expect(localState.paths).toEqual({
+      api,
+      checkout,
+    });
+    expect(registry.workspaces.platform).toBe(workspaceRoot);
+    expect(fs.readFileSync(path.join(workspaceRoot, '.gitignore'), 'utf-8')).toContain(
+      WORKSPACE_LOCAL_STATE_IGNORE_PATTERN
+    );
+
+    const list = await runCLI(['workspace', 'ls', '--json'], { cwd: tempDir, env });
+    expect(list.exitCode).toBe(0);
+    const listPayload = parseJson(list);
+    expect(listPayload.workspaces).toEqual([
+      expect.objectContaining({
+        name: 'platform',
+        root: workspaceRoot,
+        links: [
+          expect.objectContaining({ name: 'api', path: api, status: [] }),
+          expect.objectContaining({ name: 'checkout', path: checkout, status: [] }),
+        ],
+        status: [],
+      }),
+    ]);
+  });
+
+  it('preserves equals signs in inferred and explicit setup link paths', async () => {
+    const inferred = mkdir('repos/foo=bar');
+    const explicit = mkdir('repos/api=service');
+
+    const setup = await setupWorkspace('equals-paths', [inferred, `api=${explicit}`]);
+
+    expect(setup.workspace.links).toEqual([
+      expect.objectContaining({
+        name: 'api',
+        path: explicit,
+        status: [],
+      }),
+      expect.objectContaining({
+        name: 'foo=bar',
+        path: inferred,
+        status: [],
+      }),
+    ]);
+
+    const localState = parseWorkspaceLocalState(
+      fs.readFileSync(getWorkspaceLocalStatePath(setup.workspace.root), 'utf-8')
+    );
+    expect(localState.paths).toEqual({
+      api: explicit,
+      'foo=bar': inferred,
+    });
+  });
+
+  it('resolves relative setup, link, and relink paths before storing local state', async () => {
+    const project = mkdir('project');
+    fs.mkdirSync(path.join(project, 'repos', 'api'), { recursive: true });
+    fs.mkdirSync(path.join(project, 'services', 'billing'), { recursive: true });
+    fs.mkdirSync(path.join(project, 'archive', 'billing'), { recursive: true });
+    const resolvedProject = fs.realpathSync.native(project);
+
+    const setup = await runCLI(
+      [
+        'workspace',
+        'setup',
+        '--no-interactive',
+        '--json',
+        '--name',
+        'platform',
+        '--link',
+        'repos/api',
+      ],
+      { cwd: project, env }
+    );
+    expect(setup.exitCode).toBe(0);
+
+    const setupPayload = parseJson(setup);
+    expect(readLocalState(setupPayload.workspace.root).paths.api).toBe(
+      path.join(resolvedProject, 'repos', 'api')
+    );
+
+    const link = await runCLI(['workspace', 'link', 'services/billing', '--json'], {
+      cwd: project,
+      env,
+    });
+    expect(link.exitCode).toBe(0);
+    expect(parseJson(link).link).toEqual(
+      expect.objectContaining({
+        name: 'billing',
+        path: path.join(resolvedProject, 'services', 'billing'),
+      })
+    );
+
+    const relink = await runCLI(
+      ['workspace', 'relink', 'billing', 'archive/billing', '--json'],
+      { cwd: project, env }
+    );
+    expect(relink.exitCode).toBe(0);
+    expect(parseJson(relink).link).toEqual(
+      expect.objectContaining({
+        name: 'billing',
+        path: path.join(resolvedProject, 'archive', 'billing'),
+      })
+    );
+
+    expect(readLocalState(setupPayload.workspace.root).paths).toEqual({
+      api: path.join(resolvedProject, 'repos', 'api'),
+      billing: path.join(resolvedProject, 'archive', 'billing'),
+    });
+  });
+
+  it('rejects duplicate setup link names without creating or rewriting a workspace', async () => {
+    const firstApi = mkdir('repos/current/api');
+    const secondApi = mkdir('repos/archive/api');
+
+    const duplicate = await runCLI(
+      [
+        'workspace',
+        'setup',
+        '--no-interactive',
+        '--json',
+        '--name',
+        'platform',
+        '--link',
+        firstApi,
+        '--link',
+        secondApi,
+      ],
+      { cwd: tempDir, env }
+    );
+
+    expect(duplicate.exitCode).toBe(1);
+    expect(parseJson(duplicate).status[0]).toEqual(
+      expect.objectContaining({
+        code: 'duplicate_link_name',
+        message: expect.stringContaining(firstApi),
+        fix: expect.stringContaining('--link api-alt='),
+      })
+    );
+    expect(fs.existsSync(getWorkspaceRegistryPath({ globalDataDir: path.join(dataHome, 'openspec') }))).toBe(false);
+  });
+
+  it('rejects existing workspace names without overwriting workspace state', async () => {
+    const api = mkdir('repos/api');
+    const web = mkdir('repos/web');
+    const setup = await setupWorkspace('platform', [`api=${api}`]);
+    const workspaceRoot = setup.workspace.root;
+    const sharedBefore = fs.readFileSync(getWorkspaceSharedStatePath(workspaceRoot), 'utf-8');
+    const localBefore = fs.readFileSync(getWorkspaceLocalStatePath(workspaceRoot), 'utf-8');
+    const markerPath = path.join(workspaceRoot, WORKSPACE_CHANGES_DIR_NAME, 'sentinel.txt');
+    fs.writeFileSync(markerPath, 'keep me');
+
+    const duplicate = await runCLI(
+      [
+        'workspace',
+        'setup',
+        '--no-interactive',
+        '--json',
+        '--name',
+        'platform',
+        '--link',
+        `web=${web}`,
+      ],
+      { cwd: tempDir, env }
+    );
+
+    expect(duplicate.exitCode).toBe(1);
+    expect(parseJson(duplicate).status[0]).toEqual(
+      expect.objectContaining({
+        code: 'workspace_already_exists',
+        target: 'workspace.name',
+      })
+    );
+    expect(fs.readFileSync(getWorkspaceSharedStatePath(workspaceRoot), 'utf-8')).toBe(sharedBefore);
+    expect(fs.readFileSync(getWorkspaceLocalStatePath(workspaceRoot), 'utf-8')).toBe(localBefore);
+    expect(fs.readFileSync(markerPath, 'utf-8')).toBe('keep me');
+  });
+
+  it('fails setup cleanly for missing automation inputs and JSON without no-interactive', async () => {
+    const api = mkdir('repos/api');
+
+    const noWorkspaces = await runCLI(['workspace', 'list'], { cwd: tempDir, env });
+    expect(noWorkspaces.exitCode).toBe(0);
+    expect(noWorkspaces.stdout).toContain("No OpenSpec workspaces found. Run 'openspec workspace setup' first.");
+
+    const missing = await runCLI(['workspace', 'setup', '--no-interactive', '--json'], {
+      cwd: tempDir,
+      env,
+    });
+    expect(missing.exitCode).toBe(1);
+    expect(parseJson(missing).status[0]).toEqual(
+      expect.objectContaining({
+        code: 'missing_setup_inputs',
+        severity: 'error',
+      })
+    );
+
+    const jsonInteractive = await runCLI(
+      ['workspace', 'setup', '--json', '--name', 'platform', '--link', api],
+      { cwd: tempDir, env }
+    );
+    expect(jsonInteractive.exitCode).toBe(1);
+    expect(parseJson(jsonInteractive).status[0]).toEqual(
+      expect.objectContaining({
+        code: 'setup_json_requires_no_interactive',
+      })
+    );
+
+    const invalidName = await runCLI(
+      ['workspace', 'setup', '--no-interactive', '--json', '--name', 'Bad_Name', '--link', api],
+      { cwd: tempDir, env }
+    );
+    expect(invalidName.exitCode).toBe(1);
+    expect(parseJson(invalidName).status[0]).toEqual(
+      expect.objectContaining({
+        code: 'invalid_workspace_name',
+        message: expect.stringContaining('kebab-case'),
+      })
+    );
+
+    const noKnown = await runCLI(['workspace', 'doctor', '--json'], { cwd: tempDir, env });
+    expect(noKnown.exitCode).toBe(1);
+    expect(parseJson(noKnown).status[0]).toEqual(
+      expect.objectContaining({
+        code: 'no_known_workspaces',
+      })
+    );
+  });
+
+  it('rejects missing setup, link, and relink paths with structured status', async () => {
+    const api = mkdir('repos/api');
+    const billing = mkdir('repos/billing');
+
+    const missingSetupPath = await runCLI(
+      [
+        'workspace',
+        'setup',
+        '--no-interactive',
+        '--json',
+        '--name',
+        'missing-setup-path',
+        '--link',
+        'missing-api',
+      ],
+      { cwd: tempDir, env }
+    );
+    expect(missingSetupPath.exitCode).toBe(1);
+    expect(parseJson(missingSetupPath).status[0]).toEqual(
+      expect.objectContaining({
+        code: 'linked_path_missing',
+        target: 'link.path',
+      })
+    );
+
+    await setupWorkspace('platform', [`api=${api}`]);
+
+    const missingLinkPath = await runCLI(
+      ['workspace', 'link', 'missing-service', '--json'],
+      { cwd: tempDir, env }
+    );
+    expect(missingLinkPath.exitCode).toBe(1);
+    expect(parseJson(missingLinkPath).status[0]).toEqual(
+      expect.objectContaining({
+        code: 'linked_path_missing',
+        target: 'link.path',
+      })
+    );
+
+    const link = await runCLI(['workspace', 'link', 'billing', billing, '--json'], {
+      cwd: tempDir,
+      env,
+    });
+    expect(link.exitCode).toBe(0);
+
+    const missingRelinkPath = await runCLI(
+      ['workspace', 'relink', 'billing', 'missing-billing', '--json'],
+      { cwd: tempDir, env }
+    );
+    expect(missingRelinkPath.exitCode).toBe(1);
+    expect(parseJson(missingRelinkPath).status[0]).toEqual(
+      expect.objectContaining({
+        code: 'linked_path_missing',
+        target: 'link.path',
+      })
+    );
+  });
+
+  it('links, rejects duplicate link names, relinks, and reports unknown relinks', async () => {
+    const api = mkdir('repos/api');
+    const billing = mkdir('repos/platform/services/billing');
+    const billingNew = mkdir('repos/archive/billing');
+    const duplicate = mkdir('repos/duplicate-billing');
+
+    await setupWorkspace('platform', [`api=${api}`]);
+
+    const link = await runCLI(['workspace', 'link', billing, '--json'], { cwd: tempDir, env });
+    expect(link.exitCode).toBe(0);
+    expect(parseJson(link).link).toEqual(
+      expect.objectContaining({
+        name: 'billing',
+        path: billing,
+        status: [],
+      })
+    );
+
+    const duplicateResult = await runCLI(
+      ['workspace', 'link', 'billing', duplicate, '--json'],
+      { cwd: tempDir, env }
+    );
+    expect(duplicateResult.exitCode).toBe(1);
+    expect(parseJson(duplicateResult).status[0]).toEqual(
+      expect.objectContaining({
+        code: 'duplicate_link_name',
+        message: expect.stringContaining('already uses that name'),
+      })
+    );
+
+    const relink = await runCLI(['workspace', 'relink', 'billing', billingNew, '--json'], {
+      cwd: tempDir,
+      env,
+    });
+    expect(relink.exitCode).toBe(0);
+    expect(parseJson(relink).link).toEqual(
+      expect.objectContaining({
+        name: 'billing',
+        path: billingNew,
+      })
+    );
+
+    const unknown = await runCLI(['workspace', 'relink', 'web', billingNew, '--json'], {
+      cwd: tempDir,
+      env,
+    });
+    expect(unknown.exitCode).toBe(1);
+    expect(parseJson(unknown).status[0]).toEqual(
+      expect.objectContaining({
+        code: 'unknown_link_name',
+      })
+    );
+  });
+
+  it('links monorepo folders without editing the linked folder', async () => {
+    const api = mkdir('repos/api');
+    const packageDir = mkdir('monorepo/apps/checkout');
+    const sentinelPath = path.join(packageDir, 'package.json');
+    fs.writeFileSync(sentinelPath, '{"name":"checkout"}\n');
+    const entriesBefore = fs.readdirSync(packageDir).sort();
+
+    await setupWorkspace('platform', [`api=${api}`]);
+
+    const link = await runCLI(['workspace', 'link', packageDir, '--json'], {
+      cwd: tempDir,
+      env,
+    });
+
+    expect(link.exitCode).toBe(0);
+    expect(parseJson(link).link).toEqual(
+      expect.objectContaining({
+        name: 'checkout',
+        path: packageDir,
+      })
+    );
+    expect(fs.readFileSync(sentinelPath, 'utf-8')).toBe('{"name":"checkout"}\n');
+    expect(fs.readdirSync(packageDir).sort()).toEqual(entriesBefore);
+    expect(fs.existsSync(path.join(packageDir, 'openspec'))).toBe(false);
+    expect(fs.existsSync(path.join(packageDir, WORKSPACE_METADATA_DIR_NAME))).toBe(false);
+  });
+
+  it('fails link and relink without rewriting malformed local state', async () => {
+    const api = mkdir('repos/api');
+    const billing = mkdir('repos/billing');
+    const setup = await setupWorkspace('broken-local', [`api=${api}`]);
+    const sharedPath = getWorkspaceSharedStatePath(setup.workspace.root);
+    const localPath = getWorkspaceLocalStatePath(setup.workspace.root);
+    const sharedBefore = fs.readFileSync(sharedPath, 'utf-8');
+    const malformedLocalState = 'version: 1\npaths: []\n';
+    fs.writeFileSync(localPath, malformedLocalState);
+
+    const link = await runCLI(
+      ['workspace', 'link', 'billing', billing, '--workspace', 'broken-local', '--json'],
+      { cwd: tempDir, env }
+    );
+    expect(link.exitCode).toBe(1);
+    expect(parseJson(link).status[0]).toEqual(
+      expect.objectContaining({
+        code: 'workspace_local_state_invalid',
+        target: 'workspace.local_state',
+      })
+    );
+    expect(fs.readFileSync(sharedPath, 'utf-8')).toBe(sharedBefore);
+    expect(fs.readFileSync(localPath, 'utf-8')).toBe(malformedLocalState);
+
+    const relink = await runCLI(
+      ['workspace', 'relink', 'api', billing, '--workspace', 'broken-local', '--json'],
+      { cwd: tempDir, env }
+    );
+    expect(relink.exitCode).toBe(1);
+    expect(parseJson(relink).status[0]).toEqual(
+      expect.objectContaining({
+        code: 'workspace_local_state_invalid',
+        target: 'workspace.local_state',
+      })
+    );
+    expect(fs.readFileSync(sharedPath, 'utf-8')).toBe(sharedBefore);
+    expect(fs.readFileSync(localPath, 'utf-8')).toBe(malformedLocalState);
+  });
+
+  it('reports stale registry entries without rewriting the registry', async () => {
+    const api = mkdir('repos/api');
+    const setup = await setupWorkspace('platform', [`api=${api}`]);
+    const registryPath = getWorkspaceRegistryPath({ globalDataDir: path.join(dataHome, 'openspec') });
+    const registryBefore = fs.readFileSync(registryPath, 'utf-8');
+
+    fs.rmSync(setup.workspace.root, { recursive: true, force: true });
+
+    const list = await runCLI(['workspace', 'list', '--json'], { cwd: tempDir, env });
+    expect(list.exitCode).toBe(0);
+    expect(parseJson(list).workspaces[0].status[0]).toEqual(
+      expect.objectContaining({
+        code: 'workspace_root_missing',
+      })
+    );
+
+    const doctor = await runCLI(['workspace', 'doctor', '--workspace', 'platform', '--json'], {
+      cwd: tempDir,
+      env,
+    });
+    expect(doctor.exitCode).toBe(0);
+    expect(parseJson(doctor).workspace.status[0]).toEqual(
+      expect.objectContaining({
+        code: 'selected_workspace_root_missing',
+      })
+    );
+    expect(fs.readFileSync(registryPath, 'utf-8')).toBe(registryBefore);
+  });
+
+  it('reports malformed local state in list and doctor without rewriting files', async () => {
+    const api = mkdir('repos/api');
+    const setup = await setupWorkspace('doctor-local-invalid', [`api=${api}`]);
+    const localPath = getWorkspaceLocalStatePath(setup.workspace.root);
+    const registryPath = getWorkspaceRegistryPath({ globalDataDir: path.join(dataHome, 'openspec') });
+    const malformedLocalState = 'version: 1\npaths: []\n';
+    const registryBefore = fs.readFileSync(registryPath, 'utf-8');
+    fs.writeFileSync(localPath, malformedLocalState);
+
+    const list = await runCLI(['workspace', 'list', '--json'], { cwd: tempDir, env });
+    expect(list.exitCode).toBe(0);
+    expect(parseJson(list).workspaces[0].status[0]).toEqual(
+      expect.objectContaining({
+        code: 'workspace_local_state_invalid',
+      })
+    );
+
+    const doctor = await runCLI(
+      ['workspace', 'doctor', '--workspace', 'doctor-local-invalid', '--json'],
+      { cwd: tempDir, env }
+    );
+    expect(doctor.exitCode).toBe(0);
+    const doctorPayload = parseJson(doctor);
+    expect(doctorPayload.workspace.status[0]).toEqual(
+      expect.objectContaining({
+        code: 'workspace_local_state_invalid',
+        target: 'workspace.local_state',
+      })
+    );
+    expect(doctorPayload.workspace.links[0]).toEqual(
+      expect.objectContaining({
+        name: 'api',
+        path: null,
+        status: [],
+      })
+    );
+    expect(fs.readFileSync(localPath, 'utf-8')).toBe(malformedLocalState);
+    expect(fs.readFileSync(registryPath, 'utf-8')).toBe(registryBefore);
+  });
+
+  it('reports shared/local drift and missing paths without repairing workspace state', async () => {
+    const api = mkdir('repos/api');
+    const localOnly = mkdir('repos/local-only');
+    const setup = await setupWorkspace('platform', [`api=${api}`]);
+    const workspaceRoot = setup.workspace.root;
+    const registryPath = getWorkspaceRegistryPath({ globalDataDir: path.join(dataHome, 'openspec') });
+    const missingApiPath = path.join(tempDir, 'repos', 'missing-api');
+    const sharedDrift = `version: 1
+name: platform
+links:
+  api: {}
+  web: {}
+`;
+    const localDrift = `version: 1
+paths:
+  api: ${missingApiPath}
+  local-only: ${localOnly}
+`;
+    fs.writeFileSync(getWorkspaceSharedStatePath(workspaceRoot), sharedDrift);
+    fs.writeFileSync(getWorkspaceLocalStatePath(workspaceRoot), localDrift);
+    fs.rmSync(path.join(workspaceRoot, WORKSPACE_CHANGES_DIR_NAME), { recursive: true, force: true });
+    const registryBefore = fs.readFileSync(registryPath, 'utf-8');
+
+    const doctor = await runCLI(['workspace', 'doctor', '--workspace', 'platform', '--json'], {
+      cwd: tempDir,
+      env,
+    });
+
+    expect(doctor.exitCode).toBe(0);
+    const payload = parseJson(doctor);
+    expect(payload.workspace.status).toEqual([
+      expect.objectContaining({
+        code: 'workspace_planning_path_missing',
+        target: 'workspace.planning_path',
+      }),
+    ]);
+    expect(payload.workspace.links).toEqual([
+      expect.objectContaining({
+        name: 'api',
+        path: missingApiPath,
+        status: [
+          expect.objectContaining({
+            code: 'linked_path_missing',
+            fix: expect.stringContaining('workspace relink api'),
+          }),
+        ],
+      }),
+      expect.objectContaining({
+        name: 'local-only',
+        path: localOnly,
+        status: [
+          expect.objectContaining({
+            code: 'local_path_without_shared_link',
+            severity: 'warning',
+          }),
+        ],
+      }),
+      expect.objectContaining({
+        name: 'web',
+        path: null,
+        status: [
+          expect.objectContaining({
+            code: 'linked_path_missing_from_local_state',
+            fix: expect.stringContaining('workspace relink web'),
+          }),
+        ],
+      }),
+    ]);
+    expect(fs.readFileSync(getWorkspaceSharedStatePath(workspaceRoot), 'utf-8')).toBe(sharedDrift);
+    expect(fs.readFileSync(getWorkspaceLocalStatePath(workspaceRoot), 'utf-8')).toBe(localDrift);
+    expect(fs.readFileSync(registryPath, 'utf-8')).toBe(registryBefore);
+  });
+
+  it('uses current unregistered workspaces for doctor and records them after link', async () => {
+    const manualRoot = path.join(tempDir, 'manual-workspace');
+    const nested = path.join(manualRoot, WORKSPACE_CHANGES_DIR_NAME, 'add-billing');
+    const api = mkdir('repos/api');
+
+    fs.mkdirSync(path.join(manualRoot, WORKSPACE_METADATA_DIR_NAME), { recursive: true });
+    fs.mkdirSync(nested, { recursive: true });
+    fs.writeFileSync(
+      path.join(manualRoot, WORKSPACE_METADATA_DIR_NAME, WORKSPACE_SHARED_STATE_FILE_NAME),
+      'version: 1\nname: manual-workspace\nlinks: {}\n'
+    );
+    fs.writeFileSync(
+      path.join(manualRoot, WORKSPACE_METADATA_DIR_NAME, WORKSPACE_LOCAL_STATE_FILE_NAME),
+      'version: 1\npaths: {}\n'
+    );
+
+    const registryPath = getWorkspaceRegistryPath({ globalDataDir: path.join(dataHome, 'openspec') });
+    const doctor = await runCLI(['workspace', 'doctor', '--json'], { cwd: nested, env });
+    expect(doctor.exitCode).toBe(0);
+    expect(parseJson(doctor).status[0]).toEqual(
+      expect.objectContaining({
+        code: 'workspace_not_in_local_registry',
+        severity: 'warning',
+      })
+    );
+    expect(fs.existsSync(registryPath)).toBe(false);
+
+    const link = await runCLI(['workspace', 'link', 'api', api, '--json'], {
+      cwd: nested,
+      env,
+    });
+    expect(link.exitCode).toBe(0);
+    expect(parseJson(link).status[0]).toEqual(
+      expect.objectContaining({
+        code: 'workspace_not_in_local_registry',
+      })
+    );
+
+    const registry = parseWorkspaceRegistryState(fs.readFileSync(registryPath, 'utf-8'));
+    expect(registry.workspaces['manual-workspace']).toBe(fs.realpathSync.native(manualRoot));
+  });
+
+  it('fails JSON workspace selection when multiple known workspaces are available', async () => {
+    const api = mkdir('repos/api');
+    const web = mkdir('repos/web');
+
+    await setupWorkspace('platform', [`api=${api}`]);
+    await setupWorkspace('checkout-web', [`web=${web}`]);
+
+    const doctor = await runCLI(['workspace', 'doctor', '--json'], { cwd: tempDir, env });
+    expect(doctor.exitCode).toBe(1);
+    expect(parseJson(doctor).status[0]).toEqual(
+      expect.objectContaining({
+        code: 'workspace_selection_ambiguous',
+        fix: expect.stringContaining('--workspace <name>'),
+      })
+    );
+  });
+
+  it('uses --workspace for explicit selection and reports unknown workspace names', async () => {
+    const api = mkdir('repos/api');
+    const web = mkdir('repos/web');
+
+    await setupWorkspace('platform', [`api=${api}`]);
+    const checkout = await setupWorkspace('checkout-web', [`web=${web}`]);
+
+    const doctor = await runCLI(
+      ['workspace', 'doctor', '--workspace', 'checkout-web', '--json'],
+      { cwd: tempDir, env }
+    );
+    expect(doctor.exitCode).toBe(0);
+    expect(parseJson(doctor).workspace).toEqual(
+      expect.objectContaining({
+        name: 'checkout-web',
+        root: checkout.workspace.root,
+      })
+    );
+
+    const unknown = await runCLI(
+      ['workspace', 'doctor', '--workspace', 'unknown-workspace', '--json'],
+      { cwd: tempDir, env }
+    );
+    expect(unknown.exitCode).toBe(1);
+    expect(parseJson(unknown).status[0]).toEqual(
+      expect.objectContaining({
+        code: 'workspace_not_found',
+        target: 'workspace.name',
+      })
+    );
+  });
+
+  it('fails non-interactive ambiguous workspace selection in human output mode', async () => {
+    const api = mkdir('repos/api');
+    const web = mkdir('repos/web');
+
+    await setupWorkspace('platform', [`api=${api}`]);
+    await setupWorkspace('checkout-web', [`web=${web}`]);
+
+    const doctor = await runCLI(['workspace', 'doctor', '--no-interactive'], {
+      cwd: tempDir,
+      env,
+    });
+
+    expect(doctor.exitCode).toBe(1);
+    expect(doctor.stderr).toContain('Multiple OpenSpec workspaces are known. Pass --workspace <name>.');
+    expect(doctor.stderr).toContain('openspec workspace doctor --workspace <name>');
+  });
+
+  it('prints readable human output for setup, list, and doctor', async () => {
+    const api = mkdir('repos/api');
+
+    const setup = await runCLI(
+      ['workspace', 'setup', '--no-interactive', '--name', 'platform', '--link', `api=${api}`],
+      { cwd: tempDir, env }
+    );
+    expect(setup.exitCode).toBe(0);
+    expect(setup.stdout).toContain('Workspace setup complete');
+    expect(setup.stdout).toContain('Workspace check:');
+    expect(setup.stdout).toContain('No workspace issues found.');
+    expect(setup.stdout).toContain('Next useful commands:');
+
+    const list = await runCLI(['workspace', 'list'], { cwd: tempDir, env });
+    expect(list.exitCode).toBe(0);
+    expect(list.stdout).toContain('Known OpenSpec workspaces:');
+    expect(list.stdout).toContain('platform');
+    expect(list.stdout).toContain('Linked repos or folders:');
+    expect(list.stdout).toContain(`api -> ${api}`);
+
+    const doctor = await runCLI(['workspace', 'doctor', '--workspace', 'platform'], {
+      cwd: tempDir,
+      env,
+    });
+    expect(doctor.exitCode).toBe(0);
+    expect(doctor.stdout).toContain('Workspace: platform');
+    expect(doctor.stdout).toContain('Planning path:');
+    expect(doctor.stdout).toContain('Linked repos or folders:');
+    expect(doctor.stdout).toContain('No workspace issues found.');
+  });
+
+  it('does not expose workspace create as a public command', async () => {
+    const help = await runCLI(['workspace', '--help'], { cwd: tempDir, env });
+    expect(help.exitCode).toBe(0);
+    expect(help.stdout).toContain('setup');
+    expect(help.stdout).toContain('link');
+    expect(help.stdout).toContain('relink');
+    expect(help.stdout).not.toMatch(/\bcreate\b/u);
+  });
+
+  it('registers workspace subcommands for shell completions', () => {
+    const workspace = COMMAND_REGISTRY.find((command) => command.name === 'workspace');
+
+    expect(workspace?.subcommands?.map((command) => command.name)).toEqual([
+      'setup',
+      'list',
+      'ls',
+      'link',
+      'relink',
+      'doctor',
+    ]);
+  });
+});

--- a/test/commands/workspace.test.ts
+++ b/test/commands/workspace.test.ts
@@ -606,7 +606,7 @@ describe('workspace command', () => {
 
     const humanList = await runCLI(['workspace', 'list'], { cwd: tempDir, env });
     expect(humanList.exitCode).toBe(0);
-    expect(humanList.stdout).toContain('Linked repos or folders:');
+    expect(humanList.stdout).toContain('Linked repos or folders (1):');
     expect(humanList.stdout).toContain('api -> (no local path recorded)');
 
     const doctor = await runCLI(
@@ -822,15 +822,22 @@ paths:
     );
     expect(setup.exitCode).toBe(0);
     expect(setup.stdout).toContain('Workspace setup complete');
+    expect(setup.stdout).toContain('OpenSpec workspaces (1)');
+    expect(setup.stdout).toContain('Location:');
+    expect(setup.stdout).not.toContain('Root:');
+    expect(setup.stdout).toContain('Linked repos or folders (1):');
+    expect(setup.stdout).toContain(`api -> ${api}`);
     expect(setup.stdout).toContain('Workspace check:');
     expect(setup.stdout).toContain('No workspace issues found.');
     expect(setup.stdout).toContain('Next useful commands:');
 
     const list = await runCLI(['workspace', 'list'], { cwd: tempDir, env });
     expect(list.exitCode).toBe(0);
-    expect(list.stdout).toContain('Known OpenSpec workspaces:');
+    expect(list.stdout).toContain('OpenSpec workspaces (1)');
     expect(list.stdout).toContain('platform');
-    expect(list.stdout).toContain('Linked repos or folders:');
+    expect(list.stdout).toContain('Location:');
+    expect(list.stdout).not.toContain('Root:');
+    expect(list.stdout).toContain('Linked repos or folders (1):');
     expect(list.stdout).toContain(`api -> ${api}`);
 
     const doctor = await runCLI(['workspace', 'doctor', '--workspace', 'platform'], {
@@ -839,6 +846,8 @@ paths:
     });
     expect(doctor.exitCode).toBe(0);
     expect(doctor.stdout).toContain('Workspace: platform');
+    expect(doctor.stdout).toContain('Location:');
+    expect(doctor.stdout).not.toContain('Root:');
     expect(doctor.stdout).toContain('Planning path:');
     expect(doctor.stdout).toContain('Linked repos or folders:');
     expect(doctor.stdout).toContain('No workspace issues found.');

--- a/test/commands/workspace.test.ts
+++ b/test/commands/workspace.test.ts
@@ -1,15 +1,17 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
 import { COMMAND_REGISTRY } from '../../src/core/completions/command-registry.js';
+import { createManagedWorkspace } from '../../src/commands/workspace/operations.js';
 import {
   WORKSPACE_CHANGES_DIR_NAME,
   WORKSPACE_LOCAL_STATE_FILE_NAME,
   WORKSPACE_LOCAL_STATE_IGNORE_PATTERN,
   WORKSPACE_METADATA_DIR_NAME,
   WORKSPACE_SHARED_STATE_FILE_NAME,
+  getManagedWorkspaceRoot,
   getWorkspaceLocalStatePath,
   getWorkspaceRegistryPath,
   getWorkspaceSharedStatePath,
@@ -17,6 +19,7 @@ import {
   parseWorkspaceRegistryState,
   parseWorkspaceSharedState,
 } from '../../src/core/workspace/index.js';
+import { FileSystemUtils } from '../../src/utils/file-system.js';
 import { runCLI, type RunCLIResult } from '../helpers/run-cli.js';
 
 describe('workspace command', () => {
@@ -260,6 +263,34 @@ describe('workspace command', () => {
       })
     );
     expect(fs.existsSync(getWorkspaceRegistryPath({ globalDataDir: path.join(dataHome, 'openspec') }))).toBe(false);
+  });
+
+  it('removes a partially created workspace when setup fails after creating the root', async () => {
+    const api = mkdir('repos/api');
+    const originalDataHome = process.env.XDG_DATA_HOME;
+    process.env.XDG_DATA_HOME = dataHome;
+    const writeFileSpy = vi
+      .spyOn(FileSystemUtils, 'writeFile')
+      .mockRejectedValueOnce(new Error('disk full'));
+
+    try {
+      await expect(createManagedWorkspace('platform', { api })).rejects.toMatchObject({
+        status: {
+          code: 'workspace_create_failed',
+        },
+      });
+    } finally {
+      writeFileSpy.mockRestore();
+      if (originalDataHome === undefined) {
+        delete process.env.XDG_DATA_HOME;
+      } else {
+        process.env.XDG_DATA_HOME = originalDataHome;
+      }
+    }
+
+    const globalDataDir = path.join(dataHome, 'openspec');
+    expect(fs.existsSync(getManagedWorkspaceRoot('platform', { globalDataDir }))).toBe(false);
+    expect(fs.existsSync(getWorkspaceRegistryPath({ globalDataDir }))).toBe(false);
   });
 
   it('rejects existing workspace names without overwriting workspace state', async () => {
@@ -573,6 +604,11 @@ describe('workspace command', () => {
       })
     );
 
+    const humanList = await runCLI(['workspace', 'list'], { cwd: tempDir, env });
+    expect(humanList.exitCode).toBe(0);
+    expect(humanList.stdout).toContain('Linked repos or folders:');
+    expect(humanList.stdout).toContain('api -> (no local path recorded)');
+
     const doctor = await runCLI(
       ['workspace', 'doctor', '--workspace', 'doctor-local-invalid', '--json'],
       { cwd: tempDir, env }
@@ -819,6 +855,8 @@ paths:
 
   it('registers workspace subcommands for shell completions', () => {
     const workspace = COMMAND_REGISTRY.find((command) => command.name === 'workspace');
+    const link = workspace?.subcommands?.find((command) => command.name === 'link');
+    const relink = workspace?.subcommands?.find((command) => command.name === 'relink');
 
     expect(workspace?.subcommands?.map((command) => command.name)).toEqual([
       'setup',
@@ -827,6 +865,14 @@ paths:
       'link',
       'relink',
       'doctor',
+    ]);
+    expect(link?.positionals).toEqual([
+      { name: 'name-or-path', type: 'path', optional: true },
+      { name: 'path', type: 'path' },
+    ]);
+    expect(relink?.positionals).toEqual([
+      { name: 'name' },
+      { name: 'path', type: 'path' },
     ]);
   });
 });

--- a/test/core/completions/generators/bash-generator.test.ts
+++ b/test/core/completions/generators/bash-generator.test.ts
@@ -332,6 +332,23 @@ describe('BashGenerator', () => {
       expect(script).toContain('compgen -f');
     });
 
+    it('should handle positional arguments for schema names', () => {
+      const commands: CommandDefinition[] = [
+        {
+          name: 'schema',
+          description: 'Manage schemas',
+          acceptsPositional: true,
+          positionalType: 'schema-name',
+          flags: [],
+        },
+      ];
+
+      const script = generator.generate(commands);
+
+      expect(script).toContain('_openspec_complete_schemas');
+      expect(script).toContain('openspec __complete schemas 2>/dev/null');
+    });
+
     it('should generate dynamic completion helper for changes', () => {
       const commands: CommandDefinition[] = [
         {

--- a/test/core/completions/generators/fish-generator.test.ts
+++ b/test/core/completions/generators/fish-generator.test.ts
@@ -294,6 +294,23 @@ describe('FishGenerator', () => {
       expect(script).toContain('powershell');
     });
 
+    it('should handle positional arguments for schema names', () => {
+      const commands: CommandDefinition[] = [
+        {
+          name: 'schema',
+          description: 'Manage schemas',
+          acceptsPositional: true,
+          positionalType: 'schema-name',
+          flags: [],
+        },
+      ];
+
+      const script = generator.generate(commands);
+
+      expect(script).toContain('__fish_openspec_schemas');
+      expect(script).toContain('openspec __complete schemas 2>/dev/null');
+    });
+
     it('should generate dynamic completion helper for changes', () => {
       const commands: CommandDefinition[] = [
         {

--- a/test/core/completions/generators/powershell-generator.test.ts
+++ b/test/core/completions/generators/powershell-generator.test.ts
@@ -353,6 +353,23 @@ describe('PowerShellGenerator', () => {
 			expect(script).toContain('"init"');
 		});
 
+		it('should handle positional arguments for schema names', () => {
+			const commands: CommandDefinition[] = [
+				{
+					name: 'schema',
+					description: 'Manage schemas',
+					acceptsPositional: true,
+					positionalType: 'schema-name',
+					flags: [],
+				},
+			];
+
+			const script = generator.generate(commands);
+
+			expect(script).toContain('Get-OpenSpecSchemas');
+			expect(script).toContain('openspec __complete schemas 2>$null');
+		});
+
 		it('should generate dynamic completion helper for changes', () => {
 			const commands: CommandDefinition[] = [
 				{

--- a/test/core/completions/generators/zsh-generator.test.ts
+++ b/test/core/completions/generators/zsh-generator.test.ts
@@ -268,6 +268,50 @@ describe('ZshGenerator', () => {
       expect(script).toContain("'*:path:_files'");
     });
 
+    it('should handle positional arguments for schema names', () => {
+      const commands: CommandDefinition[] = [
+        {
+          name: 'schema',
+          description: 'Manage schemas',
+          acceptsPositional: true,
+          positionalType: 'schema-name',
+          flags: [],
+        },
+      ];
+
+      const script = generator.generate(commands);
+
+      expect(script).toContain("'*: :_openspec_complete_schemas'");
+      expect(script).toContain('_openspec_complete_schemas()');
+    });
+
+    it('should emit optional indexed positional arguments with double-colon syntax', () => {
+      const commands: CommandDefinition[] = [
+        {
+          name: 'workspace',
+          description: 'Manage workspaces',
+          flags: [],
+          subcommands: [
+            {
+              name: 'link',
+              description: 'Link a folder',
+              acceptsPositional: true,
+              positionals: [
+                { name: 'name-or-path', type: 'path', optional: true },
+                { name: 'path', type: 'path' },
+              ],
+              flags: [],
+            },
+          ],
+        },
+      ];
+
+      const script = generator.generate(commands);
+
+      expect(script).toContain("'1::name-or-path:_files'");
+      expect(script).toContain("'2:path:_files'");
+    });
+
     it('should escape special characters in descriptions', () => {
       const commands: CommandDefinition[] = [
         {

--- a/test/core/workspace/foundation.test.ts
+++ b/test/core/workspace/foundation.test.ts
@@ -84,7 +84,7 @@ paths: {}
       expect(WORKSPACE_REGISTRY_FILE_NAME).toBe('registry.yaml');
     });
 
-    it('returns workspace paths using platform-aware path helpers', () => {
+    it('returns workspace file paths using platform-aware path helpers', () => {
       const workspaceRoot = path.join(tempDir, 'platform');
 
       expect(getWorkspaceMetadataDir(workspaceRoot)).toBe(
@@ -99,7 +99,7 @@ paths: {}
       expect(getWorkspaceChangesDir(workspaceRoot)).toBe(path.join(workspaceRoot, 'changes'));
     });
 
-    it('preserves Windows-style root strings when building workspace paths', () => {
+    it('preserves Windows-style location strings when building workspace file paths', () => {
       const workspaceRoot = 'D:\\repos\\platform-workspace';
 
       expect(getWorkspaceSharedStatePath(workspaceRoot)).toBe(
@@ -185,8 +185,8 @@ paths: {}
     });
   });
 
-  describe('workspace root detection', () => {
-    it('detects a workspace root from the root and nested directories', async () => {
+  describe('workspace folder detection', () => {
+    it('detects a workspace folder from itself and nested directories', async () => {
       const workspaceRoot = createWorkspaceRoot();
       const nestedDir = path.join(workspaceRoot, 'changes', 'add-billing', 'specs');
       fs.mkdirSync(nestedDir, { recursive: true });
@@ -308,7 +308,7 @@ paths:
       );
     });
 
-    it('reads shared and local state from a workspace root', async () => {
+    it('reads shared and local state from a workspace folder', async () => {
       const workspaceRoot = createWorkspaceRoot();
 
       await expect(readWorkspaceSharedState(workspaceRoot)).resolves.toEqual({

--- a/test/core/workspace/foundation.test.ts
+++ b/test/core/workspace/foundation.test.ts
@@ -28,7 +28,9 @@ import {
   parseWorkspaceLocalState,
   parseWorkspaceRegistryState,
   parseWorkspaceSharedState,
+  parseWorkspaceSetupLinkInput,
   readWorkspaceLocalState,
+  readOptionalWorkspaceLocalState,
   readWorkspaceRegistryState,
   readWorkspaceSharedState,
   serializeWorkspaceLocalState,
@@ -151,14 +153,33 @@ paths: {}
   });
 
   describe('name validation', () => {
-    it('accepts folder-style workspace and link names', () => {
+    it('accepts kebab-case workspace names and folder-style link names', () => {
       expect(isValidWorkspaceName('platform')).toBe(true);
+      expect(isValidWorkspaceName('checkout-web')).toBe(true);
+      expect(isValidWorkspaceName('api2')).toBe(true);
       expect(isValidWorkspaceLinkName('billing')).toBe(true);
+      expect(isValidWorkspaceLinkName('Checkout App')).toBe(true);
     });
 
-    it('rejects empty names, dot names, and path separators', () => {
-      for (const invalidName of ['', '.', '..', 'bad/name', 'bad\\name']) {
+    it('rejects invalid workspace names while keeping link names folder-style', () => {
+      for (const invalidName of [
+        '',
+        '.',
+        '..',
+        'bad/name',
+        'bad\\name',
+        'Checkout',
+        'checkout_app',
+        'checkout.app',
+        'checkout app',
+        '-checkout',
+        'checkout-',
+        'checkout--web',
+      ]) {
         expect(isValidWorkspaceName(invalidName)).toBe(false);
+      }
+
+      for (const invalidName of ['', '.', '..', 'bad/name', 'bad\\name']) {
         expect(isValidWorkspaceLinkName(invalidName)).toBe(false);
       }
     });
@@ -298,6 +319,42 @@ paths:
       await expect(readWorkspaceLocalState(workspaceRoot)).resolves.toEqual({
         version: 1,
         paths: {},
+      });
+    });
+
+    it('returns null only when optional local state is absent', async () => {
+      const workspaceRoot = createWorkspaceRoot();
+      fs.rmSync(getWorkspaceLocalStatePath(workspaceRoot));
+
+      await expect(readOptionalWorkspaceLocalState(workspaceRoot)).resolves.toBeNull();
+    });
+
+    it('rejects invalid optional local state instead of treating it as missing', async () => {
+      const workspaceRoot = createWorkspaceRoot();
+      fs.writeFileSync(getWorkspaceLocalStatePath(workspaceRoot), 'version: 1\npaths: []\n');
+
+      await expect(readOptionalWorkspaceLocalState(workspaceRoot)).rejects.toThrow(
+        /Invalid workspace local state/
+      );
+    });
+  });
+
+  describe('workspace link input parsing', () => {
+    it('preserves an existing path with equals signs as an inferred-name link input', async () => {
+      const linkPath = path.join(tempDir, 'repos', 'foo=bar');
+      fs.mkdirSync(linkPath, { recursive: true });
+
+      await expect(parseWorkspaceSetupLinkInput(linkPath)).resolves.toEqual({
+        pathInput: linkPath,
+      });
+    });
+
+    it('parses explicit link names while preserving equals signs in the path', async () => {
+      const linkPath = path.join(tempDir, 'repos', 'foo=bar');
+
+      await expect(parseWorkspaceSetupLinkInput(`api=${linkPath}`)).resolves.toEqual({
+        name: 'api',
+        pathInput: linkPath,
       });
     });
   });


### PR DESCRIPTION
## Summary

- Adds the beta `openspec workspace` command surface for `setup`, `list`/`ls`, `link`, `relink`, and `doctor`.
- Records shared workspace identity/link names separately from machine-local paths, including JSON/status output for scriptable flows.
- Updates workspace docs, OpenSpec change artifacts, shell completion metadata, and regression coverage.

## Validation

- [x] `pnpm exec vitest run test/commands/workspace.test.ts test/commands/workspace.interactive.test.ts test/core/workspace/foundation.test.ts`
- [x] `pnpm run build`
- [x] `node bin/openspec.js validate workspace-create-and-register-repos --strict`

## Manual Completeness Checklist

- [ ] Run `node bin/openspec.js workspace setup` interactively in a clean temp folder and verify it asks for the workspace name first, rejects invalid names, links at least one existing folder, prints the workspace root/planning path, runs the workspace check, and shows next commands.
- [ ] Run `node bin/openspec.js workspace setup --no-interactive --json --name platform --link /path/to/api --link web=/path/to/web` and verify the JSON includes the workspace, sorted links, `status: []`, and absolute paths in machine-local state.
- [ ] Run `node bin/openspec.js workspace list` and `node bin/openspec.js workspace ls --json` with no workspaces, one workspace, and a stale registry path; verify stale entries are reported without registry repair.
- [ ] From outside any workspace, run `node bin/openspec.js workspace doctor --workspace platform --json` and verify missing paths, repo-local specs paths, and suggested fixes appear in structured status entries.
- [ ] From inside a workspace, run `workspace link /path/to/folder`, `workspace link name /path/to/folder`, and `workspace relink name /new/path`; verify duplicate and unknown-name errors preserve existing state.
- [ ] Create a folder path containing `=` and confirm `--link /tmp/foo=bar` infers `foo=bar`, while `--link api=/tmp/foo=bar` uses `api` and preserves the full path.
- [ ] Confirm setup/link/relink do not create, move, initialize, or edit files inside linked repos or folders, especially a monorepo subfolder without repo-local `openspec/` state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds Workspace CLI: setup, list/ls, link, relink, doctor with JSON (--json) and script-safe (--no-interactive) modes.

* **Product / UX**
  * Terminology pivots to “workspace setup” and “links”; workspace identity uses kebab-case; links verified and stored as runtime-local absolute locations; workspace selection/visibility and agent context use workspace location + linked repos/folders; doctor reports structured diagnostics (no auto-repair).

* **Documentation**
  * Expanded CLI, concepts, and spec docs with examples, JSON shapes, and behavioral rules.

* **Completions**
  * Shell completions support schema-name positional completions and new schema helpers.

* **Tests**
  * New unit and integration tests for interactive flows, validations, JSON modes, and completions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->