### PR TITLE
[codex] Fix Windows workspace path aliases

### DIFF
--- a/src/commands/workspace/operations.ts
+++ b/src/commands/workspace/operations.ts
@@ -49,11 +49,13 @@ export async function readRegistry(): Promise<WorkspaceRegistryState> {
 
 async function recordWorkspaceInRegistry(name: string, workspaceRoot: string): Promise<void> {
   const registry = await readRegistry();
+  const recordedWorkspaceRoot = normalizeExistingPathForStorage(workspaceRoot);
+
   await writeWorkspaceRegistryState({
     version: 1,
     workspaces: {
       ...registry.workspaces,
-      [name]: workspaceRoot,
+      [name]: recordedWorkspaceRoot,
     },
   });
 }
@@ -72,6 +74,12 @@ async function fileExists(filePath: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+function normalizeExistingPathForStorage(existingPath: string): string {
+  return process.platform === 'win32'
+    ? FileSystemUtils.canonicalizeExistingPath(existingPath)
+    : existingPath;
 }
 
 export async function resolveExistingDirectory(
@@ -100,7 +108,7 @@ export async function resolveExistingDirectory(
     );
   }
 
-  return resolvedPath;
+  return normalizeExistingPathForStorage(resolvedPath);
 }
 
 export function inferLinkName(absolutePath: string): string {

--- a/src/commands/workspace/selection.ts
+++ b/src/commands/workspace/selection.ts
@@ -3,6 +3,7 @@ import {
   listWorkspaceRegistryEntries,
   readWorkspaceSharedState,
 } from '../../core/workspace/index.js';
+import { FileSystemUtils } from '../../utils/file-system.js';
 import { isInteractive, resolveNoInteractive } from '../../utils/interactive.js';
 import { readRegistry, validateWorkspaceNameForSetup } from './operations.js';
 import {
@@ -11,6 +12,12 @@ import {
   WorkspaceSelectionOptions,
   makeStatus,
 } from './types.js';
+
+function normalizeRegistryRootForComparison(workspaceRoot: string): string {
+  return process.platform === 'win32'
+    ? FileSystemUtils.canonicalizeExistingPath(workspaceRoot)
+    : workspaceRoot;
+}
 
 export async function selectWorkspaceForCommand(
   options: WorkspaceSelectionOptions,
@@ -46,7 +53,9 @@ export async function selectWorkspaceForCommand(
   if (currentWorkspaceRoot) {
     const sharedState = await readWorkspaceSharedState(currentWorkspaceRoot);
     const registeredRoot = registry.workspaces[sharedState.name];
-    const isRegistered = registeredRoot === currentWorkspaceRoot;
+    const isRegistered =
+      registeredRoot !== undefined &&
+      normalizeRegistryRootForComparison(registeredRoot) === currentWorkspaceRoot;
     const warning = makeStatus(
       'warning',
       'workspace_not_in_local_registry',

--- a/src/core/workspace/foundation.ts
+++ b/src/core/workspace/foundation.ts
@@ -175,7 +175,9 @@ export async function findWorkspaceRoot(startPath = process.cwd()): Promise<stri
 
   while (true) {
     if (await isWorkspaceRoot(currentDir)) {
-      return currentDir;
+      return process.platform === 'win32'
+        ? FileSystemUtils.canonicalizeExistingPath(currentDir)
+        : currentDir;
     }
 
     const parentDir = path.dirname(currentDir);

--- a/test/commands/workspace.test.ts
+++ b/test/commands/workspace.test.ts
@@ -4,7 +4,10 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 
 import { COMMAND_REGISTRY } from '../../src/core/completions/command-registry.js';
-import { createManagedWorkspace } from '../../src/commands/workspace/operations.js';
+import {
+  createManagedWorkspace,
+  resolveExistingDirectory,
+} from '../../src/commands/workspace/operations.js';
 import {
   WORKSPACE_CHANGES_DIR_NAME,
   WORKSPACE_LOCAL_STATE_FILE_NAME,
@@ -232,6 +235,25 @@ describe('workspace command', () => {
       api: path.join(resolvedProject, 'repos', 'api'),
       billing: path.join(resolvedProject, 'archive', 'billing'),
     });
+  });
+
+  it('canonicalizes existing link directories on Windows before storing local paths', async () => {
+    const api = mkdir('repos/api');
+    const canonicalApi = path.join(tempDir, 'canonical', 'api');
+    const originalPlatform = process.platform;
+    const canonicalize = vi
+      .spyOn(FileSystemUtils, 'canonicalizeExistingPath')
+      .mockImplementation((targetPath) => (targetPath === api ? canonicalApi : targetPath));
+
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+
+    try {
+      await expect(resolveExistingDirectory(api)).resolves.toBe(canonicalApi);
+      expect(canonicalize).toHaveBeenCalledWith(api);
+    } finally {
+      canonicalize.mockRestore();
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+    }
   });
 
   it('rejects duplicate setup link names without creating or rewriting a workspace', async () => {

--- a/test/core/workspace/foundation.test.ts
+++ b/test/core/workspace/foundation.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
 import { getGlobalDataDir } from '../../../src/core/global-config.js';
+import { FileSystemUtils } from '../../../src/utils/file-system.js';
 import {
   MANAGED_WORKSPACES_DIR_NAME,
   WORKSPACE_CHANGES_DIR_NAME,
@@ -223,6 +224,27 @@ paths: {}
       fs.mkdirSync(linkedPath, { recursive: true });
 
       await expect(findWorkspaceRoot(linkedPath)).resolves.toBe(workspaceRoot);
+    });
+
+    it('canonicalizes detected workspace roots on Windows before returning them', async () => {
+      const workspaceRoot = createWorkspaceRoot();
+      const canonicalWorkspaceRoot = path.join(tempDir, 'canonical-platform');
+      const originalPlatform = process.platform;
+      const canonicalize = vi
+        .spyOn(FileSystemUtils, 'canonicalizeExistingPath')
+        .mockImplementation((targetPath) =>
+          targetPath === workspaceRoot ? canonicalWorkspaceRoot : targetPath
+        );
+
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+
+      try {
+        await expect(findWorkspaceRoot(workspaceRoot)).resolves.toBe(canonicalWorkspaceRoot);
+        expect(canonicalize).toHaveBeenCalledWith(workspaceRoot);
+      } finally {
+        canonicalize.mockRestore();
+        Object.defineProperty(process, 'platform', { value: originalPlatform });
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

Fix Windows workspace path persistence so GitHub Actions and native Windows shells do not store 8.3 short-name aliases such as `C:\Users\RUNNER~1\...` in workspace local state or the workspace registry.

## Root Cause

Workspace link paths and detected workspace roots were resolved with `path.resolve(...)` / `process.cwd()` and then persisted directly. On Windows runners, spawned Node processes can observe short path aliases for temp directories, while tests and user-facing path expectations use the long native path.

## Changes

- Canonicalize existing workspace link paths on Windows before storing them in machine-local state.
- Canonicalize detected workspace roots on Windows before using them for current-workspace selection and registry writes.
- Compare registry roots through the same Windows canonicalization path so old alias spellings do not falsely mark the current workspace as unregistered.
- Add Windows-focused regression tests for link path storage and workspace root detection.

## Validation

- `pnpm run build`
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm exec vitest run test/commands/workspace.test.ts test/core/workspace/foundation.test.ts`
- `pnpm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace path handling on Windows systems by implementing path normalization. Workspace paths are now canonicalized when stored in the local registry and compared during workspace detection, ensuring consistent behavior regardless of how the workspace path is specified. This prevents the CLI from incorrectly treating the same workspace as unregistered due to path format differences on Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->