### PR TITLE
[codex] Fix Windows workspace path test expectations

### DIFF
--- a/test/commands/workspace.interactive.test.ts
+++ b/test/commands/workspace.interactive.test.ts
@@ -88,6 +88,10 @@ describe('workspace command interactive flows', () => {
     return dir;
   }
 
+  function expectedExistingPath(existingPath: string): string {
+    return process.platform === 'win32' ? fs.realpathSync.native(existingPath) : existingPath;
+  }
+
   function readLocalState(workspaceName: string) {
     const workspaceRoot = getManagedWorkspaceRoot(workspaceName);
     return parseWorkspaceLocalState(
@@ -97,6 +101,7 @@ describe('workspace command interactive flows', () => {
 
   it('asks for the workspace name first and validates kebab-case before asking for links', async () => {
     const api = mkdir('repos/api');
+    const expectedApi = expectedExistingPath(api);
     const { input, confirm, select } = await getPromptMocks();
 
     input.mockImplementation(async (options: { message: string; validate?: (value: string) => true | string }) => {
@@ -139,7 +144,7 @@ describe('workspace command interactive flows', () => {
         ]),
       })
     );
-    expect(readLocalState('platform').paths).toEqual({ api });
+    expect(readLocalState('platform').paths).toEqual({ api: expectedApi });
   });
 
   it('handles prompt cancellation without printing the raw SIGINT error', async () => {
@@ -160,6 +165,8 @@ describe('workspace command interactive flows', () => {
   it('lets users add another path and rename an inferred link-name conflict', async () => {
     const firstApi = mkdir('repos/current/api');
     const secondApi = mkdir('repos/archive/api');
+    const expectedFirstApi = expectedExistingPath(firstApi);
+    const expectedSecondApi = expectedExistingPath(secondApi);
     const { input, confirm, select } = await getPromptMocks();
 
     input.mockImplementation(async (options: { message: string; validate?: (value: string) => true | string }) => {
@@ -176,7 +183,9 @@ describe('workspace command interactive flows', () => {
       }
 
       if (options.message === 'Link name:') {
-        expect(options.validate?.('api')).toBe(`Link name 'api' is already linked to ${firstApi}.`);
+        expect(options.validate?.('api')).toBe(
+          `Link name 'api' is already linked to ${expectedFirstApi}.`
+        );
         expect(options.validate?.('api-archive')).toBe(true);
         return 'api-archive';
       }
@@ -196,16 +205,17 @@ describe('workspace command interactive flows', () => {
     ]);
     expect(confirm).not.toHaveBeenCalled();
     expect(consoleLogSpy).toHaveBeenCalledWith(
-      `Link name 'api' is already linked to ${firstApi}.`
+      `Link name 'api' is already linked to ${expectedFirstApi}.`
     );
     expect(readLocalState('platform').paths).toEqual({
-      api: firstApi,
-      'api-archive': secondApi,
+      api: expectedFirstApi,
+      'api-archive': expectedSecondApi,
     });
   });
 
   it('asks for a link name when the inferred basename is invalid', async () => {
     const linkedRoot = path.parse(tempDir).root;
+    const expectedLinkedRoot = expectedExistingPath(linkedRoot);
     const { input, confirm, select } = await getPromptMocks();
 
     input.mockImplementation(async (options: { message: string; validate?: (value: string) => true | string }) => {
@@ -237,7 +247,7 @@ describe('workspace command interactive flows', () => {
     ]);
     expect(confirm).not.toHaveBeenCalled();
     expect(readLocalState('platform').paths).toEqual({
-      root: linkedRoot,
+      root: expectedLinkedRoot,
     });
   });
 

--- a/test/commands/workspace.test.ts
+++ b/test/commands/workspace.test.ts
@@ -50,6 +50,10 @@ describe('workspace command', () => {
     return dir;
   }
 
+  function expectedExistingPath(existingPath: string): string {
+    return process.platform === 'win32' ? fs.realpathSync.native(existingPath) : existingPath;
+  }
+
   function parseJson(result: RunCLIResult): any {
     try {
       return JSON.parse(result.stdout);
@@ -85,27 +89,30 @@ describe('workspace command', () => {
     const api = mkdir('repos/api');
     mkdir('repos/api/openspec/specs');
     const checkout = mkdir('repos/platform/apps/checkout');
+    const expectedApi = expectedExistingPath(api);
+    const expectedCheckout = expectedExistingPath(checkout);
 
     const setup = await setupWorkspace('platform', [`api=${api}`, checkout]);
+    const workspaceRoot = setup.workspace.root;
+    const expectedWorkspaceRoot = expectedExistingPath(workspaceRoot);
 
     expect(setup.status).toEqual([]);
     expect(setup.workspace.name).toBe('platform');
     expect(setup.workspace.links).toEqual([
       expect.objectContaining({
         name: 'api',
-        path: api,
-        repo_specs_path: path.join(api, 'openspec', 'specs'),
+        path: expectedApi,
+        repo_specs_path: path.join(expectedApi, 'openspec', 'specs'),
         status: [],
       }),
       expect.objectContaining({
         name: 'checkout',
-        path: checkout,
+        path: expectedCheckout,
         repo_specs_path: null,
         status: [],
       }),
     ]);
 
-    const workspaceRoot = setup.workspace.root;
     const sharedState = parseWorkspaceSharedState(
       fs.readFileSync(getWorkspaceSharedStatePath(workspaceRoot), 'utf-8')
     );
@@ -128,10 +135,10 @@ describe('workspace command', () => {
       },
     });
     expect(localState.paths).toEqual({
-      api,
-      checkout,
+      api: expectedApi,
+      checkout: expectedCheckout,
     });
-    expect(registry.workspaces.platform).toBe(workspaceRoot);
+    expect(registry.workspaces.platform).toBe(expectedWorkspaceRoot);
     expect(fs.readFileSync(path.join(workspaceRoot, '.gitignore'), 'utf-8')).toContain(
       WORKSPACE_LOCAL_STATE_IGNORE_PATTERN
     );
@@ -142,10 +149,10 @@ describe('workspace command', () => {
     expect(listPayload.workspaces).toEqual([
       expect.objectContaining({
         name: 'platform',
-        root: workspaceRoot,
+        root: expectedWorkspaceRoot,
         links: [
-          expect.objectContaining({ name: 'api', path: api, status: [] }),
-          expect.objectContaining({ name: 'checkout', path: checkout, status: [] }),
+          expect.objectContaining({ name: 'api', path: expectedApi, status: [] }),
+          expect.objectContaining({ name: 'checkout', path: expectedCheckout, status: [] }),
         ],
         status: [],
       }),
@@ -155,18 +162,20 @@ describe('workspace command', () => {
   it('preserves equals signs in inferred and explicit setup link paths', async () => {
     const inferred = mkdir('repos/foo=bar');
     const explicit = mkdir('repos/api=service');
+    const expectedInferred = expectedExistingPath(inferred);
+    const expectedExplicit = expectedExistingPath(explicit);
 
     const setup = await setupWorkspace('equals-paths', [inferred, `api=${explicit}`]);
 
     expect(setup.workspace.links).toEqual([
       expect.objectContaining({
         name: 'api',
-        path: explicit,
+        path: expectedExplicit,
         status: [],
       }),
       expect.objectContaining({
         name: 'foo=bar',
-        path: inferred,
+        path: expectedInferred,
         status: [],
       }),
     ]);
@@ -175,8 +184,8 @@ describe('workspace command', () => {
       fs.readFileSync(getWorkspaceLocalStatePath(setup.workspace.root), 'utf-8')
     );
     expect(localState.paths).toEqual({
-      api: explicit,
-      'foo=bar': inferred,
+      api: expectedExplicit,
+      'foo=bar': expectedInferred,
     });
   });
 
@@ -259,6 +268,7 @@ describe('workspace command', () => {
   it('rejects duplicate setup link names without creating or rewriting a workspace', async () => {
     const firstApi = mkdir('repos/current/api');
     const secondApi = mkdir('repos/archive/api');
+    const expectedFirstApi = expectedExistingPath(firstApi);
 
     const duplicate = await runCLI(
       [
@@ -280,7 +290,7 @@ describe('workspace command', () => {
     expect(parseJson(duplicate).status[0]).toEqual(
       expect.objectContaining({
         code: 'duplicate_link_name',
-        message: expect.stringContaining(firstApi),
+        message: expect.stringContaining(expectedFirstApi),
         fix: expect.stringContaining('--link api-alt='),
       })
     );
@@ -465,6 +475,8 @@ describe('workspace command', () => {
     const billing = mkdir('repos/platform/services/billing');
     const billingNew = mkdir('repos/archive/billing');
     const duplicate = mkdir('repos/duplicate-billing');
+    const expectedBilling = expectedExistingPath(billing);
+    const expectedBillingNew = expectedExistingPath(billingNew);
 
     await setupWorkspace('platform', [`api=${api}`]);
 
@@ -473,7 +485,7 @@ describe('workspace command', () => {
     expect(parseJson(link).link).toEqual(
       expect.objectContaining({
         name: 'billing',
-        path: billing,
+        path: expectedBilling,
         status: [],
       })
     );
@@ -498,7 +510,7 @@ describe('workspace command', () => {
     expect(parseJson(relink).link).toEqual(
       expect.objectContaining({
         name: 'billing',
-        path: billingNew,
+        path: expectedBillingNew,
       })
     );
 
@@ -517,6 +529,7 @@ describe('workspace command', () => {
   it('links monorepo folders without editing the linked folder', async () => {
     const api = mkdir('repos/api');
     const packageDir = mkdir('monorepo/apps/checkout');
+    const expectedPackageDir = expectedExistingPath(packageDir);
     const sentinelPath = path.join(packageDir, 'package.json');
     fs.writeFileSync(sentinelPath, '{"name":"checkout"}\n');
     const entriesBefore = fs.readdirSync(packageDir).sort();
@@ -532,7 +545,7 @@ describe('workspace command', () => {
     expect(parseJson(link).link).toEqual(
       expect.objectContaining({
         name: 'checkout',
-        path: packageDir,
+        path: expectedPackageDir,
       })
     );
     expect(fs.readFileSync(sentinelPath, 'utf-8')).toBe('{"name":"checkout"}\n');
@@ -801,7 +814,7 @@ paths:
     expect(parseJson(doctor).workspace).toEqual(
       expect.objectContaining({
         name: 'checkout-web',
-        root: checkout.workspace.root,
+        root: expectedExistingPath(checkout.workspace.root),
       })
     );
 
@@ -837,6 +850,7 @@ paths:
 
   it('prints readable human output for setup, list, and doctor', async () => {
     const api = mkdir('repos/api');
+    const expectedApi = expectedExistingPath(api);
 
     const setup = await runCLI(
       ['workspace', 'setup', '--no-interactive', '--name', 'platform', '--link', `api=${api}`],
@@ -848,7 +862,7 @@ paths:
     expect(setup.stdout).toContain('Location:');
     expect(setup.stdout).not.toContain('Root:');
     expect(setup.stdout).toContain('Linked repos or folders (1):');
-    expect(setup.stdout).toContain(`api -> ${api}`);
+    expect(setup.stdout).toContain(`api -> ${expectedApi}`);
     expect(setup.stdout).toContain('Planning path:');
     expect(setup.stdout).toContain('Workspace check:');
     expect(setup.stdout).toContain('No workspace issues found.');
@@ -861,7 +875,7 @@ paths:
     expect(list.stdout).toContain('Location:');
     expect(list.stdout).not.toContain('Root:');
     expect(list.stdout).toContain('Linked repos or folders (1):');
-    expect(list.stdout).toContain(`api -> ${api}`);
+    expect(list.stdout).toContain(`api -> ${expectedApi}`);
 
     const doctor = await runCLI(['workspace', 'doctor', '--workspace', 'platform'], {
       cwd: tempDir,

--- a/test/core/workspace/foundation.test.ts
+++ b/test/core/workspace/foundation.test.ts
@@ -75,6 +75,10 @@ paths: {}
     return workspaceRoot;
   }
 
+  function expectedExistingPath(existingPath: string): string {
+    return process.platform === 'win32' ? fs.realpathSync.native(existingPath) : existingPath;
+  }
+
   describe('path helpers', () => {
     it('exposes the workspace constants', () => {
       expect(WORKSPACE_METADATA_DIR_NAME).toBe('.openspec-workspace');
@@ -193,8 +197,12 @@ paths: {}
       fs.mkdirSync(nestedDir, { recursive: true });
 
       await expect(isWorkspaceRoot(workspaceRoot)).resolves.toBe(true);
-      await expect(findWorkspaceRoot(workspaceRoot)).resolves.toBe(workspaceRoot);
-      await expect(findWorkspaceRoot(nestedDir)).resolves.toBe(workspaceRoot);
+      await expect(findWorkspaceRoot(workspaceRoot)).resolves.toBe(
+        expectedExistingPath(workspaceRoot)
+      );
+      await expect(findWorkspaceRoot(nestedDir)).resolves.toBe(
+        expectedExistingPath(workspaceRoot)
+      );
       await expect(workspaceChangesDirExists(workspaceRoot)).resolves.toBe(true);
     });
 
@@ -223,7 +231,9 @@ paths: {}
       const linkedPath = path.join(workspaceRoot, 'external-folder');
       fs.mkdirSync(linkedPath, { recursive: true });
 
-      await expect(findWorkspaceRoot(linkedPath)).resolves.toBe(workspaceRoot);
+      await expect(findWorkspaceRoot(linkedPath)).resolves.toBe(
+        expectedExistingPath(workspaceRoot)
+      );
     });
 
     it('canonicalizes detected workspace roots on Windows before returning them', async () => {


### PR DESCRIPTION
## Summary

Updates workspace-related tests to expect canonical existing paths where the runtime now canonicalizes Windows paths.

## Root Cause

The latest `main` CI failure is in `Test (windows-pwsh)`. The production change in #1050 intentionally canonicalizes existing Windows paths, so temporary paths like `C:\Users\RUNNER~1\...` are reported as `C:\Users\runneradmin\...`. Several tests still compared against the raw temporary path.

## Impact

This keeps the Windows path alias fix intact and aligns test expectations with the intended canonical path behavior. Non-Windows expectations remain unchanged where the code preserves raw paths.

## Validation

- `pnpm run build`
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test suite robustness with enhanced cross-platform path handling to ensure consistent test behavior across Windows and other operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->