### PR TITLE
[codex] Fix Windows workspace CI tests

### DIFF
--- a/test/commands/workspace.interactive.test.ts
+++ b/test/commands/workspace.interactive.test.ts
@@ -342,7 +342,8 @@ describe('workspace command interactive flows', () => {
       process.platform === 'win32' ? '@echo off\r\nexit /B 0\r\n' : '#!/bin/sh\nexit 0\n'
     );
     fs.chmodSync(codePath, 0o755);
-    process.env.PATH = binDir;
+    const pathKey = Object.keys(process.env).find((key) => key.toLowerCase() === 'path') ?? 'PATH';
+    process.env[pathKey] = `${binDir}${path.delimiter}${process.env[pathKey] ?? ''}`;
     const { select } = await getPromptMocks();
 
     await runWorkspaceCommand(['setup', '--no-interactive', '--name', 'platform', '--link', `api=${api}`]);
@@ -358,10 +359,10 @@ describe('workspace command interactive flows', () => {
       })
     );
     const openerPrompt = select.mock.calls.find(([options]) => options.message === 'Open with:')?.[0];
-    expect(openerPrompt?.choices.map((choice: { value: string }) => choice.value).sort()).toEqual([
-      'editor',
-      'github-copilot',
-    ]);
+    expect(openerPrompt?.default).toBe('editor');
+    expect(openerPrompt?.choices.map((choice: { value: string }) => choice.value)).toEqual(
+      expect.arrayContaining(['editor', 'github-copilot'])
+    );
     expect(consoleLogSpy).toHaveBeenCalledWith('Opening workspace: platform');
     expect(readLocalState('platform').preferred_opener).toBeUndefined();
   });

--- a/test/commands/workspace.test.ts
+++ b/test/commands/workspace.test.ts
@@ -203,11 +203,11 @@ describe('workspace command', () => {
       },
       {
         name: 'api',
-        path: api,
+        path: expectedApi,
       },
       {
         name: 'checkout',
-        path: checkout,
+        path: expectedCheckout,
       },
     ]);
 
@@ -959,6 +959,7 @@ paths:
 
   it('opens a workspace through VS Code editor and agent overrides without changing stored preference', async () => {
     const api = mkdir('repos/api');
+    const expectedApi = expectedExistingPath(api);
     const web = mkdir('repos/web');
     const setup = await setupWorkspace('platform', [`api=${api}`, `web=${web}`], ['--opener', 'editor']);
     fs.rmSync(web, { recursive: true, force: true });
@@ -982,7 +983,7 @@ paths:
       },
       {
         name: 'api',
-        path: api,
+        path: expectedApi,
       },
     ]);
     const editorLaunch = readLaunchLog(code.logPath);
@@ -1111,7 +1112,7 @@ preferred_opener:
     expect(unavailable.exitCode).toBe(1);
     expect(unavailable.stderr).toContain("'code' was not found on PATH");
     expect(unavailable.stderr).toContain(
-      getWorkspaceCodeWorkspacePath(platform.workspace.root, 'platform')
+      getWorkspaceCodeWorkspacePath(expectedExistingPath(platform.workspace.root), 'platform')
     );
   });
 


### PR DESCRIPTION
## Summary

Fixes the failing main CI Windows test job by aligning the workspace tests with the intended Windows path behavior.

## Root cause

The latest `main` CI failure was in `Test (windows-pwsh)` for workflow run `25415627238`. The workspace implementation canonicalizes existing Windows paths before persisting or using them in generated workspace surfaces, expanding short temp aliases like `C:\Users\RUNNER~1\...` to long paths like `C:\Users\runneradmin\...`. A few test assertions for generated `.code-workspace` files and unavailable-opener messages still expected the short alias.

One interactive test also replaced `PATH` with only a fake bin directory. On Windows that can remove the system shell path needed to launch a `.cmd` shim, leaving `process.exitCode` set to `1` even though the fake opener was meant to succeed.

## Changes

- Compare generated workspace folder paths and manual workspace-file paths against canonicalized expected paths on Windows.
- Prepend the fake opener bin directory to the existing PATH in the interactive opener test instead of replacing PATH.
- Loosen the opener-choice assertion so it remains valid when additional supported tools are installed locally.

## Validation

- `pnpm vitest run test/commands/workspace.test.ts test/commands/workspace.interactive.test.ts`
- `pnpm test`
- `pnpm run build`
- `pnpm exec tsc --noEmit`
- `pnpm lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved cross-platform path handling in workspace tests to ensure robust behavior across different operating systems
  * Updated path canonicalization in VS Code integration tests for consistency
  * Refined workspace opener preference validation tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->