### PR TITLE
[codex] Fix Windows workspace launch arg expectation

### DIFF
--- a/test/commands/workspace.test.ts
+++ b/test/commands/workspace.test.ts
@@ -991,7 +991,7 @@ paths:
       fs.realpathSync.native(setup.workspace.root)
     );
     expect(editorLaunch.args).toEqual([
-      getWorkspaceCodeWorkspacePath(setup.workspace.root, 'platform'),
+      getWorkspaceCodeWorkspacePath(expectedExistingPath(setup.workspace.root), 'platform'),
     ]);
 
     const currentWorkspaceOpen = await runCLI(['workspace', 'open', '--editor', '--no-interactive'], {
@@ -1014,7 +1014,11 @@ paths:
     expect(fs.realpathSync.native(codexLaunch.cwd)).toBe(
       fs.realpathSync.native(setup.workspace.root)
     );
-    expect(codexLaunch.args).toEqual(['--add-dir', api, 'Open this OpenSpec workspace.']);
+    expect(codexLaunch.args).toEqual([
+      '--add-dir',
+      expectedApi,
+      'Open this OpenSpec workspace.',
+    ]);
     expect(readLocalState(setup.workspace.root).preferred_opener).toEqual({
       kind: 'editor',
       id: 'vscode',


### PR DESCRIPTION
## Summary

Fixes the remaining Windows `main` CI failure after #1056 by canonicalizing the launch argument expectations in the workspace open test.

## Root cause

The latest `main` CI run after #1056 still failed in `Test (windows-pwsh)` for workflow run `25416165547`. The earlier fix updated generated workspace file and manual path assertions, but the same test still expected `editorLaunch.args` to contain the raw short temp alias path. On Windows, the workspace root has already been canonicalized before the opener command is built, so the actual launch argument uses the long path.

The agent launch assertion in the same test had the same raw-path assumption for `--add-dir`, so this updates it too before it can become the next Windows-only failure.

## Changes

- Expect the VS Code workspace file launch argument to use `expectedExistingPath(setup.workspace.root)`.
- Expect the Codex `--add-dir` argument to use the canonicalized `expectedApi` link path.

## Validation

- `pnpm vitest run test/commands/workspace.test.ts`
- `pnpm test`
- `pnpm run build`
- `pnpm exec tsc --noEmit`
- `pnpm lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved workspace path and API path handling in tests to ensure proper canonicalization across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->