### PR TITLE
docs(migration-guide): fix inconsistent /opsx:sync description

### DIFF
--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -297,7 +297,7 @@ Command availability is profile-dependent:
 | `/opsx:continue` | Create the next artifact (one at a time) |
 | `/opsx:ff` | Fast-forward—create planning artifacts at once |
 | `/opsx:verify` | Validate implementation matches specs |
-| `/opsx:sync` | Preview/spec-merge without archiving |
+| `/opsx:sync` | Merge delta specs into main specs |
 | `/opsx:bulk-archive` | Archive multiple changes at once |
 | `/opsx:onboard` | Guided end-to-end onboarding workflow |
 


### PR DESCRIPTION
## Issue
The `/opsx:sync` command has inconsistent descriptions across three documentation files:
- `migration-guide.md`: "Preview/spec-merge without archiving"
- `commands.md`: "Merge delta specs into main specs"
- `workflows.md`: "Merge delta specs"

## Change
Unified the description to match `commands.md`: "Merge delta specs into main specs"

## Rationale
- More accurate and clearer description
- Consistent with the main command reference documentation
- Reduces user confusion

## Impact
Documentation-only change, no functional impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the migration guide to clarify the description of the /opsx:sync command functionality, improving accuracy for users following the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->