### PR TITLE
docs(opsx): fix /opsx:sync description and add detailed documentation

### DIFF
--- a/docs/opsx.md
+++ b/docs/opsx.md
@@ -209,7 +209,7 @@ Creates all planning artifacts at once. Use when you have a clear picture of wha
 Works through tasks, checking them off as you go. If you're juggling multiple changes, you can run `/opsx:apply <name>`; otherwise it should infer from the conversation and prompt you to choose if it can't tell.
 
 ### Sync delta specs
-```
+```text
 /opsx:sync
 ```
 Merges delta specs from the current change into main specs. Optional—archive will prompt to sync if needed.

--- a/docs/opsx.md
+++ b/docs/opsx.md
@@ -164,7 +164,7 @@ rules:
 | `/opsx:ff` | Fast-forward planning artifacts (expanded workflow) |
 | `/opsx:apply` | Implement tasks, updating artifacts as needed |
 | `/opsx:verify` | Validate implementation against artifacts (expanded workflow) |
-| `/opsx:sync` | Sync delta specs to main (default workflow, optional) |
+| `/opsx:sync` | Merge delta specs into main specs (optional) |
 | `/opsx:archive` | Archive when done |
 | `/opsx:bulk-archive` | Archive multiple completed changes (expanded workflow) |
 | `/opsx:onboard` | Guided walkthrough of an end-to-end change (expanded workflow) |
@@ -207,6 +207,22 @@ Creates all planning artifacts at once. Use when you have a clear picture of wha
 /opsx:apply
 ```
 Works through tasks, checking them off as you go. If you're juggling multiple changes, you can run `/opsx:apply <name>`; otherwise it should infer from the conversation and prompt you to choose if it can't tell.
+
+### Sync delta specs
+```
+/opsx:sync
+```
+Merges delta specs from the current change into main specs. Optional—archive will prompt to sync if needed.
+
+**What it does:**
+- Reads delta specs from change folder
+- Merges changes into main `openspec/specs/` directory
+- Does not archive the change (remains active)
+
+**When to use:**
+- You want to update main specs before archiving
+- Multiple changes need to see each other's specs
+- You're iterating on specs and want to test integration
 
 ### Finish up
 ```


### PR DESCRIPTION
## Issue
The `/opsx:sync` command has inconsistent description and missing documentation in `opsx.md`:
- Description uses "Sync" instead of "Merge" (inconsistent with other docs)
- Description is unclear: "to main" vs "into main specs"
- Missing detailed Usage section documentation

## Changes
1. **Fixed command table description** (line 167):
   - Before: `"Sync delta specs to main (default workflow, optional)"`
   - After: `"Merge delta specs into main specs (optional)"`

2. **Added detailed Usage section**:
   - Explains what the command does
   - Lists when to use it
   - Provides context for users

## Rationale
- **Consistency**: Now matches `commands.md` and `migration-guide.md`
- **Clarity**: "Merge" is more accurate than "Sync" for this operation
- **Completeness**: Usage section now documents all commands in the table
- **User experience**: Users can find detailed information in `opsx.md`

## Impact
Documentation-only change, no functional impact.

## Related
- PR #1059: Fixed similar issue in `migration-guide.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified `/opsx:sync` behavior: now described as merging delta specs into main specs and marked optional.
  * Added a new "Sync delta specs" usage section explaining merge behavior, when to use the command, and prompts to sync before archiving.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->