### PR TITLE
feat: add oh-my-pi (OMP) support

### DIFF
--- a/src/core/command-generation/adapters/index.ts
+++ b/src/core/command-generation/adapters/index.ts
@@ -23,6 +23,7 @@ export { iflowAdapter } from './iflow.js';
 export { junieAdapter } from './junie.js';
 export { kilocodeAdapter } from './kilocode.js';
 export { kiroAdapter } from './kiro.js';
+export { ohMyPiAdapter } from './oh-my-pi.js';
 export { opencodeAdapter } from './opencode.js';
 export { piAdapter } from './pi.js';
 export { qoderAdapter } from './qoder.js';

--- a/src/core/command-generation/adapters/oh-my-pi.ts
+++ b/src/core/command-generation/adapters/oh-my-pi.ts
@@ -1,0 +1,40 @@
+/**
+ * Oh My Pi (OMP) Command Adapter
+ *
+ * Formats commands for Oh My Pi following its slash command specification.
+ * OMP loads slash commands from .omp/commands/*.md with YAML frontmatter.
+ * The filename (minus .md) becomes the slash command name.
+ */
+
+import path from 'path';
+import type { CommandContent, ToolCommandAdapter } from '../types.js';
+import { transformToHyphenCommands } from '../../../utils/command-references.js';
+
+/**
+ * Oh My Pi adapter for command generation.
+ * File path: .omp/commands/opsx-<id>.md
+ * Frontmatter: description
+ *
+ * OMP uses the filename (minus .md) as the slash command name, so
+ * opsx-propose.md → /opsx-propose. Command references in the body
+ * are transformed from /opsx: to /opsx- for consistency.
+ */
+export const ohMyPiAdapter: ToolCommandAdapter = {
+  toolId: 'oh-my-pi',
+
+  getFilePath(commandId: string): string {
+    return path.join('.omp', 'commands', `opsx-${commandId}.md`);
+  },
+
+  formatFile(content: CommandContent): string {
+    // Transform /opsx: references to /opsx- for filename-based command naming
+    const transformedBody = transformToHyphenCommands(content.body);
+
+    return `---
+description: ${content.description}
+---
+
+${transformedBody}
+`;
+  },
+};

--- a/src/core/command-generation/registry.ts
+++ b/src/core/command-generation/registry.ts
@@ -25,6 +25,7 @@ import { iflowAdapter } from './adapters/iflow.js';
 import { junieAdapter } from './adapters/junie.js';
 import { kilocodeAdapter } from './adapters/kilocode.js';
 import { kiroAdapter } from './adapters/kiro.js';
+import { ohMyPiAdapter } from './adapters/oh-my-pi.js';
 import { opencodeAdapter } from './adapters/opencode.js';
 import { piAdapter } from './adapters/pi.js';
 import { qoderAdapter } from './adapters/qoder.js';
@@ -60,6 +61,7 @@ export class CommandAdapterRegistry {
     CommandAdapterRegistry.register(junieAdapter);
     CommandAdapterRegistry.register(kilocodeAdapter);
     CommandAdapterRegistry.register(kiroAdapter);
+    CommandAdapterRegistry.register(ohMyPiAdapter);
     CommandAdapterRegistry.register(opencodeAdapter);
     CommandAdapterRegistry.register(piAdapter);
     CommandAdapterRegistry.register(qoderAdapter);

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -40,6 +40,7 @@ export const AI_TOOLS: AIToolOption[] = [
   { name: 'Kilo Code', value: 'kilocode', available: true, successLabel: 'Kilo Code', skillsDir: '.kilocode' },
   { name: 'Kimi CLI', value: 'kimi', available: true, successLabel: 'Kimi CLI', skillsDir: '.kimi' },
   { name: 'Kiro', value: 'kiro', available: true, successLabel: 'Kiro', skillsDir: '.kiro' },
+  { name: 'Oh My Pi', value: 'oh-my-pi', available: true, successLabel: 'Oh My Pi', skillsDir: '.omp' },
   { name: 'OpenCode', value: 'opencode', available: true, successLabel: 'OpenCode', skillsDir: '.opencode' },
   { name: 'Pi', value: 'pi', available: true, successLabel: 'Pi', skillsDir: '.pi' },
   { name: 'Qoder', value: 'qoder', available: true, successLabel: 'Qoder', skillsDir: '.qoder' },

--- a/src/core/init.ts
+++ b/src/core/init.ts
@@ -315,7 +315,7 @@ export class InitCommand {
         if (!a.configured && b.configured) return 1;
         if (a.detected && !b.detected) return -1;
         if (!a.detected && b.detected) return 1;
-        return 0;
+        return a.name.localeCompare(b.name);
       });
 
     const configuredNames = validTools
@@ -538,7 +538,7 @@ export class InitCommand {
 
             // Generate SKILL.md content with YAML frontmatter including generatedBy
             // Use hyphen-based command references for tools where filename = command name
-            const transformer = (tool.value === 'opencode' || tool.value === 'pi') ? transformToHyphenCommands : undefined;
+            const transformer = (tool.value === 'opencode' || tool.value === 'pi' || tool.value === 'oh-my-pi') ? transformToHyphenCommands : undefined;
             const skillContent = generateSkillContent(template, OPENSPEC_VERSION, transformer);
 
             // Write the skill file

--- a/src/core/update.ts
+++ b/src/core/update.ts
@@ -197,7 +197,7 @@ export class UpdateCommand {
             const skillFile = path.join(skillDir, 'SKILL.md');
 
             // Use hyphen-based command references for OpenCode
-            const transformer = (tool.value === 'opencode' || tool.value === 'pi') ? transformToHyphenCommands : undefined;
+            const transformer = (tool.value === 'opencode' || tool.value === 'pi' || tool.value === 'oh-my-pi') ? transformToHyphenCommands : undefined;
             const skillContent = generateSkillContent(template, OPENSPEC_VERSION, transformer);
             await FileSystemUtils.writeFile(skillFile, skillContent);
           }
@@ -691,7 +691,7 @@ export class UpdateCommand {
             const skillFile = path.join(skillDir, 'SKILL.md');
 
             // Use hyphen-based command references for OpenCode
-            const transformer = (tool.value === 'opencode' || tool.value === 'pi') ? transformToHyphenCommands : undefined;
+            const transformer = (tool.value === 'opencode' || tool.value === 'pi' || tool.value === 'oh-my-pi') ? transformToHyphenCommands : undefined;
             const skillContent = generateSkillContent(template, OPENSPEC_VERSION, transformer);
             await FileSystemUtils.writeFile(skillFile, skillContent);
           }

--- a/test/core/command-generation/adapters.test.ts
+++ b/test/core/command-generation/adapters.test.ts
@@ -18,6 +18,7 @@ import { geminiAdapter } from '../../../src/core/command-generation/adapters/gem
 import { githubCopilotAdapter } from '../../../src/core/command-generation/adapters/github-copilot.js';
 import { iflowAdapter } from '../../../src/core/command-generation/adapters/iflow.js';
 import { kilocodeAdapter } from '../../../src/core/command-generation/adapters/kilocode.js';
+import { ohMyPiAdapter } from '../../../src/core/command-generation/adapters/oh-my-pi.js';
 import { opencodeAdapter } from '../../../src/core/command-generation/adapters/opencode.js';
 import { piAdapter } from '../../../src/core/command-generation/adapters/pi.js';
 import { qoderAdapter } from '../../../src/core/command-generation/adapters/qoder.js';
@@ -653,6 +654,56 @@ describe('command-generation/adapters', () => {
       expect(output).toContain('description: "Line 1\\nLine 2"');
     });
   });
+  describe('ohMyPiAdapter', () => {
+    it('should have correct toolId', () => {
+      expect(ohMyPiAdapter.toolId).toBe('oh-my-pi');
+    });
+
+    it('should generate correct file path', () => {
+      const filePath = ohMyPiAdapter.getFilePath('explore');
+      expect(filePath).toBe(path.join('.omp', 'commands', 'opsx-explore.md'));
+    });
+
+    it('should generate correct file paths for different commands', () => {
+      expect(ohMyPiAdapter.getFilePath('new')).toBe(path.join('.omp', 'commands', 'opsx-new.md'));
+      expect(ohMyPiAdapter.getFilePath('bulk-archive')).toBe(path.join('.omp', 'commands', 'opsx-bulk-archive.md'));
+    });
+
+    it('should format file with description frontmatter', () => {
+      const output = ohMyPiAdapter.formatFile(sampleContent);
+      expect(output).toContain('---\n');
+      expect(output).toContain('description: Enter explore mode for thinking');
+      expect(output).toContain('---\n\n');
+      expect(output).toContain('This is the command body.');
+    });
+
+    it('should transform command references from colon to hyphen format', () => {
+      const contentWithRefs: CommandContent = {
+        ...sampleContent,
+        body: 'Run /opsx:apply to implement. Then /opsx:archive when done.',
+      };
+
+      const output = ohMyPiAdapter.formatFile(contentWithRefs);
+      expect(output).toContain('/opsx-apply');
+      expect(output).toContain('/opsx-archive');
+      expect(output).not.toContain('/opsx:apply');
+    });
+
+    it('should handle multiple command references in body', () => {
+      const contentWithMultipleCommands: CommandContent = {
+        ...sampleContent,
+        body: `/opsx:explore for ideas
+/opsx:new to create
+/opsx:continue to proceed
+/opsx:apply to implement`,
+      };
+      const output = ohMyPiAdapter.formatFile(contentWithMultipleCommands);
+      expect(output).toContain('/opsx-explore');
+      expect(output).toContain('/opsx-new');
+      expect(output).toContain('/opsx-continue');
+      expect(output).toContain('/opsx-apply');
+    });
+  });
 
   describe('roocodeAdapter', () => {
     it('should have correct toolId', () => {
@@ -697,7 +748,7 @@ describe('command-generation/adapters', () => {
         amazonQAdapter, antigravityAdapter, auggieAdapter, bobAdapter, clineAdapter,
         codexAdapter, codebuddyAdapter, continueAdapter, costrictAdapter,
         crushAdapter, factoryAdapter, geminiAdapter, githubCopilotAdapter,
-        iflowAdapter, kilocodeAdapter, opencodeAdapter, piAdapter, qoderAdapter,
+        iflowAdapter, kilocodeAdapter, ohMyPiAdapter, opencodeAdapter, piAdapter, qoderAdapter,
         qwenAdapter, roocodeAdapter
       ];
       for (const adapter of adapters) {


### PR DESCRIPTION
Add ToolCommandAdapter for oh-my-pi terminal AI coding agent. Commands generate to .omp/commands/opsx-<id>.md with description frontmatter and hyphen-based command references.
Skills generate to .omp/skills/ via transformToHyphenCommands.

- New adapter: src/core/command-generation/adapters/oh-my-pi.ts
- Register in CommandAdapterRegistry and index
- Add to AI_TOOLS with skillsDir: '.omp'
- Add to hyphen command transformer whitelist in init.ts and update.ts
- Full test coverage following OMP patterns

takes care of: https://github.com/Fission-AI/OpenSpec/issues/713

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Oh My Pi as a supported tool with tailored command generation, Markdown output, and dedicated skill directory handling.

* **Improvements**
  * Tool-picker now sorts entries more predictably (locale-aware).
  * Command-reference transformation updated to include Oh My Pi for consistent formatting across tools.

* **Tests**
  * Added tests validating Oh My Pi command generation, file formatting, and reference conversions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Fission-AI/OpenSpec/pull/1069)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->