### PR TITLE
feat: add GSD tool command adapter

### DIFF
--- a/src/core/command-generation/adapters/gsd.ts
+++ b/src/core/command-generation/adapters/gsd.ts
@@ -1,0 +1,50 @@
+/**
+ * GSD Command Adapter
+ *
+ * Formats commands for GSD (Pi's project management system).
+ * GSD agent files live in .gsd/agents/*.md with YAML frontmatter
+ * containing name and description for the agent definition.
+ */
+
+import path from 'path';
+import type { CommandContent, ToolCommandAdapter } from '../types.js';
+
+/**
+ * Escapes a string value for safe YAML output.
+ * Quotes the string if it contains special YAML characters.
+ */
+function escapeYamlValue(value: string): string {
+  const needsQuoting = /[:\n\r#{}[\],&*!|>'"%@`]|^\s|\s$/.test(value);
+  if (needsQuoting) {
+    const escaped = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n');
+    return `"${escaped}"`;
+  }
+  return value;
+}
+
+/**
+ * GSD adapter for agent file generation.
+ * File path: .gsd/agents/opsx-<id>.md
+ * Frontmatter: name, description
+ *
+ * GSD uses the agent .md files as agent definitions that can be
+ * invoked by the GSD subagent system. Command references in the
+ * body use hyphen-based format (/opsx-*) for compatibility.
+ */
+export const gsdAdapter: ToolCommandAdapter = {
+  toolId: 'gsd',
+
+  getFilePath(commandId: string): string {
+    return path.join('.gsd', 'agents', `opsx-${commandId}.md`);
+  },
+
+  formatFile(content: CommandContent): string {
+    return `---
+name: ${escapeYamlValue(content.name)}
+description: ${escapeYamlValue(content.description)}
+---
+
+${content.body}
+`;
+  },
+};

--- a/src/core/command-generation/adapters/index.ts
+++ b/src/core/command-generation/adapters/index.ts
@@ -30,3 +30,4 @@ export { lingmaAdapter } from './lingma.js';
 export { qwenAdapter } from './qwen.js';
 export { roocodeAdapter } from './roocode.js';
 export { windsurfAdapter } from './windsurf.js';
+export { gsdAdapter } from './gsd.js';

--- a/src/core/command-generation/registry.ts
+++ b/src/core/command-generation/registry.ts
@@ -32,6 +32,7 @@ import { lingmaAdapter } from './adapters/lingma.js';
 import { qwenAdapter } from './adapters/qwen.js';
 import { roocodeAdapter } from './adapters/roocode.js';
 import { windsurfAdapter } from './adapters/windsurf.js';
+import { gsdAdapter } from './adapters/gsd.js';
 
 /**
  * Registry for looking up tool command adapters.
@@ -67,6 +68,7 @@ export class CommandAdapterRegistry {
     CommandAdapterRegistry.register(qwenAdapter);
     CommandAdapterRegistry.register(roocodeAdapter);
     CommandAdapterRegistry.register(windsurfAdapter);
+    CommandAdapterRegistry.register(gsdAdapter);
   }
 
   /**

--- a/test/core/command-generation/adapters.test.ts
+++ b/test/core/command-generation/adapters.test.ts
@@ -24,6 +24,7 @@ import { qoderAdapter } from '../../../src/core/command-generation/adapters/qode
 import { qwenAdapter } from '../../../src/core/command-generation/adapters/qwen.js';
 import { roocodeAdapter } from '../../../src/core/command-generation/adapters/roocode.js';
 import { windsurfAdapter } from '../../../src/core/command-generation/adapters/windsurf.js';
+import { gsdAdapter } from '../../../src/core/command-generation/adapters/gsd.js';
 import type { CommandContent } from '../../../src/core/command-generation/types.js';
 
 describe('command-generation/adapters', () => {
@@ -673,6 +674,36 @@ describe('command-generation/adapters', () => {
     });
   });
 
+  describe('gsdAdapter', () => {
+    it('should have correct toolId', () => {
+      expect(gsdAdapter.toolId).toBe('gsd');
+    });
+
+    it('should generate correct file path', () => {
+      const filePath = gsdAdapter.getFilePath('explore');
+      expect(filePath).toBe(path.join('.gsd', 'agents', 'opsx-explore.md'));
+    });
+
+    it('should format file with YAML frontmatter', () => {
+      const output = gsdAdapter.formatFile(sampleContent);
+      expect(output).toContain('---');
+      expect(output).toContain('name: OpenSpec Explore');
+      expect(output).toContain('description: Enter explore mode for thinking');
+      expect(output).toContain('This is the command body.');
+    });
+
+    it('should quote YAML values containing special characters', () => {
+      const contentWithSpecial: CommandContent = {
+        ...sampleContent,
+        name: 'Test: special',
+        description: 'Has #hash and "quotes"',
+      };
+      const output = gsdAdapter.formatFile(contentWithSpecial);
+      expect(output).toContain('name: "Test: special"');
+      expect(output).toContain('description: "Has #hash and \\"quotes\\""');
+    });
+  });
+
   describe('cross-platform path handling', () => {
     it('Claude adapter uses path.join for paths', () => {
       // path.join handles platform-specific separators
@@ -698,7 +729,7 @@ describe('command-generation/adapters', () => {
         codexAdapter, codebuddyAdapter, continueAdapter, costrictAdapter,
         crushAdapter, factoryAdapter, geminiAdapter, githubCopilotAdapter,
         iflowAdapter, kilocodeAdapter, opencodeAdapter, piAdapter, qoderAdapter,
-        qwenAdapter, roocodeAdapter
+        qwenAdapter, roocodeAdapter, gsdAdapter
       ];
       for (const adapter of adapters) {
         const filePath = adapter.getFilePath('test');


### PR DESCRIPTION
Add support for GSD (Pi's project management system) as a new AI tool integration. GSD uses agent definition files stored in .gsd/agents/ directory with YAML frontmatter containing name and description fields.

Changes:
- Add gsd.ts adapter with YAML frontmatter formatting and path generation
- Register gsdAdapter in CommandAdapterRegistry and adapters index
- Add unit tests covering toolId, file path generation, YAML formatting, and special character escaping in YAML values

GSD agent files follow the pattern: .gsd/agents/opsx-<command-id>.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for generating and formatting commands for GSD, a new command adapter capability.

* **Tests**
  * Added comprehensive test coverage for the new adapter functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Fission-AI/OpenSpec/pull/1082)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->