### PR TITLE
fix: make apply blocked-state guidance profile-agnostic

### DIFF
--- a/.changeset/fix-apply-blocked-guidance.md
+++ b/.changeset/fix-apply-blocked-guidance.md
@@ -1,0 +1,7 @@
+---
+"@fission-ai/openspec": patch
+---
+
+### Bug Fixes
+
+- Core profile apply guidance no longer suggests the unavailable `openspec-continue-change` skill when a change is blocked by missing artifacts.

--- a/src/core/templates/workflows/apply-change.ts
+++ b/src/core/templates/workflows/apply-change.ts
@@ -47,7 +47,7 @@ export function getApplyChangeSkillTemplate(): SkillTemplate {
    - Dynamic instruction based on current state
 
    **Handle states:**
-   - If \`state: "blocked"\` (missing artifacts): show message, suggest using openspec-continue-change
+   - If \`state: "blocked"\` (missing artifacts): show message, suggest continuing work on the missing artifacts before re-running apply
    - If \`state: "all_done"\`: congratulate, suggest archive
    - Otherwise: proceed to implementation
 

--- a/src/core/templates/workflows/apply-change.ts
+++ b/src/core/templates/workflows/apply-change.ts
@@ -207,7 +207,7 @@ export function getOpsxApplyCommandTemplate(): CommandTemplate {
    - Dynamic instruction based on current state
 
    **Handle states:**
-   - If \`state: "blocked"\` (missing artifacts): show message, suggest using \`/opsx:continue\`
+   - If \`state: "blocked"\` (missing artifacts): show message, suggest continuing work on the missing artifacts before re-running apply
    - If \`state: "all_done"\`: congratulate, suggest archive
    - Otherwise: proceed to implementation
 

--- a/test/core/templates/skill-templates-parity.test.ts
+++ b/test/core/templates/skill-templates-parity.test.ts
@@ -33,7 +33,7 @@ const EXPECTED_FUNCTION_HASHES: Record<string, string> = {
   getExploreSkillTemplate: 'e2765fae6c2e960f4ce07058cfdaa547ff3435d454eacd5e924e38139e97ad52',
   getNewChangeSkillTemplate: 'b0c26f0b65380062e586505c08c72230e59dccea89e6acca7b673f01cba70d5a',
   getContinueChangeSkillTemplate: 'fbc6c379ed3dd39f59f52b10584b8df5b1dc08b5422bcf1c6d6255a944d22a11',
-  getApplyChangeSkillTemplate: 'e746f230c2513a5fd40842bde494bb3cdb3c5f7c1bcece101f92090983d4ff55',
+  getApplyChangeSkillTemplate: 'e74d0e69c66427cd6f4787fd5e1007f817a8d47aac8d6ea2d27a81f80942054b',
   getFfChangeSkillTemplate: '50e68fbb49b76d2690b614bffa9e6210e45539fb74419fc2e4311158b6d38485',
   getSyncSpecsSkillTemplate: '9f02b41227db70875b89eefeb275c769142607dc5b2593f4e606794aed2fdbad',
   getOnboardSkillTemplate: '4f4b60fea6e3fc7d2185815b2808fad51535fdd00cd4401b32d1536f32fa2b6d',
@@ -59,7 +59,7 @@ const EXPECTED_GENERATED_SKILL_CONTENT_HASHES: Record<string, string> = {
   'openspec-explore': '28d900ef82b325beb65e69ee6435949adcfdf14a4314638e7006e6dc359b92d4',
   'openspec-new-change': 'c99989810f982d72eefc74a35f2282b71f1956f23f61b83aaa58fa3dd921716f',
   'openspec-continue-change': 'c00e2a60f79cd60197094cc59762babe5ee6a2dc1e859a0ede3f436a775ccecf',
-  'openspec-apply-change': 'd849442efd925b9247651e254a5cd696945321610cca5a9432ad420430554548',
+  'openspec-apply-change': 'f016c33de813c9a6838869dd80af492e1051461b9cc3934954d0dd25ea98ec2b',
   'openspec-ff-change': '9d9b1995b6f4adb3da570676f7d11fee4cd1cf6c5df8ec83c033e02783a544df',
   'openspec-sync-specs': '2e0f67ec6fadffc6107b4b1a28eef23a99a6649e5fae706897ea1dd9deb852a8',
   'openspec-archive-change': '8d14af2c8b2e4358308ac9fc14f75db42a4b41a07e175825035852a82479793e',
@@ -168,5 +168,12 @@ describe('skill templates split parity', () => {
       expect(content, dirName).not.toContain('openspec/changes/<name>');
       expect(content, dirName).not.toContain('mv openspec/changes');
     }
+  });
+
+  it('keeps apply blocked-state guidance profile-agnostic', () => {
+    const content = generateSkillContent(getApplyChangeSkillTemplate(), 'PARITY-BASELINE');
+
+    expect(content).toContain('suggest continuing work on the missing artifacts before re-running apply');
+    expect(content).not.toContain('openspec-continue-change');
   });
 });

--- a/test/core/templates/skill-templates-parity.test.ts
+++ b/test/core/templates/skill-templates-parity.test.ts
@@ -40,7 +40,7 @@ const EXPECTED_FUNCTION_HASHES: Record<string, string> = {
   getOpsxExploreCommandTemplate: '4d5e64e3ede6703113cf2fd23b797371ef2407b702478b4f7240fc81cbf2d3a5',
   getOpsxNewCommandTemplate: '757f72e2d9a1a6794b2188704fd39dd2ab65428899b4b361c76cc15a5e4f2ccc',
   getOpsxContinueCommandTemplate: '62f8863edda2bfe4e210f8bc3095fd4369aaaaf7772a5cba9602d0f0bca1d0c9',
-  getOpsxApplyCommandTemplate: '812feefd32a4d9d468e03e456d06e3d2d08d1118d29cce4911f0be59cdd30bfc',
+  getOpsxApplyCommandTemplate: '33128eea4694f6b9b3dcf40773885ae71759a3c8ac0010b89cf20ace52f90db6',
   getOpsxFfCommandTemplate: 'f775b242bcfd56594c431c7f31a0129208a1bacfdb2427074d412543072ef7ca',
   getArchiveChangeSkillTemplate: 'bdf022ae2cdef1feef4d641a068bef3a7fc5d98a323f7ce9f77ac578fe8d20c6',
   getBulkArchiveChangeSkillTemplate: 'fdb1715804e86de85be96222b8efeb9d5b350c6d5c19e343e244655deff8e62b',


### PR DESCRIPTION
## Summary

The blocked-state branch of `getApplyChangeSkillTemplate` suggested running `openspec-continue-change`, which is only available on the full profile. Users on the core profile (no continue-change skill) saw a dead suggestion when their change was blocked by missing artifacts. Change the guidance to ask the user to continue the missing artifacts before re-running apply, which works on every profile.

## Why this matters

#963 reports the dead suggestion on the core profile. The skill template is the same source for both profiles, so any profile-specific suggestion creates this asymmetry. The replacement text is plain language and works on full profile too (since the suggestion is "continue the missing artifacts," which is what `openspec-continue-change` does anyway). Updated parity test enforces the new text and asserts the core-only skill name is gone.

Fixes #963

AI was used for assistance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved apply workflow guidance when apply is blocked by missing artifacts: users are now instructed to continue work on those artifacts before re-running apply, removing references to unavailable actions.

* **Tests**
  * Updated tests to reflect the new blocked-state guidance and verify profile-agnostic messaging.

* **Chores**
  * Recorded a patch release documenting the fix.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Fission-AI/OpenSpec/pull/1096?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->