### PR TITLE
feat: add Mistral Vibe as a supported tool

### DIFF
--- a/docs/supported-tools.md
+++ b/docs/supported-tools.md
@@ -50,11 +50,14 @@ You can enable expanded workflows (`new`, `continue`, `ff`, `verify`, `bulk-arch
 | Qwen Code (`qwen`) | `.qwen/skills/openspec-*/SKILL.md` | `.qwen/commands/opsx-<id>.toml` |
 | RooCode (`roocode`) | `.roo/skills/openspec-*/SKILL.md` | `.roo/commands/opsx-<id>.md` |
 | Trae (`trae`) | `.trae/skills/openspec-*/SKILL.md` | Not generated (no command adapter; use skill-based `/openspec-*` invocations) |
+| Vibe — Mistral (`vibe`) | `.vibe/skills/openspec-*/SKILL.md` | Not generated (no command adapter; use skill-based invocations)\*\*\* |
 | Windsurf (`windsurf`) | `.windsurf/skills/openspec-*/SKILL.md` | `.windsurf/workflows/opsx-<id>.md` |
 
 \* Codex commands are installed in the global Codex home (`$CODEX_HOME/prompts/` if set, otherwise `~/.codex/prompts/`), not your project directory.
 
 \*\* GitHub Copilot prompt files are recognized as custom slash commands in IDE extensions (VS Code, JetBrains, Visual Studio). Copilot CLI does not currently consume `.github/prompts/*.prompt.md` directly.
+
+\*\*\* Vibe loads skills globally from `~/.vibe/skills/`. To use project-local skills installed by OpenSpec (`.vibe/skills/`), add the path to `skill_paths` in `~/.vibe/config.toml`.
 
 ## Non-Interactive Setup
 
@@ -74,7 +77,7 @@ openspec init --tools none
 openspec init --profile core
 ```
 
-**Available tool IDs (`--tools`):** `amazon-q`, `antigravity`, `auggie`, `bob`, `claude`, `cline`, `codex`, `forgecode`, `codebuddy`, `continue`, `costrict`, `crush`, `cursor`, `factory`, `gemini`, `github-copilot`, `iflow`, `junie`, `kilocode`, `kimi`, `kiro`, `opencode`, `pi`, `qoder`, `lingma`, `qwen`, `roocode`, `trae`, `windsurf`
+**Available tool IDs (`--tools`):** `amazon-q`, `antigravity`, `auggie`, `bob`, `claude`, `cline`, `codex`, `forgecode`, `codebuddy`, `continue`, `costrict`, `crush`, `cursor`, `factory`, `gemini`, `github-copilot`, `iflow`, `junie`, `kilocode`, `kimi`, `kiro`, `opencode`, `pi`, `qoder`, `lingma`, `qwen`, `roocode`, `trae`, `vibe`, `windsurf`
 
 ## Workflow-Dependent Installation
 

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -47,6 +47,7 @@ export const AI_TOOLS: AIToolOption[] = [
   { name: 'Qwen Code', value: 'qwen', available: true, successLabel: 'Qwen Code', skillsDir: '.qwen' },
   { name: 'RooCode', value: 'roocode', available: true, successLabel: 'RooCode', skillsDir: '.roo' },
   { name: 'Trae', value: 'trae', available: true, successLabel: 'Trae', skillsDir: '.trae' },
+  { name: 'Vibe (Mistral)', value: 'vibe', available: true, successLabel: 'Vibe', skillsDir: '.vibe' },
   { name: 'Windsurf', value: 'windsurf', available: true, successLabel: 'Windsurf', skillsDir: '.windsurf' },
   { name: 'AGENTS.md (works with Amp, VS Code, …)', value: 'agents', available: false, successLabel: 'your AGENTS.md-compatible assistant' }
 ];


### PR DESCRIPTION
## Summary

- Adds **Vibe (Mistral)** to the `AI_TOOLS` array in `src/core/config.ts` with `skillsDir: '.vibe'`
- Adds the corresponding row to the Tool Directory Reference table in `docs/supported-tools.md`
- Adds `vibe` to the `--tools` ID list
- Adds a footnote explaining that Vibe loads skills globally from `~/.vibe/skills/` by default, and project-local `.vibe/skills/` requires adding the path to `skill_paths` in `~/.vibe/config.toml`

## Notes

Vibe uses the SKILL.md standard natively (same frontmatter format). Skills are invoked as `/skill-name` commands. No command adapter exists — commands are "Not generated", consistent with Trae and ForgeCode.

This was surfaced while adding nanopm as a community schema (PR #1109) — nanopm now ships Vibe-translated skills and installs to `~/.vibe/skills/` automatically. Vibe being absent from this list was the gap.

## Test plan

- [ ] `openspec init --tools vibe` installs skills to `.vibe/skills/openspec-*/SKILL.md`
- [ ] `openspec init --tools all` includes Vibe
- [ ] `vibe` appears in `--help` tool ID list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vibe (Mistral) is now available as an AI tool option with support for configurable skills directories enabling both global and project-local skill management.

* **Documentation**
  * Supported tools documentation updated to include Vibe, with details on tool availability, command-line options, and guidance for configuring global versus project-specific skills.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Fission-AI/OpenSpec/pull/1114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->