### PR TITLE
[codex] Document cross-platform path assertions

### DIFF
--- a/.changeset/windows-path-guidance.md
+++ b/.changeset/windows-path-guidance.md
@@ -1,7 +1,0 @@
----
-"@fission-ai/openspec": patch
----
-
-### Documentation
-
-- Document cross-platform path assertion guidance for tests, especially Windows path separators in CLI output.

--- a/.changeset/windows-path-guidance.md
+++ b/.changeset/windows-path-guidance.md
@@ -1,0 +1,7 @@
+---
+"@fission-ai/openspec": patch
+---
+
+### Documentation
+
+- Document cross-platform path assertion guidance for tests, especially Windows path separators in CLI output.

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -9,6 +9,13 @@ Applies to tests under `test/`.
 - Full suite: `pnpm test`
 - Run `pnpm run build` before focused CLI tests when implementation changes may leave `dist/` stale.
 
+## Cross-Platform Paths
+
+- Do not hard-code Unix path separators in CLI output expectations unless the implementation intentionally emits POSIX paths.
+- For filesystem paths, build expected values with `path.join(...)`, `path.relative(...)`, or `FileSystemUtils.joinPath(...)`.
+- For human-readable output, either assert a deliberately normalized display format or normalize both actual and expected strings before comparing.
+- When touching path behavior, add coverage that would fail on Windows path separators.
+
 ## Path Canonicalization
 
 Path identity is a recurring CI failure mode: Windows short/long paths, symlink or

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -13,7 +13,7 @@ Applies to tests under `test/`.
 
 - Do not hard-code Unix path separators in CLI output expectations unless the implementation intentionally emits POSIX paths.
 - For filesystem paths, build expected values with `path.join(...)`, `path.relative(...)`, or `FileSystemUtils.joinPath(...)`.
-- For human-readable output, either assert a deliberately normalized display format or normalize both actual and expected strings before comparing.
+- For human-readable output, either assert a deliberately normalized display format or normalize both actual and expected strings before comparing, for example with `FileSystemUtils.toPosixPath()` to convert backslashes to forward slashes for cross-platform consistency.
 - When touching path behavior, add coverage that would fail on Windows path separators.
 
 ## Path Canonicalization


### PR DESCRIPTION
## Summary

- Add test guidance that calls out Unix-only path separator assumptions in CLI output assertions.
- Tell contributors to use platform-aware path helpers or normalize display output before comparing.
- Add a patch changeset for the docs update.

## Validation

- `pnpm exec changeset status --since=origin/main`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added cross-platform guidance for CLI tests: avoid hard-coded Unix path separators, use platform-safe path construction, normalize human-readable output for comparisons, and include Windows-separator regression coverage when path behavior changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Fission-AI/OpenSpec/pull/1116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->