### PR TITLE
fix(validator): hint when SHALL/MUST appears only in requirement header

### DIFF
--- a/src/core/validation/validator.ts
+++ b/src/core/validation/validator.ts
@@ -165,7 +165,7 @@ export class Validator {
           if (!requirementText) {
             issues.push({ level: 'ERROR', path: entryPath, message: `ADDED "${block.name}" is missing requirement text` });
           } else if (!this.containsShallOrMust(requirementText)) {
-            issues.push({ level: 'ERROR', path: entryPath, message: `ADDED "${block.name}" must contain SHALL or MUST` });
+            issues.push({ level: 'ERROR', path: entryPath, message: this.buildMissingShallOrMustMessage('ADDED', block.name) });
           }
           const scenarioCount = this.countScenarios(block.raw);
           if (scenarioCount < 1) {
@@ -186,7 +186,7 @@ export class Validator {
           if (!requirementText) {
             issues.push({ level: 'ERROR', path: entryPath, message: `MODIFIED "${block.name}" is missing requirement text` });
           } else if (!this.containsShallOrMust(requirementText)) {
-            issues.push({ level: 'ERROR', path: entryPath, message: `MODIFIED "${block.name}" must contain SHALL or MUST` });
+            issues.push({ level: 'ERROR', path: entryPath, message: this.buildMissingShallOrMustMessage('MODIFIED', block.name) });
           }
           const scenarioCount = this.countScenarios(block.raw);
           if (scenarioCount < 1) {
@@ -442,6 +442,24 @@ export class Validator {
 
   private containsShallOrMust(text: string): boolean {
     return /\b(SHALL|MUST)\b/.test(text);
+  }
+
+  /**
+   * Build an error message for a requirement block whose body lacks SHALL/MUST.
+   *
+   * When the SHALL/MUST keyword already appears in the requirement header (e.g.
+   * `### Requirement: The system SHALL ...`) the original generic error
+   * ("must contain SHALL or MUST") is confusing because the keyword is visibly
+   * present in the spec. Per the OpenSpec conventions the keyword has to live
+   * on the requirement body line (the line right after the header), so we point
+   * the author at that exact fix when the keyword is found in the header only.
+   */
+  private buildMissingShallOrMustMessage(action: 'ADDED' | 'MODIFIED', blockName: string): string {
+    const base = `${action} "${blockName}" must contain SHALL or MUST`;
+    if (this.containsShallOrMust(blockName)) {
+      return `${base} in the requirement body, not only in the header. Move the SHALL/MUST statement to the line immediately after the "### Requirement: ..." header.`;
+    }
+    return base;
   }
 
   private countScenarios(blockRaw: string): number {

--- a/test/core/validation.test.ts
+++ b/test/core/validation.test.ts
@@ -535,6 +535,92 @@ The system will log all events.
       expect(report.issues.some(i => i.message.includes('must contain SHALL or MUST'))).toBe(true);
     });
 
+    it('should hint the author when ADDED requirement only has SHALL/MUST in the header', async () => {
+      const changeDir = path.join(testDir, 'test-change-shall-in-header-added');
+      const specsDir = path.join(changeDir, 'specs', 'test-spec');
+      await fs.mkdir(specsDir, { recursive: true });
+
+      const deltaSpec = `# Test Spec
+
+## ADDED Requirements
+
+### Requirement: The system SHALL log all errors
+Error handling logic goes here.
+
+#### Scenario: Error occurs
+**Given** an error
+**When** it occurs
+**Then** it is logged`;
+
+      const specPath = path.join(specsDir, 'spec.md');
+      await fs.writeFile(specPath, deltaSpec);
+
+      const validator = new Validator(true);
+      const report = await validator.validateChangeDeltaSpecs(changeDir);
+
+      expect(report.valid).toBe(false);
+      const shallMessage = report.issues.find(i => i.message.includes('must contain SHALL or MUST'));
+      expect(shallMessage?.message).toContain('not only in the header');
+      expect(shallMessage?.message).toContain('### Requirement:');
+    });
+
+    it('should hint the author when MODIFIED requirement only has SHALL/MUST in the header', async () => {
+      const changeDir = path.join(testDir, 'test-change-shall-in-header-modified');
+      const specsDir = path.join(changeDir, 'specs', 'test-spec');
+      await fs.mkdir(specsDir, { recursive: true });
+
+      const deltaSpec = `# Test Spec
+
+## MODIFIED Requirements
+
+### Requirement: The system MUST validate user input
+Please describe how validation should work here.
+
+#### Scenario: Invalid input
+**Given** invalid input
+**When** validation runs
+**Then** an error surfaces`;
+
+      const specPath = path.join(specsDir, 'spec.md');
+      await fs.writeFile(specPath, deltaSpec);
+
+      const validator = new Validator(true);
+      const report = await validator.validateChangeDeltaSpecs(changeDir);
+
+      expect(report.valid).toBe(false);
+      const shallMessage = report.issues.find(i => i.message.includes('must contain SHALL or MUST'));
+      expect(shallMessage?.message).toContain('not only in the header');
+      expect(shallMessage?.message).toContain('### Requirement:');
+    });
+
+    it('should keep the generic SHALL/MUST error when neither header nor body contain the keyword', async () => {
+      const changeDir = path.join(testDir, 'test-change-shall-nowhere');
+      const specsDir = path.join(changeDir, 'specs', 'test-spec');
+      await fs.mkdir(specsDir, { recursive: true });
+
+      const deltaSpec = `# Test Spec
+
+## ADDED Requirements
+
+### Requirement: Logging Feature
+The system will log all events.
+
+#### Scenario: Event occurs
+**Given** an event
+**When** it occurs
+**Then** it is logged`;
+
+      const specPath = path.join(specsDir, 'spec.md');
+      await fs.writeFile(specPath, deltaSpec);
+
+      const validator = new Validator(true);
+      const report = await validator.validateChangeDeltaSpecs(changeDir);
+
+      expect(report.valid).toBe(false);
+      const shallMessage = report.issues.find(i => i.message.includes('must contain SHALL or MUST'));
+      expect(shallMessage?.message).not.toContain('not only in the header');
+    });
+
     it('should handle requirements without metadata fields', async () => {
       const changeDir = path.join(testDir, 'test-change-4');
       const specsDir = path.join(changeDir, 'specs', 'test-spec');


### PR DESCRIPTION
## Summary

Fixes #356.

When a change delta contains a requirement whose body is missing `SHALL`/`MUST` **but whose header (the text after `### Requirement:`) already contains the keyword**, the validator currently emits the generic error:

```
✗ [ERROR] agent-management/spec.md: MODIFIED "系统 SHALL 支持为 Box 智能体配置 Prompt Caching 开关" must contain SHALL or MUST
```

Authors then re-read the spec, see `SHALL` right there in the header, and have no idea what the validator wants. The reporter of #356 hit exactly this case with an LLM-generated spec where the keyword lived only in the heading.

Per the [OpenSpec conventions](https://github.com/Fission-AI/OpenSpec/blob/main/docs/concepts.md) (and `openspec/specs/openspec-conventions/spec.md`, *Structured Format for Behavioral Specs*), the SHALL/MUST statement has to live on the requirement body line, i.e. the line immediately after the header. When the keyword is present in the header only, this PR appends a one-sentence hint that points the author at that exact fix:

```
✗ [ERROR] agent-management/spec.md: MODIFIED "系统 SHALL 支持为 Box 智能体配置 Prompt Caching 开关" must contain SHALL or MUST in the requirement body, not only in the header. Move the SHALL/MUST statement to the line immediately after the "### Requirement: ..." header.
```

The general "keyword missing everywhere" case keeps the original short message — no behaviour change other than the diagnostic for the header-only situation.

## Scope

Two-line touch in `src/core/validation/validator.ts` (the `validateChangeDeltaSpecs` ADDED + MODIFIED branches) plus a small helper that picks the message based on whether `block.name` itself contains `SHALL`/`MUST`. `RequirementSchema` (used by `validateSpec`) is intentionally untouched — that path already promotes body text to the requirement string and reports its own error; this PR is limited to the change-delta diagnostic the bug report actually triggers.

| File | Change |
|------|--------|
| `src/core/validation/validator.ts` | `+22 -2` — new private `buildMissingShallOrMustMessage('ADDED' \| 'MODIFIED', name)` helper; both error sites delegate to it |
| `test/core/validation.test.ts` | `+86 -2` — three new vitest cases inside `Validator > validateChangeDeltaSpecs with metadata` |

## Diff (key sites)

`src/core/validation/validator.ts`:

```diff
-          } else if (!this.containsShallOrMust(requirementText)) {
-            issues.push({ level: 'ERROR', path: entryPath, message: \`ADDED \"\${block.name}\" must contain SHALL or MUST\` });
-          }
+          } else if (!this.containsShallOrMust(requirementText)) {
+            issues.push({ level: 'ERROR', path: entryPath, message: this.buildMissingShallOrMustMessage('ADDED', block.name) });
+          }
```

```diff
-          } else if (!this.containsShallOrMust(requirementText)) {
-            issues.push({ level: 'ERROR', path: entryPath, message: \`MODIFIED \"\${block.name}\" must contain SHALL or MUST\` });
-          }
+          } else if (!this.containsShallOrMust(requirementText)) {
+            issues.push({ level: 'ERROR', path: entryPath, message: this.buildMissingShallOrMustMessage('MODIFIED', block.name) });
+          }
```

```diff
+  private buildMissingShallOrMustMessage(action: 'ADDED' | 'MODIFIED', blockName: string): string {
+    const base = \`\${action} \"\${blockName}\" must contain SHALL or MUST\`;
+    if (this.containsShallOrMust(blockName)) {
+      return \`\${base} in the requirement body, not only in the header. Move the SHALL/MUST statement to the line immediately after the \"### Requirement: ...\" header.\`;
+    }
+    return base;
+  }
```

## Behaviour matrix

| Case | Header has SHALL/MUST | Body has SHALL/MUST | Validator result |
|------|-----------------------|----------------------|------------------|
| Original convention (recommended) | optional | yes | ✅ valid |
| **Bug report from #356** | yes | no | ❌ ERROR with new **header-only hint** pointing at the fix |
| Keyword missing everywhere | no | no | ❌ ERROR with original generic message (unchanged) |
| Body literally empty | n/a | n/a | ❌ existing "missing requirement text" error (unchanged) |

## Reproduction & verification

Reproduced #356 directly with the spec from the bug report against the rebuilt CLI:

```bash
$ cat openspec/changes/test-356/specs/agent-management/spec.md
## MODIFIED Requirements

### Requirement:  系统 SHALL 支持为 Box 智能体配置 Prompt Caching 开关
HOW TO DO ? NO CMD(S H A L L /  M U S T) HERE

#### Scenario: Toggle is enabled
- **WHEN** the user enables the toggle
- **THEN** subsequent calls reuse cached prompts

$ openspec validate test-356
Change 'test-356' has issues
✗ [ERROR] agent-management/spec.md: MODIFIED "系统 SHALL 支持为 Box 智能体配置 Prompt Caching 开关" must contain SHALL or MUST in the requirement body, not only in the header. Move the SHALL/MUST statement to the line immediately after the "### Requirement: ..." header.
```

Author follows the hint and rewrites the body:

```bash
$ openspec validate test-356
Change 'test-356' is valid
```

Generic case (no SHALL/MUST anywhere) keeps the short message:

```bash
$ openspec validate test-356
✗ [ERROR] agent-management/spec.md: ADDED "Logging Feature" must contain SHALL or MUST
```

### Regression evidence

Tests genuinely cover the new branch — `git stash` the `validator.ts` change, rerun:

```
FAIL  test/core/validation.test.ts > should hint the author when ADDED requirement only has SHALL/MUST in the header
AssertionError: expected '...must contain SHALL or MUST' to contain 'not only in the header'

FAIL  test/core/validation.test.ts > should hint the author when MODIFIED requirement only has SHALL/MUST in the header
AssertionError: expected '...must contain SHALL or MUST' to contain 'not only in the header'
```

`git stash pop` and both pass again.

## Local CI

```
$ pnpm run build
✅ Build completed successfully!

$ pnpm run lint
$ eslint src/
(no output)

$ pnpm test
 Test Files  89 passed (89)
      Tests  1637 passed (1637)
```

(The previously flaky `change-initiative-link.test.ts > sets and surfaces initiative links ...` 10s timeout happened on the very first baseline run before any of my changes and did not reproduce on subsequent runs.)

## Notes

- AI-generated code: this change was written with Cursor using Claude Opus 4.7 (`claude-4.6-opus-max-thinking`). All reasoning, diffs, tests, repro runs, and the PR body were reviewed by me before submission.
- No new dependencies, no public API changes, no schema or template changes.
- Conventional commit, single-line subject per `README.md` Contributing.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation error messages for requirements lacking SHALL/MUST keywords, providing more specific guidance when these keywords appear only in requirement headers rather than bodies.

* **Tests**
  * Added validation test cases to verify improved error messaging scenarios for header-only and missing SHALL/MUST keywords.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Fission-AI/OpenSpec/pull/1135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->