### PR TITLE
[codex] Polish beta context workspace flow

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -194,7 +194,7 @@ openspec workspace setup [options]
 | `--name <name>` | Workspace name. Names must be kebab-case |
 | `--link <path>` | Link an existing repo or folder and infer the link name from the folder name |
 | `--link <name>=<path>` | Link an existing repo or folder with an explicit link name |
-| `--opener <id>` | Store a preferred opener during non-interactive setup: `codex`, `claude`, `github-copilot`, or `editor` |
+| `--opener <id>` | Store a preferred opener during non-interactive setup: `codex-cli`, `claude`, `github-copilot`, or `editor` |
 | `--tools <tools>` | Install workspace-local OpenSpec skills for agents. Use `all`, `none`, or comma-separated tool IDs |
 | `--no-interactive` | Disable prompts; requires `--name` and at least one `--link` |
 | `--json` | Output JSON; requires `--no-interactive` |
@@ -204,7 +204,7 @@ openspec workspace setup [options]
 ```bash
 openspec workspace setup
 openspec workspace setup --no-interactive --name platform --link /repos/api --link web=/repos/web
-openspec workspace setup --no-interactive --name platform --link /repos/api --opener codex
+openspec workspace setup --no-interactive --name platform --link /repos/api --opener codex-cli
 openspec workspace setup --no-interactive --name platform --link /repos/api --tools codex,claude
 openspec workspace setup --no-interactive --json --name checkout --link /repos/platform/apps/checkout
 ```
@@ -320,7 +320,7 @@ openspec workspace open [name] [options]
 | `--initiative <id>` | Open an initiative as a local workspace view. Accepts `<id>` or `<store>/<id>` |
 | `--store <id>` | Registered context store id for `--initiative` |
 | `--store-path <path>` | Existing local context store root for `--initiative` |
-| `--agent <tool>` | One-session agent override: `codex`, `claude`, or `github-copilot` |
+| `--agent <tool>` | One-session agent override: `codex-cli`, `claude`, or `github-copilot` |
 | `--editor` | Open the maintained VS Code workspace file as a normal editor workspace |
 | `--no-interactive` | Disable workspace and opener picker prompts |
 
@@ -330,7 +330,7 @@ openspec workspace open [name] [options]
 openspec workspace open
 openspec workspace open platform
 openspec workspace open platform --agent github-copilot
-openspec workspace open --agent codex
+openspec workspace open --agent codex-cli
 openspec workspace open --editor
 openspec workspace open --initiative billing-launch --store platform
 openspec workspace open --initiative platform/billing-launch
@@ -340,9 +340,9 @@ openspec workspace open --initiative platform/billing-launch
 
 When `--initiative` is used, OpenSpec prepares or selects a private local workspace view for that initiative. Registry-selected stores are stored by id; `--store-path` stores a runtime-local path selector because workspace views are private local state.
 
-OpenSpec maintains `<workspace-name>.code-workspace` at the workspace root for VS Code editor and GitHub Copilot-in-VS-Code opens. That file is machine-local and ignored by default with a specific `<workspace-name>.code-workspace` `.gitignore` entry, so user-authored `*.code-workspace` files remain eligible for tracking.
+OpenSpec maintains `<workspace-name>.code-workspace` at the workspace root for VS Code editor and GitHub Copilot-in-VS-Code opens. That file is machine-local workspace view state.
 
-The maintained VS Code workspace includes the coordination root as `.` plus valid linked repos or folders as additional roots. VS Code displays those entries as a multi-root workspace.
+The maintained VS Code workspace lists valid linked repos or folders first, then initiative context when attached, then the OpenSpec workspace files. VS Code displays those entries as a multi-root workspace.
 
 Root workspace open makes linked repos or folders visible for exploration and context. Implementation edits should start only after an explicit user request and a normal OpenSpec implementation workflow.
 
@@ -364,10 +364,12 @@ openspec context-store setup [id] [options]
 
 | Option | Description |
 |--------|-------------|
-| `--path <path>` | Context store folder path; defaults to `./<id>` |
+| `--path <path>` | Context store folder path; defaults to OpenSpec's managed local data directory |
 | `--init-git` | Initialize a Git repository in the context store |
 | `--no-init-git` | Do not initialize a Git repository |
 | `--json` | Output JSON |
+
+When `--path` is omitted, setup creates the store under `getGlobalDataDir()/context-stores/<id>`: `$XDG_DATA_HOME/openspec/context-stores/<id>` when `XDG_DATA_HOME` is set, or `~/.local/share/openspec/context-stores/<id>` on Unix-style fallbacks. Pass `--path` when you want the store in a visible clone or team-specific folder.
 
 Examples:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -268,7 +268,7 @@ Check what one workspace can resolve on the current machine.
 openspec workspace doctor [options]
 ```
 
-Doctor shows the workspace location, planning path, linked repos or folders, missing paths, repo-local specs paths when present, and suggested fixes. It reports issues only; it does not repair them automatically.
+Doctor shows the workspace location, linked repos or folders, missing paths, repo-local specs paths when present, and suggested fixes. JSON output also includes the workspace planning path for compatibility. It reports issues only; it does not repair them automatically.
 
 Commands that need one workspace use the current workspace when run from inside a workspace folder or subdirectory. From elsewhere, pass `--workspace <name>`, select from the picker in an interactive terminal, or rely on the only known workspace when exactly one exists. In `--json` or `--no-interactive` mode, ambiguous selection fails with a structured status error and suggests `--workspace <name>`.
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -145,7 +145,7 @@ openspec workspace setup
 
 # Automation-friendly setup
 openspec workspace setup --no-interactive --name platform --link /repos/api --link web=/repos/web
-openspec workspace setup --no-interactive --name platform --link /repos/api --opener codex
+openspec workspace setup --no-interactive --name platform --link /repos/api --opener codex-cli
 
 # See known workspaces from the local registry
 openspec workspace list
@@ -174,13 +174,13 @@ openspec workspace open --initiative billing-launch --store platform
 openspec workspace open --initiative billing-launch --store-path /repos/platform-context
 ```
 
-`workspace setup` always creates the workspace in the standard workspace location, records it in the local registry, shows the workspace location, and requires at least one linked repo or folder. Interactive setup asks for a preferred opener and can install OpenSpec skills for selected agents. Non-interactive setup stores one only when `--opener codex`, `--opener claude`, `--opener github-copilot`, or `--opener editor` is provided.
+`workspace setup` always creates the workspace in the standard workspace location, records it in the local registry, shows the workspace location, and requires at least one linked repo or folder. Interactive setup asks for a preferred opener and can install OpenSpec skills for selected agents. Non-interactive setup stores one only when `--opener codex-cli`, `--opener claude`, `--opener github-copilot`, or `--opener editor` is provided.
 
 Workspace skills are installed only in the workspace root. The active global profile selects which workflow skills are generated; `--tools` selects which agents receive them. Workspace setup and update do not create slash command files even when global delivery includes commands. Run `openspec workspace update` to refresh workspace-local guidance and add, refresh, or remove managed workspace-local skill directories without editing linked repos or folders.
 
-OpenSpec also maintains root workspace open files: an OpenSpec-managed guidance block in `AGENTS.md`, a machine-local `<workspace-name>.code-workspace` file for VS Code and GitHub Copilot-in-VS-Code opens, and a specific ignore entry for that maintained `.code-workspace` file. User-authored `*.code-workspace` files remain trackable because the ignore rule targets only the maintained file.
+OpenSpec also maintains root workspace open files: an OpenSpec-managed guidance block in `AGENTS.md` and a machine-local `<workspace-name>.code-workspace` file for VS Code and GitHub Copilot-in-VS-Code opens. A managed workspace is not a repo, so OpenSpec does not create a default workspace `.gitignore` or a default workspace-level `changes/` directory.
 
-The maintained VS Code workspace includes the coordination root as `.` plus valid linked repos or folders as additional roots. VS Code displays those entries as a multi-root workspace.
+The maintained VS Code workspace lists valid linked repos or folders first, then initiative context when attached, then the OpenSpec workspace files. VS Code displays those entries as a multi-root workspace.
 
 `workspace open` opens the linked working set with the stored preferred opener unless `--agent <tool>` or `--editor` is passed for that one session. Passing both opener overrides is an error. Root workspace open makes linked repos and folders visible for exploration and context; implementation starts after the user explicitly asks for implementation work.
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -184,7 +184,7 @@ The maintained VS Code workspace lists valid linked repos or folders first, then
 
 `workspace open` opens the linked working set with the stored preferred opener unless `--agent <tool>` or `--editor` is passed for that one session. Passing both opener overrides is an error. Root workspace open makes linked repos and folders visible for exploration and context; implementation starts after the user explicitly asks for implementation work.
 
-`workspace link` and `workspace relink` record existing folders only; they do not create, copy, move, initialize, or edit the linked repo or folder. After a successful link or relink, OpenSpec refreshes the managed guidance, VS Code workspace file, and ignore rule.
+`workspace link` and `workspace relink` record existing folders only; they do not create, copy, move, initialize, or edit the linked repo or folder. After a successful link or relink, OpenSpec refreshes the managed guidance and VS Code workspace file.
 
 Workspace commands that need one workspace can run from anywhere with `--workspace <name>`. If you run them inside a workspace folder or subdirectory, OpenSpec uses that current workspace. If several known workspaces are available and you do not pass `--workspace <name>`, human commands show a picker; `--json` and `--no-interactive` fail with a structured status error instead of prompting.
 

--- a/docs/workspaces-beta/agent-cli-playbook.md
+++ b/docs/workspaces-beta/agent-cli-playbook.md
@@ -1,0 +1,82 @@
+# OpenSpec CLI Playbook For Agents
+
+Beta note: workspace and initiative flows are usable, but still small. Prefer
+plain commands, clear paths, and short status reports.
+
+## Start By Resolving Context
+
+Use JSON when you need exact paths.
+
+```bash
+openspec context-store list --json
+openspec initiative list --json
+openspec initiative show <store>/<initiative> --json
+openspec workspace doctor --json
+```
+
+When the user is working from an opened workspace, treat the workspace as the
+local view. Use `workspace doctor --json` to read linked repos/folders and the
+selected initiative. Do not assume the current directory is the repo that should
+own implementation artifacts.
+
+## Create Initiatives In Context Stores
+
+Create shared coordination context in a context store.
+
+```bash
+openspec initiative create billing-launch --store team-context --title "Billing Launch" --summary "Get billing live without losing the plot."
+```
+
+Then edit the initiative files in the context store:
+
+- `requirements.md`
+- `design.md`
+- `decisions.md`
+- `questions.md`
+- `tasks.md`
+
+## Explore Or Propose From A Workspace
+
+When the user asks to explore or draft work from a workspace:
+
+1. Resolve the workspace with `openspec workspace doctor --json`.
+2. Resolve the initiative with `openspec initiative show <store>/<initiative> --json`.
+3. Inspect linked repos or folders and identify the likely owning repo.
+4. If ownership is ambiguous, ask the user which linked repo should own the
+   repo-local OpenSpec change.
+5. Run explore/propose workflow commands from the owning repo, not from the
+   workspace root.
+
+The workspace is the cockpit for the conversation. It is not the durable home
+for implementation plans.
+
+## Create Changes From The Owning Repo
+
+Repo-local changes belong in the repo that owns the work.
+
+```bash
+openspec new change add-billing-api --initiative team-context/billing-launch
+```
+
+Run this command with the owning repo as the current working directory. Do not
+ask the user to type it and do not run initiative-linked change creation from a
+workspace root. If you only know the workspace, resolve linked repo paths first.
+
+After creating a change, report the absolute paths of the created files and the
+initiative link you used.
+
+## Use Doctor Before Guessing
+
+```bash
+openspec workspace doctor --workspace billing-launch --json
+openspec context-store doctor --json
+```
+
+## Do Not Promise Yet
+
+- Automatic sync, pull, push, or conflict handling.
+- Cloning repos.
+- Creating branches, worktrees, or submodules.
+- Workspace apply, verify, or archive.
+- Progress dashboards.
+- Enforced edit boundaries.

--- a/docs/workspaces-beta/user-guide.md
+++ b/docs/workspaces-beta/user-guide.md
@@ -1,0 +1,76 @@
+# Using OpenSpec With Your Coding Agent
+
+Beta note: this is the smallest useful path. You do the local setup. Your agent
+manages the OpenSpec work.
+
+## 1. Create The Shared Place
+
+```bash
+openspec context-store setup team-context --init-git
+```
+
+This creates a local context store. Add `--path <folder>` if you want it
+somewhere specific; otherwise OpenSpec keeps it in its managed local data
+directory.
+
+## 2. Ask Your Agent To Create The Initiative
+
+> Create an OpenSpec initiative called `billing-launch` in `team-context`. Keep
+> it short and useful.
+
+## 3. Open Your Local Workbench
+
+```bash
+openspec workspace open
+```
+
+Select the initiative from the picker. OpenSpec creates a local workspace view
+for it if you do not already have one. When creating a new view, it also asks
+which local repos or folders to include.
+
+The opened editor view shows linked repos and folders first, initiative context
+when attached, and a small `OpenSpec workspace` folder last with `AGENTS.md`,
+`workspace.yaml`, and the generated `.code-workspace` file.
+
+Use `openspec workspace open --initiative team-context/billing-launch --editor`
+when you want to skip the picker. Use `--agent codex-cli`, `--agent claude`, or
+`--agent github-copilot` instead of `--editor` when you want to open an agent
+directly.
+
+## 4. Check The Local Context
+
+Ask your agent to inspect the opened workspace before planning work:
+
+> Check this OpenSpec workspace. Resolve the selected initiative, list the
+> linked repos or folders, and tell me if anything important is missing before
+> we explore the work.
+
+If a repo or folder is missing, tell the agent which local path should be linked.
+OpenSpec does not clone anything.
+
+## 5. Explore Before Creating Artifacts
+
+Use the workspace as the place where the conversation happens:
+
+> Using initiative `team-context/billing-launch`, explore the work in this
+> workspace. Read the initiative context and linked repo context first. Do not
+> create a change yet; help me decide what should be proposed and where the
+> OpenSpec artifacts should live.
+
+## 6. Ask For A Draft When Ready
+
+When exploration has converged, ask the agent to create the right artifact in
+the right place:
+
+> Create a draft repo-local OpenSpec proposal for the owning linked repo and
+> link it to `team-context/billing-launch`. Resolve the workspace and initiative
+> context yourself, run the needed OpenSpec commands from the correct repo, and
+> report the files you created.
+
+## Tiny Caveat Box
+
+OpenSpec is not cloning, syncing, branching, or tracking progress dashboards in
+this beta flow. It gives you shared initiative context, a local workspace view,
+and repo-local plans tied back to the bigger mission. The workspace is where
+you and the agent work together; durable plan artifacts should live in the
+context store initiative or in the owning repo, not in the workspace root.

--- a/openspec/initiatives/context-store-and-initiatives/roadmap.md
+++ b/openspec/initiatives/context-store-and-initiatives/roadmap.md
@@ -12,6 +12,26 @@ Workspaces open local views.
 Changes implement repo-owned slices.
 ```
 
+## Current Beta Priority
+
+The manual beta pass should pull first-run friction forward. Work in this order
+before investing in deeper schema or lifecycle machinery:
+
+1. Finish the manual beta reality pass enough to keep the next slices grounded.
+2. Item 12, context-store first-run and cleanup UX: interactive no-argument setup,
+   target-path safety, and a supported unregister/remove path.
+3. Item 13, agent handoff output and delivery polish: "Next for your agent" blocks,
+   direct JSON paths, and baseline OpenSpec guidance even when workflow
+   entrypoints are commands-oriented.
+4. Item 14, workspaces beta guide split: make user docs match the interactive
+   setup path and keep exact flags in the agent playbook.
+5. Item 15, context store project roots and schema-led initiatives: sparse initiative
+   creation and store-local schemas.
+
+Escalation UX, team-sharing hardening, and initiative-hosted target-bound
+changes remain important, but they should wait until the first-run path feels
+boring in the good way.
+
 ## 1. Lock The Direction
 
 Goal: make the workspace-to-initiative pivot explicit so future workspace work
@@ -417,10 +437,151 @@ Done when:
 - Generated runtime files are clearly derived and can be regenerated without
   losing the user's local view choices.
 
-## 11. Add Escalation UX
+## 11. Manual Beta Reality Pass
+
+Status: proposed immediate beta-learning item.
+
+Goal: manually run what exists and use the friction to update initiative notes
+before designing more surface area.
+
+Ship:
+
+- A fresh-user walkthrough of context-store setup, initiative creation,
+  workspace opening, repo linking, doctor output, and repo-local linked change
+  creation.
+- Notes on what felt clear, what felt odd, where prompts were missing, and where
+  docs pushed too many flags onto the user.
+- A short disposition that separates docs-only fixes from follow-on
+  implementation slices.
+
+Done when:
+
+- The initiative contains concrete notes from trying the current beta flow by
+  hand.
+- The next implementation or docs slice is grounded in observed friction rather
+  than guessed workflow shape.
+
+## 12. Context Store First-Run And Cleanup UX
+
+Goal: make context-store setup and cleanup feel like a normal local workflow,
+without adding sync, remote, or governance automation.
+
+Work item:
+`work-items/12-context-store-first-run-and-cleanup-ux/`
+
+Ship:
+
+- Interactive no-argument `context-store setup` for terminal users.
+- Deterministic non-interactive and JSON behavior when required setup choices
+  are missing.
+- Target-path safety output for managed defaults, explicit paths, existing Git
+  repos, and non-empty directories.
+- A supported local cleanup path for unregistering or removing a context store
+  without hand-editing the registry.
+- Setup output that explains local registry state and Git state, including
+  uncommitted shared-store files after `--init-git`.
+
+Done when:
+
+- A fresh user can set up or clean up a local context store without knowing
+  hidden registry paths, environment variables, or manual file edits.
+
+## 13. Agent Handoff Output And Delivery Polish
+
+Goal: make existing command output and delivery choices enough for a fresh
+agent to continue safely, before adding any broader `initiative next` command.
+
+Work item:
+`work-items/13-agent-handoff-output-and-delivery-polish/`
+
+Ship:
+
+- "Next for your agent" handoff guidance in the command outputs where first-run
+  flow otherwise depends on pasted beta knowledge.
+- JSON output with direct created artifact paths where agents need to write
+  files, while preserving existing relative fields for compatibility.
+- Clear delivery wording that separates baseline OpenSpec guidance from
+  workflow entrypoints such as skills or slash commands.
+- Warnings when a selected tool cannot receive workflow slash commands.
+
+Done when:
+
+- A coding agent can continue from setup or initiative creation output without
+  guessing command names, reconstructing writable paths, or losing baseline
+  OpenSpec guidance because the user chose commands-oriented delivery.
+
+## 14. Workspaces Beta Guide Split
+
+Status: proposed immediate beta-learning item.
+
+Goal: make the beta docs reflect the intended division of labor:
+
+```text
+Users make local choices.
+Agents run OpenSpec work commands.
+```
+
+Ship:
+
+- A user-facing guide that prefers interactive terminal setup for local choices
+  such as context-store location, opener, and local repo paths.
+- An agent-facing CLI playbook that keeps explicit commands, JSON output,
+  current-directory rules, and caveats.
+- A clear rule for which flags are normal user-facing escape hatches and which
+  are mostly agent-facing precision.
+
+Done when:
+
+- A new user can get to a working beta setup without reading a flag-heavy CLI
+  tutorial.
+- A coding agent can still find the exact commands needed to create initiatives,
+  link repo-local changes, and inspect state safely.
+
+## 15. Context Store Project Roots And Schema-Led Initiatives
+
+Goal: let context stores behave like OpenSpec roots for shared planning config
+and schemas, while keeping implementation changes repo-owned by default.
+
+Work item:
+`work-items/15-context-store-project-roots-and-schema-led-initiatives/`
+
+Product decision to confirm:
+
+- A context store can have `openspec/config.yaml` and `openspec/schemas/` like a
+  repo after `openspec init`.
+- That project-like shape is for shared context configuration and initiative
+  schemas. It must not silently make the context store an implementation repo.
+- `initiative create` should create a sparse shell and let reviewed initiative
+  artifacts grow through schema-led status/instructions.
+
+Ship:
+
+- Context-store setup that creates or supports store-local OpenSpec config.
+- A default initiative schema for high-level requirements and design artifacts.
+- Sparse initiative creation: `initiative.yaml` plus a short `brief.md`, with no
+  `TBD` placeholders and no default `tasks.md`.
+- Initiative artifact status and instructions output rooted in the initiative
+  directory.
+- Guardrails so `openspec new change` does not accidentally create executable
+  repo-local changes inside a context store just because the store has an
+  `openspec/` directory.
+- Compatibility for existing six-file MVP initiatives.
+
+Done when:
+
+- A context store can resolve store-local initiative schemas.
+- Agents can iteratively create initiative requirements and design artifacts
+  from CLI instructions.
+- Existing MVP initiatives continue to list and show.
+- Docs stop presenting initiative creation as "fill every markdown file now."
+
+## 16. Add Escalation UX
 
 Goal: let users start locally and upgrade only when coordination is actually
 needed.
+
+Work item:
+`work-items/16-add-escalation-ux/`
 
 Ship:
 
@@ -443,10 +604,13 @@ Done when:
 - Coordinated planning feels like a continuation of local planning, not a
   workflow restart.
 
-## 12. Harden Team-Shared Coordination
+## 17. Harden Team-Shared Coordination
 
 Goal: make initiatives practical for teams without turning setup into an admin
 ceremony.
+
+Work item:
+`work-items/17-harden-team-shared-coordination/`
 
 Ship:
 
@@ -469,12 +633,15 @@ Done when:
 - Several teammates can share the same initiative while each keeps their own
   local checkout layout.
 
-## 13. Explore Initiative-Hosted Target-Bound Change Artifacts
+## 18. Explore Initiative-Hosted Target-Bound Change Artifacts
 
 Goal: decide whether shared initiative artifacts can graduate into executable
 OpenSpec changes only after they are bound to a target repo or spec root,
 without blurring initiative coordination, repo ownership, and workspace
 local-view boundaries.
+
+Work item:
+`work-items/18-explore-initiative-hosted-target-bound-change-artifacts/`
 
 Discussion points to confirm before exploration:
 
@@ -536,8 +703,15 @@ These are important, but should wait until the initiative model has real usage:
 7. Add agent-first initiative discovery.
 8. Link repo-local changes to initiatives.
 9. Keep initiative resolve rejected; use workspace local-view mapping instead.
-10. Pending discussion: optionally add initiative next / agent handoff UX.
-11. Let workspaces open initiatives.
-12. Add local-to-initiative escalation UX.
-13. Harden team-shared coordination.
-14. Explore configurable change homes.
+10. Let workspaces open initiatives.
+11. Manual beta reality pass.
+12. Context store first-run and cleanup UX.
+13. Agent handoff output and delivery polish.
+14. Workspaces beta guide split.
+15. Context store project roots and schema-led initiatives.
+16. Add local-to-initiative escalation UX.
+17. Harden team-shared coordination.
+18. Explore initiative-hosted target-bound change artifacts.
+
+Pending discussion: optionally add initiative next / agent handoff UX before or
+alongside the handoff polish work.

--- a/openspec/initiatives/context-store-and-initiatives/roadmap.md
+++ b/openspec/initiatives/context-store-and-initiatives/roadmap.md
@@ -32,6 +32,10 @@ Escalation UX, team-sharing hardening, and initiative-hosted target-bound
 changes remain important, but they should wait until the first-run path feels
 boring in the good way.
 
+Before workspaces become public/stable, run Item 19 as a late beta cleanup pass
+so beta compatibility code is reviewed intentionally instead of treated as a
+permanent contract.
+
 ## 1. Lock The Direction
 
 Goal: make the workspace-to-initiative pivot explicit so future workspace work
@@ -679,6 +683,43 @@ Done when:
 - The initiative has a concrete recommendation, opt-in/config examples, affected
   command list, and go/no-go criteria for implementation.
 
+## 19. Review Workspace Beta Compatibility Before Public Release
+
+Goal: decide which workspace beta compatibility behavior should survive into the
+public workspace contract, and remove or migrate the rest while workspaces are
+still unpublished.
+
+Work item:
+`work-items/19-review-workspace-beta-compatibility-before-public-release/`
+
+Why this is late:
+
+- Workspaces are still beta and not public/stable yet.
+- We do not need to preserve every intermediate beta file shape forever.
+- Early cleanup risks churn while first-run UX and initiative behavior are still
+  changing.
+- The right compatibility contract is easier to define after manual beta usage
+  shows which local workspace artifacts real users have actually created.
+
+Ship:
+
+- Inventory workspace compatibility code, including legacy split state readers,
+  registry fallbacks, `codex` to `codex-cli` aliases, generated `.gitignore`
+  cleanup, and empty compatibility shims.
+- Classify each path as public contract, beta migration, test-only shim, or
+  removable dead weight.
+- Remove beta-only shims that only support unpublished intermediate workspace
+  shapes.
+- Define any migration behavior worth keeping for people who tried the beta.
+- Update docs, tests, generated guidance, and release notes so the public
+  workspace compatibility promise is explicit.
+
+Done when:
+
+- The workspace compatibility surface is intentionally small.
+- Public docs do not imply support for beta-only workspace internals.
+- Any remaining migration code has a clear owner, reason, and removal policy.
+
 ## Later, Not First
 
 These are important, but should wait until the initiative model has real usage:
@@ -712,6 +753,7 @@ These are important, but should wait until the initiative model has real usage:
 16. Add local-to-initiative escalation UX.
 17. Harden team-shared coordination.
 18. Explore initiative-hosted target-bound change artifacts.
+19. Review workspace beta compatibility before public release.
 
 Pending discussion: optionally add initiative next / agent handoff UX before or
 alongside the handoff polish work.

--- a/openspec/initiatives/context-store-and-initiatives/tasks.md
+++ b/openspec/initiatives/context-store-and-initiatives/tasks.md
@@ -18,6 +18,8 @@ getting started before deeper model work:
    initiatives.
 6. Items 16-18: leave escalation, team hardening, and initiative-hosted
    target-bound changes until after the onboarding path feels sane.
+7. Item 19: review beta workspace compatibility near the end, before workspace
+   behavior becomes public/stable.
 
 ## 1. Lock The Direction
 
@@ -289,3 +291,18 @@ Work item: `work-items/18-explore-initiative-hosted-target-bound-change-artifact
 - [ ] Record compatibility behavior for existing repo-local and
   workspace-local changes.
 - [ ] Identify follow-on implementation slices and risks.
+
+## 19. Review Workspace Beta Compatibility Before Public Release
+
+Work item:
+`work-items/19-review-workspace-beta-compatibility-before-public-release/`
+
+- [ ] Inventory workspace beta compatibility code and tests.
+- [ ] Decide which beta-only compatibility paths should be removed before
+  public release.
+- [ ] Decide which compatibility paths need explicit migration behavior or
+  release notes.
+- [ ] Remove low-value shims that only support unpublished beta workspace
+  shapes.
+- [ ] Update docs, tests, and agent guidance to match the chosen public
+  workspace compatibility contract.

--- a/openspec/initiatives/context-store-and-initiatives/tasks.md
+++ b/openspec/initiatives/context-store-and-initiatives/tasks.md
@@ -3,6 +3,22 @@
 This tracks roadmap execution for the initiative. Roadmap items live in
 `roadmap.md`; detailed working notes live under `work-items/`.
 
+## Current Beta Priority
+
+After the manual beta pass, prioritize the things a fresh user hits while
+getting started before deeper model work:
+
+1. Finish Item 11 observations enough to keep implementation grounded.
+2. Item 12: no-argument context-store setup, path safety, and
+   cleanup.
+3. Item 13: "Next for your agent" output, direct JSON paths,
+   and baseline guidance/delivery polish.
+4. Item 14: update the beta guide so it matches the improved first-run flow.
+5. Item 15: context-store project roots and sparse schema-led
+   initiatives.
+6. Items 16-18: leave escalation, team hardening, and initiative-hosted
+   target-bound changes until after the onboarding path feels sane.
+
 ## 1. Lock The Direction
 
 Work item: `work-items/01-lock-the-direction/`
@@ -153,30 +169,122 @@ Work item draft:
 - [x] Confirm this slice opens known local paths only and does not create
   clones, branches, worktrees, or submodules.
 
-## 11. Add Escalation UX
+## 11. Manual Beta Reality Pass
+
+Work item: `work-items/11-manual-beta-reality-pass/`
+
+- [ ] Manually run the current context-store, initiative, workspace, and
+  repo-local change flows from a fresh user's point of view.
+- [ ] Capture notes on confusing commands, missing prompts, unclear output, and
+  places where the docs over-explain or under-explain.
+- [ ] Update initiative notes as observations come in.
+- [ ] Decide which findings should become implementation slices versus docs-only
+  fixes.
+
+## 12. Context Store First-Run And Cleanup UX
+
+Work item: `work-items/12-context-store-first-run-and-cleanup-ux/`
+
+- [ ] Decide and implement interactive no-argument `context-store setup`.
+- [ ] Define target-path safety behavior for managed defaults, explicit paths,
+  Git repos, and non-empty directories.
+- [ ] Add local cleanup support for unregistering or removing a context store.
+- [ ] Make setup and cleanup output report store root, registry state, Git
+  state, created files, and next commands.
+- [ ] Update docs and tests for first-run setup and cleanup behavior.
+
+## 13. Agent Handoff Output And Delivery Polish
+
+Work item: `work-items/13-agent-handoff-output-and-delivery-polish/`
+
+- [ ] Decide which commands should print "Next for your agent" handoff guidance.
+- [ ] Add direct created-path JSON fields where agents currently have to
+  reconstruct artifact paths.
+- [ ] Clarify commands-oriented delivery so workflow slash commands are separate
+  from baseline OpenSpec guidance.
+- [ ] Warn when a selected tool cannot receive workflow slash commands.
+- [ ] Update docs, generated agent guidance, and tests for the polished handoff
+  and delivery output.
+
+## 14. Workspaces Beta Guide Split
+
+Work item: `work-items/14-workspaces-beta-guide-split/`
+
+- [ ] Update the user-facing guide to prefer interactive terminal setup for
+  local choices.
+- [ ] Move initiative creation, initiative editing, and repo-local change
+  creation into "ask your coding agent" guidance.
+- [ ] Keep explicit flags, JSON output, cwd rules, and caveats in the
+  agent-facing CLI playbook.
+- [ ] Decide which flags remain useful in user docs as escape hatches for
+  ambiguity.
+- [ ] Record any interactive prompt gaps found while writing the guide.
+
+## 15. Context Store Project Roots And Schema-Led Initiatives
+
+Work item:
+`work-items/15-context-store-project-roots-and-schema-led-initiatives/`
+
+- [x] Create Item 15 work-item tracking notes.
+- [ ] Update initiative direction language so context stores are OpenSpec-aware
+  shared project roots, not only cross-team/cross-repo coordination folders.
+- [ ] Decide the minimal context-store OpenSpec structure:
+  `.openspec-store/store.yaml`, `openspec/config.yaml`,
+  `openspec/schemas/`, and collection mounts.
+- [ ] Decide the store-local config shape for initiative collection defaults,
+  including whether to use `collections.initiatives.schema`.
+- [ ] Decide how context-store setup creates, preserves, or repairs
+  store-local `openspec/config.yaml`.
+- [ ] Define the built-in high-level initiative schema and its initial
+  artifacts.
+- [ ] Decide whether `initiative create` creates only `initiative.yaml`, or
+  `initiative.yaml` plus one schema-selected seed artifact such as `brief.md`.
+- [ ] Replace eager six-file initiative scaffolding with sparse iterative
+  creation.
+- [ ] Add initiative artifact status/instructions behavior rooted at the
+  initiative directory.
+- [ ] Reuse project-local schema resolution with the context-store root as the
+  project root for initiative commands.
+- [ ] Decide whether schema CLI commands need `--store` or `--store-path`
+  selectors.
+- [ ] Guard planning-home resolution so context stores with `openspec/config.yaml`
+  do not accidentally make the store an implementation repo.
+- [ ] Preserve existing six-file beta initiatives as readable valid
+  initiatives.
+- [ ] Update docs, generated agent guidance, and tests for the project-like
+  context-store model.
+
+## 16. Add Escalation UX
+
+Work item: `work-items/16-add-escalation-ux/`
 
 - [ ] Define local-to-initiative recommendation triggers.
 - [ ] Carry current planning context into a new initiative.
 - [ ] Keep prompts grounded in affected areas.
 
-## 12. Harden Team-Shared Coordination
+## 17. Harden Team-Shared Coordination
+
+Work item: `work-items/17-harden-team-shared-coordination/`
 
 - [ ] Document recommended Git-backed store setup.
 - [ ] Define teammate onboarding and repair flows.
 - [ ] Add sync status and conflict guidance.
 
-## 13. Explore Configurable Change Homes
+## 18. Explore Initiative-Hosted Target-Bound Change Artifacts
 
-Work item: `work-items/13-explore-configurable-change-homes/`
+Work item: `work-items/18-explore-initiative-hosted-target-bound-change-artifacts/`
 
 - [ ] Confirm "change home" stays internal language and user-facing wording is
   closer to "where should this plan live?"
-- [ ] Explore when changes should live in a context store versus a local
-  OpenSpec repo.
-- [ ] Decide the configuration surface for selecting a default change home.
-- [ ] Define how `new change`, initiative linking, and workspace guidance
-  discover the configured change home.
-- [ ] Decide how context-store-hosted changes bind to target repo specs,
+- [ ] Define user-facing naming for initiative work items, briefs,
+  target-bound changes, artifact homes, and editable targets.
+- [ ] Decide whether initiative-hosted artifacts can graduate into executable
+  changes, and which target metadata is required first.
+- [ ] Decide the configuration or opt-in surface for repo-local versus
+  initiative-hosted artifacts.
+- [ ] Define how `openspec new change` selects and reports the artifact home,
+  implementation target, initiative link, and action context.
+- [ ] Decide how initiative-hosted target-bound changes bind to repo specs,
   implementation roots, validation, archive, and sync behavior.
 - [ ] Record compatibility behavior for existing repo-local and
   workspace-local changes.

--- a/openspec/initiatives/context-store-and-initiatives/work-items/11-manual-beta-reality-pass/notes.md
+++ b/openspec/initiatives/context-store-and-initiatives/work-items/11-manual-beta-reality-pass/notes.md
@@ -1,0 +1,289 @@
+# Manual Beta Reality Pass Notes
+
+Use this as the scratchpad while trying the beta flow.
+
+## What Worked
+
+- Manual beta pass caught the bad default before building more surface area.
+- After changing the default, rerunning
+  `openspec context-store setup team-context --init-git` from inside the
+  OpenSpec repo created the store at
+  `~/.local/share/openspec/context-stores/team-context` instead of nesting it in
+  the repo.
+- Minimal fresh-agent handoff worked for initiative creation. A subagent given
+  only the store id and a loose topic created `agent-trace-hooks` in the correct
+  context-store location:
+  `~/.local/share/openspec/context-stores/team-context/initiatives/agent-trace-hooks`.
+
+## What Felt Weird
+
+- Fresh-user guidance immediately drifted into sandbox/environment setup
+  (`XDG_CONFIG_HOME`, `XDG_DATA_HOME`) instead of letting the user just run the
+  beta locally. Strong reaction: this should work as a normal local workflow.
+- `openspec context-store setup` with no args feels like it should start an
+  interactive setup, but it does not. The command name itself creates that
+  expectation.
+- `openspec context-store setup team-context --init-git` created
+  `team-context/` inside the current OpenSpec repo because the default path is
+  `./<id>`. User expected a default outside the current repo, not a new Git repo
+  nested in whatever directory they happened to run from.
+- Cleaning up the accidental store had no obvious CLI path. `context-store`
+  exposes setup/register/list/doctor, but no unregister/remove command, so
+  cleanup required removing the folder and editing the registry manually.
+- `context-store setup --init-git` initializes Git, but leaves
+  `.openspec-store/` and new initiatives untracked. That may be fine, but the
+  beta flow does not tell the user or agent whether to stage/commit the shared
+  context store.
+- `openspec workspace open` with no arguments prompts only for known local
+  workspace views. It does not show registered context stores or initiatives, so
+  `team-context` is absent even though the next guide step is opening an
+  initiative from that store. This is technically consistent with the current
+  implementation, but confusing in the beta flow because the command name reads
+  like the broad "open something OpenSpec-related" entrypoint.
+- The post-initiative step has the wrong first-run verb. After creating a
+  context store and an initiative, the user is conceptually creating a local
+  workspace view for that initiative. "Open" implies the workspace already
+  exists, so the beta guide and CLI make the user infer a hidden create-or-open
+  behavior.
+
+## Missing Prompts Or Too Many Flags
+
+- Need clearer guidance for whether a beta pass should use existing local
+  OpenSpec state or create a normal local test context store. Avoid requiring
+  environment variables as the default manual path.
+- Missing prompt: when no context-store id is provided, ask for the store id,
+  path, and Git initialization choice instead of requiring the user to know the
+  positional argument/flags.
+- Missing prompt/safety check: before creating a default context store under
+  the current directory, show the target path and ask for confirmation or offer
+  a managed default location.
+- Missing handoff guidance: after context-store setup, the guide tells the user
+  to ask an agent to create an initiative, but a fresh agent may not know the
+  beta initiative CLI or where to find the agent playbook.
+- Missing prompt: `workspace open` should either offer an "open initiative from
+  context store" path when registered initiatives exist, or make the zero-arg
+  prompt text explicit that it is selecting an existing local workspace view
+  only. If it offers initiatives, it should likely list references like
+  `team-context/agent-trace-hooks`, not just the store id.
+- Missing first-run workspace creation flow: after an initiative exists, the
+  user should be guided through creating the local workspace view. A simple
+  interactive path could ask what to set up, list registered initiatives such as
+  `team-context/agent-trace-hooks`, suggest a workspace name from the initiative
+  id, optionally link existing repo/folder paths, choose an opener, then create
+  the workspace view.
+- Better minimal beta path: keep lazy workspace creation, but make bare
+  interactive `openspec workspace open` initiative-aware. The picker should show
+  existing local workspace views and registered initiatives that can create a
+  local view on selection, with labels that preserve the distinction between
+  "workspace" and "initiative."
+- The generated initiative file contract is underexplained. The CLI creates
+  exactly `initiative.yaml`, `requirements.md`, `design.md`, `decisions.md`,
+  `questions.md`, and `tasks.md`, but docs describe the Markdown files as
+  "typical" or "then edit" rather than naming the contract clearly.
+- A user looking at the generated initiative tree may reasonably ask where that
+  structure came from. The exact six-file contract is clear in code and the
+  internal MVP work item, but public beta docs do not make it explicit and the
+  broader direction doc still mentions future `contracts/` content.
+
+## Agent Handoff Notes
+
+- The first agent step has a bootstrapping problem. `context-store setup` does
+  not create repo-local guidance, and `workspace open --initiative` cannot run
+  until the initiative exists. A fresh agent needs either an explicit pasted
+  mini-playbook, installed OpenSpec skills, or CLI output that prints the exact
+  next agent prompt/command.
+- In the manual subagent test, the agent ran `initiative create --help`, then
+  created the initiative with `--store team-context --title ... --summary ...
+  --json`. It correctly resolved the store and did not create files in the
+  OpenSpec repo.
+- The subagent replaced generated `TBD` placeholders with useful short content,
+  which suggests the templates give enough structure but not enough guidance.
+  There is no CLI option to seed richer content beyond title and summary.
+- `initiative create --json` reports `created_files` as relative names. Agents
+  have to combine those with the returned root to get absolute paths.
+- "Commands only" is product-ambiguous for this beta. The implementation treats
+  it as "remove all skills and install only slash command files," but users may
+  read it as "I prefer slash commands for workflow entry points." They still
+  likely expect their coding agent to understand OpenSpec concepts, context
+  stores, initiatives, and workspace handoff.
+
+## Delivery UX Model
+
+- Split the concept into two layers:
+  - Baseline OpenSpec literacy: "Does the agent understand OpenSpec concepts and
+    know how to inspect context stores, initiatives, workspaces, and repo-local
+    changes?"
+  - Workflow entrypoints: "How does the user invoke workflow actions such as
+    propose/apply/archive?"
+- Current `delivery` acts like a generated-artifact cleanup switch. That is too
+  low-level for the user-facing choice.
+- Better meaning:
+  - `skills`: install the baseline guide skill plus workflow skills.
+  - `commands`: install the baseline guide skill plus workflow slash commands.
+  - `both`: install the baseline guide skill plus workflow skills and workflow
+    slash commands.
+- In UI copy, avoid "commands only" if it implies no skills at all. Prefer
+  labels like "Slash commands as workflow entrypoints" or "Workflow commands
+  only" with helper text that baseline OpenSpec guidance is still installed
+  when the selected agent supports skills.
+- For tools without a command adapter, commands-oriented delivery should warn
+  clearly that workflow slash commands are unavailable for that tool. The tool
+  should still receive the baseline guide skill if it supports skills, so the
+  selected agent is not left with nothing.
+
+## Initiative Placement UX
+
+- A fresh agent also needs to know whether a new planning object belongs in a
+  context store or in the current repo. This should not be left to vibes.
+- Product distinction:
+  - Initiatives in context stores are durable planning and coordination context
+    that intentionally lives outside implementation repos: product intent,
+    decisions, questions, roadmap notes, and tasks that should not necessarily
+    be checked into the code repo.
+  - Repo-local OpenSpec changes are implementation plans owned by the repo that
+    will change: proposal/design/spec deltas/tasks/validation.
+  - Workspaces are local views that connect shared context to local repos; they
+    should not become a third durable planning home.
+- Agent guidance should not assume repo-local is preferred just because work
+  touches one repo. Use or create a context-store initiative when the user wants
+  OpenSpec artifacts outside the repo, when a monorepo has multiple teams with
+  separate planning contexts, when repo policy discourages planning artifacts,
+  when work is cross-repo/team-coordinated, long-lived, pre-implementation
+  discovery, or already tied to an existing context store.
+- If a request is ambiguous, the agent should inspect first:
+  `openspec initiative list --json`, `openspec list --json`, and workspace
+  state when available. If still ambiguous, ask: "Should these OpenSpec
+  artifacts live outside the repo in a context store, or inside this repo as a
+  repo-local implementation change?"
+- CLI/skill copy should make the linked flow explicit: create/read initiative
+  in the context store, then create repo-local changes from the owning repo with
+  `--initiative <store>/<initiative>`.
+
+## Initiative Creation Rethink
+
+- `openspec initiative create` currently creates a full six-file planning
+  packet with `TBD` placeholders. That is too eager for the intended audience:
+  PMs, designers, architects, and agents facilitating early product/architecture
+  thinking.
+- Initial creation should register the initiative shell, not invent the plan.
+  The most conservative first slice is `initiative.yaml` plus either:
+  - a short `brief.md` seeded from title/summary/current understanding; or
+  - a lightweight `requirements.md` with no `TBD` placeholders and no claims of
+    accepted requirements until the content has been reviewed.
+- Follow-up artifacts should be created iteratively when they become real:
+  - `requirements.md`: accepted high-level requirements, goals, non-goals,
+    unresolved product questions.
+  - `design.md`: reviewed product/UX/architecture direction and tradeoffs.
+  - `questions.md`: optional question log when questions need tracking.
+  - `decisions.md`: optional decision log appended only after decisions happen.
+  - Avoid default `tasks.md`; implementation tasks belong in repo-local changes.
+    If initiative-level coordination is needed later, use clearer language like
+    `workstreams.md`, `milestones.md`, or `coordination.md`.
+- This should ideally become schema-led. Reuse the artifact-graph idea
+  (artifact ids, generated paths, templates, dependencies, status/instructions),
+  but root it at the initiative directory instead of repo-local changes.
+- A minimal initiative schema could start with only `requirements` and `design`,
+  where design depends on requirements. `decisions` and `questions` are living
+  logs, so file-existence completion semantics may not fit them.
+- For next-release safety, avoid a strict top-level `schema:` field in
+  `initiative.yaml` until metadata compatibility is designed. If a schema hint
+  needs persistence, store it under `metadata` or keep the default implicit.
+
+## Docs Fixes
+
+- The beta guide says "This creates a local context store" but does not explain
+  that the default location is `./<id>` relative to the current working
+  directory. That needs to be explicit if the default remains.
+- Immediate docs/code fix changed the default away from `./<id>` and documented
+  the managed local data location instead.
+- Step 2 should not assume the agent already knows the beta initiative command.
+  Include a copy-paste bootstrap prompt or link/inline excerpt from the agent
+  CLI playbook.
+- Step 3 says "Open Your Local Workbench," but the command is actually
+  create-or-open when `--initiative` is passed. The guide should make that
+  explicit: "Create or open a local workspace view for the initiative." It
+  should also warn that bare `openspec workspace open` selects existing
+  workspace views only and will not list context stores like `team-context`.
+- Better: change the user-facing flow so the first-time path is explicitly
+  creation/setup. The guide should send humans to an interactive workspace setup
+  path for the initiative, then reserve `workspace open` for reopening an
+  existing workspace view.
+- Subagent UX/model passes recommended a leaner beta change: keep
+  `workspace open --initiative <store>/<initiative>` as the explicit
+  create-or-reuse path, but make bare interactive `workspace open` show
+  initiatives as selectable targets. Selecting an initiative should say it is
+  creating/opening a local workspace view.
+
+## Possible Implementation Slices
+
+- Make `openspec context-store setup` interactive when no id is provided:
+  prompt for store id, default path, and Git initialization; keep `--json` /
+  non-interactive behavior deterministic with a helpful fix message.
+- Reconsider the default context-store setup path. Options: use the managed
+  OpenSpec data directory by default, or keep `./<id>` only after an interactive
+  confirmation that names the full target path.
+  - Implemented during the pass: use the managed OpenSpec data directory by
+    default and keep `--path` for explicit locations.
+- Add `openspec context-store unregister <id>` or `remove <id>` for local
+  registry cleanup, with an explicit choice about whether to delete files or
+  only forget the local registration.
+- Add a first-run handoff affordance after context-store setup, such as printing
+  "Next for your agent" guidance or adding a command that emits the agent
+  playbook for shared context/initiative setup.
+- Add interactive workspace creation for initiative views. Candidate surfaces:
+  extend `openspec workspace setup` with initiative selection, add
+  `openspec workspace setup --initiative <store>/<initiative>`, or introduce a
+  clearer `workspace create` command. The key UX requirement is that a fresh
+  user can run an interactive command after initiative creation and be led to
+  "create a local workspace view for this initiative" without knowing
+  `--initiative` or the derived workspace-name convention.
+- Add an initiative-aware `workspace open` picker as the smallest product fix:
+  on bare interactive open, list local workspaces plus registered initiatives.
+  If the user selects an initiative, feed it through the existing
+  `--initiative` create/reuse path. Do not auto-create workspaces during
+  context-store setup or initiative creation, and do not make workspaces 1:1
+  with initiatives.
+  - Implemented during the pass: bare interactive `workspace open` now shows
+    registered initiatives that do not already have a known local view, and
+    selecting one creates/reuses the initiative-bound workspace view.
+  - Follow-up fix: when that lazy initiative view is new, `workspace open`
+    now runs the same repo/folder link prompt as `workspace setup` before
+    creating the workspace view. This avoids opening an empty workspace and
+    makes the first-run path collect implementation roots at the moment the
+    user expects it.
+- Consider splitting baseline OpenSpec literacy from workflow delivery. A
+  small default `use-openspec` skill could be installed whenever a selected
+  agent supports skills, even if workflow delivery is set to commands-only, so
+  "commands only" means "workflow actions are slash commands" rather than "the
+  agent gets no OpenSpec context."
+- Simpler possible slice: treat `use-openspec` as a normal managed skill bundled
+  with the configurator and installed by default. Keep it skill-only even if it
+  is presented as part of the default profile, so it does not create a slash
+  command, workflow artifact, or user-facing workflow action.
+- Rethink `openspec initiative create` as a sparse, schema-led container
+  instead of a fully scaffolded planning packet. Initial create should likely
+  write only `initiative.yaml` plus a short `brief.md` seeded from title and
+  summary. Follow-up agent/CLI actions can add `requirements.md`, `design.md`,
+  `questions.md`, `decisions.md`, or coordination artifacts when there is
+  reviewed content to capture. Avoid default `TBD` sections, fake decisions,
+  and default initiative-level `tasks.md` that may be confused with repo-local
+  implementation tasks.
+- Manual follow-up converted the test `agent-trace-hooks` initiative to the
+  proposed sparse shape: kept `initiative.yaml`, added `brief.md`, and removed
+  the eager generated planning files. `initiative show` still resolves because
+  current initiative identity depends on `initiative.yaml`.
+- Promoted the broader fix into
+  `work-items/15-context-store-project-roots-and-schema-led-initiatives/`:
+  context stores should behave like OpenSpec roots for shared context, with
+  store-local config, schemas, and sparse schema-led initiative artifacts.
+- Workspace shape correction: managed workspace views should not look like
+  repos. New workspace views should contain the generated root files
+  (`AGENTS.md`, `workspace.yaml`, and `<workspace>.code-workspace`) without a
+  default `changes/` directory or generated `.gitignore`; VS Code multi-root
+  views should show linked repos first, then initiative context, then the small
+  OpenSpec workspace folder.
+- Guide correction: after opening a workspace, the user should ask the agent to
+  explore or draft using the initiative. The agent should resolve workspace
+  state, initiative context, and linked repo ownership, then run repo-local
+  OpenSpec commands from the owning repo. The user-facing flow should not make
+  humans type `openspec new change` or `cd` into implementation repos.

--- a/openspec/initiatives/context-store-and-initiatives/work-items/11-manual-beta-reality-pass/plan.md
+++ b/openspec/initiatives/context-store-and-initiatives/work-items/11-manual-beta-reality-pass/plan.md
@@ -1,0 +1,39 @@
+# Manual Beta Reality Pass
+
+## Status
+
+Proposed next work item.
+
+## Goal
+
+Try the current beta flow by hand and use the friction as product input before
+building more surface area.
+
+## Pass Shape
+
+Start from a fresh local setup and walk through:
+
+- context store setup or registration
+- initiative creation and editing through an agent
+- workspace open
+- workspace link or relink
+- workspace doctor
+- repo-local change creation linked to an initiative
+- handoff back to an agent
+
+## Output
+
+The output should be notes, not polish:
+
+- what felt easy
+- what felt weird
+- where flags leaked into user-facing docs
+- where prompts were missing
+- what an agent needed to be told explicitly
+- what should become a follow-on implementation slice
+
+## Non-Goals
+
+- Do not require a clean public tutorial state.
+- Do not solve every issue found during the pass.
+- Do not turn the beta flow into a progress dashboard.

--- a/openspec/initiatives/context-store-and-initiatives/work-items/11-manual-beta-reality-pass/tasks.md
+++ b/openspec/initiatives/context-store-and-initiatives/work-items/11-manual-beta-reality-pass/tasks.md
@@ -1,0 +1,8 @@
+# Manual Beta Reality Pass Tasks
+
+- [ ] Run the current beta flow from a fresh user's point of view.
+- [ ] Capture notes in the initiative as the pass happens.
+- [ ] Mark where the user should type commands versus prompt an agent.
+- [ ] Record confusing output, missing prompts, and unclear command names.
+- [ ] Update beta docs with immediate findings.
+- [ ] Split larger findings into proposed implementation work items.

--- a/openspec/initiatives/context-store-and-initiatives/work-items/12-context-store-first-run-and-cleanup-ux/evidence.md
+++ b/openspec/initiatives/context-store-and-initiatives/work-items/12-context-store-first-run-and-cleanup-ux/evidence.md
@@ -1,0 +1,23 @@
+# Context Store First-Run And Cleanup UX Evidence
+
+## Manual Beta Source Notes
+
+The manual beta pass found:
+
+- no-argument `openspec context-store setup` feels like it should start an
+  interactive setup;
+- accidental setup previously created a store under the current repo before the
+  managed default was corrected;
+- cleanup had no CLI path and required deleting files plus editing the registry
+  manually;
+- Git initialization left shared files untracked without telling the user or
+  agent what to do next.
+
+## Initial Recommendation
+
+Keep context-store first-run UX small and local:
+
+- prompt only for local setup choices;
+- never push, pull, commit, create remotes, or delete files implicitly;
+- keep JSON output explicit enough for agents to continue safely;
+- leave team sync policy to the later shared-coordination hardening work.

--- a/openspec/initiatives/context-store-and-initiatives/work-items/12-context-store-first-run-and-cleanup-ux/plan.md
+++ b/openspec/initiatives/context-store-and-initiatives/work-items/12-context-store-first-run-and-cleanup-ux/plan.md
@@ -1,0 +1,116 @@
+# Context Store First-Run And Cleanup UX
+
+## Status
+
+Proposed from the manual beta reality pass.
+
+This work item covers the context-store setup and cleanup gaps that were not
+fully captured by later docs, schema, or handoff work.
+
+## Source Of Truth
+
+Manual beta notes:
+
+- `../11-manual-beta-reality-pass/notes.md`, especially the findings around
+  no-argument setup, cleanup, target path safety, and shared-store Git guidance.
+
+Preserve the current boundary:
+
+```text
+Context stores sync truth.
+Collections shape truth.
+Initiatives coordinate work.
+Workspaces open local views.
+Changes implement repo-owned slices.
+```
+
+## Why This Exists
+
+The beta pass found that `openspec context-store setup` feels like a first-run
+entrypoint, but no-argument setup currently does not guide the user through the
+choices they need to make. The pass also found that recovering from a mistaken
+store setup requires manual registry edits and file deletion.
+
+These are local lifecycle problems, not shared coordination model problems.
+They should be solved before asking new users or teammates to trust context
+stores as normal local workflow.
+
+## Goals
+
+- Make no-argument `context-store setup` a friendly interactive setup path in a
+  terminal.
+- Keep non-interactive and JSON behavior deterministic and agent-safe.
+- Make the target store path explicit before creation.
+- Provide a supported local cleanup command for removing or unregistering a
+  context store from this machine.
+- Explain the Git/stage/commit state after initializing a shared store, without
+  pushing, committing, or creating remotes automatically.
+
+## Non-Goals
+
+- Do not add remote creation, clone, pull, push, watch, or sync automation.
+- Do not make setup choose team governance, branching, or review policy.
+- Do not delete shared files without an explicit user choice.
+- Do not make context stores implementation repos.
+
+## UX Direction
+
+Interactive setup should cover the minimum choices:
+
+```text
+Store id
+Target path, defaulting to the managed OpenSpec context-store location
+Whether to initialize Git
+```
+
+Before writing files, output should show the resolved target path. If an
+explicit path is inside another Git repo or an existing non-empty directory,
+the command should either ask for confirmation with clear wording or fail with
+a fix message in non-interactive mode.
+
+Cleanup should distinguish local registration from file deletion:
+
+```bash
+openspec context-store unregister team-context
+openspec context-store remove team-context
+```
+
+The exact command names are open, but the user intent must be explicit:
+
+- forget this local registry entry only
+- delete this local context-store folder too
+
+If a Git-backed context store was initialized, setup output should say that the
+store now has uncommitted files and that the user or agent should review,
+stage, commit, and push according to their team's normal Git workflow.
+
+## Agent / JSON Contract
+
+JSON setup output should report:
+
+- store id
+- root path
+- metadata path
+- whether Git was initialized
+- whether files were created or already existed
+- local registry path or registry entry identity
+- next commands for listing, doctor, and initiative creation
+- advisory Git status summary when available
+
+JSON cleanup output should report:
+
+- store id
+- removed local registry entry, if any
+- deleted root path, if requested
+- files left on disk, if deletion was not requested
+- warnings for missing, ambiguous, or already-removed state
+
+## Done When
+
+- A fresh user can run `openspec context-store setup` in a terminal and be led
+  through the normal local setup path without knowing flags.
+- Non-interactive and JSON setup still fail predictably when required choices
+  are missing.
+- A mistaken local store registration can be removed through the CLI without
+  hand-editing the registry.
+- Setup and cleanup output make local file, registry, and Git state explicit.

--- a/openspec/initiatives/context-store-and-initiatives/work-items/12-context-store-first-run-and-cleanup-ux/tasks.md
+++ b/openspec/initiatives/context-store-and-initiatives/work-items/12-context-store-first-run-and-cleanup-ux/tasks.md
@@ -1,0 +1,24 @@
+# Context Store First-Run And Cleanup UX Tasks
+
+- [ ] Decide exact no-argument `context-store setup` behavior for TTY,
+      non-TTY, and `--json` invocations.
+- [ ] Design the interactive setup prompts for store id, target path, and Git
+      initialization.
+- [ ] Define target-path safety behavior for managed defaults, explicit paths,
+      paths inside existing Git repos, and non-empty directories.
+- [ ] Implement the interactive setup flow without changing deterministic
+      non-interactive behavior.
+- [ ] Decide whether the cleanup surface is `unregister`, `remove`, or both.
+- [ ] Define cleanup semantics for "forget local registration" versus "delete
+      local files too".
+- [ ] Implement local registry cleanup with explicit confirmation before file
+      deletion.
+- [ ] Add human and JSON output that reports store root, metadata path, registry
+      state, created files, and next commands.
+- [ ] Add setup guidance for initialized Git stores that explains uncommitted
+      shared files without auto-staging, committing, pushing, or creating a
+      remote.
+- [ ] Add focused tests for setup prompts, non-interactive failures, path
+      safety, registry cleanup, and JSON output.
+- [ ] Update beta docs and agent playbook references for first-run setup and
+      cleanup.

--- a/openspec/initiatives/context-store-and-initiatives/work-items/13-agent-handoff-output-and-delivery-polish/evidence.md
+++ b/openspec/initiatives/context-store-and-initiatives/work-items/13-agent-handoff-output-and-delivery-polish/evidence.md
@@ -1,0 +1,25 @@
+# Agent Handoff Output And Delivery Polish Evidence
+
+## Manual Beta Source Notes
+
+The manual beta pass found:
+
+- after context-store setup, the user is told to ask an agent to create an
+  initiative, but a fresh agent may not know the beta CLI or where to find the
+  playbook;
+- `initiative create --json` reports `created_files` as relative names, so
+  agents must combine them with the returned root before writing;
+- "commands only" can sound like "the agent gets no OpenSpec guidance," even
+  though users may only mean slash commands as workflow entrypoints;
+- tools without command adapters need a clear warning when workflow slash
+  commands cannot be installed.
+
+## Initial Recommendation
+
+Treat this as output polish, not a new workflow engine:
+
+- add direct path fields rather than breaking existing relative fields;
+- keep handoff guidance concrete and command-sized;
+- keep baseline OpenSpec literacy separate from workflow entrypoints;
+- leave the broader "what should I do next?" command to the proposed handoff
+  work item.

--- a/openspec/initiatives/context-store-and-initiatives/work-items/13-agent-handoff-output-and-delivery-polish/plan.md
+++ b/openspec/initiatives/context-store-and-initiatives/work-items/13-agent-handoff-output-and-delivery-polish/plan.md
@@ -1,0 +1,98 @@
+# Agent Handoff Output And Delivery Polish
+
+## Status
+
+Proposed from the manual beta reality pass.
+
+This work item captures the remaining agent-handoff and delivery-output gaps
+that are smaller than the broader `initiative next` discussion but still matter
+for the beta flow.
+
+## Source Of Truth
+
+Manual beta notes:
+
+- `../11-manual-beta-reality-pass/notes.md`, especially the findings around
+  post-setup agent guidance, relative `created_files`, and commands-oriented
+  delivery warnings.
+
+Related work:
+
+- `../proposed-initiative-next-agent-handoff-ux/`
+- `../14-workspaces-beta-guide-split/`
+- `../15-context-store-project-roots-and-schema-led-initiatives/`
+
+## Why This Exists
+
+The beta pass showed that agents can succeed if they know which command to run,
+but the first handoff is still too implicit. Setup output, JSON receipts, docs,
+and generated delivery artifacts should make the next move obvious without
+requiring the user to paste tribal knowledge.
+
+This work item is deliberately narrower than an `initiative next` command. It
+polishes existing command outputs and delivery semantics so a fresh agent can
+continue safely.
+
+## Goals
+
+- Make setup and initiative creation output point to the next useful agent
+  action.
+- Ensure agent-readable JSON returns paths that can be used directly without
+  path reconstruction when practical.
+- Clarify commands-oriented delivery so "workflow commands" does not mean "the
+  agent receives no OpenSpec guidance."
+- Warn clearly when the selected tool cannot receive workflow slash commands.
+- Keep baseline OpenSpec literacy separate from workflow entrypoints.
+
+## Non-Goals
+
+- Do not implement an `initiative next` command in this slice.
+- Do not add progress dashboards or work-status rollups.
+- Do not create initiatives, changes, or workspaces automatically as part of
+  setup output.
+- Do not make every relative path field disappear if existing compatibility
+  requires it; add direct absolute path fields instead.
+
+## Output Direction
+
+Commands that create or prepare OpenSpec shared context should include a small
+handoff block in human output:
+
+```text
+Next for your agent:
+  Ask your coding agent to create or update an initiative in team-context.
+```
+
+JSON output should prefer both stable relative names and direct absolute paths
+where agents need to write files:
+
+```json
+{
+  "created_files": ["initiative.yaml", "brief.md"],
+  "created_paths": [
+    "/path/to/store/initiatives/billing-launch/initiative.yaml",
+    "/path/to/store/initiatives/billing-launch/brief.md"
+  ],
+  "next_commands": {}
+}
+```
+
+Delivery copy should distinguish:
+
+- baseline OpenSpec guidance or literacy;
+- workflow entrypoints such as skills or slash commands.
+
+If a user selects commands-oriented delivery for a tool that has no command
+adapter, output should warn that workflow slash commands are unavailable while
+still installing or recommending baseline guidance when the tool supports it.
+
+## Done When
+
+- A fresh agent can continue after context-store setup or initiative creation
+  using command output and docs, without guessing paths or beta command names.
+- JSON receipts expose direct paths for created initiative artifacts or explain
+  why only relative names are available.
+- Commands-oriented delivery output clearly reports what guidance and workflow
+  entrypoints were installed, skipped, or unavailable.
+- The broader `initiative next` proposal can build on these outputs instead of
+  solving first-run handoff from scratch.

--- a/openspec/initiatives/context-store-and-initiatives/work-items/13-agent-handoff-output-and-delivery-polish/tasks.md
+++ b/openspec/initiatives/context-store-and-initiatives/work-items/13-agent-handoff-output-and-delivery-polish/tasks.md
@@ -1,0 +1,25 @@
+# Agent Handoff Output And Delivery Polish Tasks
+
+- [ ] Decide which existing commands should print a "Next for your agent"
+      handoff block.
+- [ ] Define the minimal handoff content for context-store setup, initiative
+      creation, workspace opening, and repo-local linked change creation.
+- [ ] Add direct created-path fields, such as `created_paths`, where JSON output
+      currently forces agents to combine relative file names with returned
+      roots.
+- [ ] Preserve compatibility for existing relative `created_files` fields where
+      callers may already depend on them.
+- [ ] Update `initiative create --json` and sparse initiative creation output
+      from Item 15 to include direct artifact paths and next commands.
+- [ ] Decide how generated docs or setup output points to the agent CLI
+      playbook without requiring a pasted mini-playbook in every guide step.
+- [ ] Clarify delivery terminology so commands-oriented delivery means workflow
+      commands as entrypoints, not absence of baseline OpenSpec guidance.
+- [ ] Add warnings when a selected tool does not support workflow slash command
+      delivery.
+- [ ] Define how baseline OpenSpec guidance is reported when commands-oriented
+      delivery is selected for a tool that still supports skills.
+- [ ] Add tests or fixtures for human output, JSON output, and delivery-warning
+      behavior.
+- [ ] Update beta docs and generated agent guidance with the polished handoff
+      and delivery language.

--- a/openspec/initiatives/context-store-and-initiatives/work-items/14-workspaces-beta-guide-split/plan.md
+++ b/openspec/initiatives/context-store-and-initiatives/work-items/14-workspaces-beta-guide-split/plan.md
@@ -1,0 +1,37 @@
+# Workspaces Beta Guide Split
+
+## Status
+
+Proposed next work item.
+
+## Goal
+
+Make the beta docs match how people should actually use the feature:
+
+- humans use terminal prompts for local setup and local paths
+- coding agents use explicit CLI commands for OpenSpec work
+
+## Working Model
+
+User-facing docs should be light on flags and heavy on agent prompts. The agent
+CLI playbook should carry the exact commands, JSON surfaces, cwd rules, and
+current caveats.
+
+Manual beta clarification: after a workspace is opened, the user should ask the
+agent to explore or draft from the workspace. The agent should resolve the
+workspace and initiative context, identify the owning linked repo, and run
+repo-local OpenSpec commands from that repo. The workspace is the conversation
+surface, not the artifact home.
+
+## Scope
+
+- Revise `docs/workspaces-beta/user-guide.md`.
+- Revise `docs/workspaces-beta/agent-cli-playbook.md`.
+- Keep the docs minimal until the flow has been tried manually.
+- Record command or prompt gaps found during the doc pass.
+
+## Non-Goals
+
+- Do not change CLI behavior in this work item.
+- Do not promise sync, cloning, branching, worktrees, progress dashboards, or
+  enforced edit boundaries.

--- a/openspec/initiatives/context-store-and-initiatives/work-items/14-workspaces-beta-guide-split/tasks.md
+++ b/openspec/initiatives/context-store-and-initiatives/work-items/14-workspaces-beta-guide-split/tasks.md
@@ -1,0 +1,9 @@
+# Workspaces Beta Guide Split Tasks
+
+- [x] Identify which setup steps should be typed by the user.
+- [x] Identify which initiative and change steps should be delegated to a coding
+  agent.
+- [x] Update the user guide around interactive setup and agent prompts.
+- [x] Update the agent CLI playbook around explicit commands and cwd rules.
+- [x] Add a tiny caveat section that reflects shipped beta behavior.
+- [ ] Capture any product gaps exposed by the docs pass.

--- a/openspec/initiatives/context-store-and-initiatives/work-items/15-context-store-project-roots-and-schema-led-initiatives/evidence.md
+++ b/openspec/initiatives/context-store-and-initiatives/work-items/15-context-store-project-roots-and-schema-led-initiatives/evidence.md
@@ -1,0 +1,140 @@
+# Context Store Project Roots And Schema-Led Initiatives Evidence
+
+## Manual Beta Findings
+
+- A fresh-agent style prompt successfully created `agent-trace-hooks` in the
+  registered `team-context` context store.
+- The current CLI created this hardcoded file set:
+
+```text
+initiative.yaml
+requirements.md
+design.md
+decisions.md
+questions.md
+tasks.md
+```
+
+- The generated markdown templates started with `TBD` placeholders.
+- The agent filled those documents with plausible but unreviewed planning
+  content.
+- We manually reduced the test initiative to a sparse shape:
+
+```text
+initiative.yaml
+brief.md
+```
+
+- `openspec initiative show team-context/agent-trace-hooks --json` and
+  `openspec initiative list --store team-context --json` continued to resolve,
+  which proves current identity/listing logic does not require the six-file
+  packet.
+
+## Code Observations
+
+- Initiative file names are hardcoded in
+  `src/core/collections/initiatives/schema.ts`.
+- Initiative markdown templates are hardcoded in
+  `src/core/collections/initiatives/templates.ts`.
+- `createInitiative` writes `initiative.yaml` and then all default template
+  files in `src/core/collections/initiatives/operations.ts`.
+- `initiative create --json` reports `created_files` from
+  `INITIATIVE_FILE_NAMES` in `src/commands/initiative.ts`.
+- Initiative list/show read only `initiative.yaml`.
+- Project-local schema resolution already uses
+  `<projectRoot>/openspec/schemas/<name>/schema.yaml` in
+  `src/core/artifact-graph/resolver.ts`.
+- Project config already reads `<projectRoot>/openspec/config.yaml` in
+  `src/core/project-config.ts`.
+- Change artifact status/instructions are coupled to repo-local change context
+  through `src/core/artifact-graph/instruction-loader.ts`.
+- Planning-home detection currently treats an ancestor containing `openspec/`
+  as a possible repo planning root, so adding config to context stores needs a
+  safety check.
+
+## UX/Product Pass
+
+Recommended user meaning:
+
+```text
+context store = shared OpenSpec context project
+initiative    = iterative high-level planning object
+repo change   = implementation plan
+workspace     = local view
+```
+
+Docs should avoid saying initiatives are only for cross-repo or cross-team
+work. A user may choose a context store simply because they want OpenSpec
+artifacts outside the implementation repo.
+
+`initiative create` should make the smallest useful shared object and then
+teach the agent how to continue through status/instructions. It should not
+pretend requirements, decisions, and tasks exist before review.
+
+## Architecture Pass
+
+Feasible minimal path:
+
+1. Treat the context store root as a project root for config/schema resolution.
+2. Create `openspec/config.yaml` during context-store setup.
+3. Resolve initiative schemas with `projectRoot = contextStoreRoot`.
+4. Add initiative-specific status/instructions helpers using artifact graph
+   primitives.
+5. Change initiative creation to write a sparse shell.
+
+Main risks:
+
+- strict `initiative.yaml` parsing if a new top-level `schema` field is added
+- tests currently asserting the six-file MVP contract
+- docs and generated agent guidance currently telling agents to edit the five
+  generated Markdown files
+- ambiguity between initiative planning artifacts and repo-local implementation
+  tasks
+- context-store roots becoming accidental repo planning homes after they gain
+  `openspec/config.yaml`
+
+## Subagent / Research Notes
+
+Three focused passes converged on the same direction.
+
+Architecture pass:
+
+- Model a context store as an OpenSpec planning root:
+
+```text
+context-store/
+  .openspec-store/store.yaml
+  openspec/config.yaml
+  openspec/schemas/
+  initiatives/
+```
+
+- Keep `.openspec-store/store.yaml` as store identity and
+  `openspec/config.yaml` as behavior/configuration.
+- Reuse project-local config and schema resolution with the context-store root
+  as the project root.
+- Add an initiative-specific artifact context instead of forcing initiatives
+  through repo-local change context.
+- Guard planning-home discovery so a context store with `openspec/config.yaml`
+  does not become an accidental implementation repo.
+
+UX/product pass:
+
+- Describe a context store as an OpenSpec-managed planning home. It may be used
+  for cross-repo coordination, but also simply to keep OpenSpec artifacts out of
+  an implementation repo.
+- Make `initiative create` sparse: `initiative.yaml` plus a seed artifact such
+  as `brief.md`.
+- Add status/instructions output so agents create requirements and design
+  artifacts only when there is reviewed content to capture.
+- Stop treating default initiative artifacts as files the user or agent should
+  immediately fill in.
+
+Release-risk pass:
+
+- Keep old six-file beta initiatives readable.
+- Update tests that assert the old generated file list.
+- Avoid strict top-level additions to `initiative.yaml` until metadata
+  versioning is designed.
+- Defer context-store-hosted executable changes to the configurable change-home
+  work instead of bundling them into this slice.

--- a/openspec/initiatives/context-store-and-initiatives/work-items/15-context-store-project-roots-and-schema-led-initiatives/plan.md
+++ b/openspec/initiatives/context-store-and-initiatives/work-items/15-context-store-project-roots-and-schema-led-initiatives/plan.md
@@ -1,0 +1,345 @@
+# Context Store Project Roots And Schema-Led Initiatives
+
+## Status
+
+Proposed from the manual beta reality pass.
+
+This work item replaces the current "initiative create writes a full hardcoded
+six-file packet" model with a project-like context-store root and an iterative,
+schema-led initiative artifact flow.
+
+## Source Of Truth
+
+Start from `../../direction.md` and preserve the current boundary:
+
+```text
+Context stores sync truth.
+Collections shape truth.
+Initiatives coordinate work.
+Workspaces open local views.
+Changes implement repo-owned slices.
+```
+
+Manual beta evidence: agents can create the current MVP initiative shape, but
+the generated `requirements.md`, `design.md`, `decisions.md`, `questions.md`,
+and `tasks.md` invite premature, unreviewed planning content.
+
+## Why This Exists
+
+`openspec initiative create` currently creates a complete-looking planning
+packet from hardcoded TypeScript constants and `TBD` templates. That made the
+MVP tangible, but it is the wrong default for real initiative work.
+
+Initiatives are high-level shared planning surfaces for PMs, designers,
+architects, and agents. They should capture intent, reviewed requirements,
+design direction, open questions, and decisions as those artifacts become real.
+They should not create empty or fake documents that look finished just because
+the folder exists.
+
+The broader product shape is that a context store should feel like an OpenSpec
+root in the same way a repo does after `openspec init`: it can have local
+OpenSpec configuration and project-local schemas. The difference is lifecycle:
+a context store is the shared context root, not an implementation repo.
+
+## Product Model
+
+Repo after `openspec init`:
+
+```text
+repo/
+  openspec/
+    config.yaml
+    schemas/
+    changes/
+    specs/
+```
+
+Context store after setup:
+
+```text
+context-store/
+  .openspec-store/
+    store.yaml
+  openspec/
+    config.yaml
+    schemas/
+  initiatives/
+```
+
+The `openspec/` directory inside a context store exists for OpenSpec config and
+schema resolution. It does not by itself make the context store an executable
+implementation planning home.
+
+## Goals
+
+- Let context stores carry OpenSpec config, including a default initiative
+  schema.
+- Let context stores carry project-local schemas under `openspec/schemas/`.
+- Replace hardcoded initiative file creation with a schema-led artifact model.
+- Make `initiative create` sparse and safe by default.
+- Let agents grow initiative artifacts one step at a time through status and
+  instructions output.
+- Keep existing six-file MVP initiatives readable.
+- Keep repo-local changes as the default implementation artifact.
+
+## Non-Goals
+
+- Do not make context-store-hosted executable changes part of this slice. That
+  remains Item 18.
+- Do not add cross-repo apply, archive, validation, or spec-sync orchestration.
+- Do not make workspace-local artifacts the shared planning source of truth.
+- Do not migrate existing initiatives automatically.
+- Do not install AI-tool runtime files into context stores by default unless a
+  later UX decision explicitly opts into that.
+
+## Default Initiative Shape
+
+New initiative creation should create a shell, not the whole plan:
+
+```text
+initiatives/<id>/
+  initiative.yaml
+  brief.md
+```
+
+`brief.md` is a seed document, not a completion marker for reviewed
+requirements or design. It should contain the title, summary, and a short
+"current understanding" section with no `TBD` placeholders.
+
+Reviewed planning artifacts are created later through the initiative schema.
+
+Default built-in schema, conceptually:
+
+```yaml
+name: product-initiative
+version: 1
+description: High-level initiative planning for PMs, designers, architects, and agents
+usage: initiative
+artifacts:
+  - id: requirements
+    generates: requirements.md
+    description: Product intent, goals, non-goals, requirements, and open questions
+    template: requirements.md
+    requires: []
+
+  - id: design
+    generates: design.md
+    description: Product, UX, and architecture direction with constraints and tradeoffs
+    template: design.md
+    requires:
+      - requirements
+```
+
+Do not include `tasks.md` in the default initiative schema. Implementation
+tasks belong in repo-local changes. Coordination tasks, workstreams, decision
+logs, and question logs can be separate later schemas or explicit artifacts once
+the usage pattern is clearer.
+
+## UX Direction
+
+Store setup should make the store project-like enough for schemas:
+
+```bash
+openspec context-store setup team-context --init-git
+```
+
+Expected created shape:
+
+```text
+team-context/
+  .openspec-store/store.yaml
+  openspec/config.yaml
+  initiatives/
+```
+
+Preferred config direction:
+
+```yaml
+initiative_schema: product-initiative
+```
+
+This avoids overloading the existing repo-local `schema` field, which currently
+means "default change schema." If implementation chooses to reuse `schema`
+instead, docs and JSON output must make the context-store scope explicit.
+
+Then initiative creation stays small:
+
+```bash
+openspec initiative create agent-trace-hooks \
+  --store team-context \
+  --title "Agent Trace Hooks" \
+  --summary "Explore lightweight capture of agent trace events and hook outcomes."
+```
+
+Expected next action:
+
+```bash
+openspec initiative status team-context/agent-trace-hooks --json
+openspec initiative instructions requirements team-context/agent-trace-hooks --json
+```
+
+The agent writes `requirements.md` only when the conversation has enough
+reviewed content. `design.md` becomes ready after requirements exist.
+
+## Technical Approach
+
+Reuse the artifact graph primitives, but add an initiative-specific loader
+instead of forcing initiatives through `loadChangeContext`.
+
+Current reusable pieces:
+
+- `src/core/artifact-graph/graph.ts`
+- `src/core/artifact-graph/state.ts`
+- `src/core/artifact-graph/outputs.ts`
+- `src/core/artifact-graph/resolver.ts`
+- `src/core/artifact-graph/instruction-loader.ts` template loading
+- `src/core/project-config.ts`
+
+New initiative-specific pieces:
+
+- a context-store OpenSpec-root helper that treats the store root as the
+  `projectRoot` for config and schema lookup
+- an initiative artifact context loader rooted at
+  `context-store/initiatives/<id>/`
+- initiative `status` and `instructions` commands that mirror the repo-local
+  artifact workflow but return initiative-specific fields
+- a sparse `initiative create` path that writes `initiative.yaml` and `brief.md`
+  only
+
+Do not use the existing repo planning-home resolver unchanged. Once context
+stores contain `openspec/config.yaml`, the current "nearest `openspec/` folder
+means repo planning home" heuristic can accidentally make a context store look
+like an implementation repo. This work must either:
+
+- teach planning-home resolution to detect `.openspec-store/store.yaml` and
+  return or reject a context-store kind for implementation commands, or
+- explicitly reject `openspec new change` from a context-store root until Item
+  15 defines target-bound executable changes.
+
+## Schema And Config Compatibility
+
+Prefer a next-release-safe config path:
+
+- Add `initiative_schema` to project config, or an equivalent
+  collection-specific config field.
+- Continue using existing `schema` as the default repo-local change schema.
+- Store per-initiative schema overrides in existing `metadata` if needed.
+- Avoid adding a new top-level `schema` field to `initiative.yaml` until
+  initiative metadata versioning is designed.
+
+Why: `initiative.yaml` is currently strict and versioned as `version: 1`.
+Adding a top-level field would make older CLIs reject new initiatives. Existing
+`metadata` can carry forward-compatible fields without breaking old readers.
+
+Schema namespace needs one explicit decision:
+
+- Either add a `usage: change | initiative` discriminator to schema files and
+  filter commands accordingly, or
+- use a separate initiative schema namespace while reusing the same artifact
+  graph format.
+
+The simplest user-facing model is still `openspec/schemas/`, but commands must
+avoid listing `product-initiative` as a valid repo-local change workflow.
+
+## JSON Contract
+
+`initiative create --json` should report the shell and next actions:
+
+```json
+{
+  "context_store": {
+    "id": "team-context",
+    "root": "/path/to/store"
+  },
+  "initiative": {
+    "id": "agent-trace-hooks",
+    "root": "/path/to/store/initiatives/agent-trace-hooks",
+    "metadata_path": "/path/to/store/initiatives/agent-trace-hooks/initiative.yaml",
+    "schema": "product-initiative"
+  },
+  "created_files": [
+    "initiative.yaml",
+    "brief.md"
+  ],
+  "next_commands": {
+    "status": "openspec initiative status team-context/agent-trace-hooks --json",
+    "requirements": "openspec initiative instructions requirements team-context/agent-trace-hooks --json"
+  },
+  "status": []
+}
+```
+
+`initiative status --json` should include:
+
+- context store identity and root
+- initiative identity, root, metadata path, and selected schema
+- artifact paths keyed by artifact id
+- artifact statuses: `done`, `ready`, `blocked`
+- next steps
+- action context that says this is shared planning context, not an editable
+  implementation target
+
+`initiative instructions --json` should include:
+
+- resolved output path
+- existing output paths
+- schema instruction
+- template content
+- dependencies and unlocks
+- store config context/rules if supported
+
+## Release Risk And Migration
+
+This is compatible if implemented as a sparse, additive layer:
+
+- Existing six-file initiatives remain readable because list/show only require
+  `initiative.yaml`.
+- Existing optional markdown files can remain in old initiative folders.
+- New status/instructions can ignore files outside the selected schema.
+- Old CLIs can still read new initiatives if schema data stays under
+  `metadata` or store config rather than new strict top-level fields.
+
+High-risk areas:
+
+- Planning-home detection after context stores gain `openspec/config.yaml`.
+- Tests and docs that assert the six-file MVP initiative shape.
+- Schema lists and completions if initiative schemas share the same namespace
+  as change schemas.
+- Agent guidance that still tells agents to edit every generated initiative
+  markdown file after creation.
+
+## Test And Doc Touch Points
+
+Likely tests to update or add:
+
+- `test/core/collections/initiatives/schema.test.ts`
+- `test/core/collections/initiatives/templates.test.ts`
+- `test/core/collections/initiatives/operations.test.ts`
+- `test/commands/initiative.test.ts`
+- `test/commands/context-store.test.ts`
+- `test/commands/artifact-workflow.test.ts`
+- planning-home tests for context-store roots with `openspec/config.yaml`
+- schema listing/completion tests if schema usage filtering is added
+
+Likely docs to update:
+
+- `docs/workspaces-beta/agent-cli-playbook.md`
+- `docs/workspaces-beta/user-guide.md`
+- `docs/cli.md`
+- schema docs if `usage` or `initiative_schema` is added
+- `openspec/initiatives/context-store-and-initiatives/work-items/05-ship-initiative-mvp/`
+  with a note that the MVP shape was superseded by this work item
+
+## Done When
+
+- A new context store has OpenSpec config and can resolve project-local
+  initiative schemas.
+- `initiative create` creates only the sparse initiative shell.
+- Agents can use initiative status/instructions to create high-level planning
+  artifacts iteratively.
+- `openspec new change` does not accidentally treat a context store as a normal
+  implementation repo just because the store has `openspec/config.yaml`.
+- Existing MVP initiatives continue to list and show.
+- Docs describe initiative artifacts as reviewed, iterative context rather than
+  files to fill in immediately.
+

--- a/openspec/initiatives/context-store-and-initiatives/work-items/15-context-store-project-roots-and-schema-led-initiatives/plan.md
+++ b/openspec/initiatives/context-store-and-initiatives/work-items/15-context-store-project-roots-and-schema-led-initiatives/plan.md
@@ -342,4 +342,3 @@ Likely docs to update:
 - Existing MVP initiatives continue to list and show.
 - Docs describe initiative artifacts as reviewed, iterative context rather than
   files to fill in immediately.
-

--- a/openspec/initiatives/context-store-and-initiatives/work-items/15-context-store-project-roots-and-schema-led-initiatives/tasks.md
+++ b/openspec/initiatives/context-store-and-initiatives/work-items/15-context-store-project-roots-and-schema-led-initiatives/tasks.md
@@ -1,0 +1,40 @@
+# Context Store Project Roots And Schema-Led Initiatives Tasks
+
+- [x] Create Item 15 work-item tracking notes.
+- [ ] Record the product decision that context stores should behave like
+      OpenSpec roots for config and schema resolution, but not as implementation
+      repos by default.
+- [ ] Define the context-store root layout, including `.openspec-store/`,
+      `openspec/config.yaml`, `openspec/schemas/`, and `initiatives/`.
+- [ ] Decide the config key for the default initiative schema, with
+      `initiative_schema` as the preferred next-release-safe direction.
+- [ ] Decide whether initiative schemas share `openspec/schemas/` with a
+      `usage: initiative` discriminator or use a separate namespace while
+      reusing the artifact graph format.
+- [ ] Add or design the built-in `product-initiative` schema for high-level
+      requirements and design artifacts.
+- [ ] Define `brief.md` as the sparse creation seed and decide whether it sits
+      outside the artifact graph or is represented as an already-complete
+      artifact.
+- [ ] Change `initiative create` from hardcoded six-file generation to sparse
+      `initiative.yaml` plus `brief.md` creation.
+- [ ] Add initiative artifact status resolution rooted at
+      `context-store/initiatives/<id>/`.
+- [ ] Add initiative artifact instructions output that returns schema guidance,
+      template content, dependencies, output path, and existing paths.
+- [ ] Ensure store-local config context and rules can be read for initiative
+      artifact instructions without confusing repo-local change config.
+- [ ] Guard planning-home resolution so context stores with
+      `openspec/config.yaml` do not silently become repo-local implementation
+      homes.
+- [ ] Update `initiative create --json`, human output, and next-command guidance
+      for sparse creation and iterative artifacts.
+- [ ] Update tests that currently assert the MVP six-file initiative shape.
+- [ ] Add compatibility tests proving old six-file initiatives still list and
+      show.
+- [ ] Add tests for context-store local schemas and store config defaults.
+- [ ] Update beta docs and agent guidance to stop telling agents to edit every
+      initiative markdown file immediately after creation.
+- [ ] Record migration behavior and a note that Item 5's six-file MVP shape has
+      been superseded by this schema-led sparse model.
+

--- a/openspec/initiatives/context-store-and-initiatives/work-items/15-context-store-project-roots-and-schema-led-initiatives/tasks.md
+++ b/openspec/initiatives/context-store-and-initiatives/work-items/15-context-store-project-roots-and-schema-led-initiatives/tasks.md
@@ -37,4 +37,3 @@
       initiative markdown file immediately after creation.
 - [ ] Record migration behavior and a note that Item 5's six-file MVP shape has
       been superseded by this schema-led sparse model.
-

--- a/openspec/initiatives/context-store-and-initiatives/work-items/16-add-escalation-ux/plan.md
+++ b/openspec/initiatives/context-store-and-initiatives/work-items/16-add-escalation-ux/plan.md
@@ -1,0 +1,26 @@
+# Add Escalation UX
+
+## Status
+
+Future work item. Kept after first-run setup, handoff output, guide cleanup,
+and schema-led initiatives because escalation should build on a sane onboarding
+path.
+
+## Goal
+
+Let users start locally and upgrade into a coordinated initiative only when the
+work actually needs shared context.
+
+## Ship
+
+- Explore/propose guidance that starts in the current repo by default.
+- Recommendation triggers when work spans multiple owned areas.
+- Carry-forward behavior for current change name, product goal, notes, inferred
+  areas, and relevant questions.
+- Prompts grounded in concrete affected areas instead of abstract storage
+  models.
+
+## Done When
+
+- Coordinated planning feels like a continuation of local planning, not a
+  workflow restart.

--- a/openspec/initiatives/context-store-and-initiatives/work-items/16-add-escalation-ux/tasks.md
+++ b/openspec/initiatives/context-store-and-initiatives/work-items/16-add-escalation-ux/tasks.md
@@ -1,0 +1,7 @@
+# Add Escalation UX Tasks
+
+- [ ] Define local-to-initiative recommendation triggers.
+- [ ] Carry current planning context into a new initiative.
+- [ ] Keep prompts grounded in affected areas.
+- [ ] Decide where escalation guidance appears in agent instructions, command
+      output, or interactive prompts.

--- a/openspec/initiatives/context-store-and-initiatives/work-items/17-harden-team-shared-coordination/plan.md
+++ b/openspec/initiatives/context-store-and-initiatives/work-items/17-harden-team-shared-coordination/plan.md
@@ -1,0 +1,25 @@
+# Harden Team-Shared Coordination
+
+## Status
+
+Future work item. This should follow the first-run UX and schema-led initiative
+work so team guidance is built on the stable beta path.
+
+## Goal
+
+Make initiatives practical for several teammates without turning setup into an
+admin ceremony.
+
+## Ship
+
+- Recommended Git-backed shared context-store setup.
+- Lightweight teammate onboarding.
+- Repair flows for local path mappings.
+- Sync status and conflict guidance.
+- Clear separation between committed initiative state and machine-local
+  workspace state.
+
+## Done When
+
+- Several teammates can share the same initiative while each keeps their own
+  local checkout layout.

--- a/openspec/initiatives/context-store-and-initiatives/work-items/17-harden-team-shared-coordination/tasks.md
+++ b/openspec/initiatives/context-store-and-initiatives/work-items/17-harden-team-shared-coordination/tasks.md
@@ -1,0 +1,7 @@
+# Harden Team-Shared Coordination Tasks
+
+- [ ] Document recommended Git-backed store setup.
+- [ ] Define teammate onboarding and repair flows.
+- [ ] Add sync status and conflict guidance.
+- [ ] Define how committed initiative state and machine-local workspace state
+      should be explained in docs and generated guidance.

--- a/openspec/initiatives/context-store-and-initiatives/work-items/18-explore-initiative-hosted-target-bound-change-artifacts/evidence.md
+++ b/openspec/initiatives/context-store-and-initiatives/work-items/18-explore-initiative-hosted-target-bound-change-artifacts/evidence.md
@@ -111,7 +111,7 @@ Workspace context:
 
 Use for shared initiative planning before repo ownership or implementation
 targets are clear. These should be called initiative work items, planning
-briefs, or proposals, not executable OpenSpec changes, until Item 13 defines a
+briefs, or proposals, not executable OpenSpec changes, until Item 18 defines a
 full lifecycle for context-store-backed changes.
 
 Workspace-local changes:
@@ -256,7 +256,7 @@ Keep Item 8 narrow:
   backbone.
 - Do not implement context-store-backed OpenSpec changes in Item 8.
 
-Use Item 13 to decide the larger model:
+Use Item 18 to decide the larger model:
 
 - Whether initiative work items should become a first-class artifact.
 - Whether "change home" remains internal language.
@@ -273,10 +273,10 @@ Question explored:
 
 ```text
 Given the product tension around central versus repo-local change storage, how
-should Item 13 be reframed before implementation work begins?
+should Item 18 be reframed before implementation work begins?
 ```
 
-Three subagent passes reviewed Item 13 from product semantics, agent-first UX,
+Three subagent passes reviewed Item 18 from product semantics, agent-first UX,
 and lifecycle/implementation angles.
 
 ### Product Semantics Findings
@@ -374,7 +374,7 @@ Keep Item 8 narrow:
 - Add JSON output for the agent handoff.
 - Do not implement context-store-hosted executable changes in Item 8.
 
-Use Item 13 to answer the bigger question:
+Use Item 18 to answer the bigger question:
 
 - What initiative-hosted artifacts exist before an implementation target is
   known?

--- a/openspec/initiatives/context-store-and-initiatives/work-items/18-explore-initiative-hosted-target-bound-change-artifacts/plan.md
+++ b/openspec/initiatives/context-store-and-initiatives/work-items/18-explore-initiative-hosted-target-bound-change-artifacts/plan.md
@@ -40,7 +40,7 @@ graduate into executable changes only after they are bound to an implementation
 target.
 
 Repo-local changes remain the default executable implementation artifact. Item
-13 should decide if, when, and how a context-store-hosted artifact can safely be
+18 should decide if, when, and how a context-store-hosted artifact can safely be
 treated as a change.
 
 The answer should preserve three boundaries:

--- a/openspec/initiatives/context-store-and-initiatives/work-items/18-explore-initiative-hosted-target-bound-change-artifacts/tasks.md
+++ b/openspec/initiatives/context-store-and-initiatives/work-items/18-explore-initiative-hosted-target-bound-change-artifacts/tasks.md
@@ -1,7 +1,7 @@
 # Explore Initiative-Hosted Target-Bound Change Artifacts Tasks
 
-- [x] Create Item 13 work-item tracking notes.
-- [x] Reframe Item 13 from generic change-home configuration to
+- [x] Create Item 18 work-item tracking notes.
+- [x] Reframe Item 18 from generic change-home configuration to
   initiative-hosted target-bound change artifacts.
 - [ ] Audit commands, templates, validation, archive, apply, completion, and
   docs for repo-local `openspec/changes/` assumptions.

--- a/openspec/initiatives/context-store-and-initiatives/work-items/19-review-workspace-beta-compatibility-before-public-release/plan.md
+++ b/openspec/initiatives/context-store-and-initiatives/work-items/19-review-workspace-beta-compatibility-before-public-release/plan.md
@@ -1,0 +1,62 @@
+# Review Workspace Beta Compatibility Before Public Release
+
+## Goal
+
+Before workspaces become public/stable, decide what beta workspace
+compatibility behavior is actually worth carrying forward.
+
+This is intentionally late-stage work. Workspaces have not been publicly
+released yet, so unpublished beta internals should not automatically become a
+permanent compatibility contract.
+
+## Background
+
+The beta currently contains a few compatibility paths:
+
+- Legacy split workspace state readers for `.openspec-workspace/workspace.yaml`
+  and `.openspec-workspace/local.yaml`.
+- Managed workspace registry fallback behavior.
+- `codex` to `codex-cli` opener normalization.
+- Generated `.gitignore` cleanup for old workspace `.code-workspace` ignore
+  rules.
+- Empty or deprecated helper shims that exist only because previous workspace
+  slices exposed them internally.
+
+Some of these may be useful for local beta testers. Others may be safer to
+delete before public release.
+
+## Scope
+
+Review workspace compatibility only. Do not use this item to reopen unrelated
+legacy migration systems such as old slash-command cleanup, telemetry config
+migration, or deprecated `change`/`spec` command aliases.
+
+## Decisions To Make
+
+- Which workspace compatibility paths are part of the public contract?
+- Which paths are beta-only migration helpers and can be removed after one
+  release note or cleanup pass?
+- Which paths are only test compatibility and can be deleted before release?
+- Should beta workspace roots be migrated automatically, left readable, or
+  intentionally unsupported?
+- Should old generated `.gitignore` cleanup exist at all, given workspaces are
+  managed local folders rather than repos?
+
+## Implementation Notes
+
+- Prefer deletion over preserving compatibility for unpublished intermediate
+  beta states.
+- If a compatibility path remains, document why it exists and what would allow
+  it to be removed later.
+- Keep user-owned files safe. Do not clean or rewrite ambiguous local files
+  unless OpenSpec can prove it owns them.
+- Update tests so they describe the chosen public contract rather than the
+  accidental beta history.
+
+## Done When
+
+- Workspace compatibility code is inventoried and classified.
+- Low-value beta-only shims are removed.
+- Remaining compatibility behavior has focused tests and release-note language.
+- Public docs and generated agent guidance do not mention unsupported beta
+  internals.

--- a/openspec/initiatives/context-store-and-initiatives/work-items/19-review-workspace-beta-compatibility-before-public-release/tasks.md
+++ b/openspec/initiatives/context-store-and-initiatives/work-items/19-review-workspace-beta-compatibility-before-public-release/tasks.md
@@ -1,0 +1,16 @@
+# Tasks
+
+- [ ] Inventory workspace compatibility code paths and tests.
+- [ ] Classify each path as public contract, beta migration, test-only shim, or
+  removable dead weight.
+- [ ] Decide whether legacy split workspace state remains readable after public
+  release.
+- [ ] Decide whether old generated `.gitignore` cleanup should remain, become
+  more conservative, or be removed entirely.
+- [ ] Decide how long `codex` should remain accepted as an alias for
+  `codex-cli`.
+- [ ] Remove beta-only compatibility paths that do not need to survive public
+  release.
+- [ ] Update tests to encode the chosen compatibility contract.
+- [ ] Update docs, generated guidance, and release notes with the final public
+  behavior.

--- a/openspec/initiatives/context-store-and-initiatives/work-items/proposed-initiative-next-agent-handoff-ux/evidence.md
+++ b/openspec/initiatives/context-store-and-initiatives/work-items/proposed-initiative-next-agent-handoff-ux/evidence.md
@@ -26,3 +26,22 @@ by hand.
 Keep this as a discussion draft until workspace initiative opening is clearer.
 If accepted, the first version should be a small handoff/readiness command, not
 status, progress, dashboarding, or workspace orchestration.
+
+## Manual Beta Pass Addition
+
+The 2026-05-28 manual beta pass found that command-level handoff is not the
+only missing layer. A fresh agent also needs a small, tool-readable guide for
+how to use OpenSpec at all:
+
+- inspect context stores, initiatives, workspaces, and repo-local changes before
+  guessing;
+- understand that context stores can be artifact homes outside implementation
+  repos, not only cross-team coordination spaces;
+- understand that repo-local changes own implementation planning when the user
+  wants artifacts in the repo;
+- treat workspaces as local views, not durable planning homes;
+- route to narrower OpenSpec workflow skills when available.
+
+As a temporary beta aid, a manual Codex skill was created at
+`.codex/skills/use-openspec/` with references for shared context and artifact
+placement. This is not yet productized in the configurator.

--- a/openspec/initiatives/context-store-and-initiatives/work-items/proposed-initiative-next-agent-handoff-ux/plan.md
+++ b/openspec/initiatives/context-store-and-initiatives/work-items/proposed-initiative-next-agent-handoff-ux/plan.md
@@ -14,6 +14,12 @@ The candidate idea is a tiny "what now?" handoff command after initiative
 discovery from the current repo or workspace. It should not become a dashboard,
 work-progress status view, or replacement for workspace local-view behavior.
 
+The manual beta pass surfaced a second, related handoff gap: before a command
+like `initiative next` exists, a fresh coding agent still needs baseline
+OpenSpec literacy. It needs to understand context stores, initiatives,
+workspaces, repo-local changes, and where artifacts should live. A small
+`use-openspec` skill may be the simplest first slice.
+
 ## Candidate Goal
 
 Help an agent answer:
@@ -39,6 +45,24 @@ Possible response:
 }
 ```
 
+## Possible Skill Shape
+
+```text
+use-openspec/
+  SKILL.md
+  references/
+    shared-context-beta.md
+    artifact-placement.md
+```
+
+This would be a baseline guide skill, not a workflow action. It should not
+produce `/opsx:use-openspec`, should not appear as an implementation workflow,
+and should not imply that workflow command delivery is unavailable.
+
+Open design question: whether this is literally part of the default profile, a
+separate always-on bundled skill, or a managed guide skill installed by default
+whenever the selected agent supports skills.
+
 ## Discussion Points To Review
 
 - Should this become a numbered roadmap item before workspace initiative
@@ -50,6 +74,11 @@ Possible response:
 - Should it inspect actual work progress, or stay limited to handoff readiness?
 - How should it behave when no stores are registered, the initiative is
   ambiguous, the local repo is unrelated, or linked changes already exist?
+- Should baseline OpenSpec guidance be modeled as a default skill, a profile
+  member, or a separate managed guide?
+- How should the guide skill interact with commands-oriented delivery?
+- How should it teach artifact placement: context-store initiative vs
+  repo-local change vs workspace view?
 
 ## Boundaries
 
@@ -57,3 +86,5 @@ Possible response:
 - Do not create changes, clone repos, or mutate workspace state.
 - Do not make workspace opening a prerequisite.
 - Prefer agent-readable JSON over broad interactive UX in the first slice.
+- Do not turn baseline guidance into a new slash command unless a separate
+  workflow need emerges.

--- a/openspec/initiatives/context-store-and-initiatives/work-items/proposed-initiative-next-agent-handoff-ux/tasks.md
+++ b/openspec/initiatives/context-store-and-initiatives/work-items/proposed-initiative-next-agent-handoff-ux/tasks.md
@@ -10,3 +10,9 @@ scope are confirmed.
 - [ ] Decide whether the command returns one next action or multiple options.
 - [ ] Decide the error and empty-state behavior.
 - [ ] Decide whether actual work progress/status is explicitly out of scope.
+- [ ] Decide whether to ship `use-openspec` as a managed default skill.
+- [ ] Decide whether `use-openspec` is a default-profile member or a separate
+      always-on guide skill.
+- [ ] Decide how `use-openspec` interacts with commands-oriented delivery.
+- [ ] Decide the minimal artifact-placement guidance for context-store
+      initiatives, repo-local changes, and workspace views.

--- a/openspec/specs/workspace-foundation/spec.md
+++ b/openspec/specs/workspace-foundation/spec.md
@@ -76,10 +76,10 @@ OpenSpec SHALL keep shared workspace information separate from local machine pat
 - **THEN** it SHALL preserve path strings valid for the current runtime
 - **AND** it SHALL support native Windows paths and WSL2/Linux paths as local state values
 
-#### Scenario: Excluding local state from portable collaboration
-- **WHEN** OpenSpec creates a workspace
-- **THEN** it SHALL exclude `.openspec-workspace/local.yaml` from portable collaboration state by default
-- **AND** `.openspec-workspace/workspace.yaml` SHALL remain the portable workspace identity and link-name state
+#### Scenario: Keeping managed workspace view state local
+- **WHEN** OpenSpec creates a managed workspace
+- **THEN** it SHALL write `workspace.yaml` in the workspace root as private local view state
+- **AND** the file SHALL preserve stable link names and local path values for the current machine
 
 ### Requirement: Standard Workspace Location
 OpenSpec SHALL use a standard location for OpenSpec-managed workspaces without asking most users to choose one.
@@ -242,31 +242,29 @@ OpenSpec SHALL maintain files that make a workspace directly openable after setu
 - **WHEN** `openspec workspace setup` creates a workspace
 - **THEN** OpenSpec SHALL create or refresh `AGENTS.md`
 - **AND** it SHALL create or refresh `<workspace-name>.code-workspace`
-- **AND** it SHALL create or refresh workspace ignore rules for machine-local open files
+- **AND** it SHALL not create workspace ignore rules for machine-local open files by default
 
 #### Scenario: Refreshing the open surface after linking
 - **WHEN** `openspec workspace link` succeeds
 - **THEN** OpenSpec SHALL refresh `AGENTS.md`
 - **AND** it SHALL refresh `<workspace-name>.code-workspace`
-- **AND** it SHALL refresh workspace ignore rules for machine-local open files
 
 #### Scenario: Refreshing the open surface after relinking
 - **WHEN** `openspec workspace relink` succeeds
 - **THEN** OpenSpec SHALL refresh `AGENTS.md`
 - **AND** it SHALL refresh `<workspace-name>.code-workspace`
-- **AND** it SHALL refresh workspace ignore rules for machine-local open files
 
 #### Scenario: Building the VS Code workspace file
 - **WHEN** OpenSpec refreshes `<workspace-name>.code-workspace`
-- **THEN** the file SHALL include the workspace root
-- **AND** the workspace root folder entry SHALL use the root path without a synthetic display name
-- **AND** it SHALL include every linked repo or folder with a valid local path
+- **THEN** the file SHALL include every linked repo or folder with a valid local path before workspace-local files
+- **AND** it SHALL include attached initiative context when available
+- **AND** it SHALL include the workspace root as `OpenSpec workspace`
 - **AND** it SHALL omit linked repos or folders whose local paths are missing or invalid
 
-#### Scenario: Ignoring the maintained VS Code workspace file
-- **WHEN** OpenSpec refreshes workspace ignore rules
-- **THEN** it SHALL ignore the specific maintained `<workspace-name>.code-workspace` file
-- **AND** user-authored `*.code-workspace` files SHALL remain eligible for tracking
+#### Scenario: Cleaning legacy workspace ignore rules
+- **WHEN** OpenSpec refreshes the workspace open surface
+- **THEN** it SHALL remove the legacy ignore rule for the maintained `<workspace-name>.code-workspace` file when present
+- **AND** it SHALL preserve unrelated user-authored ignore rules
 
 #### Scenario: Preserving user-authored AGENTS content
 - **GIVEN** `AGENTS.md` contains content outside the OpenSpec workspace guidance markers
@@ -279,4 +277,3 @@ OpenSpec SHALL maintain files that make a workspace directly openable after setu
 - **WHEN** OpenSpec refreshes workspace guidance
 - **THEN** it SHALL append the marked OpenSpec workspace guidance block
 - **AND** it SHALL preserve the existing file content
-

--- a/src/commands/context-store.ts
+++ b/src/commands/context-store.ts
@@ -366,7 +366,7 @@ export function registerContextStoreCommand(program: Command): void {
   contextStore
     .command('setup [id]')
     .description('Create and register a local context store')
-    .option('--path <path>', 'Context store folder path; defaults to ./<id>')
+    .option('--path <path>', 'Context store folder path; defaults to OpenSpec managed local data')
     .option('--init-git', 'Initialize a Git repository in the context store')
     .option('--no-init-git', 'Do not initialize a Git repository')
     .option('--json', 'Output as JSON')

--- a/src/commands/workspace.ts
+++ b/src/commands/workspace.ts
@@ -1,7 +1,5 @@
 import { Command } from 'commander';
 import chalk from 'chalk';
-import * as nodeFs from 'node:fs';
-import * as path from 'node:path';
 
 import {
   WorkspacePreferredOpener,
@@ -22,14 +20,11 @@ import { isInteractive, resolveNoInteractive } from '../utils/interactive.js';
 import {
   addWorkspaceLink,
   createManagedWorkspace,
-  inferLinkName,
   loadWorkspaceForDoctor,
   loadWorkspaceForList,
   parseSetupLinks,
   readWorkspaceForMutation,
-  resolveExistingDirectory,
   updateWorkspaceLink,
-  validateLinkNameForCommand,
   validateWorkspaceNameForSetup,
 } from './workspace/operations.js';
 import {
@@ -49,8 +44,9 @@ import {
   parseSetupOpenerOption,
   promptPreferredOpener,
 } from './workspace/opener-selection.js';
-import { workspacePromptTheme, workspaceSelectTheme } from './workspace/prompt-theme.js';
+import { workspacePromptTheme } from './workspace/prompt-theme.js';
 import { registerWorkspaceCommandWith } from './workspace/registration.js';
+import { promptSetupLinks } from './workspace/setup-prompts.js';
 import {
   WorkspaceCliError,
   WorkspaceLinkMutationPayload,
@@ -108,109 +104,6 @@ async function promptWorkspaceName(initialName?: string): Promise<string> {
       }
     },
   });
-}
-
-async function promptExistingPath(message: string, defaultPath?: string): Promise<string> {
-  const { input } = await import('@inquirer/prompts');
-
-  const pathInput = await input({
-    message,
-    default: defaultPath,
-    prefill: defaultPath ? 'editable' : undefined,
-    required: true,
-    theme: workspacePromptTheme,
-    validate(value: string) {
-      const resolvedPath = path.isAbsolute(value)
-        ? path.resolve(value)
-        : path.resolve(process.cwd(), value);
-      return nodeFs.existsSync(resolvedPath) && nodeFs.statSync(resolvedPath).isDirectory()
-        ? true
-        : 'Enter an existing repo or folder path.';
-    },
-  });
-
-  return resolveExistingDirectory(pathInput);
-}
-
-async function promptLinkName(existingLinks: Record<string, string>): Promise<string> {
-  const { input } = await import('@inquirer/prompts');
-
-  return input({
-    message: 'Link name:',
-    required: true,
-    theme: workspacePromptTheme,
-    validate(value: string) {
-      try {
-        validateLinkNameForCommand(value);
-      } catch (error) {
-        return asErrorMessage(error);
-      }
-
-      if (existingLinks[value]) {
-        return `Link name '${value}' is already linked to ${existingLinks[value]}.`;
-      }
-
-      return true;
-    },
-  });
-}
-
-async function promptSetupLinks(): Promise<Record<string, string>> {
-  const { select } = await import('@inquirer/prompts');
-  const links: Record<string, string> = {};
-
-  console.log('');
-  console.log(chalk.bold('[2/5] Link repos or folders'));
-  console.log(chalk.dim('Start with the current directory, or enter another repo path.'));
-  console.log('');
-
-  while (true) {
-    const linkCount = Object.keys(links).length;
-    const resolvedPath = await promptExistingPath(
-      linkCount === 0 ? 'Repo or folder path:' : 'Another repo or folder path:',
-      linkCount === 0 ? '.' : undefined
-    );
-    let linkName = inferLinkName(resolvedPath);
-
-    try {
-      validateLinkNameForCommand(linkName);
-    } catch {
-      linkName = await promptLinkName(links);
-    }
-
-    if (links[linkName]) {
-      console.log(`Link name '${linkName}' is already linked to ${links[linkName]}.`);
-      linkName = await promptLinkName(links);
-    }
-
-    links[linkName] = resolvedPath;
-    console.log(chalk.green(`Added link '${linkName}'`));
-    console.log(chalk.dim(`  ${resolvedPath}`));
-
-    const nextAction = await select({
-      message: 'Continue',
-      default: 'finish',
-      choices: [
-        {
-          name: 'Create workspace files',
-          short: 'Create workspace files',
-          value: 'finish',
-          description: 'Run a workspace check after setup',
-        },
-        {
-          name: 'Add another repo or folder',
-          short: 'Add another',
-          value: 'add',
-          description: 'Include another local directory in this workspace',
-        },
-      ],
-      theme: workspaceSelectTheme,
-    });
-
-    if (nextAction === 'finish') {
-      return links;
-    }
-  }
 }
 
 function parseSetupToolsOption(tools: string): string[] {
@@ -313,7 +206,6 @@ function printDoctorHuman(result: { workspace: WorkspaceOutput; status: Workspac
   } else {
     console.log('Context: (none)');
   }
-  console.log(`Planning path: ${result.workspace.planning_path}`);
   console.log('');
   printStatusLines(result.status);
   if (result.status.length > 0) {
@@ -644,8 +536,6 @@ class WorkspaceCommand {
       console.log(chalk.green('Workspace setup complete'));
       console.log('');
       printWorkspaceListHuman([doctorResult.workspace]);
-      console.log('');
-      console.log(`Planning path: ${doctorResult.workspace.planning_path}`);
       console.log('');
       console.log('Workspace check:');
       printWorkspaceCheckSummaryHuman(doctorResult);

--- a/src/commands/workspace/open-target-selection.ts
+++ b/src/commands/workspace/open-target-selection.ts
@@ -1,0 +1,243 @@
+import {
+  InitiativeResolutionError,
+  type InitiativeDiagnostic,
+  type InitiativeViewReference,
+  initiativeDiagnosticFromError,
+  listInitiativeViewReferences,
+} from '../../core/collections/initiatives/index.js';
+import {
+  createRegisteredContextStoreBinding,
+  sameContextStoreBinding,
+} from '../../core/context-store/index.js';
+import {
+  findWorkspaceRoot,
+  getWorkspaceContextInitiativeId,
+  listKnownWorkspaceEntries,
+  readWorkspaceViewState,
+  type WorkspaceContextState,
+  type WorkspaceRegistryEntry,
+} from '../../core/workspace/index.js';
+import { isInteractive, resolveNoInteractive } from '../../utils/interactive.js';
+import {
+  selectWorkspaceForCommand,
+  selectedWorkspaceFromEntry,
+  selectedWorkspaceFromRoot,
+} from './selection.js';
+import {
+  WorkspaceCliError,
+  type SelectedWorkspace,
+  type WorkspaceOpenOptions,
+  type WorkspaceStatus,
+} from './types.js';
+
+export type WorkspaceOpenTarget =
+  | {
+      kind: 'workspace';
+      selected: SelectedWorkspace;
+      status: WorkspaceStatus[];
+    }
+  | {
+      kind: 'initiative';
+      initiative: InitiativeViewReference;
+      status: WorkspaceStatus[];
+    };
+
+type WorkspaceOpenChoice =
+  | {
+      kind: 'workspace';
+      entry: WorkspaceRegistryEntry;
+    }
+  | {
+      kind: 'initiative';
+      initiative: InitiativeViewReference;
+    };
+
+type OpenableInitiatives =
+  | {
+      kind: 'listed';
+      initiatives: InitiativeViewReference[];
+      status: WorkspaceStatus[];
+    }
+  | {
+      kind: 'unavailable';
+      initiatives: [];
+      status: WorkspaceStatus[];
+      error: WorkspaceCliError;
+    };
+
+async function readKnownWorkspaceContexts(
+  entries: WorkspaceRegistryEntry[]
+): Promise<Array<WorkspaceContextState | null>> {
+  return Promise.all(entries.map(async (entry) => {
+    try {
+      return (await readWorkspaceViewState(entry.workspaceRoot)).context;
+    } catch {
+      // Broken workspaces are surfaced by list/doctor; open target selection
+      // should not hide otherwise openable initiatives behind unreadable views.
+      return null;
+    }
+  }));
+}
+
+function workspaceContextMatchesInitiative(
+  context: WorkspaceContextState | null,
+  initiative: InitiativeViewReference
+): boolean {
+  return (
+    context !== null &&
+    sameContextStoreBinding(context.store, createRegisteredContextStoreBinding(initiative.store)) &&
+    getWorkspaceContextInitiativeId(context) === initiative.id
+  );
+}
+
+function initiativeHasKnownWorkspace(
+  contexts: Array<WorkspaceContextState | null>,
+  initiative: InitiativeViewReference
+): boolean {
+  return contexts.some((context) => workspaceContextMatchesInitiative(context, initiative));
+}
+
+function initiativeDiagnosticToWorkspaceStatus(
+  diagnostic: InitiativeDiagnostic
+): WorkspaceStatus {
+  return {
+    severity: diagnostic.severity,
+    code: diagnostic.code,
+    message: diagnostic.message,
+    target: diagnostic.target,
+    fix: diagnostic.fix,
+    details: diagnostic.details,
+  };
+}
+
+async function listOpenableInitiatives(
+  entries: WorkspaceRegistryEntry[]
+): Promise<OpenableInitiatives> {
+  try {
+    const [result, contexts] = await Promise.all([
+      listInitiativeViewReferences(),
+      readKnownWorkspaceContexts(entries),
+    ]);
+    const initiatives: InitiativeViewReference[] = [];
+
+    for (const initiative of result.initiatives) {
+      if (!initiativeHasKnownWorkspace(contexts, initiative)) {
+        initiatives.push(initiative);
+      }
+    }
+
+    return {
+      kind: 'listed',
+      initiatives,
+      status: result.status.map(initiativeDiagnosticToWorkspaceStatus),
+    };
+  } catch (error) {
+    const diagnostic: InitiativeDiagnostic = error instanceof InitiativeResolutionError
+      ? initiativeDiagnosticFromError(error)
+      : {
+          severity: 'error' as const,
+          code: 'initiative_discovery_failed',
+          message: error instanceof Error ? error.message : String(error),
+          target: 'initiative',
+          fix: 'openspec context-store doctor',
+        };
+
+    return {
+      kind: 'unavailable',
+      initiatives: [],
+      status: [initiativeDiagnosticToWorkspaceStatus(diagnostic)],
+      error: new WorkspaceCliError(diagnostic.message, diagnostic.code, {
+        target: diagnostic.target,
+        fix: diagnostic.fix,
+        details: diagnostic.details,
+      }),
+    };
+  }
+}
+
+export async function selectWorkspaceOpenTarget(
+  workspaceName: string | undefined,
+  options: WorkspaceOpenOptions
+): Promise<WorkspaceOpenTarget> {
+  if (
+    workspaceName ||
+    options.json ||
+    resolveNoInteractive(options) ||
+    !isInteractive(options)
+  ) {
+    return {
+      kind: 'workspace',
+      selected: await selectWorkspaceForCommand(
+        {
+          ...options,
+          workspace: workspaceName,
+        },
+        'open',
+        { preferPositionalName: true }
+      ),
+      status: [],
+    };
+  }
+
+  const entries = await listKnownWorkspaceEntries();
+  const currentWorkspaceRoot = await findWorkspaceRoot(process.cwd());
+
+  if (currentWorkspaceRoot) {
+    return {
+      kind: 'workspace',
+      selected: await selectedWorkspaceFromRoot(currentWorkspaceRoot, entries),
+      status: [],
+    };
+  }
+
+  const listed = await listOpenableInitiatives(entries);
+
+  if (listed.initiatives.length === 0) {
+    if (listed.kind === 'unavailable' && entries.length === 0) {
+      throw listed.error;
+    }
+
+    return {
+      kind: 'workspace',
+      selected: await selectWorkspaceForCommand(options, 'open', {
+        preferPositionalName: true,
+      }),
+      status: listed.status,
+    };
+  }
+
+  const { select } = await import('@inquirer/prompts');
+  const selected = await select<WorkspaceOpenChoice>({
+    message: 'Select workspace or initiative:',
+    choices: [
+      ...entries.map((entry) => ({
+        name: `Workspace: ${entry.name} (${entry.workspaceRoot})`,
+        value: {
+          kind: 'workspace' as const,
+          entry,
+        },
+      })),
+      ...listed.initiatives.map((initiative) => ({
+        name: `Initiative: ${initiative.store}/${initiative.id} - ${initiative.title} (create local workspace view)`,
+        value: {
+          kind: 'initiative' as const,
+          initiative,
+        },
+      })),
+    ],
+  });
+
+  if (selected.kind === 'workspace') {
+    return {
+      kind: 'workspace',
+      selected: selectedWorkspaceFromEntry(selected.entry),
+      status: listed.status,
+    };
+  }
+
+  return {
+    kind: 'initiative',
+    initiative: selected.initiative,
+    status: listed.status,
+  };
+}

--- a/src/commands/workspace/open-view.ts
+++ b/src/commands/workspace/open-view.ts
@@ -285,7 +285,10 @@ export async function prepareWorkspaceOpen(
   const target = requestedInitiative
     ? { kind: 'initiative' as const, initiative: requestedInitiative, status: [] }
     : await selectWorkspaceOpenTarget(workspaceName, options);
-  const interactiveCreate = target.kind === 'initiative' && !resolveNoInteractive(options) && isInteractive(options);
+  const interactiveCreate = target.kind === 'initiative'
+    && !options.json
+    && !resolveNoInteractive(options)
+    && isInteractive(options);
 
   const baseSelected = target.kind === 'initiative'
     ? (
@@ -299,7 +302,11 @@ export async function prepareWorkspaceOpen(
           linksForNewWorkspace: interactiveCreate
             ? () => promptSetupLinks({
                 heading: 'Link repos or folders for this workspace',
-                intro: 'Choose local repos or folders to include when opening this initiative.',
+                intro: 'Choose local repos or folders to include when opening this initiative, or create the view without links for now.',
+                allowEmpty: true,
+                emptyName: 'Create without linked repos',
+                emptyShort: 'Create without links',
+                emptyDescription: 'Create the local workspace view and add repos or folders later',
                 finishName: 'Create and open workspace',
                 finishShort: 'Create and open',
                 finishDescription: 'Create the local workspace view and continue opening it',

--- a/src/commands/workspace/open-view.ts
+++ b/src/commands/workspace/open-view.ts
@@ -20,6 +20,7 @@ import {
   getWorkspaceContextInitiativeId,
   getWorkspaceOpenerLabel,
 } from '../../core/workspace/index.js';
+import { isInteractive, resolveNoInteractive } from '../../utils/interactive.js';
 import {
   assertWorkspaceOpenerAvailable,
   buildWorkspaceOpenCommandForState,
@@ -29,9 +30,7 @@ import {
 import {
   selectOrCreateWorkspaceForInitiativeOpen,
 } from './operations.js';
-import {
-  selectWorkspaceForCommand,
-} from './selection.js';
+import { selectWorkspaceOpenTarget } from './open-target-selection.js';
 import {
   SelectedWorkspace,
   WorkspaceCliError,
@@ -43,6 +42,7 @@ import {
   resolveWorkspaceOpenOpener,
   resolveWorkspaceOpenOpenerOverride,
 } from './opener-selection.js';
+import { promptSetupLinks } from './setup-prompts.js';
 
 export interface PreparedWorkspaceOpen extends WorkspaceOpenCommandBuildResult {
   selected: SelectedWorkspace;
@@ -280,34 +280,44 @@ export async function prepareWorkspaceOpen(
   assertWorkspaceOpenSupportedOptions(options);
 
   const workspaceName = resolveOpenWorkspaceName(positionalName, options);
+  const openerOverride = resolveWorkspaceOpenOpenerOverride(options);
   const requestedInitiative = await resolveWorkspaceOpenInitiative(options);
-  const requestedContext = requestedInitiative
-    ? createWorkspaceInitiativeContext(
-        contextStoreBindingFromInitiative(requestedInitiative),
-        requestedInitiative.id
-      )
-    : null;
-  const selected = requestedContext
+  const target = requestedInitiative
+    ? { kind: 'initiative' as const, initiative: requestedInitiative, status: [] }
+    : await selectWorkspaceOpenTarget(workspaceName, options);
+  const interactiveCreate = target.kind === 'initiative' && !resolveNoInteractive(options) && isInteractive(options);
+
+  const baseSelected = target.kind === 'initiative'
     ? (
         await selectOrCreateWorkspaceForInitiativeOpen({
           workspaceName,
-          context: requestedContext,
-          preferredOpener: resolveWorkspaceOpenOpenerOverride(options),
+          context: createWorkspaceInitiativeContext(
+            contextStoreBindingFromInitiative(target.initiative),
+            target.initiative.id
+          ),
+          preferredOpener: openerOverride,
+          linksForNewWorkspace: interactiveCreate
+            ? () => promptSetupLinks({
+                heading: 'Link repos or folders for this workspace',
+                intro: 'Choose local repos or folders to include when opening this initiative.',
+                finishName: 'Create and open workspace',
+                finishShort: 'Create and open',
+                finishDescription: 'Create the local workspace view and continue opening it',
+              })
+            : undefined,
         })
       ).selected
-    : await selectWorkspaceForCommand(
-        {
-          ...options,
-          workspace: workspaceName,
-        },
-        'open',
-        { preferPositionalName: true }
-      );
+    : target.selected;
+  const selected: SelectedWorkspace = {
+    ...baseSelected,
+    status: [...baseSelected.status, ...target.status],
+  };
+
   const state = await readWorkspaceOpenState(selected);
-  const stored = !requestedInitiative && state.viewState.context
+  const stored = target.kind === 'workspace' && state.viewState.context
     ? await resolveStoredWorkspaceInitiative(state.viewState.context)
     : null;
-  const initiative = requestedInitiative ?? stored?.initiative ?? null;
+  const initiative = target.kind === 'initiative' ? target.initiative : stored?.initiative ?? null;
   const resolvedContext = initiative ? toWorkspaceOpenResolvedContext(initiative) : null;
   const opener = await resolveWorkspaceOpenOpener(state.viewState, options);
 

--- a/src/commands/workspace/open.ts
+++ b/src/commands/workspace/open.ts
@@ -17,6 +17,7 @@ import {
 import { SelectedWorkspace, WorkspaceCliError, asErrorMessage } from './types.js';
 
 export const WORKSPACE_OPEN_MINIMAL_PROMPT = 'Open this OpenSpec workspace.';
+const CODEX_CLI_WRITABLE_ROOT_SANDBOX_ARGS = ['--sandbox', 'workspace-write'] as const;
 const require = createRequire(import.meta.url);
 const spawn = require('cross-spawn') as typeof nodeSpawn;
 
@@ -53,6 +54,11 @@ export interface WorkspaceOpenLaunchOptions {
   stdio?: 'inherit' | 'ignore';
 }
 
+function isCodexCliOpener(opener: WorkspacePreferredOpener): boolean {
+  const openerId = opener.id as string;
+  return opener.kind === 'agent' && (openerId === 'codex-cli' || openerId === 'codex');
+}
+
 export async function readWorkspaceOpenState(
   selected: SelectedWorkspace
 ): Promise<WorkspaceOpenState> {
@@ -85,6 +91,9 @@ export function buildWorkspaceOpenLaunchCommand(
   return {
     executable,
     args: [
+      ...(isCodexCliOpener(opener) && attachedPaths.length > 0
+        ? CODEX_CLI_WRITABLE_ROOT_SANDBOX_ARGS
+        : []),
       ...attachedPaths.flatMap((linkedPath) => ['--add-dir', linkedPath]),
       WORKSPACE_OPEN_MINIMAL_PROMPT,
     ],

--- a/src/commands/workspace/opener-selection.ts
+++ b/src/commands/workspace/opener-selection.ts
@@ -2,7 +2,6 @@ import {
   WorkspacePreferredOpener,
   getDefaultWorkspaceOpenerChoiceValue,
   getWorkspaceSkillToolIds,
-  isWorkspaceAgentOpenerId,
   listWorkspaceOpenerChoices,
   parseWorkspacePreferredOpenerValue,
 } from '../../core/workspace/index.js';
@@ -46,27 +45,31 @@ export function parseSetupOpenerOption(
   } catch (error) {
     throw new WorkspaceCliError(asErrorMessage(error), 'unsupported_workspace_opener', {
       target: 'workspace.opener',
-      fix: 'Use --opener codex, --opener claude, --opener github-copilot, or --opener editor.',
+      fix: 'Use --opener codex-cli, --opener claude, --opener github-copilot, or --opener editor.',
     });
   }
 }
 
 export function parseWorkspaceAgentOverride(agent: string): WorkspacePreferredOpener {
-  if (!isWorkspaceAgentOpenerId(agent)) {
+  let opener: WorkspacePreferredOpener | null = null;
+  try {
+    opener = parseWorkspacePreferredOpenerValue(agent);
+  } catch {
+    opener = null;
+  }
+
+  if (!opener || opener.kind !== 'agent') {
     throw new WorkspaceCliError(
-      `Unsupported workspace agent '${agent}'. Supported agents: codex, claude, github-copilot.`,
+      `Unsupported workspace agent '${agent}'. Supported agents: codex-cli, claude, github-copilot.`,
       'unsupported_workspace_agent',
       {
         target: 'workspace.opener',
-        fix: 'Use --agent codex, --agent claude, or --agent github-copilot.',
+        fix: 'Use --agent codex-cli, --agent claude, or --agent github-copilot.',
       }
     );
   }
 
-  return {
-    kind: 'agent',
-    id: agent,
-  };
+  return opener;
 }
 
 export function getPreferredWorkspaceSkillAgentId(
@@ -76,7 +79,8 @@ export function getPreferredWorkspaceSkillAgentId(
     return null;
   }
 
-  return getWorkspaceSkillToolIds().includes(preferredOpener.id) ? preferredOpener.id : null;
+  const toolId = preferredOpener.id === 'codex-cli' ? 'codex' : preferredOpener.id;
+  return getWorkspaceSkillToolIds().includes(toolId) ? toolId : null;
 }
 
 export function resolveWorkspaceOpenOpenerOverride(
@@ -125,7 +129,7 @@ export async function resolveWorkspaceOpenOpener(
         'workspace_no_available_openers',
         {
           target: 'workspace.opener',
-          fix: "Install VS Code ('code'), Codex ('codex'), or Claude ('claude'), then retry.",
+          fix: "Install VS Code ('code'), codex-cli ('codex'), or Claude ('claude'), then retry.",
         }
       );
     }

--- a/src/commands/workspace/operations.ts
+++ b/src/commands/workspace/operations.ts
@@ -260,7 +260,6 @@ export async function createManagedWorkspace(
     await fs.mkdir(targetWorkspaceRoot);
     createdWorkspaceRoot = true;
     workspaceRoot = FileSystemUtils.canonicalizeExistingPath(targetWorkspaceRoot);
-    await FileSystemUtils.createDirectory(getWorkspaceChangesDir(workspaceRoot));
     const viewState: WorkspaceViewState = {
       version: 1,
       name: workspaceName,
@@ -686,15 +685,17 @@ export async function selectOrCreateWorkspaceForInitiativeOpen(input: {
   workspaceName?: string;
   context: WorkspaceContextState;
   preferredOpener?: WorkspacePreferredOpener;
+  linksForNewWorkspace?: () => Promise<Record<string, string>>;
 }): Promise<{ selected: SelectedWorkspace; created: boolean; state: WorkspaceViewState }> {
   if (input.workspaceName) {
     const workspaceName = validateWorkspaceNameForSetup(input.workspaceName);
     const existing = await readExistingManagedWorkspaceView(workspaceName);
 
     if (!existing) {
+      const links = input.linksForNewWorkspace ? await input.linksForNewWorkspace() : {};
       const workspace = await createManagedWorkspace(
         workspaceName,
-        {},
+        links,
         input.preferredOpener,
         input.context
       );
@@ -798,7 +799,7 @@ export async function selectOrCreateWorkspaceForInitiativeOpen(input: {
 
   const workspace = await createManagedWorkspace(
     derivedName,
-    {},
+    input.linksForNewWorkspace ? await input.linksForNewWorkspace() : {},
     input.preferredOpener,
     input.context
   );

--- a/src/commands/workspace/registration.ts
+++ b/src/commands/workspace/registration.ts
@@ -57,7 +57,7 @@ export function registerWorkspaceCommandWith(
     .description('Set up a workspace and link existing repos or folders')
     .option('--name <name>', 'Workspace name')
     .option('--link <link>', 'Repo or folder link. Use <path> or <name>=<path>.', collectOption, [])
-    .option('--opener <id>', 'Preferred opener: codex, claude, github-copilot, or editor')
+    .option('--opener <id>', 'Preferred opener: codex-cli, claude, github-copilot, or editor')
     .option(
       '--tools <tools>',
       `Install OpenSpec skills for agents. Use "all", "none", or a comma-separated list of: ${getWorkspaceSkillToolIds().join(', ')}`
@@ -137,7 +137,7 @@ export function registerWorkspaceCommandWith(
     .option('--initiative <id>', 'Open an initiative as a local workspace view')
     .option('--store <id>', 'Context store id for --initiative')
     .option('--store-path <path>', 'Existing local context store root for --initiative')
-    .option('--agent <tool>', 'Use an agent for this session: codex, claude, or github-copilot')
+    .option('--agent <tool>', 'Use an agent for this session: codex-cli, claude, or github-copilot')
     .option('--editor', 'Open the workspace in VS Code editor mode')
     .option('--prepare-only', 'Unsupported: preview surfaces belong to a future context/query command')
     .option('--json', 'Output generated workspace view context as JSON after launch')

--- a/src/commands/workspace/selection.ts
+++ b/src/commands/workspace/selection.ts
@@ -53,7 +53,16 @@ function findKnownWorkspaceByName(
   return entries.find((entry) => entry.name === workspaceName);
 }
 
-async function selectedWorkspaceFromRoot(
+export function selectedWorkspaceFromEntry(entry: WorkspaceRegistryEntry): SelectedWorkspace {
+  return {
+    name: entry.name,
+    root: entry.workspaceRoot,
+    status: [],
+    unregisteredCurrentWorkspace: false,
+  };
+}
+
+export async function selectedWorkspaceFromRoot(
   currentWorkspaceRoot: string,
   entries: WorkspaceRegistryEntry[]
 ): Promise<SelectedWorkspace> {
@@ -111,12 +120,7 @@ export async function selectWorkspaceForCommand(
       );
     }
 
-    return {
-      name: workspaceName,
-      root: entry.workspaceRoot,
-      status: [],
-      unregisteredCurrentWorkspace: false,
-    };
+    return selectedWorkspaceFromEntry(entry);
   }
 
   const currentWorkspaceRoot = await findWorkspaceRoot(process.cwd());
@@ -139,12 +143,7 @@ export async function selectWorkspaceForCommand(
   if (entries.length === 1) {
     const [entry] = entries;
 
-    return {
-      name: entry.name,
-      root: entry.workspaceRoot,
-      status: [],
-      unregisteredCurrentWorkspace: false,
-    };
+    return selectedWorkspaceFromEntry(entry);
   }
 
   if (options.json || resolveNoInteractive(options) || !isInteractive(options)) {
@@ -187,10 +186,5 @@ export async function selectWorkspaceForCommand(
     );
   }
 
-  return {
-    name: selectedName,
-    root: selectedEntry.workspaceRoot,
-    status: [],
-    unregisteredCurrentWorkspace: false,
-  };
+  return selectedWorkspaceFromEntry(selectedEntry);
 }

--- a/src/commands/workspace/setup-prompts.ts
+++ b/src/commands/workspace/setup-prompts.ts
@@ -15,10 +15,16 @@ const fs = nodeFs;
 export interface PromptSetupLinksOptions {
   heading?: string;
   intro?: string;
+  allowEmpty?: boolean;
+  emptyName?: string;
+  emptyShort?: string;
+  emptyDescription?: string;
   finishName?: string;
   finishShort?: string;
   finishDescription?: string;
 }
+
+type LinkPromptAction = 'finish' | 'add';
 
 async function promptExistingPath(message: string, defaultPath?: string): Promise<string> {
   const { input } = await import('@inquirer/prompts');
@@ -80,6 +86,32 @@ export async function promptSetupLinks(
 
   while (true) {
     const linkCount = Object.keys(links).length;
+    if (linkCount === 0 && options.allowEmpty) {
+      const firstAction = await select<LinkPromptAction>({
+        message: 'Continue',
+        default: 'finish',
+        choices: [
+          {
+            name: options.emptyName ?? options.finishName ?? 'Create workspace files',
+            short: options.emptyShort ?? options.finishShort ?? 'Create workspace files',
+            value: 'finish',
+            description: options.emptyDescription ?? 'Create the workspace without linked repos or folders',
+          },
+          {
+            name: 'Add a repo or folder',
+            short: 'Add repo',
+            value: 'add',
+            description: 'Include local implementation context in this workspace',
+          },
+        ],
+        theme: workspaceSelectTheme,
+      });
+
+      if (firstAction === 'finish') {
+        return links;
+      }
+    }
+
     const resolvedPath = await promptExistingPath(
       linkCount === 0 ? 'Repo or folder path:' : 'Another repo or folder path:',
       linkCount === 0 ? '.' : undefined
@@ -101,7 +133,7 @@ export async function promptSetupLinks(
     console.log(chalk.green(`Added link '${linkName}'`));
     console.log(chalk.dim(`  ${resolvedPath}`));
 
-    const nextAction = await select({
+    const nextAction = await select<LinkPromptAction>({
       message: 'Continue',
       default: 'finish',
       choices: [

--- a/src/commands/workspace/setup-prompts.ts
+++ b/src/commands/workspace/setup-prompts.ts
@@ -1,0 +1,128 @@
+import chalk from 'chalk';
+import * as nodeFs from 'node:fs';
+import * as path from 'node:path';
+
+import {
+  inferLinkName,
+  resolveExistingDirectory,
+  validateLinkNameForCommand,
+} from './operations.js';
+import { workspacePromptTheme, workspaceSelectTheme } from './prompt-theme.js';
+import { asErrorMessage } from './types.js';
+
+const fs = nodeFs;
+
+export interface PromptSetupLinksOptions {
+  heading?: string;
+  intro?: string;
+  finishName?: string;
+  finishShort?: string;
+  finishDescription?: string;
+}
+
+async function promptExistingPath(message: string, defaultPath?: string): Promise<string> {
+  const { input } = await import('@inquirer/prompts');
+
+  const pathInput = await input({
+    message,
+    default: defaultPath,
+    prefill: defaultPath ? 'editable' : undefined,
+    required: true,
+    theme: workspacePromptTheme,
+    validate(value: string) {
+      const resolvedPath = path.isAbsolute(value)
+        ? path.resolve(value)
+        : path.resolve(process.cwd(), value);
+      return fs.existsSync(resolvedPath) && fs.statSync(resolvedPath).isDirectory()
+        ? true
+        : 'Enter an existing repo or folder path.';
+    },
+  });
+
+  return resolveExistingDirectory(pathInput);
+}
+
+async function promptLinkName(existingLinks: Record<string, string>): Promise<string> {
+  const { input } = await import('@inquirer/prompts');
+
+  return input({
+    message: 'Link name:',
+    required: true,
+    theme: workspacePromptTheme,
+    validate(value: string) {
+      try {
+        validateLinkNameForCommand(value);
+      } catch (error) {
+        return asErrorMessage(error);
+      }
+
+      if (existingLinks[value]) {
+        return `Link name '${value}' is already linked to ${existingLinks[value]}.`;
+      }
+
+      return true;
+    },
+  });
+}
+
+export async function promptSetupLinks(
+  options: PromptSetupLinksOptions = {}
+): Promise<Record<string, string>> {
+  const { select } = await import('@inquirer/prompts');
+  const links: Record<string, string> = {};
+  const heading = options.heading ?? '[2/5] Link repos or folders';
+  const intro = options.intro ?? 'Start with the current directory, or enter another repo path.';
+
+  console.log('');
+  console.log(chalk.bold(heading));
+  console.log(chalk.dim(intro));
+  console.log('');
+
+  while (true) {
+    const linkCount = Object.keys(links).length;
+    const resolvedPath = await promptExistingPath(
+      linkCount === 0 ? 'Repo or folder path:' : 'Another repo or folder path:',
+      linkCount === 0 ? '.' : undefined
+    );
+    let linkName = inferLinkName(resolvedPath);
+
+    try {
+      validateLinkNameForCommand(linkName);
+    } catch {
+      linkName = await promptLinkName(links);
+    }
+
+    if (links[linkName]) {
+      console.log(`Link name '${linkName}' is already linked to ${links[linkName]}.`);
+      linkName = await promptLinkName(links);
+    }
+
+    links[linkName] = resolvedPath;
+    console.log(chalk.green(`Added link '${linkName}'`));
+    console.log(chalk.dim(`  ${resolvedPath}`));
+
+    const nextAction = await select({
+      message: 'Continue',
+      default: 'finish',
+      choices: [
+        {
+          name: options.finishName ?? 'Create workspace files',
+          short: options.finishShort ?? 'Create workspace files',
+          value: 'finish',
+          description: options.finishDescription ?? 'Run a workspace check after setup',
+        },
+        {
+          name: 'Add another repo or folder',
+          short: 'Add another',
+          value: 'add',
+          description: 'Include another local directory in this workspace',
+        },
+      ],
+      theme: workspaceSelectTheme,
+    });
+
+    if (nextAction === 'finish') {
+      return links;
+    }
+  }
+}

--- a/src/core/completions/command-registry.ts
+++ b/src/core/completions/command-registry.ts
@@ -309,9 +309,9 @@ export const COMMAND_REGISTRY: CommandDefinition[] = [
           },
           {
             name: 'opener',
-            description: 'Preferred opener: codex, claude, github-copilot, or editor',
+            description: 'Preferred opener: codex-cli, claude, github-copilot, or editor',
             takesValue: true,
-            values: ['codex', 'claude', 'github-copilot', 'editor'],
+            values: ['codex-cli', 'claude', 'github-copilot', 'editor'],
           },
           {
             name: 'tools',
@@ -433,9 +433,9 @@ export const COMMAND_REGISTRY: CommandDefinition[] = [
           },
           {
             name: 'agent',
-            description: 'Use an agent for this session: codex, claude, or github-copilot',
+            description: 'Use an agent for this session: codex-cli, claude, or github-copilot',
             takesValue: true,
-            values: ['codex', 'claude', 'github-copilot'],
+            values: ['codex-cli', 'claude', 'github-copilot'],
           },
           {
             name: 'editor',

--- a/src/core/context-store/foundation.ts
+++ b/src/core/context-store/foundation.ts
@@ -64,6 +64,10 @@ export function getContextStoreRegistryPath(options: ContextStorePathOptions = {
   return joinContextStorePath(getContextStoresDir(options), CONTEXT_STORE_REGISTRY_FILE_NAME);
 }
 
+export function getDefaultContextStoreRoot(id: string, options: ContextStorePathOptions = {}): string {
+  return joinContextStorePath(getContextStoresDir(options), id);
+}
+
 export function getContextStoreMetadataDir(storeRoot: string): string {
   return joinContextStorePath(storeRoot, CONTEXT_STORE_METADATA_DIR_NAME);
 }

--- a/src/core/context-store/operations.ts
+++ b/src/core/context-store/operations.ts
@@ -5,6 +5,7 @@ import { promisify } from 'node:util';
 
 import { FileSystemUtils } from '../../utils/file-system.js';
 import {
+  getDefaultContextStoreRoot,
   getContextStoreMetadataPath,
   getContextStoreRegistryPath,
   listContextStoreRegistryEntries,
@@ -163,11 +164,15 @@ function resolveSetupRoot(id: string, inputPath: string | undefined): string {
   if (inputPath !== undefined && inputPath.trim().length === 0) {
     throw new ContextStoreError('Pass a non-empty --path value.', 'context_store_path_required', {
       target: 'context_store.root',
-      fix: `openspec context-store setup ${id} --path ./team-context`,
+      fix: `openspec context-store setup ${id} --path /path/to/context-store`,
     });
   }
 
-  return path.resolve(inputPath ?? id);
+  if (inputPath !== undefined) {
+    return path.resolve(inputPath);
+  }
+
+  return getDefaultContextStoreRoot(id);
 }
 
 function resolveRegisterRoot(inputPath: string | undefined): string {
@@ -221,7 +226,7 @@ async function prepareSetupPlan(
       'context_store_setup_path_not_directory',
       {
         target: 'context_store.root',
-        fix: 'Choose an empty directory or omit --path to use ./<id>.',
+        fix: 'Choose an empty directory or omit --path to use the managed OpenSpec context-store location.',
       }
     );
   }

--- a/src/core/workspace/foundation.ts
+++ b/src/core/workspace/foundation.ts
@@ -14,14 +14,14 @@ export const WORKSPACE_CHANGES_DIR_NAME = 'changes';
 export const WORKSPACE_CODE_WORKSPACE_EXTENSION = '.code-workspace';
 
 export const WORKSPACE_SUPPORTED_OPENER_VALUES = [
-  'codex',
+  'codex-cli',
   'claude',
   'github-copilot',
   'editor',
 ] as const;
 
 export const WORKSPACE_AGENT_OPENER_IDS = [
-  'codex',
+  'codex-cli',
   'claude',
   'github-copilot',
 ] as const;
@@ -93,8 +93,8 @@ export function getWorkspaceCodeWorkspacePath(workspaceRoot: string, workspaceNa
   return joinWorkspacePath(workspaceRoot, getWorkspaceCodeWorkspaceFileName(workspaceName));
 }
 
-export function getWorkspacePortableIgnorePatterns(workspaceName?: string): string[] {
-  return workspaceName ? [getWorkspaceCodeWorkspaceFileName(workspaceName)] : [];
+export function getWorkspacePortableIgnorePatterns(_workspaceName?: string): string[] {
+  return [];
 }
 
 function validateFolderStyleName(name: string, label: string): string {
@@ -250,6 +250,18 @@ function formatSupportedOpenerValues(): string {
   return WORKSPACE_SUPPORTED_OPENER_VALUES.join(', ');
 }
 
+function normalizeWorkspaceAgentOpenerId(value: string): WorkspaceAgentOpenerId | null {
+  if (value === 'codex') {
+    return 'codex-cli';
+  }
+
+  if (isWorkspaceAgentOpenerId(value)) {
+    return value;
+  }
+
+  return null;
+}
+
 export function isWorkspaceAgentOpenerId(value: string): value is WorkspaceAgentOpenerId {
   return (WORKSPACE_AGENT_OPENER_IDS as readonly string[]).includes(value);
 }
@@ -268,10 +280,11 @@ export function parseWorkspacePreferredOpenerValue(value: string): WorkspacePref
     };
   }
 
-  if (isWorkspaceAgentOpenerId(value)) {
+  const agentId = normalizeWorkspaceAgentOpenerId(value);
+  if (agentId) {
     return {
       kind: 'agent',
-      id: value,
+      id: agentId,
     };
   }
 
@@ -287,8 +300,14 @@ export function validateWorkspacePreferredOpener(
     return opener;
   }
 
-  if (opener.kind === 'agent' && isWorkspaceAgentOpenerId(opener.id)) {
-    return opener;
+  if (opener.kind === 'agent') {
+    const agentId = normalizeWorkspaceAgentOpenerId(opener.id);
+    if (agentId) {
+      return {
+        kind: 'agent',
+        id: agentId,
+      };
+    }
   }
 
   throw new Error(

--- a/src/core/workspace/foundation.ts
+++ b/src/core/workspace/foundation.ts
@@ -93,6 +93,11 @@ export function getWorkspaceCodeWorkspacePath(workspaceRoot: string, workspaceNa
   return joinWorkspacePath(workspaceRoot, getWorkspaceCodeWorkspaceFileName(workspaceName));
 }
 
+/**
+ * @deprecated Managed workspaces no longer create portable ignore rules.
+ * This compatibility shim remains for callers that still ask which ignore
+ * patterns OpenSpec owns for workspace-local generated files.
+ */
 export function getWorkspacePortableIgnorePatterns(_workspaceName?: string): string[] {
   return [];
 }

--- a/src/core/workspace/open-surface.ts
+++ b/src/core/workspace/open-surface.ts
@@ -304,30 +304,15 @@ async function cleanupLegacyWorkspaceIgnoreRules(
   const legacyGeneratedPattern = getWorkspaceCodeWorkspaceFileName(workspaceName);
   const existingContent = await fs.readFile(gitignorePath, 'utf-8');
   const existingLines = existingContent.split(/\r?\n/u);
-  let removedLegacyPattern = false;
-  const keptLines = existingLines.filter((line) => {
-    if (line.trim() === legacyGeneratedPattern) {
-      removedLegacyPattern = true;
-      return false;
-    }
+  const nonEmptyLines = existingLines.filter((line) => line.trim().length > 0);
+  const isPureLegacyGeneratedFile =
+    nonEmptyLines.length === 1 && nonEmptyLines[0]?.trim() === legacyGeneratedPattern;
 
-    return true;
-  });
-
-  if (!removedLegacyPattern) {
+  if (!isPureLegacyGeneratedFile) {
     return;
   }
 
-  while (keptLines.length > 0 && keptLines[keptLines.length - 1]?.trim().length === 0) {
-    keptLines.pop();
-  }
-
-  if (keptLines.every((line) => line.trim().length === 0)) {
-    await fs.rm(gitignorePath, { force: true });
-    return;
-  }
-
-  await FileSystemUtils.writeFile(gitignorePath, `${keptLines.join('\n')}\n`);
+  await fs.rm(gitignorePath, { force: true });
 }
 
 export async function syncWorkspaceOpenSurface(

--- a/src/core/workspace/open-surface.ts
+++ b/src/core/workspace/open-surface.ts
@@ -6,13 +6,15 @@ import {
   WorkspaceViewState,
   getWorkspaceContextInitiativeId,
   getWorkspaceCodeWorkspacePath,
-  getWorkspacePortableIgnorePatterns,
+  getWorkspaceCodeWorkspaceFileName,
 } from './foundation.js';
 
 const fs = nodeFs.promises;
 
 export const WORKSPACE_GUIDANCE_START_MARKER = '<!-- OPENSPEC:WORKSPACE-GUIDANCE:START -->';
 export const WORKSPACE_GUIDANCE_END_MARKER = '<!-- OPENSPEC:WORKSPACE-GUIDANCE:END -->';
+export const WORKSPACE_OPEN_ROOT_FOLDER_LABEL = 'OpenSpec workspace';
+export const WORKSPACE_OPEN_INITIATIVE_FOLDER_LABEL = 'Initiative context';
 
 export const WORKSPACE_GUIDANCE_BODY = `# OpenSpec Workspace Guidance
 
@@ -191,21 +193,22 @@ export function buildWorkspaceCodeWorkspaceContent(
   resolvedContext?: WorkspaceOpenResolvedContext | null
 ): string {
   const folders = [
-    {
-      path: '.',
-    },
-    ...(resolvedContext
-      ? [
-          {
-            name: `initiative:${resolvedContext.initiative.id}`,
-            path: resolvedContext.initiative.root,
-          },
-        ]
-      : []),
     ...links.map((link) => ({
       name: link.name,
       path: link.path,
     })),
+    ...(resolvedContext
+      ? [
+          {
+            name: WORKSPACE_OPEN_INITIATIVE_FOLDER_LABEL,
+            path: resolvedContext.initiative.root,
+          },
+        ]
+      : []),
+    {
+      name: WORKSPACE_OPEN_ROOT_FOLDER_LABEL,
+      path: '.',
+    },
   ];
 
   return `${JSON.stringify({ folders }, null, 2)}\n`;
@@ -288,32 +291,43 @@ async function syncWorkspaceCodeWorkspace(
   return codeWorkspacePath;
 }
 
-async function syncWorkspaceIgnoreRules(
+async function cleanupLegacyWorkspaceIgnoreRules(
   workspaceRoot: string,
   workspaceName: string
 ): Promise<void> {
   const gitignorePath = path.join(workspaceRoot, '.gitignore');
-  const patterns = getWorkspacePortableIgnorePatterns(workspaceName);
-  const existingContent = (await fileExists(gitignorePath))
-    ? await fs.readFile(gitignorePath, 'utf-8')
-    : '';
-  const existingLines = new Set(
-    existingContent
-      .split(/\r?\n/u)
-      .map((line) => line.trim())
-      .filter((line) => line.length > 0)
-  );
-  const missingPatterns = patterns.filter((pattern) => !existingLines.has(pattern));
 
-  if (missingPatterns.length === 0) {
+  if (!(await fileExists(gitignorePath))) {
     return;
   }
 
-  const prefix = existingContent.length > 0 && !existingContent.endsWith('\n') ? '\n' : '';
-  await FileSystemUtils.writeFile(
-    gitignorePath,
-    `${existingContent}${prefix}${missingPatterns.join('\n')}\n`
-  );
+  const legacyGeneratedPattern = getWorkspaceCodeWorkspaceFileName(workspaceName);
+  const existingContent = await fs.readFile(gitignorePath, 'utf-8');
+  const existingLines = existingContent.split(/\r?\n/u);
+  let removedLegacyPattern = false;
+  const keptLines = existingLines.filter((line) => {
+    if (line.trim() === legacyGeneratedPattern) {
+      removedLegacyPattern = true;
+      return false;
+    }
+
+    return true;
+  });
+
+  if (!removedLegacyPattern) {
+    return;
+  }
+
+  while (keptLines.length > 0 && keptLines[keptLines.length - 1]?.trim().length === 0) {
+    keptLines.pop();
+  }
+
+  if (keptLines.every((line) => line.trim().length === 0)) {
+    await fs.rm(gitignorePath, { force: true });
+    return;
+  }
+
+  await FileSystemUtils.writeFile(gitignorePath, `${keptLines.join('\n')}\n`);
 }
 
 export async function syncWorkspaceOpenSurface(
@@ -334,7 +348,7 @@ export async function syncWorkspaceOpenSurface(
     resolvedContext
   );
 
-  await syncWorkspaceIgnoreRules(workspaceRoot, viewState.name);
+  await cleanupLegacyWorkspaceIgnoreRules(workspaceRoot, viewState.name);
 
   return {
     ...openLinks,

--- a/src/core/workspace/openers.ts
+++ b/src/core/workspace/openers.ts
@@ -29,8 +29,8 @@ const WORKSPACE_OPENER_CHOICE_DEFINITIONS: Array<{
     executable: 'code',
   },
   {
-    value: 'codex',
-    label: 'Codex',
+    value: 'codex-cli',
+    label: 'codex-cli',
     executable: 'codex',
   },
   {
@@ -108,28 +108,34 @@ export function isWorkspaceExecutableAvailable(
 }
 
 export function getWorkspaceOpenerExecutable(opener: WorkspacePreferredOpener): string {
+  const openerId = opener.id as string;
   if (opener.kind === 'editor') {
     return 'code';
   }
 
-  if (opener.id === 'github-copilot') {
+  if (openerId === 'github-copilot') {
     return 'code';
+  }
+
+  if (openerId === 'codex-cli' || openerId === 'codex') {
+    return 'codex';
   }
 
   return opener.id;
 }
 
 export function getWorkspaceOpenerLabel(opener: WorkspacePreferredOpener): string {
+  const openerId = opener.id as string;
   if (opener.kind === 'editor') {
     return 'VS Code editor';
   }
 
-  if (opener.id === 'github-copilot') {
+  if (openerId === 'github-copilot') {
     return 'GitHub Copilot in VS Code';
   }
 
-  if (opener.id === 'codex') {
-    return 'Codex';
+  if (openerId === 'codex-cli' || openerId === 'codex') {
+    return 'codex-cli';
   }
 
   return 'Claude';

--- a/test/commands/context-store.test.ts
+++ b/test/commands/context-store.test.ts
@@ -5,6 +5,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 
 import {
+  getDefaultContextStoreRoot,
   getGlobalDataDir,
   getContextStoreMetadataPath,
   readContextStoreMetadataState,
@@ -99,13 +100,13 @@ describe('context-store command', () => {
     }
   }
 
-  it('sets up a context store at ./<id> without Git in non-interactive JSON mode', async () => {
+  it('sets up a context store in the managed local data directory without Git in non-interactive JSON mode', async () => {
     const result = await runCLI(
       ['context-store', 'setup', 'team-context', '--no-init-git', '--json'],
       { cwd: tempDir, env }
     );
 
-    const storeRoot = expectedExistingPath(path.join(tempDir, 'team-context'));
+    const storeRoot = expectedExistingPath(getDefaultContextStoreRoot('team-context', { globalDataDir }));
 
     expect(result.exitCode).toBe(0);
     expect(result.stderr).toBe('');
@@ -378,7 +379,7 @@ describe('context-store command', () => {
 
     await runContextStoreCommand(['setup', 'interactive-context']);
 
-    const storeRoot = path.join(tempDir, 'interactive-context');
+    const storeRoot = getDefaultContextStoreRoot('interactive-context', { globalDataDir });
     expect(confirm).toHaveBeenCalledWith({
       message: 'Initialize Git repository?',
       default: true,

--- a/test/commands/workspace-initiative-open.test.ts
+++ b/test/commands/workspace-initiative-open.test.ts
@@ -14,6 +14,7 @@ import {
   registerContextStore,
   writeContextStoreMetadataState,
 } from '../../src/core/index.js';
+import { withPrependedPathEnv } from '../helpers/path-env.js';
 import { runCLI, type RunCLIResult } from '../helpers/run-cli.js';
 
 describe('workspace open initiative views', () => {
@@ -110,8 +111,7 @@ describe('workspace open initiative views', () => {
 
   function envWithFakeExecutable(fake: { binDir: string; logPath: string }): NodeJS.ProcessEnv {
     return {
-      ...env,
-      PATH: `${fake.binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+      ...withPrependedPathEnv(env, fake.binDir),
       OPENSPEC_FAKE_OPEN_RECORDER: path.join(fake.binDir, 'record-launch.cjs'),
       OPENSPEC_FAKE_OPEN_LOG: fake.logPath,
     };
@@ -237,16 +237,19 @@ describe('workspace open initiative views', () => {
       'Initiative title: Billing Launch'
     );
     expect(JSON.parse(fs.readFileSync(getWorkspaceCodeWorkspacePath(workspaceRoot, 'billing-launch'), 'utf-8')).folders).toEqual([
-      { path: '.' },
       {
-        name: 'initiative:billing-launch',
+        name: 'Initiative context',
         path: expect.any(String),
+      },
+      {
+        name: 'OpenSpec workspace',
+        path: '.',
       },
     ]);
     const codeWorkspaceFolders = JSON.parse(
       fs.readFileSync(getWorkspaceCodeWorkspacePath(workspaceRoot, 'billing-launch'), 'utf-8')
     ).folders;
-    expectSameExistingPath(codeWorkspaceFolders[1].path, initiative.initiativeRoot);
+    expectSameExistingPath(codeWorkspaceFolders[0].path, initiative.initiativeRoot);
 
     const launch = readLaunchLog(code.logPath);
     expect(fs.realpathSync.native(launch.cwd)).toBe(fs.realpathSync.native(workspaceRoot));

--- a/test/commands/workspace-open.test.ts
+++ b/test/commands/workspace-open.test.ts
@@ -7,7 +7,7 @@ import {
 } from '../../src/commands/workspace/open.js';
 
 describe('workspace open launchers', () => {
-  it('builds launcher commands for VS Code, GitHub Copilot, Codex, and Claude', () => {
+  it('builds launcher commands for VS Code, GitHub Copilot, codex-cli, and Claude', () => {
     expect(
       buildWorkspaceOpenLaunchCommand(
         { kind: 'editor', id: 'vscode' },
@@ -38,7 +38,7 @@ describe('workspace open launchers', () => {
 
     expect(
       buildWorkspaceOpenLaunchCommand(
-        { kind: 'agent', id: 'codex' },
+        { kind: 'agent', id: 'codex-cli' },
         '/workspace',
         '/workspace/platform.code-workspace',
         ['/repos/api', '/repos/web']
@@ -46,6 +46,8 @@ describe('workspace open launchers', () => {
     ).toEqual({
       executable: 'codex',
       args: [
+        '--sandbox',
+        'workspace-write',
         '--add-dir',
         '/repos/api',
         '--add-dir',
@@ -53,7 +55,7 @@ describe('workspace open launchers', () => {
         'Open this OpenSpec workspace.',
       ],
       cwd: '/workspace',
-      openerLabel: 'Codex',
+      openerLabel: 'codex-cli',
     });
 
     expect(
@@ -93,7 +95,7 @@ describe('workspace open launchers', () => {
       };
     }) as any;
     const command = buildWorkspaceOpenLaunchCommand(
-      { kind: 'agent', id: 'codex' },
+      { kind: 'agent', id: 'codex-cli' },
       '/workspace',
       '/workspace/platform.code-workspace',
       ['/repos/api', 'C:\\Program Files\\repo']
@@ -105,6 +107,8 @@ describe('workspace open launchers', () => {
       {
         command: 'codex',
         args: [
+          '--sandbox',
+          'workspace-write',
           '--add-dir',
           '/repos/api',
           '--add-dir',

--- a/test/commands/workspace.interactive.test.ts
+++ b/test/commands/workspace.interactive.test.ts
@@ -5,10 +5,16 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 
 import {
+  createInitiative,
+  mountInitiativesCollection,
+  registerContextStore,
+} from '../../src/core/index.js';
+import {
   getManagedWorkspaceRoot,
   getWorkspaceViewStatePath,
   parseWorkspaceViewState,
 } from '../../src/core/workspace/index.js';
+import { prependProcessPathEnv, setProcessPathEnv } from '../helpers/path-env.js';
 
 const searchableMultiSelectMock = vi.hoisted(() => vi.fn(async () => []));
 
@@ -109,6 +115,27 @@ describe('workspace command interactive flows', () => {
     return parseWorkspaceViewState(fs.readFileSync(getWorkspaceViewStatePath(workspaceRoot), 'utf-8'));
   }
 
+  async function setupInitiative(storeId = 'team-context', initiativeId = 'agent-trace-hooks') {
+    const storeRoot = mkdir(`stores/${storeId}`);
+    await registerContextStore({
+      id: storeId,
+      localPath: storeRoot,
+    });
+    await createInitiative({
+      collection: mountInitiativesCollection(storeRoot),
+      id: initiativeId,
+      title: 'Agent Trace Hooks',
+      summary: 'Explore lightweight capture of agent trace events.',
+    });
+
+    return {
+      storeId,
+      storeRoot,
+      initiativeId,
+      initiativeRoot: path.join(storeRoot, 'initiatives', initiativeId),
+    };
+  }
+
   it('asks for the workspace name first and validates kebab-case before asking for links', async () => {
     const api = mkdir('repos/api');
     const expectedApi = expectedExistingPath(api);
@@ -178,7 +205,7 @@ describe('workspace command interactive flows', () => {
     const codePath = path.join(binDir, process.platform === 'win32' ? 'code.cmd' : 'code');
     fs.writeFileSync(codePath, '');
     fs.chmodSync(codePath, 0o755);
-    process.env.PATH = binDir;
+    setProcessPathEnv(binDir);
     const { input, confirm, select } = await getPromptMocks();
 
     input.mockImplementation(async (options: { message: string }) => {
@@ -202,7 +229,7 @@ describe('workspace command interactive flows', () => {
           'editor',
           'github-copilot',
         ]);
-        expect(options.choices?.find((choice) => choice.value === 'codex')?.name).toContain(
+        expect(options.choices?.find((choice) => choice.value === 'codex-cli')?.name).toContain(
           'codex not found on PATH'
         );
         return 'github-copilot';
@@ -227,7 +254,7 @@ describe('workspace command interactive flows', () => {
     const codexPath = path.join(binDir, process.platform === 'win32' ? 'codex.cmd' : 'codex');
     fs.writeFileSync(codexPath, '');
     fs.chmodSync(codexPath, 0o755);
-    process.env.PATH = binDir;
+    setProcessPathEnv(binDir);
     const { input, select } = await getPromptMocks();
 
     input.mockImplementation(async (options: { message: string }) => {
@@ -247,7 +274,7 @@ describe('workspace command interactive flows', () => {
       }
 
       if (options.message === 'Preferred opener:') {
-        return 'codex';
+        return 'codex-cli';
       }
 
       throw new Error(`Unexpected select prompt: ${options.message}`);
@@ -405,8 +432,7 @@ describe('workspace command interactive flows', () => {
       process.platform === 'win32' ? '@echo off\r\nexit /B 0\r\n' : '#!/bin/sh\nexit 0\n'
     );
     fs.chmodSync(codePath, 0o755);
-    const pathKey = Object.keys(process.env).find((key) => key.toLowerCase() === 'path') ?? 'PATH';
-    process.env[pathKey] = `${binDir}${path.delimiter}${process.env[pathKey] ?? ''}`;
+    prependProcessPathEnv(binDir);
     const { select } = await getPromptMocks();
 
     await runWorkspaceCommand(['setup', '--no-interactive', '--name', 'platform', '--link', `api=${api}`]);
@@ -433,7 +459,7 @@ describe('workspace command interactive flows', () => {
   it('fails workspace open without prompting when no opener is available', async () => {
     const api = mkdir('repos/api');
     const { select } = await getPromptMocks();
-    process.env.PATH = '';
+    setProcessPathEnv('');
 
     await runWorkspaceCommand(['setup', '--no-interactive', '--name', 'platform', '--link', `api=${api}`]);
     consoleErrorSpy.mockClear();
@@ -457,7 +483,7 @@ describe('workspace command interactive flows', () => {
       process.platform === 'win32' ? '@echo off\r\nexit /B 0\r\n' : '#!/bin/sh\nexit 0\n'
     );
     fs.chmodSync(codePath, 0o755);
-    process.env.PATH = `${binDir}${path.delimiter}${process.env.PATH ?? ''}`;
+    prependProcessPathEnv(binDir);
     const { select } = await getPromptMocks();
 
     await runWorkspaceCommand([
@@ -492,5 +518,85 @@ describe('workspace command interactive flows', () => {
       })
     );
     expect(consoleLogSpy).toHaveBeenCalledWith('Opening workspace: checkout-web');
+  });
+
+  it('shows initiatives in the bare workspace open picker and creates a local view', async () => {
+    const initiative = await setupInitiative();
+    const api = mkdir('repos/api');
+    const expectedApi = expectedExistingPath(api);
+    const binDir = mkdir('bin');
+    const codePath = path.join(binDir, process.platform === 'win32' ? 'code.cmd' : 'code');
+    fs.writeFileSync(
+      codePath,
+      process.platform === 'win32' ? '@echo off\r\nexit /B 0\r\n' : '#!/bin/sh\nexit 0\n'
+    );
+    fs.chmodSync(codePath, 0o755);
+    prependProcessPathEnv(binDir);
+    const { input, select } = await getPromptMocks();
+
+    input.mockImplementation(async (options: { message: string }) => {
+      if (options.message === 'Repo or folder path:') {
+        return api;
+      }
+
+      throw new Error(`Unexpected input prompt: ${options.message}`);
+    });
+
+    select.mockImplementation(async (options: { message: string; choices?: Array<{ name: string; value: unknown }> }) => {
+      if (options.message === 'Select workspace or initiative:') {
+        const choice = options.choices?.find((candidate) =>
+          candidate.name.includes('Initiative: team-context/agent-trace-hooks')
+        );
+        if (!choice) {
+          throw new Error('Expected initiative choice to be present');
+        }
+        expect(choice?.name).toContain('create local workspace view');
+        return choice.value;
+      }
+
+      if (options.message === 'Continue') {
+        return 'finish';
+      }
+
+      throw new Error(`Unexpected select prompt: ${options.message}`);
+    });
+
+    await runWorkspaceCommand(['open', '--editor']);
+
+    expect(process.exitCode).toBeUndefined();
+    expect(select).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Select workspace or initiative:',
+        choices: expect.arrayContaining([
+          expect.objectContaining({
+            name: expect.stringContaining('Initiative: team-context/agent-trace-hooks'),
+            value: expect.objectContaining({
+              kind: 'initiative',
+              initiative: expect.objectContaining({
+                store: 'team-context',
+                id: 'agent-trace-hooks',
+              }),
+            }),
+          }),
+        ]),
+      })
+    );
+    expect(consoleLogSpy).toHaveBeenCalledWith('Opening workspace: agent-trace-hooks');
+    expect(consoleLogSpy).toHaveBeenCalledWith('Initiative: team-context/agent-trace-hooks');
+    const workspaceState = readWorkspaceState('agent-trace-hooks');
+    expect(workspaceState.context).toEqual({
+      kind: 'initiative',
+      store: {
+        id: initiative.storeId,
+        selector: {
+          kind: 'registry',
+          id: initiative.storeId,
+        },
+      },
+      initiative: {
+        id: initiative.initiativeId,
+      },
+    });
+    expect(workspaceState.links).toEqual({ api: expectedApi });
   });
 });

--- a/test/commands/workspace.interactive.test.ts
+++ b/test/commands/workspace.interactive.test.ts
@@ -533,6 +533,7 @@ describe('workspace command interactive flows', () => {
     fs.chmodSync(codePath, 0o755);
     prependProcessPathEnv(binDir);
     const { input, select } = await getPromptMocks();
+    let continuePromptCount = 0;
 
     input.mockImplementation(async (options: { message: string }) => {
       if (options.message === 'Repo or folder path:') {
@@ -555,7 +556,8 @@ describe('workspace command interactive flows', () => {
       }
 
       if (options.message === 'Continue') {
-        return 'finish';
+        continuePromptCount += 1;
+        return continuePromptCount === 1 ? 'add' : 'finish';
       }
 
       throw new Error(`Unexpected select prompt: ${options.message}`);
@@ -598,5 +600,97 @@ describe('workspace command interactive flows', () => {
       },
     });
     expect(workspaceState.links).toEqual({ api: expectedApi });
+  });
+
+  it('can create an initiative workspace view without linked repos from the picker', async () => {
+    const initiative = await setupInitiative('team-context', 'context-only-launch');
+    const binDir = mkdir('bin');
+    const codePath = path.join(binDir, process.platform === 'win32' ? 'code.cmd' : 'code');
+    fs.writeFileSync(
+      codePath,
+      process.platform === 'win32' ? '@echo off\r\nexit /B 0\r\n' : '#!/bin/sh\nexit 0\n'
+    );
+    fs.chmodSync(codePath, 0o755);
+    prependProcessPathEnv(binDir);
+    const { input, select } = await getPromptMocks();
+
+    select.mockImplementation(async (options: { message: string; choices?: Array<{ name: string; value: unknown }> }) => {
+      if (options.message === 'Select workspace or initiative:') {
+        const choice = options.choices?.find((candidate) =>
+          candidate.name.includes('Initiative: team-context/context-only-launch')
+        );
+        if (!choice) {
+          throw new Error('Expected initiative choice to be present');
+        }
+        return choice.value;
+      }
+
+      if (options.message === 'Continue') {
+        expect(options.choices).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              name: 'Create without linked repos',
+              value: 'finish',
+            }),
+            expect.objectContaining({
+              name: 'Add a repo or folder',
+              value: 'add',
+            }),
+          ])
+        );
+        return 'finish';
+      }
+
+      throw new Error(`Unexpected select prompt: ${options.message}`);
+    });
+
+    await runWorkspaceCommand(['open', '--editor']);
+
+    expect(process.exitCode).toBeUndefined();
+    expect(input).not.toHaveBeenCalled();
+    expect(consoleLogSpy).toHaveBeenCalledWith('Opening workspace: context-only-launch');
+    const workspaceState = readWorkspaceState('context-only-launch');
+    expect(workspaceState.context).toEqual({
+      kind: 'initiative',
+      store: {
+        id: initiative.storeId,
+        selector: {
+          kind: 'registry',
+          id: initiative.storeId,
+        },
+      },
+      initiative: {
+        id: initiative.initiativeId,
+      },
+    });
+    expect(workspaceState.links).toEqual({});
+  });
+
+  it('does not prompt for initiative workspace links when JSON output is requested', async () => {
+    const initiative = await setupInitiative('team-context', 'json-launch');
+    const binDir = mkdir('bin');
+    const codePath = path.join(binDir, process.platform === 'win32' ? 'code.cmd' : 'code');
+    fs.writeFileSync(
+      codePath,
+      process.platform === 'win32' ? '@echo off\r\nexit /B 0\r\n' : '#!/bin/sh\nexit 0\n'
+    );
+    fs.chmodSync(codePath, 0o755);
+    prependProcessPathEnv(binDir);
+    const { input, select } = await getPromptMocks();
+
+    await runWorkspaceCommand([
+      'open',
+      '--initiative',
+      initiative.initiativeId,
+      '--store',
+      initiative.storeId,
+      '--editor',
+      '--json',
+    ]);
+
+    expect(process.exitCode).toBeUndefined();
+    expect(input).not.toHaveBeenCalled();
+    expect(select).not.toHaveBeenCalled();
+    expect(readWorkspaceState('json-launch').links).toEqual({});
   });
 });

--- a/test/commands/workspace.test.ts
+++ b/test/commands/workspace.test.ts
@@ -21,10 +21,10 @@ import {
 } from '../../src/core/workspace/index.js';
 import {
   WORKSPACE_LEGACY_LOCAL_STATE_FILE_NAME,
-  WORKSPACE_LEGACY_LOCAL_STATE_IGNORE_PATTERN,
   WORKSPACE_LEGACY_SHARED_STATE_FILE_NAME,
 } from '../../src/core/workspace/legacy-state.js';
 import { FileSystemUtils } from '../../src/utils/file-system.js';
+import { withPrependedPathEnv } from '../helpers/path-env.js';
 import { runCLI, type RunCLIResult } from '../helpers/run-cli.js';
 
 describe('workspace command', () => {
@@ -97,8 +97,7 @@ describe('workspace command', () => {
 
   function envWithFakeExecutable(fake: { binDir: string; logPath: string }): NodeJS.ProcessEnv {
     return {
-      ...env,
-      PATH: `${fake.binDir}${path.delimiter}${process.env.PATH ?? ''}`,
+      ...withPrependedPathEnv(env, fake.binDir),
       OPENSPEC_FAKE_OPEN_RECORDER: path.join(fake.binDir, 'record-launch.cjs'),
       OPENSPEC_FAKE_OPEN_LOG: fake.logPath,
     };
@@ -181,19 +180,12 @@ describe('workspace command', () => {
     });
     expect(workspaceState.preferred_opener).toBeUndefined();
     expect(fs.existsSync(getWorkspaceRegistryPath({ globalDataDir: path.join(dataHome, 'openspec') }))).toBe(false);
-    expect(fs.readFileSync(path.join(workspaceRoot, '.gitignore'), 'utf-8')).not.toContain(
-      WORKSPACE_LEGACY_LOCAL_STATE_IGNORE_PATTERN
-    );
-    expect(fs.readFileSync(path.join(workspaceRoot, '.gitignore'), 'utf-8')).toContain(
-      'platform.code-workspace'
-    );
+    expect(fs.existsSync(path.join(workspaceRoot, '.gitignore'))).toBe(false);
+    expect(fs.existsSync(path.join(workspaceRoot, WORKSPACE_CHANGES_DIR_NAME))).toBe(false);
     expect(fs.readFileSync(path.join(workspaceRoot, 'AGENTS.md'), 'utf-8')).toContain(
       'OpenSpec Workspace Guidance'
     );
     expect(JSON.parse(fs.readFileSync(getWorkspaceCodeWorkspacePath(workspaceRoot, 'platform'), 'utf-8')).folders).toEqual([
-      {
-        path: '.',
-      },
       {
         name: 'api',
         path: expectedApi,
@@ -201,6 +193,10 @@ describe('workspace command', () => {
       {
         name: 'checkout',
         path: expectedCheckout,
+      },
+      {
+        name: 'OpenSpec workspace',
+        path: '.',
       },
     ]);
 
@@ -386,7 +382,7 @@ describe('workspace command', () => {
     );
 
     const update = await runCLI(['workspace', 'update', '--json'], {
-      cwd: path.join(workspaceRoot, WORKSPACE_CHANGES_DIR_NAME),
+      cwd: workspaceRoot,
       env,
     });
     expect(update.exitCode).toBe(0);
@@ -447,7 +443,7 @@ describe('workspace command', () => {
     );
   });
 
-  it('redirects openspec update from a workspace planning home to workspace update', async () => {
+  it('redirects openspec update from a workspace root to workspace update', async () => {
     const api = mkdir('repos/api');
     const linkedEntriesBefore = fs.readdirSync(api).sort();
     writeGlobalConfig({
@@ -466,7 +462,7 @@ describe('workspace command', () => {
     });
 
     const update = await runCLI(['update'], {
-      cwd: path.join(workspaceRoot, WORKSPACE_CHANGES_DIR_NAME),
+      cwd: workspaceRoot,
       env,
     });
     expect(update.exitCode).toBe(0);
@@ -496,7 +492,7 @@ describe('workspace command', () => {
     });
 
     const update = await runCLI(
-      ['update', path.join(first.workspace.root, WORKSPACE_CHANGES_DIR_NAME)],
+      ['update', first.workspace.root],
       { cwd: tempDir, env }
     );
 
@@ -747,13 +743,18 @@ ${WORKSPACE_GUIDANCE_END_MARKER}
 
   it('stores non-interactive preferred openers only when --opener is provided', async () => {
     const api = mkdir('repos/api');
-    const codex = await setupWorkspace('codex-workspace', [`api=${api}`], ['--opener', 'codex']);
+    const codex = await setupWorkspace('codex-workspace', [`api=${api}`], ['--opener', 'codex-cli']);
+    const legacyCodex = await setupWorkspace('legacy-codex-workspace', [`api=${api}`], ['--opener', 'codex']);
     const editor = await setupWorkspace('editor-workspace', [`api=${api}`], ['--opener', 'editor']);
     const unset = await setupWorkspace('unset-workspace', [`api=${api}`]);
 
     expect(readWorkspaceState(codex.workspace.root).preferred_opener).toEqual({
       kind: 'agent',
-      id: 'codex',
+      id: 'codex-cli',
+    });
+    expect(readWorkspaceState(legacyCodex.workspace.root).preferred_opener).toEqual({
+      kind: 'agent',
+      id: 'codex-cli',
     });
     expect(readWorkspaceState(editor.workspace.root).preferred_opener).toEqual({
       kind: 'editor',
@@ -931,7 +932,7 @@ ${WORKSPACE_GUIDANCE_END_MARKER}
     const setup = await setupWorkspace('platform', [`api=${api}`]);
     const workspaceRoot = setup.workspace.root;
     const viewBefore = fs.readFileSync(getWorkspaceViewStatePath(workspaceRoot), 'utf-8');
-    const markerPath = path.join(workspaceRoot, WORKSPACE_CHANGES_DIR_NAME, 'sentinel.txt');
+    const markerPath = path.join(workspaceRoot, 'sentinel.txt');
     fs.writeFileSync(markerPath, 'keep me');
 
     const duplicate = await runCLI(
@@ -1265,7 +1266,6 @@ links:
   local-only: ${localOnly}
 `;
     fs.writeFileSync(getWorkspaceViewStatePath(workspaceRoot), viewState);
-    fs.rmSync(path.join(workspaceRoot, WORKSPACE_CHANGES_DIR_NAME), { recursive: true, force: true });
     expect(fs.existsSync(registryPath)).toBe(false);
 
     const doctor = await runCLI(['workspace', 'doctor', '--workspace', 'platform', '--json'], {
@@ -1431,11 +1431,12 @@ links:
     ).folders;
     expect(workspaceFolders).toEqual([
       {
-        path: '.',
-      },
-      {
         name: 'api',
         path: expectedApi,
+      },
+      {
+        name: 'OpenSpec workspace',
+        path: '.',
       },
     ]);
     const editorLaunch = readLaunchLog(code.logPath);
@@ -1447,7 +1448,7 @@ links:
     ]);
 
     const currentWorkspaceOpen = await runCLI(['workspace', 'open', '--editor', '--no-interactive'], {
-      cwd: path.join(setup.workspace.root, WORKSPACE_CHANGES_DIR_NAME),
+      cwd: setup.workspace.root,
       env: envWithFakeExecutable(code),
     });
     expect(currentWorkspaceOpen.exitCode).toBe(0);
@@ -1467,6 +1468,8 @@ links:
       fs.realpathSync.native(setup.workspace.root)
     );
     expect(codexLaunch.args).toEqual([
+      '--sandbox',
+      'workspace-write',
       '--add-dir',
       expectedApi,
       'Open this OpenSpec workspace.',
@@ -1477,7 +1480,7 @@ links:
     });
   });
 
-  it('reports workspace open selection, unsupported flag, unset opener, and unavailable opener errors', async () => {
+  it('reports workspace open selection errors', async () => {
     const api = mkdir('repos/api');
     const web = mkdir('repos/web');
 
@@ -1488,7 +1491,7 @@ links:
     expect(noKnown.exitCode).toBe(1);
     expect(noKnown.stderr).toContain("No known OpenSpec workspaces. Run 'openspec workspace setup' first.");
 
-    const platform = await setupWorkspace('platform', [`api=${api}`]);
+    await setupWorkspace('platform', [`api=${api}`]);
     await setupWorkspace('checkout-web', [`web=${web}`]);
 
     const conflict = await runCLI(
@@ -1506,13 +1509,6 @@ links:
     expect(ambiguous.exitCode).toBe(1);
     expect(ambiguous.stderr).toContain('Known workspaces: checkout-web, platform');
 
-    const unsupported = await runCLI(['workspace', 'open', '--prepare-only'], {
-      cwd: tempDir,
-      env,
-    });
-    expect(unsupported.exitCode).toBe(1);
-    expect(unsupported.stderr).toContain('future context/query surface');
-
     const jsonAmbiguous = await runCLI(['workspace', 'open', '--json'], {
       cwd: tempDir,
       env,
@@ -1523,6 +1519,15 @@ links:
         code: 'workspace_selection_ambiguous',
       })
     );
+  });
+
+  it('reports unsupported workspace open options before workspace selection', async () => {
+    const unsupported = await runCLI(['workspace', 'open', '--prepare-only'], {
+      cwd: tempDir,
+      env,
+    });
+    expect(unsupported.exitCode).toBe(1);
+    expect(unsupported.stderr).toContain('future context/query surface');
 
     const changeUnsupported = await runCLI(['workspace', 'open', '--change', 'add-api'], {
       cwd: tempDir,
@@ -1531,15 +1536,8 @@ links:
     expect(changeUnsupported.exitCode).toBe(1);
     expect(changeUnsupported.stderr).toContain('root workspace open only');
 
-    const unset = await runCLI(['workspace', 'open', 'platform', '--no-interactive'], {
-      cwd: tempDir,
-      env,
-    });
-    expect(unset.exitCode).toBe(1);
-    expect(unset.stderr).toContain('does not have a preferred opener');
-
     const openerConflict = await runCLI(
-      ['workspace', 'open', 'platform', '--agent', 'codex', '--editor', '--no-interactive'],
+      ['workspace', 'open', 'platform', '--agent', 'codex-cli', '--editor', '--no-interactive'],
       {
         cwd: tempDir,
         env,
@@ -1547,6 +1545,18 @@ links:
     );
     expect(openerConflict.exitCode).toBe(1);
     expect(openerConflict.stderr).toContain('either --agent <tool> or --editor');
+  });
+
+  it('reports unset and unavailable workspace opener errors', async () => {
+    const api = mkdir('repos/api');
+    const platform = await setupWorkspace('platform', [`api=${api}`]);
+
+    const unset = await runCLI(['workspace', 'open', 'platform', '--no-interactive'], {
+      cwd: tempDir,
+      env,
+    });
+    expect(unset.exitCode).toBe(1);
+    expect(unset.stderr).toContain('does not have a preferred opener');
 
     fs.writeFileSync(
       getWorkspaceViewStatePath(platform.workspace.root),
@@ -1589,7 +1599,6 @@ preferred_opener:
     expect(setup.stdout).not.toContain('Root:');
     expect(setup.stdout).toContain('Linked repos or folders (1):');
     expect(setup.stdout).toContain(`api -> ${expectedApi}`);
-    expect(setup.stdout).toContain('Planning path:');
     expect(setup.stdout).toContain('Workspace check:');
     expect(setup.stdout).toContain('No workspace issues found.');
     expect(setup.stdout).toContain('Next useful commands:');
@@ -1611,7 +1620,6 @@ preferred_opener:
     expect(doctor.stdout).toContain('Workspace: platform');
     expect(doctor.stdout).toContain('Location:');
     expect(doctor.stdout).not.toContain('Root:');
-    expect(doctor.stdout).toContain('Planning path:');
     expect(doctor.stdout).toContain('Linked repos or folders:');
     expect(doctor.stdout).toContain('No workspace issues found.');
   });
@@ -1656,7 +1664,7 @@ preferred_opener:
       'Install OpenSpec skills'
     );
     expect(setup?.flags?.find((flag) => flag.name === 'opener')?.values).toEqual([
-      'codex',
+      'codex-cli',
       'claude',
       'github-copilot',
       'editor',
@@ -1689,7 +1697,7 @@ preferred_opener:
       { name: 'name', optional: true },
     ]);
     expect(open?.flags?.find((flag) => flag.name === 'agent')?.values).toEqual([
-      'codex',
+      'codex-cli',
       'claude',
       'github-copilot',
     ]);

--- a/test/core/context-store/foundation.test.ts
+++ b/test/core/context-store/foundation.test.ts
@@ -13,6 +13,7 @@ import {
   getContextStoreMetadataPath,
   getContextStoreRegistryPath,
   getContextStoresDir,
+  getDefaultContextStoreRoot,
   isContextStoreRoot,
   isValidContextStoreId,
   listContextStoreRegistryEntries,
@@ -67,6 +68,9 @@ describe('context store foundation', () => {
       expect(getContextStoreRegistryPath()).toBe(
         path.join(tempDir, 'openspec', 'context-stores', 'registry.yaml')
       );
+      expect(getDefaultContextStoreRoot('acme-context')).toBe(
+        path.join(tempDir, 'openspec', 'context-stores', 'acme-context')
+      );
       expect(getContextStoreMetadataDir(storeRoot)).toBe(
         path.join(storeRoot, '.openspec-store')
       );
@@ -87,6 +91,9 @@ describe('context store foundation', () => {
       );
       expect(getContextStoreRegistryPath({ globalDataDir: dataDir })).toBe(
         '/home/tabish/.local/share/openspec/context-stores/registry.yaml'
+      );
+      expect(getDefaultContextStoreRoot('team-context', { globalDataDir: dataDir })).toBe(
+        '/home/tabish/.local/share/openspec/context-stores/team-context'
       );
     });
 

--- a/test/core/workspace/foundation.test.ts
+++ b/test/core/workspace/foundation.test.ts
@@ -149,7 +149,7 @@ links: {}
       );
     });
 
-    it('does not add portable collaboration ignore rules for local workspace files', () => {
+    it('keeps legacy portable ignore helper as an empty compatibility shim', () => {
       expect(getWorkspacePortableIgnorePatterns()).toEqual([]);
       expect(getWorkspacePortableIgnorePatterns('platform')).toEqual([]);
     });
@@ -513,7 +513,7 @@ After block.
       expect(fs.existsSync(path.join(workspaceRoot, '.gitignore'))).toBe(false);
     });
 
-    it('removes the legacy generated code-workspace ignore rule without touching user rules', async () => {
+    it('leaves legacy code-workspace ignore rules when .gitignore has user rules', async () => {
       const workspaceRoot = createWorkspaceRoot();
       fs.writeFileSync(
         path.join(workspaceRoot, '.gitignore'),
@@ -529,7 +529,7 @@ After block.
       await syncWorkspaceOpenSurface(workspaceRoot, workspaceState);
 
       expect(fs.readFileSync(path.join(workspaceRoot, '.gitignore'), 'utf-8')).toBe(
-        '*.code-workspace\n'
+        '*.code-workspace\nplatform.code-workspace\n'
       );
     });
 

--- a/test/core/workspace/foundation.test.ts
+++ b/test/core/workspace/foundation.test.ts
@@ -149,11 +149,9 @@ links: {}
       );
     });
 
-    it('exposes the portable collaboration ignore rule for local state', () => {
+    it('does not add portable collaboration ignore rules for local workspace files', () => {
       expect(getWorkspacePortableIgnorePatterns()).toEqual([]);
-      expect(getWorkspacePortableIgnorePatterns('platform')).toEqual([
-        'platform.code-workspace',
-      ]);
+      expect(getWorkspacePortableIgnorePatterns('platform')).toEqual([]);
     });
   });
 
@@ -334,7 +332,7 @@ preferred_opener:
 
       expect(state.preferred_opener).toEqual({
         kind: 'agent',
-        id: 'codex',
+        id: 'codex-cli',
       });
       expect(parseWorkspaceViewState(serializeWorkspaceViewState(state))).toEqual(state);
       expect(parseWorkspacePreferredOpenerValue('editor')).toEqual({
@@ -344,6 +342,10 @@ preferred_opener:
       expect(parseWorkspacePreferredOpenerValue('github-copilot')).toEqual({
         kind: 'agent',
         id: 'github-copilot',
+      });
+      expect(parseWorkspacePreferredOpenerValue('codex')).toEqual({
+        kind: 'agent',
+        id: 'codex-cli',
       });
     });
 
@@ -439,7 +441,7 @@ After block.
       );
     });
 
-    it('builds VS Code workspace content with stable root and linked paths', () => {
+    it('builds VS Code workspace content with linked paths before workspace files', () => {
       const content = buildWorkspaceCodeWorkspaceContent([
         {
           name: 'api',
@@ -454,9 +456,6 @@ After block.
 
       expect(payload.folders).toEqual([
         {
-          path: '.',
-        },
-        {
           name: 'api',
           path: '/repos/api',
         },
@@ -464,16 +463,19 @@ After block.
           name: 'windows',
           path: 'D:\\repos\\web',
         },
+        {
+          name: 'OpenSpec workspace',
+          path: '.',
+        },
       ]);
     });
 
-    it('syncs AGENTS, the maintained code-workspace file, and scoped ignore rules', async () => {
+    it('syncs AGENTS and the maintained code-workspace file without creating repo-shaped files', async () => {
       const workspaceRoot = createWorkspaceRoot();
       const api = path.join(tempDir, 'api');
       const missing = path.join(tempDir, 'missing');
       fs.mkdirSync(api, { recursive: true });
       fs.writeFileSync(path.join(workspaceRoot, 'AGENTS.md'), '# Existing\n');
-      fs.writeFileSync(path.join(workspaceRoot, '.gitignore'), '*.code-workspace\n');
       const workspaceState = {
         version: 1 as const,
         name: 'platform',
@@ -500,16 +502,50 @@ After block.
       );
       expect(JSON.parse(fs.readFileSync(getWorkspaceCodeWorkspacePath(workspaceRoot, 'platform'), 'utf-8')).folders).toEqual([
         {
-          path: '.',
-        },
-        {
           name: 'api',
           path: api,
         },
+        {
+          name: 'OpenSpec workspace',
+          path: '.',
+        },
       ]);
-      expect(fs.readFileSync(path.join(workspaceRoot, '.gitignore'), 'utf-8')).toContain(
+      expect(fs.existsSync(path.join(workspaceRoot, '.gitignore'))).toBe(false);
+    });
+
+    it('removes the legacy generated code-workspace ignore rule without touching user rules', async () => {
+      const workspaceRoot = createWorkspaceRoot();
+      fs.writeFileSync(
+        path.join(workspaceRoot, '.gitignore'),
         '*.code-workspace\nplatform.code-workspace\n'
       );
+      const workspaceState = {
+        version: 1 as const,
+        name: 'platform',
+        context: null,
+        links: {},
+      };
+
+      await syncWorkspaceOpenSurface(workspaceRoot, workspaceState);
+
+      expect(fs.readFileSync(path.join(workspaceRoot, '.gitignore'), 'utf-8')).toBe(
+        '*.code-workspace\n'
+      );
+    });
+
+    it('deletes the legacy generated .gitignore when it has no user rules', async () => {
+      const workspaceRoot = createWorkspaceRoot();
+      fs.writeFileSync(path.join(workspaceRoot, '.gitignore'), 'platform.code-workspace\n');
+      const workspaceState = {
+        version: 1 as const,
+        name: 'platform',
+        context: null,
+        links: {},
+      };
+
+      await syncWorkspaceOpenSurface(workspaceRoot, workspaceState);
+
+      expect(fs.existsSync(path.join(workspaceRoot, '.gitignore'))).toBe(false);
     });
   });
 
@@ -533,7 +569,7 @@ After block.
         'editor',
         'github-copilot',
       ]);
-      expect(choices.find((choice) => choice.value === 'codex')?.unavailableNote).toContain(
+      expect(choices.find((choice) => choice.value === 'codex-cli')?.unavailableNote).toContain(
         'codex not found on PATH'
       );
     });

--- a/test/core/workspace/legacy-state.test.ts
+++ b/test/core/workspace/legacy-state.test.ts
@@ -122,7 +122,7 @@ preferred_opener:
 `);
     expect(codexState.preferred_opener).toEqual({
       kind: 'agent',
-      id: 'codex',
+      id: 'codex-cli',
     });
     expect(parseWorkspaceLocalState(serializeWorkspaceLocalState(codexState))).toEqual(
       codexState

--- a/test/helpers/path-env.ts
+++ b/test/helpers/path-env.ts
@@ -1,0 +1,26 @@
+import * as path from 'node:path';
+
+export function pathEnvKey(env: NodeJS.ProcessEnv = process.env): string {
+  return Object.keys(env).find((key) => key.toLowerCase() === 'path') ?? 'PATH';
+}
+
+export function setProcessPathEnv(value: string): void {
+  process.env[pathEnvKey()] = value;
+}
+
+export function prependProcessPathEnv(dir: string): void {
+  const key = pathEnvKey();
+  process.env[key] = prependPathValue(dir, process.env[key]);
+}
+
+export function withPrependedPathEnv(baseEnv: NodeJS.ProcessEnv, dir: string): NodeJS.ProcessEnv {
+  const key = pathEnvKey({ ...process.env, ...baseEnv });
+  return {
+    ...baseEnv,
+    [key]: prependPathValue(dir, baseEnv[key] ?? process.env[key]),
+  };
+}
+
+function prependPathValue(dir: string, currentPath: string | undefined): string {
+  return currentPath ? `${dir}${path.delimiter}${currentPath}` : dir;
+}


### PR DESCRIPTION
## Summary

- Move context-store setup defaults into managed local storage and document the beta first-run path.
- Make `workspace open` initiative-aware, including lazy workspace creation, linked repo prompts, clearer opener behavior, and Codex CLI sandbox handling.
- Clean up generated workspace shape so workspaces are local views, not repo-like planning homes.
- Add beta guide/playbook docs plus manual beta pass work items and reordered follow-up roadmap items.

## Why

The manual beta pass exposed first-run friction around where context stores are created, how users discover initiatives from `workspace open`, how Codex receives writable roots, and whether workspaces appear to own durable planning artifacts. This keeps the beta flow oriented around context stores/initiatives as shared context and workspaces as local views.

## Validation

- `pnpm run build`
- `pnpm run lint`
- `pnpm exec vitest run test/commands/context-store.test.ts test/commands/workspace.interactive.test.ts test/commands/workspace-initiative-open.test.ts test/commands/workspace-open.test.ts test/commands/workspace.test.ts test/core/context-store/foundation.test.ts test/core/workspace/foundation.test.ts test/core/workspace/legacy-state.test.ts test/core/planning-home.test.ts test/commands/artifact-workflow.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * CLI docs now use the codex-cli identifier; VS Code workspace ordering/behavior and context-store defaults clarified; many beta guides, playbooks, roadmap and work-item docs added/updated.

* **New Features**
  * Initiative-backed workspace open flow and initiative selection in the open picker; created local initiative-backed workspace views.
  * Context-store setup defaults to an OpenSpec-managed global data location.

* **Chores / Tests**
  * Workspace setup/open prompting and opener selection refactored; extensive test updates to match new behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->