### PR TITLE
Improve context-store setup and cleanup UX

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -54,6 +54,10 @@ These commands support `--json` output for programmatic use by AI agents and scr
 | `openspec workspace relink` | Repair a linked path | `--json` for structured link output |
 | `openspec workspace doctor` | Check one workspace | `--json` for structured status output |
 | `openspec workspace update` | Refresh workspace-local guidance and agent skills | `--tools` selects agents; profile selects workflows |
+| `openspec context-store setup <id>` | Create a local context store | `--json` with explicit inputs for structured setup output |
+| `openspec context-store register <path>` | Register an existing context store | `--json` for structured registration output |
+| `openspec context-store unregister <id>` | Forget a local context-store registration | `--json` for structured cleanup output |
+| `openspec context-store remove <id>` | Delete a registered local context-store folder | `--yes --json` for non-interactive deletion |
 | `openspec context-store list` | Browse registered context stores | `--json` for structured registrations |
 | `openspec context-store doctor` | Check local store setup | `--json` for structured diagnostics |
 | `openspec initiative list` | Browse shared initiatives | `--json` for structured initiative records |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -8,7 +8,7 @@ The OpenSpec CLI (`openspec`) provides terminal commands for project setup, vali
 |----------|----------|---------|
 | **Setup** | `init`, `update` | Initialize and update OpenSpec in your project |
 | **Workspaces (beta)** | `workspace setup`, `workspace list`, `workspace ls`, `workspace link`, `workspace relink`, `workspace doctor`, `workspace update`, `workspace open` | Set up local views over linked repos or folders |
-| **Shared context (beta)** | `context-store setup`, `context-store register`, `context-store list`, `context-store doctor`, `initiative create`, `initiative show`, `initiative list` | Manage local context-store registrations and durable initiative context |
+| **Shared context (beta)** | `context-store setup`, `context-store register`, `context-store unregister`, `context-store remove`, `context-store list`, `context-store doctor`, `initiative create`, `initiative show`, `initiative list` | Manage local context-store registrations and durable initiative context |
 | **Browsing** | `list`, `view`, `show` | Explore changes and specs |
 | **Validation** | `validate` | Check changes and specs for issues |
 | **Lifecycle** | `archive` | Finalize completed changes |
@@ -354,7 +354,9 @@ Context stores and initiatives are beta coordination surfaces. A context store i
 
 ### `openspec context-store setup`
 
-Create and register a local context store.
+Create and register a local context store. With no arguments in a terminal,
+OpenSpec guides the user through setup. Agents and scripts should pass explicit
+inputs and use `--json`.
 
 ```bash
 openspec context-store setup [id] [options]
@@ -374,6 +376,7 @@ When `--path` is omitted, setup creates the store under `getGlobalDataDir()/cont
 Examples:
 
 ```bash
+openspec context-store setup
 openspec context-store setup team-context
 openspec context-store setup team-context --path /repos/team-context --no-init-git
 openspec context-store setup team-context --json --no-init-git
@@ -393,6 +396,30 @@ openspec context-store register [path] [options]
 |--------|-------------|
 | `--id <id>` | Context store id; defaults to store metadata or folder name |
 | `--json` | Output JSON |
+
+### `openspec context-store unregister`
+
+Forget a local context-store registration without deleting files.
+
+```bash
+openspec context-store unregister <id> [--json]
+```
+
+Use this when a store was moved, cloned somewhere else, or should no longer be
+shown by OpenSpec on this machine.
+
+### `openspec context-store remove`
+
+Forget a local context-store registration and delete its local folder.
+
+```bash
+openspec context-store remove <id> [--yes] [--json]
+```
+
+`remove` shows the exact folder before deleting in an interactive terminal.
+Agents, scripts, and JSON callers must pass `--yes` to confirm deletion.
+OpenSpec refuses to delete a folder that does not contain matching
+context-store metadata.
 
 ### `openspec context-store list`
 

--- a/docs/workspaces-beta/agent-cli-playbook.md
+++ b/docs/workspaces-beta/agent-cli-playbook.md
@@ -19,6 +19,20 @@ local view. Use `workspace doctor --json` to read linked repos/folders and the
 selected initiative. Do not assume the current directory is the repo that should
 own implementation artifacts.
 
+## Set Up Context Stores Non-Interactively
+
+Humans can run `openspec context-store setup` and answer prompts. Agents should
+pass the setup inputs explicitly.
+
+```bash
+openspec context-store setup team-context --no-init-git --json
+openspec context-store setup team-context --path /path/to/team-context --init-git --json
+```
+
+Use `context-store unregister <id> --json` to forget a local registration while
+leaving files alone. Use `context-store remove <id> --yes --json` only when the
+user explicitly asks to delete the local context-store folder.
+
 ## Create Initiatives In Context Stores
 
 Create shared coordination context in a context store.

--- a/docs/workspaces-beta/user-guide.md
+++ b/docs/workspaces-beta/user-guide.md
@@ -6,12 +6,12 @@ manages the OpenSpec work.
 ## 1. Create The Shared Place
 
 ```bash
-openspec context-store setup team-context --init-git
+openspec context-store setup
 ```
 
-This creates a local context store. Add `--path <folder>` if you want it
-somewhere specific; otherwise OpenSpec keeps it in its managed local data
-directory.
+OpenSpec asks for the context store name, where to put it, and whether to
+initialize Git. Press Enter for the managed local data directory unless you
+want the store somewhere specific.
 
 ## 2. Ask Your Agent To Create The Initiative
 

--- a/openspec/initiatives/context-store-and-initiatives/tasks.md
+++ b/openspec/initiatives/context-store-and-initiatives/tasks.md
@@ -187,13 +187,13 @@ Work item: `work-items/11-manual-beta-reality-pass/`
 
 Work item: `work-items/12-context-store-first-run-and-cleanup-ux/`
 
-- [ ] Decide and implement interactive no-argument `context-store setup`.
-- [ ] Define target-path safety behavior for managed defaults, explicit paths,
+- [x] Decide and implement interactive no-argument `context-store setup`.
+- [x] Define target-path safety behavior for managed defaults, explicit paths,
   Git repos, and non-empty directories.
-- [ ] Add local cleanup support for unregistering or removing a context store.
-- [ ] Make setup and cleanup output report store root, registry state, Git
-  state, created files, and next commands.
-- [ ] Update docs and tests for first-run setup and cleanup behavior.
+- [x] Add local cleanup support for unregistering or removing a context store.
+- [x] Make setup and cleanup output report the agreed human-facing summary and
+  exact JSON state without workflow `next_commands`.
+- [x] Update docs and tests for first-run setup and cleanup behavior.
 
 ## 13. Agent Handoff Output And Delivery Polish
 

--- a/openspec/initiatives/context-store-and-initiatives/work-items/12-context-store-first-run-and-cleanup-ux/evidence.md
+++ b/openspec/initiatives/context-store-and-initiatives/work-items/12-context-store-first-run-and-cleanup-ux/evidence.md
@@ -21,3 +21,25 @@ Keep context-store first-run UX small and local:
 - never push, pull, commit, create remotes, or delete files implicitly;
 - keep JSON output explicit enough for agents to continue safely;
 - leave team sync policy to the later shared-coordination hardening work.
+
+## Implementation Result
+
+- `openspec context-store setup` now runs a guided setup in interactive
+  terminals when no id is provided.
+- Non-interactive and `--json` setup require explicit inputs and fail with a
+  structured setup-id diagnostic when the id is missing.
+- Explicit setup paths inside another Git repository are blocked
+  non-interactively and require explicit confirmation interactively.
+- `context-store unregister <id>` removes only the local registry entry.
+- `context-store remove <id>` removes the local registry entry and deletes the
+  local folder only after confirmation or `--yes`; it refuses to delete folders
+  without matching context-store metadata.
+- Human success output is intentionally compact; JSON output carries exact
+  registry, file, and Git state without `next_commands`.
+
+Verification:
+
+- `pnpm build`
+- `pnpm lint`
+- `pnpm vitest run test/commands/context-store.test.ts test/core/context-store/registry.test.ts`
+- `pnpm test`

--- a/openspec/initiatives/context-store-and-initiatives/work-items/12-context-store-first-run-and-cleanup-ux/plan.md
+++ b/openspec/initiatives/context-store-and-initiatives/work-items/12-context-store-first-run-and-cleanup-ux/plan.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed from the manual beta reality pass.
+Implemented.
 
 This work item covers the context-store setup and cleanup gaps that were not
 fully captured by later docs, schema, or handoff work.
@@ -43,8 +43,8 @@ stores as normal local workflow.
 - Make the target store path explicit before creation.
 - Provide a supported local cleanup command for removing or unregistering a
   context store from this machine.
-- Explain the Git/stage/commit state after initializing a shared store, without
-  pushing, committing, or creating remotes automatically.
+- Keep Git setup limited to optional local initialization, without staging,
+  committing, pushing, creating remotes, or choosing team workflow.
 
 ## Non-Goals
 
@@ -54,6 +54,42 @@ stores as normal local workflow.
 - Do not make context stores implementation repos.
 
 ## UX Direction
+
+Locked decisions from the product pass:
+
+- `openspec context-store setup` with no arguments should start a guided setup
+  when run in an interactive terminal. Agents, scripts, CI, and `--json` callers
+  should pass the equivalent explicit inputs instead of relying on prompts.
+- The guided setup should ask only for values that map to existing setup flags:
+  context store id, context store path, and whether to initialize Git.
+- User-facing prompt copy should stay direct:
+  `Context store name`, `Where should this context store live?`,
+  `Initialize Git in this context store?`, then a final
+  `Create this context store?` confirmation after showing the resolved summary.
+- The default location should be the managed OpenSpec context-store directory,
+  not the current working directory. Users can still choose any explicit safe
+  local path; OpenSpec stores that machine-local path in the local registry, not
+  in shared context-store metadata.
+- Setup should be protective around risky paths: create missing paths, accept
+  empty directories, treat matching context-store metadata as idempotent, stop
+  on metadata/id conflicts, stop on files, and stop or explicitly warn before
+  using a non-empty unmarked directory or a path inside another Git repository.
+- Cleanup should expose two explicit intents: `context-store unregister <id>`
+  forgets the machine-local registry entry and leaves files alone, while
+  `context-store remove <id>` unregisters the store and deletes the local folder
+  only after showing the exact path and receiving confirmation.
+- Happy-path human output should stay small: show the context store id, its
+  location, and the next user-facing step. Do not show Git state, metadata
+  paths, registry paths, or created-file lists unless there is a warning,
+  failure, `--json`, or `context-store doctor` output.
+- JSON output should report exact resulting state, not workflow guidance. Include
+  ids, roots, metadata paths, registry state, Git facts, created/deleted files,
+  and warnings/errors where present, but do not include `next_commands`. Empty
+  `status: []` can be preserved where existing JSON compatibility needs it, but
+  new behavior should not rely on blank status arrays for meaning.
+- Git initialization is an optional local convenience only. When requested,
+  OpenSpec may run `git init`, but it must not stage, commit, push, create
+  remotes, create branches, or define team Git policy.
 
 Interactive setup should cover the minimum choices:
 
@@ -75,14 +111,14 @@ openspec context-store unregister team-context
 openspec context-store remove team-context
 ```
 
-The exact command names are open, but the user intent must be explicit:
+The command names are explicit because the user intents are different:
 
 - forget this local registry entry only
 - delete this local context-store folder too
 
-If a Git-backed context store was initialized, setup output should say that the
-store now has uncommitted files and that the user or agent should review,
-stage, commit, and push according to their team's normal Git workflow.
+If Git initialization fails, setup should explain that the user can install Git
+or rerun setup without Git. Successful Git initialization stays out of the
+happy-path human output.
 
 ## Agent / JSON Contract
 
@@ -94,8 +130,6 @@ JSON setup output should report:
 - whether Git was initialized
 - whether files were created or already existed
 - local registry path or registry entry identity
-- next commands for listing, doctor, and initiative creation
-- advisory Git status summary when available
 
 JSON cleanup output should report:
 

--- a/openspec/initiatives/context-store-and-initiatives/work-items/12-context-store-first-run-and-cleanup-ux/tasks.md
+++ b/openspec/initiatives/context-store-and-initiatives/work-items/12-context-store-first-run-and-cleanup-ux/tasks.md
@@ -1,24 +1,23 @@
 # Context Store First-Run And Cleanup UX Tasks
 
-- [ ] Decide exact no-argument `context-store setup` behavior for TTY,
+- [x] Decide exact no-argument `context-store setup` behavior for TTY,
       non-TTY, and `--json` invocations.
-- [ ] Design the interactive setup prompts for store id, target path, and Git
+- [x] Design the interactive setup prompts for store id, target path, and Git
       initialization.
-- [ ] Define target-path safety behavior for managed defaults, explicit paths,
+- [x] Define target-path safety behavior for managed defaults, explicit paths,
       paths inside existing Git repos, and non-empty directories.
-- [ ] Implement the interactive setup flow without changing deterministic
+- [x] Implement the interactive setup flow without changing deterministic
       non-interactive behavior.
-- [ ] Decide whether the cleanup surface is `unregister`, `remove`, or both.
-- [ ] Define cleanup semantics for "forget local registration" versus "delete
+- [x] Decide whether the cleanup surface is `unregister`, `remove`, or both.
+- [x] Define cleanup semantics for "forget local registration" versus "delete
       local files too".
-- [ ] Implement local registry cleanup with explicit confirmation before file
+- [x] Implement local registry cleanup with explicit confirmation before file
       deletion.
-- [ ] Add human and JSON output that reports store root, metadata path, registry
-      state, created files, and next commands.
-- [ ] Add setup guidance for initialized Git stores that explains uncommitted
-      shared files without auto-staging, committing, pushing, or creating a
-      remote.
-- [ ] Add focused tests for setup prompts, non-interactive failures, path
+- [x] Add human output that stays small and JSON output that reports exact setup
+      and cleanup state without `next_commands`.
+- [x] Keep Git initialization scoped to local `git init` with no auto-staging,
+      committing, pushing, remote creation, or team policy.
+- [x] Add focused tests for setup prompts, non-interactive failures, path
       safety, registry cleanup, and JSON output.
-- [ ] Update beta docs and agent playbook references for first-run setup and
+- [x] Update beta docs and agent playbook references for first-run setup and
       cleanup.

--- a/src/commands/context-store.ts
+++ b/src/commands/context-store.ts
@@ -1,18 +1,27 @@
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { Command } from 'commander';
 
 import {
   ContextStoreError,
   doctorContextStores,
+  getDefaultContextStoreRoot,
   listContextStores,
   prepareContextStoreSetup,
+  prepareContextStoreCleanup,
   registerExistingContextStore,
+  removeContextStore,
   setupPreparedContextStore,
+  unregisterContextStore,
+  validateContextStoreId,
+  type ContextStoreCleanupResult,
   type ContextStoreDiagnostic,
   type ContextStoreDoctorResult,
   type ContextStoreInfo,
   type ContextStoreInspection,
   type ContextStoreListResult,
   type ContextStoreMutationResult,
+  type SetupContextStoreInput,
 } from '../core/context-store/index.js';
 import { isInteractive } from '../utils/interactive.js';
 
@@ -27,8 +36,17 @@ interface ContextStoreRegisterOptions {
   json?: boolean;
 }
 
+interface ContextStoreRemoveOptions {
+  yes?: boolean;
+  json?: boolean;
+}
+
 interface ContextStoreJsonOptions {
   json?: boolean;
+}
+
+interface ResolvedContextStoreSetupInput extends SetupContextStoreInput {
+  id: string;
 }
 
 interface ContextStoreOutput {
@@ -48,6 +66,20 @@ interface ContextStoreMutationOutput {
     initialized: boolean;
   } | null;
   created_files: string[];
+  status: ContextStoreDiagnostic[];
+}
+
+interface ContextStoreCleanupOutput {
+  context_store: ContextStoreOutput | null;
+  registry: {
+    path: string;
+    removed: boolean;
+  } | null;
+  files: {
+    deleted: boolean;
+    deleted_path: string | null;
+    left_on_disk: string | null;
+  } | null;
   status: ContextStoreDiagnostic[];
 }
 
@@ -111,6 +143,22 @@ function toMutationOutput(result: ContextStoreMutationResult): ContextStoreMutat
   };
 }
 
+function toCleanupOutput(result: ContextStoreCleanupResult): ContextStoreCleanupOutput {
+  return {
+    context_store: toStoreOutput(result.store),
+    registry: {
+      path: result.registryCommit.path,
+      removed: result.registryCommit.removed,
+    },
+    files: {
+      deleted: result.files.deleted,
+      deleted_path: result.files.deletedPath ?? null,
+      left_on_disk: result.files.leftOnDisk ?? null,
+    },
+    status: result.diagnostics,
+  };
+}
+
 function toListOutput(result: ContextStoreListResult): ContextStoreListOutput {
   return {
     context_stores: result.stores.map(toStoreOutput),
@@ -168,15 +216,184 @@ async function shouldInitializeGit(options: ContextStoreSetupOptions): Promise<b
 
   const { confirm } = await import('@inquirer/prompts');
   return confirm({
-    message: 'Initialize Git repository?',
+    message: 'Initialize Git in this context store?',
     default: true,
   });
 }
 
-function formatGitHuman(git: ContextStoreMutationOutput['git']): string {
-  if (!git) return 'unknown';
-  if (git.initialized) return 'initialized';
-  return git.is_repository ? 'repository detected' : 'not initialized';
+function formatPathForHuman(targetPath: string): string {
+  const home = os.homedir();
+  const normalizedHome = path.resolve(home);
+  const normalizedTarget = path.resolve(targetPath);
+
+  if (normalizedTarget === normalizedHome) return '~';
+  if (normalizedTarget.startsWith(`${normalizedHome}${path.sep}`)) {
+    return `~${path.sep}${path.relative(normalizedHome, normalizedTarget)}`;
+  }
+
+  return targetPath;
+}
+
+async function promptContextStoreId(): Promise<string> {
+  const { input } = await import('@inquirer/prompts');
+
+  return input({
+    message: 'Context store name',
+    required: true,
+    validate(value: string) {
+      try {
+        validateContextStoreId(value);
+        return true;
+      } catch (error) {
+        return asErrorMessage(error);
+      }
+    },
+  });
+}
+
+async function promptContextStorePath(id: string): Promise<string> {
+  const { input } = await import('@inquirer/prompts');
+  const defaultPath = getDefaultContextStoreRoot(id);
+
+  return input({
+    message: 'Where should this context store live?',
+    default: defaultPath,
+    prefill: 'editable',
+    required: true,
+  });
+}
+
+function isSetupInsideGitRepositoryError(error: unknown): boolean {
+  return (
+    error instanceof ContextStoreError &&
+    error.diagnostic.code === 'context_store_setup_inside_git_repo'
+  );
+}
+
+async function resolveSetupInput(
+  id: string | undefined,
+  options: ContextStoreSetupOptions
+): Promise<ResolvedContextStoreSetupInput> {
+  const interactive = !options.json && isInteractive();
+
+  if (!id && !interactive) {
+    throw new ContextStoreError(
+      'Pass a context store name.',
+      'context_store_setup_id_required',
+      {
+        target: 'context_store.id',
+        fix: 'openspec context-store setup <id> --path /path/to/context-store --json',
+      }
+    );
+  }
+
+  const resolvedId = id ? validateContextStoreId(id) : await promptContextStoreId();
+  const promptedPath = !id && options.path === undefined
+    ? await promptContextStorePath(resolvedId)
+    : undefined;
+
+  return {
+    id: resolvedId,
+    path: options.path ?? promptedPath,
+  };
+}
+
+async function prepareSetupInput(
+  input: ResolvedContextStoreSetupInput,
+  options: ContextStoreSetupOptions
+) {
+  try {
+    return await prepareContextStoreSetup(input);
+  } catch (error) {
+    if (!isSetupInsideGitRepositoryError(error) || options.json || !isInteractive()) {
+      throw error;
+    }
+
+    const { confirm } = await import('@inquirer/prompts');
+    const shouldContinue = await confirm({
+      message: `${asErrorMessage(error)}. Use this location anyway?`,
+      default: false,
+    });
+
+    if (!shouldContinue) {
+      throw new ContextStoreError(
+        'Context store setup cancelled.',
+        'context_store_setup_cancelled',
+        {
+          target: 'context_store.root',
+          fix: 'Choose another path or rerun setup later.',
+        }
+      );
+    }
+
+    return prepareContextStoreSetup({
+      ...input,
+      allowInsideGitRepository: true,
+    });
+  }
+}
+
+async function confirmSetup(
+  prepared: Awaited<ReturnType<typeof prepareContextStoreSetup>>,
+  initGit: boolean
+): Promise<void> {
+  const { confirm } = await import('@inquirer/prompts');
+
+  console.log('');
+  console.log('OpenSpec will create:');
+  console.log('');
+  console.log(`  Context store: ${prepared.id}`);
+  console.log(`  Location: ${formatPathForHuman(prepared.root)}`);
+  console.log(`  Git: ${initGit ? 'initialized' : 'not initialized'}`);
+  console.log('');
+
+  const confirmed = await confirm({
+    message: 'Create this context store?',
+    default: true,
+  });
+
+  if (!confirmed) {
+    throw new ContextStoreError(
+      'Context store setup cancelled.',
+      'context_store_setup_cancelled',
+      {
+        target: 'context_store.root',
+        fix: 'Rerun setup when you are ready.',
+      }
+    );
+  }
+}
+
+async function confirmRemove(id: string, root: string, options: ContextStoreRemoveOptions): Promise<void> {
+  if (options.yes) return;
+
+  if (options.json || !isInteractive()) {
+    throw new ContextStoreError(
+      'Pass --yes to delete context-store files non-interactively.',
+      'context_store_remove_confirmation_required',
+      {
+        target: 'context_store.root',
+        fix: `openspec context-store remove ${id} --yes`,
+      }
+    );
+  }
+
+  const { confirm } = await import('@inquirer/prompts');
+  const confirmed = await confirm({
+    message: `Delete local context-store folder ${formatPathForHuman(root)}?`,
+    default: false,
+  });
+
+  if (!confirmed) {
+    throw new ContextStoreError(
+      'Context store remove cancelled.',
+      'context_store_remove_cancelled',
+      {
+        target: 'context_store.root',
+        fix: 'Run context-store unregister if you only want to forget the local registration.',
+      }
+    );
+  }
 }
 
 function printMutationHuman(title: string, payload: ContextStoreMutationOutput): void {
@@ -184,13 +401,30 @@ function printMutationHuman(title: string, payload: ContextStoreMutationOutput):
     return;
   }
 
-  console.log(title);
+  console.log(`${title}: ${payload.context_store.id}`);
+  console.log(`Location: ${formatPathForHuman(payload.context_store.root)}`);
   console.log('');
-  console.log(`ID: ${payload.context_store.id}`);
-  console.log(`Location: ${payload.context_store.root}`);
-  console.log(`Metadata: ${payload.context_store.metadata_path}`);
-  console.log(`Registry: ${payload.registry.path}`);
-  console.log(`Git: ${formatGitHuman(payload.git)}`);
+  console.log(`Next: ask your agent to create an initiative in ${payload.context_store.id}.`);
+}
+
+function printCleanupHuman(title: string, payload: ContextStoreCleanupOutput): void {
+  if (!payload.context_store || !payload.registry || !payload.files) {
+    return;
+  }
+
+  console.log(`${title}: ${payload.context_store.id}`);
+
+  if (payload.files.deleted_path) {
+    console.log(`Deleted: ${formatPathForHuman(payload.files.deleted_path)}`);
+  } else if (payload.files.left_on_disk) {
+    console.log(`Files kept at: ${formatPathForHuman(payload.files.left_on_disk)}`);
+  } else if (!payload.files.deleted) {
+    console.log(`Files were already missing: ${formatPathForHuman(payload.context_store.root)}`);
+  }
+
+  for (const status of payload.status) {
+    console.log(`${status.severity === 'warning' ? 'Note' : 'Issue'}: ${status.message}`);
+  }
 }
 
 function printListHuman(payload: ContextStoreListOutput): void {
@@ -255,11 +489,12 @@ function printDoctorHuman(payload: ContextStoreDoctorOutput): void {
 class ContextStoreCommand {
   async setup(id: string | undefined, options: ContextStoreSetupOptions = {}): Promise<void> {
     try {
-      const prepared = await prepareContextStoreSetup({
-        id,
-        path: options.path,
-      });
+      const setupInput = await resolveSetupInput(id, options);
+      const prepared = await prepareSetupInput(setupInput, options);
       const initGit = await shouldInitializeGit(options);
+      if (!options.json && isInteractive()) {
+        await confirmSetup(prepared, initGit);
+      }
       const payload = toMutationOutput(await setupPreparedContextStore(prepared, {
         initGit,
       }));
@@ -269,7 +504,7 @@ class ContextStoreCommand {
         return;
       }
 
-      printMutationHuman('Context store setup complete', payload);
+      printMutationHuman('Context store ready', payload);
     } catch (error) {
       this.handleFailure(
         options.json,
@@ -296,6 +531,46 @@ class ContextStoreCommand {
       this.handleFailure(
         options.json,
         { context_store: null, registry: null, git: null, created_files: [], status: [] },
+        error
+      );
+    }
+  }
+
+  async unregister(id: string, options: ContextStoreJsonOptions = {}): Promise<void> {
+    try {
+      const payload = toCleanupOutput(await unregisterContextStore({ id }));
+
+      if (options.json) {
+        printJson(payload);
+        return;
+      }
+
+      printCleanupHuman('Unregistered context store', payload);
+    } catch (error) {
+      this.handleFailure(
+        options.json,
+        { context_store: null, registry: null, files: null, status: [] },
+        error
+      );
+    }
+  }
+
+  async remove(id: string, options: ContextStoreRemoveOptions = {}): Promise<void> {
+    try {
+      const target = await prepareContextStoreCleanup({ id });
+      await confirmRemove(target.id, target.root, options);
+      const payload = toCleanupOutput(await removeContextStore(target));
+
+      if (options.json) {
+        printJson(payload);
+        return;
+      }
+
+      printCleanupHuman('Removed context store', payload);
+    } catch (error) {
+      this.handleFailure(
+        options.json,
+        { context_store: null, registry: null, files: null, status: [] },
         error
       );
     }
@@ -381,6 +656,23 @@ export function registerContextStoreCommand(program: Command): void {
     .option('--json', 'Output as JSON')
     .action(async (inputPath: string | undefined, options: ContextStoreRegisterOptions) => {
       await contextStoreCommand.register(inputPath, options);
+    });
+
+  contextStore
+    .command('unregister <id>')
+    .description('Forget a local context-store registration without deleting files')
+    .option('--json', 'Output as JSON')
+    .action(async (id: string, options: ContextStoreJsonOptions) => {
+      await contextStoreCommand.unregister(id, options);
+    });
+
+  contextStore
+    .command('remove <id>')
+    .description('Forget a local context-store registration and delete its local folder')
+    .option('--yes', 'Confirm local context-store folder deletion')
+    .option('--json', 'Output as JSON')
+    .action(async (id: string, options: ContextStoreRemoveOptions) => {
+      await contextStoreCommand.remove(id, options);
     });
 
   contextStore

--- a/src/core/completions/command-registry.ts
+++ b/src/core/completions/command-registry.ts
@@ -498,6 +498,28 @@ export const COMMAND_REGISTRY: CommandDefinition[] = [
         ],
       },
       {
+        name: 'unregister',
+        description: 'Forget a local context-store registration without deleting files',
+        acceptsPositional: true,
+        positionals: [{ name: 'id' }],
+        flags: [
+          COMMON_FLAGS.json,
+        ],
+      },
+      {
+        name: 'remove',
+        description: 'Forget a local context-store registration and delete its local folder',
+        acceptsPositional: true,
+        positionals: [{ name: 'id' }],
+        flags: [
+          {
+            name: 'yes',
+            description: 'Confirm local context-store folder deletion',
+          },
+          COMMON_FLAGS.json,
+        ],
+      },
+      {
         name: 'list',
         description: 'List registered context stores',
         flags: [

--- a/src/core/context-store/foundation.ts
+++ b/src/core/context-store/foundation.ts
@@ -401,7 +401,9 @@ async function acquireContextStoreRegistryLock(
 }
 
 export async function updateContextStoreRegistryState(
-  updater: (state: ContextStoreRegistryState | null) => ContextStoreRegistryState,
+  updater: (
+    state: ContextStoreRegistryState | null
+  ) => ContextStoreRegistryState | Promise<ContextStoreRegistryState>,
   options: ContextStorePathOptions = {}
 ): Promise<ContextStoreRegistryState> {
   const registryPath = getContextStoreRegistryPath(options);
@@ -409,7 +411,7 @@ export async function updateContextStoreRegistryState(
   const lock = await acquireContextStoreRegistryLock(options);
 
   try {
-    const next = updater(await readContextStoreRegistryState(options));
+    const next = await updater(await readContextStoreRegistryState(options));
     await writeContextStoreRegistryState(next, options);
     return next;
   } finally {

--- a/src/core/context-store/operations.ts
+++ b/src/core/context-store/operations.ts
@@ -189,6 +189,14 @@ async function findContainingGitRepositoryRoot(storeRoot: string): Promise<strin
     path.relative(nearestParent, resolvedStoreRoot)
   );
 
+  const gitRootContainsStore = (gitRoot: string): string | null => {
+    const normalizedGitRoot = FileSystemUtils.canonicalizeExistingPath(gitRoot);
+    const relative = path.relative(normalizedGitRoot, comparableStoreRoot);
+    return relative.length > 0 && !relative.startsWith('..') && !path.isAbsolute(relative)
+      ? normalizedGitRoot
+      : null;
+  };
+
   try {
     const { stdout } = await execFileAsync('git', [
       '-C',
@@ -196,13 +204,18 @@ async function findContainingGitRepositoryRoot(storeRoot: string): Promise<strin
       'rev-parse',
       '--show-toplevel',
     ]);
-    const gitRoot = FileSystemUtils.canonicalizeExistingPath(stdout.trim());
-    const relative = path.relative(gitRoot, comparableStoreRoot);
-    return relative.length > 0 && !relative.startsWith('..') && !path.isAbsolute(relative)
-      ? gitRoot
-      : null;
+    return gitRootContainsStore(stdout.trim());
   } catch {
-    return null;
+    let current = nearestParent;
+    while (true) {
+      if (await isGitRepositoryAtRoot(current)) {
+        return gitRootContainsStore(current);
+      }
+
+      const parent = path.dirname(current);
+      if (parent === current) return null;
+      current = parent;
+    }
   }
 }
 
@@ -614,49 +627,29 @@ export async function removeContextStore(
 ): Promise<ContextStoreCleanupResult> {
   const id = validateContextStoreId(target.id);
   const diagnostics: ContextStoreDiagnostic[] = [];
-  const safeTarget = await assertSafeToDeleteContextStoreRoot(target.root, id);
-
-  await getRegisteredContextStore({
-    id,
-    expectedBackend: target.backend,
-    globalDataDir: target.globalDataDir,
-  });
-
-  if (!safeTarget.exists) {
-    diagnostics.push(makeContextStoreDiagnostic(
-      'warning',
-      'context_store_root_missing',
-      'Context store files were already missing.',
-      {
-        target: 'context_store.root',
-      }
-    ));
-
-    const removed = await unregisterContextStoreRegistration({
-      id,
-      expectedBackend: target.backend,
-      globalDataDir: target.globalDataDir,
-    });
-
-    return {
-      store: cleanupStoreOutput(removed.id, removed.storeRoot),
-      registryCommit: {
-        path: getContextStoreRegistryPath({ globalDataDir: target.globalDataDir }),
-        removed: true,
-      },
-      files: {
-        deleted: false,
-      },
-      diagnostics,
-    };
-  }
-
-  await fs.rm(target.root, { recursive: true, force: true });
+  let deleted = false;
 
   const removed = await unregisterContextStoreRegistration({
     id,
     expectedBackend: target.backend,
     globalDataDir: target.globalDataDir,
+    beforeCommit: async (entry) => {
+      const safeTarget = await assertSafeToDeleteContextStoreRoot(entry.storeRoot, id);
+      if (!safeTarget.exists) {
+        diagnostics.push(makeContextStoreDiagnostic(
+          'warning',
+          'context_store_root_missing',
+          'Context store files were already missing.',
+          {
+            target: 'context_store.root',
+          }
+        ));
+        return;
+      }
+
+      await fs.rm(entry.storeRoot, { recursive: true, force: true });
+      deleted = true;
+    },
   });
 
   return {
@@ -666,8 +659,8 @@ export async function removeContextStore(
       removed: true,
     },
     files: {
-      deleted: true,
-      deletedPath: removed.storeRoot,
+      deleted,
+      ...(deleted ? { deletedPath: removed.storeRoot } : {}),
     },
     diagnostics,
   };

--- a/src/core/context-store/operations.ts
+++ b/src/core/context-store/operations.ts
@@ -1,5 +1,6 @@
 import { execFile } from 'node:child_process';
 import * as nodeFs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import { promisify } from 'node:util';
 
@@ -14,6 +15,7 @@ import {
   resolveGitContextStoreBackendConfig,
   validateContextStoreId,
   type ContextStoreGitBackendConfig,
+  type ContextStorePathOptions,
   type ContextStoreRegistryState,
 } from './foundation.js';
 import { ContextStoreError, type ContextStoreDiagnostic, makeContextStoreDiagnostic } from './errors.js';
@@ -21,7 +23,9 @@ import {
   getStoreRootForBackend,
   assertNoRegisteredStoreConflict,
   commitContextStoreRegistration,
+  getRegisteredContextStore,
   listRegisteredContextStores,
+  unregisterContextStoreRegistration,
 } from './registry.js';
 
 const fs = nodeFs.promises;
@@ -45,6 +49,20 @@ export interface ContextStoreMutationResult {
     initialized: boolean;
   };
   createdArtifacts: string[];
+}
+
+export interface ContextStoreCleanupResult {
+  store: ContextStoreInfo;
+  registryCommit: {
+    path: string;
+    removed: boolean;
+  };
+  files: {
+    deleted: boolean;
+    deletedPath?: string;
+    leftOnDisk?: string;
+  };
+  diagnostics: ContextStoreDiagnostic[];
 }
 
 export interface ContextStoreListResult {
@@ -72,11 +90,20 @@ export interface SetupContextStoreInput {
   id?: string;
   path?: string;
   initGit?: boolean;
+  allowInsideGitRepository?: boolean;
 }
 
 export interface RegisterExistingContextStoreInput {
   path?: string;
   id?: string;
+}
+
+export interface CleanupContextStoreInput extends ContextStorePathOptions {
+  id: string;
+}
+
+export interface PreparedContextStoreCleanup extends ContextStoreInfo, ContextStorePathOptions {
+  backend: ContextStoreGitBackendConfig;
 }
 
 export interface PreparedContextStoreSetup {
@@ -139,6 +166,65 @@ async function isGitRepositoryAtRoot(storeRoot: string): Promise<boolean> {
   return kind === 'directory' || kind === 'file';
 }
 
+async function nearestExistingDirectory(targetPath: string): Promise<string | null> {
+  let current = path.resolve(targetPath);
+
+  while (true) {
+    const kind = await pathKind(current);
+    if (kind === 'directory') return current;
+    if (kind !== 'missing') return null;
+
+    const parent = path.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+}
+
+async function findContainingGitRepositoryRoot(storeRoot: string): Promise<string | null> {
+  const resolvedStoreRoot = path.resolve(storeRoot);
+  const nearestParent = await nearestExistingDirectory(path.dirname(resolvedStoreRoot));
+  if (!nearestParent) return null;
+  const comparableStoreRoot = path.resolve(
+    FileSystemUtils.canonicalizeExistingPath(nearestParent),
+    path.relative(nearestParent, resolvedStoreRoot)
+  );
+
+  try {
+    const { stdout } = await execFileAsync('git', [
+      '-C',
+      nearestParent,
+      'rev-parse',
+      '--show-toplevel',
+    ]);
+    const gitRoot = FileSystemUtils.canonicalizeExistingPath(stdout.trim());
+    const relative = path.relative(gitRoot, comparableStoreRoot);
+    return relative.length > 0 && !relative.startsWith('..') && !path.isAbsolute(relative)
+      ? gitRoot
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+async function assertSetupPathIsNotNestedInGitRepo(
+  storeRoot: string,
+  options: { allowInsideGitRepository?: boolean }
+): Promise<void> {
+  if (options.allowInsideGitRepository) return;
+
+  const containingGitRoot = await findContainingGitRepositoryRoot(storeRoot);
+  if (!containingGitRoot) return;
+
+  throw new ContextStoreError(
+    `Context store setup path is inside another Git repository: ${containingGitRoot}`,
+    'context_store_setup_inside_git_repo',
+    {
+      target: 'context_store.root',
+      fix: 'Choose the managed OpenSpec location, choose a path outside that Git repository, or rerun setup interactively to confirm this location.',
+    }
+  );
+}
+
 async function initGitRepository(storeRoot: string): Promise<boolean> {
   if (await isGitRepositoryAtRoot(storeRoot)) {
     return false;
@@ -160,6 +246,16 @@ async function initGitRepository(storeRoot: string): Promise<boolean> {
   return true;
 }
 
+function expandUserPath(inputPath: string): string {
+  const trimmed = inputPath.trim();
+  if (trimmed === '~') return os.homedir();
+  if (trimmed.startsWith('~/') || trimmed.startsWith('~\\')) {
+    return path.join(os.homedir(), trimmed.slice(2));
+  }
+
+  return trimmed;
+}
+
 function resolveSetupRoot(id: string, inputPath: string | undefined): string {
   if (inputPath !== undefined && inputPath.trim().length === 0) {
     throw new ContextStoreError('Pass a non-empty --path value.', 'context_store_path_required', {
@@ -169,7 +265,7 @@ function resolveSetupRoot(id: string, inputPath: string | undefined): string {
   }
 
   if (inputPath !== undefined) {
-    return path.resolve(inputPath);
+    return path.resolve(expandUserPath(inputPath));
   }
 
   return getDefaultContextStoreRoot(id);
@@ -183,7 +279,7 @@ function resolveRegisterRoot(inputPath: string | undefined): string {
     });
   }
 
-  return path.resolve(inputPath);
+  return path.resolve(expandUserPath(inputPath));
 }
 
 function inferStoreIdFromPath(storeRoot: string): string {
@@ -214,7 +310,7 @@ function mutationPayload(
 }
 
 async function prepareSetupPlan(
-  input: Pick<SetupContextStoreInput, 'id' | 'path'>
+  input: Pick<SetupContextStoreInput, 'id' | 'path' | 'allowInsideGitRepository'>
 ): Promise<ContextStoreSetupPlan> {
   const id = validateContextStoreId(input.id ?? '');
   const storeRoot = resolveSetupRoot(id, input.path);
@@ -230,6 +326,12 @@ async function prepareSetupPlan(
       }
     );
   }
+
+  // Context stores may be Git-backed, but creating one inside an implementation
+  // repo is almost always an accidental nested-repo setup.
+  await assertSetupPathIsNotNestedInGitRepo(storeRoot, {
+    allowInsideGitRepository: input.allowInsideGitRepository,
+  });
 
   let metadata: Awaited<ReturnType<typeof readStoreMetadataForOperation>> = null;
   let backend: ContextStoreGitBackendConfig | undefined;
@@ -280,7 +382,7 @@ async function prepareSetupPlan(
 }
 
 export async function prepareContextStoreSetup(
-  input: Pick<SetupContextStoreInput, 'id' | 'path'>
+  input: Pick<SetupContextStoreInput, 'id' | 'path' | 'allowInsideGitRepository'>
 ): Promise<PreparedContextStoreSetup> {
   const plan = await prepareSetupPlan(input);
 
@@ -411,6 +513,164 @@ export async function registerExistingContextStore(
     isRepository: await isGitRepositoryAtRoot(registered.storeRoot),
     initialized: false,
   }, createdFiles);
+}
+
+function cleanupStoreOutput(id: string, storeRoot: string): ContextStoreInfo {
+  return {
+    id,
+    root: storeRoot,
+    metadataPath: getContextStoreMetadataPath(storeRoot),
+  };
+}
+
+export async function prepareContextStoreCleanup(
+  input: CleanupContextStoreInput
+): Promise<PreparedContextStoreCleanup> {
+  const id = validateContextStoreId(input.id);
+  const entry = await getRegisteredContextStore({
+    id,
+    globalDataDir: input.globalDataDir,
+  });
+
+  return {
+    ...cleanupStoreOutput(entry.id, entry.storeRoot),
+    backend: entry.backend,
+    ...(input.globalDataDir ? { globalDataDir: input.globalDataDir } : {}),
+  };
+}
+
+export async function unregisterContextStore(
+  input: CleanupContextStoreInput
+): Promise<ContextStoreCleanupResult> {
+  const target = await prepareContextStoreCleanup(input);
+  const removed = await unregisterContextStoreRegistration({
+    id: target.id,
+    expectedBackend: target.backend,
+    globalDataDir: target.globalDataDir,
+  });
+
+  return {
+    store: cleanupStoreOutput(removed.id, removed.storeRoot),
+    registryCommit: {
+      path: getContextStoreRegistryPath({ globalDataDir: target.globalDataDir }),
+      removed: true,
+    },
+    files: {
+      deleted: false,
+      leftOnDisk: removed.storeRoot,
+    },
+    diagnostics: [],
+  };
+}
+
+async function assertSafeToDeleteContextStoreRoot(storeRoot: string, id: string): Promise<{
+  exists: boolean;
+}> {
+  const kind = await pathKind(storeRoot);
+
+  if (kind === 'missing') {
+    return { exists: false };
+  }
+
+  if (kind !== 'directory') {
+    throw new ContextStoreError(
+      `Context store path is not a directory: ${storeRoot}`,
+      'context_store_remove_path_not_directory',
+      {
+        target: 'context_store.root',
+        fix: 'Run context-store unregister if you only want to forget this local registry entry.',
+      }
+    );
+  }
+
+  const metadata = await readStoreMetadataForOperation(storeRoot);
+  if (!metadata) {
+    throw new ContextStoreError(
+      'Context store remove refuses to delete a folder without context-store metadata.',
+      'context_store_remove_metadata_missing',
+      {
+        target: 'context_store.metadata',
+        fix: 'Run context-store unregister if you only want to forget this local registry entry.',
+      }
+    );
+  }
+
+  if (metadata.id !== id) {
+    throw new ContextStoreError(
+      `Context store metadata id '${metadata.id}' does not match requested id '${id}'.`,
+      'context_store_metadata_id_mismatch',
+      {
+        target: 'context_store.metadata',
+        fix: 'Repair the registry or run context-store unregister instead of deleting this folder.',
+      }
+    );
+  }
+
+  return { exists: true };
+}
+
+export async function removeContextStore(
+  target: PreparedContextStoreCleanup
+): Promise<ContextStoreCleanupResult> {
+  const id = validateContextStoreId(target.id);
+  const diagnostics: ContextStoreDiagnostic[] = [];
+  const safeTarget = await assertSafeToDeleteContextStoreRoot(target.root, id);
+
+  await getRegisteredContextStore({
+    id,
+    expectedBackend: target.backend,
+    globalDataDir: target.globalDataDir,
+  });
+
+  if (!safeTarget.exists) {
+    diagnostics.push(makeContextStoreDiagnostic(
+      'warning',
+      'context_store_root_missing',
+      'Context store files were already missing.',
+      {
+        target: 'context_store.root',
+      }
+    ));
+
+    const removed = await unregisterContextStoreRegistration({
+      id,
+      expectedBackend: target.backend,
+      globalDataDir: target.globalDataDir,
+    });
+
+    return {
+      store: cleanupStoreOutput(removed.id, removed.storeRoot),
+      registryCommit: {
+        path: getContextStoreRegistryPath({ globalDataDir: target.globalDataDir }),
+        removed: true,
+      },
+      files: {
+        deleted: false,
+      },
+      diagnostics,
+    };
+  }
+
+  await fs.rm(target.root, { recursive: true, force: true });
+
+  const removed = await unregisterContextStoreRegistration({
+    id,
+    expectedBackend: target.backend,
+    globalDataDir: target.globalDataDir,
+  });
+
+  return {
+    store: cleanupStoreOutput(removed.id, removed.storeRoot),
+    registryCommit: {
+      path: getContextStoreRegistryPath({ globalDataDir: target.globalDataDir }),
+      removed: true,
+    },
+    files: {
+      deleted: true,
+      deletedPath: removed.storeRoot,
+    },
+    diagnostics,
+  };
 }
 
 export async function listContextStores(): Promise<ContextStoreListResult> {

--- a/src/core/context-store/registry.ts
+++ b/src/core/context-store/registry.ts
@@ -31,6 +31,15 @@ export interface ResolveRegisteredContextStoreInput extends ContextStorePathOpti
   id: string;
 }
 
+export interface GetRegisteredContextStoreInput extends ResolveRegisteredContextStoreInput {
+  expectedBackend?: ContextStoreGitBackendConfig;
+}
+
+export interface UnregisterContextStoreInput extends ContextStorePathOptions {
+  id: string;
+  expectedBackend?: ContextStoreGitBackendConfig;
+}
+
 export type ListRegisteredContextStoresOptions = ContextStorePathOptions;
 
 export interface RegisteredContextStoreEntry extends ContextStoreRegistryEntry {
@@ -125,6 +134,74 @@ function withRegisteredStore(
     stores: Object.fromEntries(
       Object.entries(stores).sort(([leftId], [rightId]) => leftId.localeCompare(rightId))
     ),
+  };
+}
+
+function getRegisteredStoreOrThrow(
+  registry: ContextStoreRegistryState | null,
+  id: string
+): ContextStoreRegistryEntry {
+  const entry = registry?.stores[id];
+  if (!entry) {
+    throw new ContextStoreError(`Unknown context store '${id}'`, 'context_store_not_found', {
+      target: 'context_store.id',
+      fix: 'Run openspec context-store list to see registered stores.',
+    });
+  }
+
+  return {
+    id,
+    backend: entry.backend,
+  };
+}
+
+function contextStoreBackendsMatch(
+  actual: ContextStoreGitBackendConfig,
+  expected: ContextStoreGitBackendConfig
+): boolean {
+  return (
+    actual.type === expected.type &&
+    actual.local_path === expected.local_path &&
+    actual.remote === expected.remote &&
+    actual.branch === expected.branch
+  );
+}
+
+function assertExpectedRegisteredBackend(
+  id: string,
+  actual: ContextStoreGitBackendConfig,
+  expected: ContextStoreGitBackendConfig | undefined
+): void {
+  if (!expected || contextStoreBackendsMatch(actual, expected)) return;
+
+  throw new ContextStoreError(
+    `Context store '${id}' changed before cleanup completed.`,
+    'context_store_registry_changed',
+    {
+      target: 'context_store.registry',
+      fix: 'Retry the cleanup command after reviewing the current context-store registration.',
+    }
+  );
+}
+
+function withoutRegisteredStore(
+  registry: ContextStoreRegistryState | null,
+  id: string,
+  expectedBackend?: ContextStoreGitBackendConfig
+): { next: ContextStoreRegistryState; removed: ContextStoreRegistryEntry } {
+  const removed = getRegisteredStoreOrThrow(registry, id);
+  assertExpectedRegisteredBackend(id, removed.backend, expectedBackend);
+  const stores = { ...(registry?.stores ?? {}) };
+  delete stores[id];
+
+  return {
+    removed,
+    next: {
+      version: 1,
+      stores: Object.fromEntries(
+        Object.entries(stores).sort(([leftId], [rightId]) => leftId.localeCompare(rightId))
+      ),
+    },
   };
 }
 
@@ -244,6 +321,50 @@ export async function listRegisteredContextStores(
   }));
 }
 
+export async function getRegisteredContextStore(
+  input: GetRegisteredContextStoreInput
+): Promise<RegisteredContextStoreEntry> {
+  const id = validateContextStoreId(input.id);
+  const registry = await readContextStoreRegistryState({
+    globalDataDir: input.globalDataDir,
+  });
+  const entry = getRegisteredStoreOrThrow(registry, id);
+  assertExpectedRegisteredBackend(id, entry.backend, input.expectedBackend);
+
+  return {
+    ...entry,
+    storeRoot: getStoreRootForBackend(entry.backend),
+  };
+}
+
+export async function unregisterContextStoreRegistration(
+  input: UnregisterContextStoreInput
+): Promise<RegisteredContextStoreEntry> {
+  const id = validateContextStoreId(input.id);
+  let removed: ContextStoreRegistryEntry | undefined;
+
+  await updateContextStoreRegistryState(
+    (registry) => {
+      const result = withoutRegisteredStore(registry, id, input.expectedBackend);
+      removed = result.removed;
+      return result.next;
+    },
+    { globalDataDir: input.globalDataDir }
+  );
+
+  if (!removed) {
+    throw new ContextStoreError(`Unknown context store '${id}'`, 'context_store_not_found', {
+      target: 'context_store.id',
+      fix: 'Run openspec context-store list to see registered stores.',
+    });
+  }
+
+  return {
+    ...removed,
+    storeRoot: getStoreRootForBackend(removed.backend),
+  };
+}
+
 export async function resolveRegisteredContextStore(
   input: ResolveRegisteredContextStoreInput
 ): Promise<ResolvedContextStore> {
@@ -259,14 +380,7 @@ export async function resolveRegisteredContextStore(
     });
   }
 
-  const entry = registry.stores[id];
-  if (!entry) {
-    throw new ContextStoreError(`Unknown context store '${id}'`, 'context_store_not_found', {
-      target: 'context_store.id',
-      fix: 'Run openspec context-store list to see registered stores.',
-    });
-  }
-
+  const entry = getRegisteredStoreOrThrow(registry, id);
   const backend = entry.backend;
   const storeRoot = getStoreRootForBackend(backend);
   await ensureStoreMetadata(storeRoot, id, { writeIfMissing: false });

--- a/src/core/context-store/registry.ts
+++ b/src/core/context-store/registry.ts
@@ -38,6 +38,7 @@ export interface GetRegisteredContextStoreInput extends ResolveRegisteredContext
 export interface UnregisterContextStoreInput extends ContextStorePathOptions {
   id: string;
   expectedBackend?: ContextStoreGitBackendConfig;
+  beforeCommit?: (entry: RegisteredContextStoreEntry) => Promise<void>;
 }
 
 export type ListRegisteredContextStoresOptions = ContextStorePathOptions;
@@ -161,7 +162,8 @@ function contextStoreBackendsMatch(
 ): boolean {
   return (
     actual.type === expected.type &&
-    actual.local_path === expected.local_path &&
+    normalizePathForComparison(actual.local_path) ===
+      normalizePathForComparison(expected.local_path) &&
     actual.remote === expected.remote &&
     actual.branch === expected.branch
   );
@@ -344,8 +346,13 @@ export async function unregisterContextStoreRegistration(
   let removed: ContextStoreRegistryEntry | undefined;
 
   await updateContextStoreRegistryState(
-    (registry) => {
+    async (registry) => {
       const result = withoutRegisteredStore(registry, id, input.expectedBackend);
+      const removedEntry = {
+        ...result.removed,
+        storeRoot: getStoreRootForBackend(result.removed.backend),
+      };
+      await input.beforeCommit?.(removedEntry);
       removed = result.removed;
       return result.next;
     },

--- a/test/commands/context-store.test.ts
+++ b/test/commands/context-store.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Command } from 'commander';
+import { execFileSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -16,6 +17,7 @@ import {
 import { runCLI, type RunCLIResult } from '../helpers/run-cli.js';
 
 vi.mock('@inquirer/prompts', () => ({
+  input: vi.fn(),
   confirm: vi.fn(),
 }));
 
@@ -27,10 +29,12 @@ async function runContextStoreCommand(args: string[]): Promise<void> {
 }
 
 async function getPromptMocks(): Promise<{
+  input: ReturnType<typeof vi.fn>;
   confirm: ReturnType<typeof vi.fn>;
 }> {
   const prompts = await import('@inquirer/prompts');
   return {
+    input: prompts.input as unknown as ReturnType<typeof vi.fn>,
     confirm: prompts.confirm as unknown as ReturnType<typeof vi.fn>,
   };
 }
@@ -140,6 +144,60 @@ describe('context-store command', () => {
     expect(fs.existsSync(path.join(storeRoot, '.git'))).toBe(false);
   });
 
+  it('runs guided setup when no args are passed in an interactive terminal', async () => {
+    process.env = {
+      ...process.env,
+      XDG_DATA_HOME: dataHome,
+      XDG_CONFIG_HOME: configHome,
+      OPENSPEC_TELEMETRY: '0',
+    };
+    delete process.env.OPEN_SPEC_INTERACTIVE;
+    delete process.env.CI;
+    process.chdir(tempDir);
+    (process.stdin as NodeJS.ReadStream & { isTTY?: boolean }).isTTY = true;
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { input, confirm } = await getPromptMocks();
+    input.mockImplementation(async (options: { message: string; default?: string }) => {
+      if (options.message === 'Context store name') return 'guided-context';
+      return options.default;
+    });
+    confirm.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+    await runContextStoreCommand(['setup']);
+
+    const storeRoot = getDefaultContextStoreRoot('guided-context', { globalDataDir });
+    expect(input).toHaveBeenCalledWith(expect.objectContaining({
+      message: 'Context store name',
+    }));
+    expect(input).toHaveBeenCalledWith(expect.objectContaining({
+      message: 'Where should this context store live?',
+      default: storeRoot,
+    }));
+    expect(confirm).toHaveBeenNthCalledWith(1, {
+      message: 'Initialize Git in this context store?',
+      default: true,
+    });
+    expect(confirm).toHaveBeenNthCalledWith(2, {
+      message: 'Create this context store?',
+      default: true,
+    });
+    expect(fs.existsSync(getContextStoreMetadataPath(storeRoot))).toBe(true);
+    expect(fs.existsSync(path.join(storeRoot, '.git'))).toBe(false);
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it('requires a setup id for non-interactive JSON setup', async () => {
+    const result = await runCLI(['context-store', 'setup', '--json'], { cwd: tempDir, env });
+
+    expect(result.exitCode).toBe(1);
+    expect(parseJson(result).status[0]).toEqual(
+      expect.objectContaining({
+        code: 'context_store_setup_id_required',
+      })
+    );
+  });
+
   it('supports explicit current-directory setup', async () => {
     const storeRoot = mkdir('team-context');
 
@@ -150,6 +208,62 @@ describe('context-store command', () => {
 
     expect(result.exitCode).toBe(0);
     expect(parseJson(result).context_store.root).toBe(expectedExistingPath(storeRoot));
+  });
+
+  it('rejects explicit setup paths inside an existing Git repo in non-interactive mode', async () => {
+    const repoRoot = mkdir('repo');
+    execFileSync('git', ['init'], { cwd: repoRoot, stdio: 'ignore' });
+    const storeRoot = path.join(repoRoot, 'team-context');
+
+    const result = await runCLI(
+      ['context-store', 'setup', 'team-context', '--path', storeRoot, '--no-init-git', '--json'],
+      { cwd: tempDir, env }
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(parseJson(result).status[0]).toEqual(
+      expect.objectContaining({
+        code: 'context_store_setup_inside_git_repo',
+      })
+    );
+    expect(fs.existsSync(getContextStoreMetadataPath(storeRoot))).toBe(false);
+  });
+
+  it('requires confirmation before interactive setup uses a path inside an existing Git repo', async () => {
+    process.env = {
+      ...process.env,
+      XDG_DATA_HOME: dataHome,
+      XDG_CONFIG_HOME: configHome,
+      OPENSPEC_TELEMETRY: '0',
+    };
+    delete process.env.OPEN_SPEC_INTERACTIVE;
+    delete process.env.CI;
+    process.chdir(tempDir);
+    (process.stdin as NodeJS.ReadStream & { isTTY?: boolean }).isTTY = true;
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { confirm } = await getPromptMocks();
+    const repoRoot = mkdir('repo');
+    execFileSync('git', ['init'], { cwd: repoRoot, stdio: 'ignore' });
+    const storeRoot = path.join(repoRoot, 'team-context');
+    confirm.mockResolvedValueOnce(true).mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+
+    await runContextStoreCommand(['setup', 'team-context', '--path', storeRoot]);
+
+    expect(confirm).toHaveBeenNthCalledWith(1, {
+      message: expect.stringContaining('inside another Git repository'),
+      default: false,
+    });
+    expect(confirm).toHaveBeenNthCalledWith(2, {
+      message: 'Initialize Git in this context store?',
+      default: true,
+    });
+    expect(confirm).toHaveBeenNthCalledWith(3, {
+      message: 'Create this context store?',
+      default: true,
+    });
+    expect(fs.existsSync(getContextStoreMetadataPath(storeRoot))).toBe(true);
+    expect(process.exitCode).toBeUndefined();
   });
 
   it('rejects non-empty setup folders without context-store metadata', async () => {
@@ -298,6 +412,168 @@ describe('context-store command', () => {
     });
   });
 
+  it('unregisters a context store without deleting local files', async () => {
+    const storeRoot = mkdir('team-context');
+    await writeContextStoreMetadataState(storeRoot, { version: 1, id: 'team-context' });
+    await writeContextStoreRegistryState(
+      {
+        version: 1,
+        stores: {
+          'team-context': {
+            backend: {
+              type: 'git',
+              local_path: storeRoot,
+            },
+          },
+        },
+      },
+      { globalDataDir }
+    );
+
+    const result = await runCLI(
+      ['context-store', 'unregister', 'team-context', '--json'],
+      { cwd: tempDir, env }
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(parseJson(result)).toEqual(expect.objectContaining({
+      context_store: expect.objectContaining({
+        id: 'team-context',
+        root: storeRoot,
+      }),
+      registry: expect.objectContaining({
+        removed: true,
+      }),
+      files: expect.objectContaining({
+        deleted: false,
+        left_on_disk: storeRoot,
+      }),
+    }));
+    await expect(readContextStoreRegistryState({ globalDataDir })).resolves.toEqual({
+      version: 1,
+      stores: {},
+    });
+    expect(fs.existsSync(getContextStoreMetadataPath(storeRoot))).toBe(true);
+  });
+
+  it('requires explicit confirmation before removing files non-interactively', async () => {
+    const storeRoot = mkdir('team-context');
+    await writeContextStoreMetadataState(storeRoot, { version: 1, id: 'team-context' });
+    await writeContextStoreRegistryState(
+      {
+        version: 1,
+        stores: {
+          'team-context': {
+            backend: {
+              type: 'git',
+              local_path: storeRoot,
+            },
+          },
+        },
+      },
+      { globalDataDir }
+    );
+
+    const result = await runCLI(
+      ['context-store', 'remove', 'team-context', '--json'],
+      { cwd: tempDir, env }
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(parseJson(result).status[0]).toEqual(
+      expect.objectContaining({
+        code: 'context_store_remove_confirmation_required',
+      })
+    );
+    expect(fs.existsSync(getContextStoreMetadataPath(storeRoot))).toBe(true);
+  });
+
+  it('removes a context store after explicit non-interactive confirmation', async () => {
+    const storeRoot = mkdir('team-context');
+    await writeContextStoreMetadataState(storeRoot, { version: 1, id: 'team-context' });
+    await writeContextStoreRegistryState(
+      {
+        version: 1,
+        stores: {
+          'team-context': {
+            backend: {
+              type: 'git',
+              local_path: storeRoot,
+            },
+          },
+        },
+      },
+      { globalDataDir }
+    );
+
+    const result = await runCLI(
+      ['context-store', 'remove', 'team-context', '--yes', '--json'],
+      { cwd: tempDir, env }
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(parseJson(result)).toEqual(expect.objectContaining({
+      context_store: expect.objectContaining({
+        id: 'team-context',
+        root: storeRoot,
+      }),
+      registry: expect.objectContaining({
+        removed: true,
+      }),
+      files: expect.objectContaining({
+        deleted: true,
+        deleted_path: storeRoot,
+      }),
+    }));
+    await expect(readContextStoreRegistryState({ globalDataDir })).resolves.toEqual({
+      version: 1,
+      stores: {},
+    });
+    expect(fs.existsSync(storeRoot)).toBe(false);
+  });
+
+  it('refuses to remove files when the folder lacks matching context-store metadata', async () => {
+    const storeRoot = mkdir('team-context');
+    await writeContextStoreRegistryState(
+      {
+        version: 1,
+        stores: {
+          'team-context': {
+            backend: {
+              type: 'git',
+              local_path: storeRoot,
+            },
+          },
+        },
+      },
+      { globalDataDir }
+    );
+
+    const result = await runCLI(
+      ['context-store', 'remove', 'team-context', '--yes', '--json'],
+      { cwd: tempDir, env }
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(parseJson(result).status[0]).toEqual(
+      expect.objectContaining({
+        code: 'context_store_remove_metadata_missing',
+      })
+    );
+    expect(fs.existsSync(storeRoot)).toBe(true);
+    await expect(readContextStoreRegistryState({ globalDataDir })).resolves.toEqual({
+      version: 1,
+      stores: {
+        'team-context': {
+          backend: {
+            type: 'git',
+            local_path: storeRoot,
+          },
+        },
+      },
+    });
+  });
+
   it('rejects an explicit blank doctor id', async () => {
     const result = await runCLI(['context-store', 'doctor', '', '--json'], { cwd: tempDir, env });
 
@@ -380,8 +656,12 @@ describe('context-store command', () => {
     await runContextStoreCommand(['setup', 'interactive-context']);
 
     const storeRoot = getDefaultContextStoreRoot('interactive-context', { globalDataDir });
-    expect(confirm).toHaveBeenCalledWith({
-      message: 'Initialize Git repository?',
+    expect(confirm).toHaveBeenNthCalledWith(1, {
+      message: 'Initialize Git in this context store?',
+      default: true,
+    });
+    expect(confirm).toHaveBeenNthCalledWith(2, {
+      message: 'Create this context store?',
       default: true,
     });
     expect(fs.existsSync(path.join(storeRoot, '.git'))).toBe(true);

--- a/test/commands/context-store.test.ts
+++ b/test/commands/context-store.test.ts
@@ -229,6 +229,25 @@ describe('context-store command', () => {
     expect(fs.existsSync(getContextStoreMetadataPath(storeRoot))).toBe(false);
   });
 
+  it('rejects setup paths inside git-like parents when git cannot resolve the repo', async () => {
+    const repoRoot = mkdir('repo');
+    fs.writeFileSync(path.join(repoRoot, '.git'), `gitdir: ${path.join(tempDir, 'missing-gitdir')}\n`);
+    const storeRoot = path.join(repoRoot, 'team-context');
+
+    const result = await runCLI(
+      ['context-store', 'setup', 'team-context', '--path', storeRoot, '--no-init-git', '--json'],
+      { cwd: tempDir, env }
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(parseJson(result).status[0]).toEqual(
+      expect.objectContaining({
+        code: 'context_store_setup_inside_git_repo',
+      })
+    );
+    expect(fs.existsSync(getContextStoreMetadataPath(storeRoot))).toBe(false);
+  });
+
   it('requires confirmation before interactive setup uses a path inside an existing Git repo', async () => {
     process.env = {
       ...process.env,
@@ -414,6 +433,7 @@ describe('context-store command', () => {
 
   it('unregisters a context store without deleting local files', async () => {
     const storeRoot = mkdir('team-context');
+    const canonicalStoreRoot = expectedExistingPath(storeRoot);
     await writeContextStoreMetadataState(storeRoot, { version: 1, id: 'team-context' });
     await writeContextStoreRegistryState(
       {
@@ -422,7 +442,7 @@ describe('context-store command', () => {
           'team-context': {
             backend: {
               type: 'git',
-              local_path: storeRoot,
+              local_path: canonicalStoreRoot,
             },
           },
         },
@@ -439,14 +459,14 @@ describe('context-store command', () => {
     expect(parseJson(result)).toEqual(expect.objectContaining({
       context_store: expect.objectContaining({
         id: 'team-context',
-        root: storeRoot,
+        root: canonicalStoreRoot,
       }),
       registry: expect.objectContaining({
         removed: true,
       }),
       files: expect.objectContaining({
         deleted: false,
-        left_on_disk: storeRoot,
+        left_on_disk: canonicalStoreRoot,
       }),
     }));
     await expect(readContextStoreRegistryState({ globalDataDir })).resolves.toEqual({
@@ -490,6 +510,7 @@ describe('context-store command', () => {
 
   it('removes a context store after explicit non-interactive confirmation', async () => {
     const storeRoot = mkdir('team-context');
+    const canonicalStoreRoot = expectedExistingPath(storeRoot);
     await writeContextStoreMetadataState(storeRoot, { version: 1, id: 'team-context' });
     await writeContextStoreRegistryState(
       {
@@ -498,7 +519,7 @@ describe('context-store command', () => {
           'team-context': {
             backend: {
               type: 'git',
-              local_path: storeRoot,
+              local_path: canonicalStoreRoot,
             },
           },
         },
@@ -515,14 +536,14 @@ describe('context-store command', () => {
     expect(parseJson(result)).toEqual(expect.objectContaining({
       context_store: expect.objectContaining({
         id: 'team-context',
-        root: storeRoot,
+        root: canonicalStoreRoot,
       }),
       registry: expect.objectContaining({
         removed: true,
       }),
       files: expect.objectContaining({
         deleted: true,
-        deleted_path: storeRoot,
+        deleted_path: canonicalStoreRoot,
       }),
     }));
     await expect(readContextStoreRegistryState({ globalDataDir })).resolves.toEqual({
@@ -534,6 +555,7 @@ describe('context-store command', () => {
 
   it('refuses to remove files when the folder lacks matching context-store metadata', async () => {
     const storeRoot = mkdir('team-context');
+    const canonicalStoreRoot = expectedExistingPath(storeRoot);
     await writeContextStoreRegistryState(
       {
         version: 1,
@@ -541,7 +563,7 @@ describe('context-store command', () => {
           'team-context': {
             backend: {
               type: 'git',
-              local_path: storeRoot,
+              local_path: canonicalStoreRoot,
             },
           },
         },
@@ -567,7 +589,7 @@ describe('context-store command', () => {
         'team-context': {
           backend: {
             type: 'git',
-            local_path: storeRoot,
+            local_path: canonicalStoreRoot,
           },
         },
       },

--- a/test/core/completions/command-registry.test.ts
+++ b/test/core/completions/command-registry.test.ts
@@ -177,6 +177,8 @@ describe('command completion registry', () => {
     expect(contextStore?.subcommands?.map((entry) => entry.name)).toEqual([
       'setup',
       'register',
+      'unregister',
+      'remove',
       'list',
       'ls',
       'doctor',
@@ -187,6 +189,12 @@ describe('command completion registry', () => {
       'path',
       'init-git',
       'no-init-git',
+      'json',
+    ]);
+
+    const remove = contextStore?.subcommands?.find((entry) => entry.name === 'remove');
+    expect(remove?.flags.map((flag) => flag.name)).toEqual([
+      'yes',
       'json',
     ]);
   });

--- a/test/core/context-store/registry.test.ts
+++ b/test/core/context-store/registry.test.ts
@@ -19,6 +19,7 @@ import {
   resolveRegisteredContextStore,
   listRegisteredContextStores,
   setupPreparedContextStore,
+  unregisterContextStoreRegistration,
   writeContextStoreMetadataState,
   writeContextStoreRegistryState,
 } from '../../../src/core/index.js';
@@ -495,6 +496,60 @@ describe('context store registry facade', () => {
     expect(fs.existsSync(secondRoot)).toBe(true);
     const registry = await readContextStoreRegistryState({ globalDataDir: tempDir });
     expectSameExistingPath(registry?.stores['team-context'].backend.local_path ?? '', secondRoot);
+  });
+
+  it('matches prepared cleanup backends by canonical local path', async () => {
+    const storeRoot = mkdir('team-context');
+    const spelledStoreRoot = `${tempDir}${path.sep}.${path.sep}team-context`;
+    await writeContextStoreMetadataState(storeRoot, { version: 1, id: 'team-context' });
+    await writeContextStoreRegistryState(
+      {
+        version: 1,
+        stores: {
+          'team-context': {
+            backend: {
+              type: 'git',
+              local_path: spelledStoreRoot,
+            },
+          },
+        },
+      },
+      { globalDataDir: tempDir }
+    );
+    const prepared = await prepareContextStoreCleanup({
+      id: 'team-context',
+      globalDataDir: tempDir,
+    });
+
+    await writeContextStoreRegistryState(
+      {
+        version: 1,
+        stores: {
+          'team-context': {
+            backend: {
+              type: 'git',
+              local_path: storeRoot,
+            },
+          },
+        },
+      },
+      { globalDataDir: tempDir }
+    );
+
+    await expect(
+      unregisterContextStoreRegistration({
+        id: 'team-context',
+        expectedBackend: prepared.backend,
+        globalDataDir: tempDir,
+      })
+    ).resolves.toEqual(expect.objectContaining({
+      id: 'team-context',
+      storeRoot,
+    }));
+    await expect(readContextStoreRegistryState({ globalDataDir: tempDir })).resolves.toEqual({
+      version: 1,
+      stores: {},
+    });
   });
 
   it('keeps the registry entry when prepared remove fails to delete files', async () => {

--- a/test/core/context-store/registry.test.ts
+++ b/test/core/context-store/registry.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -9,10 +9,12 @@ import {
   createPathContextStoreBinding,
   createRegisteredContextStoreBinding,
   mountInitiativesCollection,
+  prepareContextStoreCleanup,
   prepareContextStoreSetup,
   readContextStoreMetadataState,
   readContextStoreRegistryState,
   registerContextStore,
+  removeContextStore,
   resolveContextStoreBinding,
   resolveRegisteredContextStore,
   listRegisteredContextStores,
@@ -447,6 +449,88 @@ describe('context store registry facade', () => {
     await expect(
       resolveRegisteredContextStore({ id: 'mismatched', globalDataDir: tempDir })
     ).rejects.toThrow(/does not match registered id/u);
+  });
+
+  it('refuses a prepared remove when the registry entry changes before deletion', async () => {
+    const firstRoot = mkdir('first/team-context');
+    const secondRoot = mkdir('second/team-context');
+    await writeContextStoreMetadataState(firstRoot, { version: 1, id: 'team-context' });
+    await writeContextStoreMetadataState(secondRoot, { version: 1, id: 'team-context' });
+    await writeContextStoreRegistryState(
+      {
+        version: 1,
+        stores: {
+          'team-context': {
+            backend: {
+              type: 'git',
+              local_path: firstRoot,
+            },
+          },
+        },
+      },
+      { globalDataDir: tempDir }
+    );
+    const prepared = await prepareContextStoreCleanup({
+      id: 'team-context',
+      globalDataDir: tempDir,
+    });
+
+    await writeContextStoreRegistryState(
+      {
+        version: 1,
+        stores: {
+          'team-context': {
+            backend: {
+              type: 'git',
+              local_path: secondRoot,
+            },
+          },
+        },
+      },
+      { globalDataDir: tempDir }
+    );
+
+    await expect(removeContextStore(prepared)).rejects.toThrow(/changed before cleanup/u);
+    expect(fs.existsSync(firstRoot)).toBe(true);
+    expect(fs.existsSync(secondRoot)).toBe(true);
+    const registry = await readContextStoreRegistryState({ globalDataDir: tempDir });
+    expectSameExistingPath(registry?.stores['team-context'].backend.local_path ?? '', secondRoot);
+  });
+
+  it('keeps the registry entry when prepared remove fails to delete files', async () => {
+    const storeRoot = mkdir('team-context');
+    await writeContextStoreMetadataState(storeRoot, { version: 1, id: 'team-context' });
+    await writeContextStoreRegistryState(
+      {
+        version: 1,
+        stores: {
+          'team-context': {
+            backend: {
+              type: 'git',
+              local_path: storeRoot,
+            },
+          },
+        },
+      },
+      { globalDataDir: tempDir }
+    );
+    const prepared = await prepareContextStoreCleanup({
+      id: 'team-context',
+      globalDataDir: tempDir,
+    });
+    const rmSpy = vi
+      .spyOn(fs.promises, 'rm')
+      .mockRejectedValueOnce(new Error('simulated delete failure'));
+
+    try {
+      await expect(removeContextStore(prepared)).rejects.toThrow(/simulated delete failure/u);
+    } finally {
+      rmSpy.mockRestore();
+    }
+
+    const registry = await readContextStoreRegistryState({ globalDataDir: tempDir });
+    expectSameExistingPath(registry?.stores['team-context'].backend.local_path ?? '', storeRoot);
+    expect(fs.existsSync(getContextStoreMetadataPath(storeRoot))).toBe(true);
   });
 
   it('mounts the initiatives collection for a resolved store root', async () => {

--- a/test/core/context-store/registry.test.ts
+++ b/test/core/context-store/registry.test.ts
@@ -536,16 +536,14 @@ describe('context store registry facade', () => {
       { globalDataDir: tempDir }
     );
 
-    await expect(
-      unregisterContextStoreRegistration({
-        id: 'team-context',
-        expectedBackend: prepared.backend,
-        globalDataDir: tempDir,
-      })
-    ).resolves.toEqual(expect.objectContaining({
+    const unregistered = await unregisterContextStoreRegistration({
       id: 'team-context',
-      storeRoot,
-    }));
+      expectedBackend: prepared.backend,
+      globalDataDir: tempDir,
+    });
+
+    expect(unregistered.id).toBe('team-context');
+    expectSameExistingPath(unregistered.storeRoot, storeRoot);
     await expect(readContextStoreRegistryState({ globalDataDir: tempDir })).resolves.toEqual({
       version: 1,
       stores: {},


### PR DESCRIPTION
## Summary
- add guided interactive `context-store setup` with explicit non-interactive/JSON validation
- add path safety checks for setup inside existing Git repositories
- add `context-store unregister` and `context-store remove` cleanup flows with docs, completions, and tests

## Verification
- `pnpm build`
- `pnpm lint`
- `pnpm vitest run test/commands/context-store.test.ts test/core/context-store/registry.test.ts`
- `pnpm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `context-store unregister` (forget registration) and `context-store remove` (forget + delete local store; non-interactive requires `--yes`)
  * `context-store setup` supports interactive no-arg guided setup and deterministic non-interactive JSON usage

* **Behavior / Safety**
  * Blocks creating managed stores inside existing Git repos unless explicitly confirmed
  * Removal refuses deletion when store metadata doesn’t match; safer deletion checks

* **Documentation**
  * Updated CLI reference, user guide, and agent playbook for these flows

* **Tests**
  * Expanded tests for setup, unregister, remove, and Git-related scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Fission-AI/OpenSpec/pull/1137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->