### PR TITLE
chore: add changeset for Mistral Vibe support and validator/completion fixes

### DIFF
--- a/.changeset/mistral-vibe-and-fixes.md
+++ b/.changeset/mistral-vibe-and-fixes.md
@@ -1,0 +1,16 @@
+---
+"@fission-ai/openspec": minor
+---
+
+### New Features
+
+- **Mistral Vibe support** — OpenSpec can now initialize Mistral Vibe as a supported skills-only tool using `.vibe/skills/`
+
+### Bug Fixes
+
+- **Case-insensitive requirement headers** — Requirement headers are now parsed regardless of capitalization, so specs no longer fail to parse over header casing
+- **Zsh completions on oh-my-zsh** — Fixed shell completion setup so tab completion installs correctly under oh-my-zsh's `compinit`
+
+### Other
+
+- **Clearer validation hints** — When a requirement has SHALL/MUST only in its header, `openspec validate` now points you to move the keyword onto the requirement body line instead of showing the generic error


### PR DESCRIPTION
## Summary

Adds dedicated release tracking (a `minor` changeset) for user-facing changes merged to `main` since `v1.3.1` that weren't yet covered by an existing changeset.

## Changes in this release

### New Features
- **Mistral Vibe support** (#1144) — New skills-only AI tool initialized via `.vibe/skills/`

### Bug Fixes
- **Case-insensitive requirement headers** (#1031) — Requirement headers parse regardless of capitalization
- **Zsh completions on oh-my-zsh** (#1033) — Fixed completion install under oh-my-zsh's `compinit`

### Other
- **Clearer validation hints** (#1135) — `openspec validate` now guides authors to move SHALL/MUST onto the requirement body line when it only appears in the header

## Notes
- Bump type is `minor` due to the new Mistral Vibe tool integration.
- Already-tracked changes (Kimi CLI, sync-in-core, workspace canonical paths) keep their existing changesets and are not duplicated here.
- Docs-only, test-only, and in-progress workspace/context-store beta commits are intentionally excluded per the changeset guidelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for "Mistral Vibe" as a skills-only tool via the `.vibe/skills/` directory.

* **Bug Fixes**
  * Fixed spec parsing to handle requirement headers case-insensitively.
  * Resolved Zsh completion installation issues with oh-my-zsh.

* **Improvements**
  * Enhanced validation output with targeted hints for keyword placement in requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->