### PR TITLE
fix(init): clarify guidance when using --tools none

### DIFF
--- a/src/core/init.ts
+++ b/src/core/init.ts
@@ -700,8 +700,12 @@ export class InitCommand {
     const globalCfg = getGlobalConfig();
     const activeProfile: Profile = (this.profileOverride as Profile) ?? globalCfg.profile ?? 'core';
     const activeWorkflows = [...getProfileWorkflows(activeProfile, globalCfg.workflows)];
+    const hasConfiguredTools = results.createdTools.length > 0 || results.refreshedTools.length > 0;
     console.log();
-    if (activeWorkflows.includes('propose')) {
+    if (!hasConfiguredTools) {
+      console.log('OpenSpec structure created, but no agent integrations were installed.');
+      console.log('  Install integrations later with: openspec init --tools <tool>');
+    } else if (activeWorkflows.includes('propose')) {
       console.log(chalk.bold('Getting started:'));
       console.log('  Start your first change: /opsx:propose "your idea"');
     } else if (activeWorkflows.includes('new')) {

--- a/test/cli-e2e/basic.test.ts
+++ b/test/cli-e2e/basic.test.ts
@@ -156,6 +156,7 @@ describe('openspec CLI e2e basics', () => {
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('OpenSpec Setup Complete');
       expect(result.stdout).toContain('Claude Code');
+      expect(result.stdout).toContain('/opsx:propose');
 
       // New init creates skills, not CLAUDE.md
       const claudeSkillPath = path.join(emptyProjectDir, '.claude/skills/openspec-explore/SKILL.md');
@@ -172,6 +173,9 @@ describe('openspec CLI e2e basics', () => {
       const result = await runCLI(['init', '--tools', 'none'], { cwd: emptyProjectDir });
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('OpenSpec Setup Complete');
+      expect(result.stdout).toContain('no agent integrations were installed');
+      expect(result.stdout).toContain('openspec init --tools <tool>');
+      expect(result.stdout).not.toContain('/opsx:propose');
 
       // With --tools none, no tool skills should be created
       const claudeSkillPath = path.join(emptyProjectDir, '.claude/skills/openspec-explore/SKILL.md');

--- a/test/core/init.test.ts
+++ b/test/core/init.test.ts
@@ -231,6 +231,11 @@ describe('InitCommand', () => {
       // No tool-specific directories should be created
       const claudeSkillsDir = path.join(testDir, '.claude', 'skills');
       expect(await directoryExists(claudeSkillsDir)).toBe(false);
+
+      const logCalls = (console.log as unknown as { mock: { calls: unknown[][] } }).mock.calls.flat().map(String);
+      expect(logCalls.some((entry) => entry.includes('no agent integrations were installed'))).toBe(true);
+      expect(logCalls.some((entry) => entry.includes('openspec init --tools <tool>'))).toBe(true);
+      expect(logCalls.some((entry) => entry.includes('/opsx:propose'))).toBe(false);
     });
 
     it('should throw error for invalid tool names', async () => {


### PR DESCRIPTION
## Summary

This PR clarifies the success message for `openspec init --tools none`.

Previously, `init --tools none` could still show the standard workflow guidance after setup, even though no AI tool integrations were installed in that mode.

This change makes the output explicit for the `--tools none` case:
- OpenSpec structure was created
- no agent integrations were installed
- integrations can be added later with `openspec init --tools <tool>`

All existing guidance for tool-configured setups remains unchanged.

## Why

`--tools none` is a valid non-interactive setup mode when a user wants to initialize the OpenSpec project structure without installing any tool-specific skills/commands yet.

In that case, showing the normal workflow entrypoint guidance is misleading, because there is no installed tool surface to invoke.

## Changes

- update the `init` success message for the `--tools none` path
- add test coverage for the revised output
- keep existing configured-tool guidance unchanged

## Validation

- `pnpm vitest run test/core/init.test.ts`
- `pnpm build`
- `pnpm vitest run test/cli-e2e/basic.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced initialization feedback: When no agent integrations are installed during setup, users now receive a message confirming the OpenSpec structure was created and instructions on how to add integrations later using the provided command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->