### PR TITLE
fix(templates): start generated docs with H1 headings

### DIFF
--- a/schemas/spec-driven/templates/design.md
+++ b/schemas/spec-driven/templates/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Context
 
 <!-- Background and current state -->

--- a/schemas/spec-driven/templates/proposal.md
+++ b/schemas/spec-driven/templates/proposal.md
@@ -1,3 +1,5 @@
+# Proposal
+
 ## Why
 
 <!-- Explain the motivation for this change. What problem does this solve? Why now? -->

--- a/schemas/spec-driven/templates/spec.md
+++ b/schemas/spec-driven/templates/spec.md
@@ -1,3 +1,5 @@
+# Specifications
+
 ## ADDED Requirements
 
 ### Requirement: <!-- requirement name -->

--- a/schemas/spec-driven/templates/tasks.md
+++ b/schemas/spec-driven/templates/tasks.md
@@ -1,3 +1,5 @@
+# Tasks
+
 ## 1. <!-- Task Group Name -->
 
 - [ ] 1.1 <!-- Task description -->

--- a/schemas/workspace-planning/templates/design.md
+++ b/schemas/workspace-planning/templates/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Context
 
 Summarize the workspace planning context, relevant linked areas, and constraints.

--- a/schemas/workspace-planning/templates/proposal.md
+++ b/schemas/workspace-planning/templates/proposal.md
@@ -1,3 +1,5 @@
+# Proposal
+
 ## Why
 
 Describe the shared product goal, problem, or opportunity that makes this workspace-level change worth planning.

--- a/schemas/workspace-planning/templates/spec.md
+++ b/schemas/workspace-planning/templates/spec.md
@@ -1,3 +1,5 @@
+# Specifications
+
 ## ADDED Requirements
 
 ### Requirement: <workspace requirement name>

--- a/schemas/workspace-planning/templates/tasks.md
+++ b/schemas/workspace-planning/templates/tasks.md
@@ -1,3 +1,5 @@
+# Tasks
+
 ## 1. Workspace Planning
 
 - [ ] 1.1 Confirm the shared product goal and unresolved scope questions.

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -928,7 +928,9 @@ export function registerSchemaCommand(program: Command): void {
 function createDefaultTemplate(artifactId: string): string {
   switch (artifactId) {
     case 'proposal':
-      return `## Why
+      return `# Proposal
+
+## Why
 
 <!-- Describe the motivation for this change -->
 
@@ -950,7 +952,9 @@ function createDefaultTemplate(artifactId: string): string {
 `;
 
     case 'specs':
-      return `## ADDED Requirements
+      return `# Specifications
+
+## ADDED Requirements
 
 ### Requirement: Example requirement
 
@@ -962,7 +966,9 @@ Description of the requirement.
 `;
 
     case 'design':
-      return `## Context
+      return `# Design
+
+## Context
 
 <!-- Background and context -->
 
@@ -989,7 +995,9 @@ Description and rationale.
 `;
 
     case 'tasks':
-      return `## Implementation Tasks
+      return `# Tasks
+
+## Implementation Tasks
 
 - [ ] Task 1
 - [ ] Task 2
@@ -997,7 +1005,7 @@ Description and rationale.
 `;
 
     default:
-      return `## ${artifactId}
+      return `# ${artifactId}
 
 <!-- Add content here -->
 `;

--- a/test/core/artifact-graph/instruction-loader.test.ts
+++ b/test/core/artifact-graph/instruction-loader.test.ts
@@ -20,6 +20,22 @@ describe('instruction-loader', () => {
       expect(template).toContain('## What Changes');
     });
 
+    it('should start built-in generated markdown templates with top-level headings', () => {
+      const expectedHeadings = [
+        ['proposal.md', '# Proposal'],
+        ['spec.md', '# Specifications'],
+        ['design.md', '# Design'],
+        ['tasks.md', '# Tasks'],
+      ] as const;
+
+      for (const schemaName of ['spec-driven', 'workspace-planning']) {
+        for (const [templatePath, heading] of expectedHeadings) {
+          const template = loadTemplate(schemaName, templatePath);
+          expect(template.split(/\r?\n/, 1)[0], `${schemaName}/${templatePath}`).toBe(heading);
+        }
+      }
+    });
+
     it('should throw TemplateLoadError for non-existent template', () => {
       expect(() => loadTemplate('spec-driven', 'nonexistent.md')).toThrow(
         TemplateLoadError


### PR DESCRIPTION
## Summary

Fixes #1138.

OpenSpec's built-in generated markdown templates currently start with second-level headings such as `## Why`, `## ADDED Requirements`, `## Context`, and task group headings. Markdownlint's MD041 rule expects generated markdown files to start with a top-level heading.

This PR adds first-line H1 headings to generated proposal, specs, design, and tasks templates while preserving the existing section structure that OpenSpec parsers consume.

## Changes

- Add `# Proposal`, `# Specifications`, `# Design`, and `# Tasks` to the built-in `spec-driven` templates.
- Add the same H1 headings to the built-in `workspace-planning` templates.
- Update schema init default template generation so newly scaffolded custom schemas also start generated docs with H1 headings.
- Add a regression test that checks built-in templates start with the expected top-level headings.

## Verification

- `pnpm exec vitest run test/core/artifact-graph/instruction-loader.test.ts test/core/parsers/markdown-parser.test.ts test/core/parsers/requirement-blocks.test.ts`
- `pnpm run build`
- `pnpm run lint`
- `pnpm test` (89 files, 1656 tests)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced template structure for design documents, proposals, specifications, and task lists with consistent top-level formatting and organized section layouts across schema templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->