### PR TITLE
fix: use Node.js 22 in Nix flake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -116,7 +116,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Print environment diagnostics
@@ -155,7 +155,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -277,7 +277,7 @@ jobs:
         if: steps.changed-changesets.outputs.has_changesets == 'true'
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/flake.nix
+++ b/flake.nix
@@ -55,7 +55,7 @@
             };
 
             nativeBuildInputs = with pkgs; [
-              nodejs_20
+              nodejs_22
               npmHooks.npmInstallHook
               pnpmConfigHook
               pnpm_9
@@ -97,7 +97,7 @@
         {
           default = pkgs.mkShell {
             buildInputs = with pkgs; [
-              nodejs_20
+              nodejs_22
               pnpm_9
             ];
 


### PR DESCRIPTION
## Summary
- update the Nix package build inputs from nodejs_20 to nodejs_22
- update the dev shell Node runtime to nodejs_22 as well

## Why
Node.js 20 is now marked insecure in nixpkgs after reaching EOL, which causes Nix evaluation/builds to fail for OpenSpec users.

Fixes #1119.

## Validation
- Confirmed flake.nix no longer references nodejs_20
- Not run: nix build, because Nix is not installed in this local environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Node.js runtime to version 22 for build and development environments.
  * Updated CI workflows to use Node.js 22 for testing, linting, type-checking, and release validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->