### PR TITLE
fix: use checkbox markers in tool multiselect

### DIFF
--- a/src/prompts/searchable-multi-select.ts
+++ b/src/prompts/searchable-multi-select.ts
@@ -172,7 +172,7 @@ async function createSearchableMultiSelect(): Promise<
         const actualIndex = startIndex + i;
         const isActive = actualIndex === cursor;
         const selected = selectedSet.has(item.value);
-        const icon = selected ? chalk.green('◉') : chalk.dim('○');
+        const icon = selected ? chalk.green('[x]') : chalk.dim('[ ]');
         const arrow = isActive ? chalk.cyan('›') : ' ';
         const name = isActive ? chalk.cyan(item.name) : item.name;
         const isRefresh = selected && item.configured;

--- a/test/prompts/searchable-multi-select.test.ts
+++ b/test/prompts/searchable-multi-select.test.ts
@@ -217,4 +217,14 @@ describe('searchable-multi-select keybindings', () => {
       expect(renderOutput).not.toMatch(/Tab.*confirm/);
     });
   });
+
+  describe('selection markers', () => {
+    it('should render checkbox-style markers for selected and unselected items', async () => {
+      await setup();
+      expect(renderOutput).toContain('[ ] Tool A');
+
+      pressKey('space');
+      expect(renderOutput).toContain('[x] Tool A');
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- render the searchable multi-select prompt with [x] and [ ] markers instead of radio-style circles
- add coverage that verifies selected and unselected options use checkbox-style markers

## Why
The init tool selector supports multiple selections, but circular markers make it look like a radio-button single-select control.

Fixes #647.

## Validation
- pnpm exec vitest run test/prompts/searchable-multi-select.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated visual indicators in multi-select selection lists: selected items now display with a checkmark `[x]` and unselected items display with an empty box `[ ]` for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->