### PR TITLE
fix: use generic progress tracking in prompts

### DIFF
--- a/src/core/templates/workflows/ff-change.ts
+++ b/src/core/templates/workflows/ff-change.ts
@@ -42,7 +42,7 @@ export function getFfChangeSkillTemplate(): SkillTemplate {
 
 4. **Create artifacts in sequence until apply-ready**
 
-   Use the **TodoWrite tool** to track progress through the artifacts.
+   Track progress through the artifacts using the agent's native planning or checklist mechanism if available; otherwise keep a concise visible checklist.
 
    Loop through artifacts in dependency order (artifacts with no pending dependencies first):
 
@@ -145,7 +145,7 @@ export function getOpsxFfCommandTemplate(): CommandTemplate {
 
 4. **Create artifacts in sequence until apply-ready**
 
-   Use the **TodoWrite tool** to track progress through the artifacts.
+   Track progress through the artifacts using the agent's native planning or checklist mechanism if available; otherwise keep a concise visible checklist.
 
    Loop through artifacts in dependency order (artifacts with no pending dependencies first):
 

--- a/src/core/templates/workflows/propose.ts
+++ b/src/core/templates/workflows/propose.ts
@@ -51,7 +51,7 @@ When ready to implement, run /opsx:apply
 
 4. **Create artifacts in sequence until apply-ready**
 
-   Use the **TodoWrite tool** to track progress through the artifacts.
+   Track progress through the artifacts using the agent's native planning or checklist mechanism if available; otherwise keep a concise visible checklist.
 
    Loop through artifacts in dependency order (artifacts with no pending dependencies first):
 
@@ -163,7 +163,7 @@ When ready to implement, run /opsx:apply
 
 4. **Create artifacts in sequence until apply-ready**
 
-   Use the **TodoWrite tool** to track progress through the artifacts.
+   Track progress through the artifacts using the agent's native planning or checklist mechanism if available; otherwise keep a concise visible checklist.
 
    Loop through artifacts in dependency order (artifacts with no pending dependencies first):
 

--- a/test/core/templates/skill-templates-parity.test.ts
+++ b/test/core/templates/skill-templates-parity.test.ts
@@ -34,14 +34,14 @@ const EXPECTED_FUNCTION_HASHES: Record<string, string> = {
   getNewChangeSkillTemplate: 'b0c26f0b65380062e586505c08c72230e59dccea89e6acca7b673f01cba70d5a',
   getContinueChangeSkillTemplate: 'fbc6c379ed3dd39f59f52b10584b8df5b1dc08b5422bcf1c6d6255a944d22a11',
   getApplyChangeSkillTemplate: 'e746f230c2513a5fd40842bde494bb3cdb3c5f7c1bcece101f92090983d4ff55',
-  getFfChangeSkillTemplate: '50e68fbb49b76d2690b614bffa9e6210e45539fb74419fc2e4311158b6d38485',
+  getFfChangeSkillTemplate: '1560eec8651e606dfd191006dff8b82648db51995d163544230d96a5e27195d6',
   getSyncSpecsSkillTemplate: '9f02b41227db70875b89eefeb275c769142607dc5b2593f4e606794aed2fdbad',
   getOnboardSkillTemplate: '4f4b60fea6e3fc7d2185815b2808fad51535fdd00cd4401b32d1536f32fa2b6d',
   getOpsxExploreCommandTemplate: '4d5e64e3ede6703113cf2fd23b797371ef2407b702478b4f7240fc81cbf2d3a5',
   getOpsxNewCommandTemplate: '757f72e2d9a1a6794b2188704fd39dd2ab65428899b4b361c76cc15a5e4f2ccc',
   getOpsxContinueCommandTemplate: '62f8863edda2bfe4e210f8bc3095fd4369aaaaf7772a5cba9602d0f0bca1d0c9',
   getOpsxApplyCommandTemplate: '812feefd32a4d9d468e03e456d06e3d2d08d1118d29cce4911f0be59cdd30bfc',
-  getOpsxFfCommandTemplate: 'f775b242bcfd56594c431c7f31a0129208a1bacfdb2427074d412543072ef7ca',
+  getOpsxFfCommandTemplate: '6cf9d677fc2d3f9da4fefee1c70f77b180a2f660a7ceaa4f8a7bd6d3194b7890',
   getArchiveChangeSkillTemplate: 'bdf022ae2cdef1feef4d641a068bef3a7fc5d98a323f7ce9f77ac578fe8d20c6',
   getBulkArchiveChangeSkillTemplate: 'fdb1715804e86de85be96222b8efeb9d5b350c6d5c19e343e244655deff8e62b',
   getOpsxSyncCommandTemplate: '4c8118afaea79ff4fed3d946c88e6a7abbba904a5fbf643e4372da1e3735a467',
@@ -50,8 +50,8 @@ const EXPECTED_FUNCTION_HASHES: Record<string, string> = {
   getOpsxOnboardCommandTemplate: '57c1f3e2590bda8f47818bab1d528456c1b8a9a7501f63ab9e2115e0cfaf6f35',
   getOpsxBulkArchiveCommandTemplate: 'b76c421023ccb5a12867c349f27cdb186234b692c1811980fb94127567bdabda',
   getOpsxVerifyCommandTemplate: '9a7a3f9e5bc3d0c0878b1a4493efbbb38729597d9b9be78f63284cc2da7c20c3',
-  getOpsxProposeSkillTemplate: 'bae22279f8c7f711a8d5c5289551551d48197ddf5a99b695d96fff5339e08a49',
-  getOpsxProposeCommandTemplate: '870ab824c2aeb825fe3fe161a1f223633b4fff308ecaeb8197cbf309db2ddf02',
+  getOpsxProposeSkillTemplate: '4429dcdfd425564035e43edf35a9443a48df6e4921ab09dd469c60b4ec876bfa',
+  getOpsxProposeCommandTemplate: 'a1d0bdc8a5728fb9ddc031dabc65d31eb5b8d62cf4cdda241a244f9a60eb53ee',
   getFeedbackSkillTemplate: 'd7d83c5f7fc2b92fe8f4588a5bf2d9cb315e4c73ec19bcd5ef28270906319a0d',
 };
 
@@ -60,13 +60,13 @@ const EXPECTED_GENERATED_SKILL_CONTENT_HASHES: Record<string, string> = {
   'openspec-new-change': 'c99989810f982d72eefc74a35f2282b71f1956f23f61b83aaa58fa3dd921716f',
   'openspec-continue-change': 'c00e2a60f79cd60197094cc59762babe5ee6a2dc1e859a0ede3f436a775ccecf',
   'openspec-apply-change': 'd849442efd925b9247651e254a5cd696945321610cca5a9432ad420430554548',
-  'openspec-ff-change': '9d9b1995b6f4adb3da570676f7d11fee4cd1cf6c5df8ec83c033e02783a544df',
+  'openspec-ff-change': '0219d992167251069f5d94fc0459662eef0dcef812a5770bdc2478c648983164',
   'openspec-sync-specs': '2e0f67ec6fadffc6107b4b1a28eef23a99a6649e5fae706897ea1dd9deb852a8',
   'openspec-archive-change': '8d14af2c8b2e4358308ac9fc14f75db42a4b41a07e175825035852a82479793e',
   'openspec-bulk-archive-change': '16207683996b1952559cd4e33463f28fb097761f2c5d912107733d01a90d3f2f',
   'openspec-verify-change': 'a2acecd0c2b4e57080a314e5e7a093e0688293c37e446eb45d378f5050058550',
   'openspec-onboard': 'b924ea3c97543ebb7ee82c5f194afe7ce87a521c32b85616f445240ab33a02ab',
-  'openspec-propose': '56aa526fe1e9fac956ad3ad570a3a259d27f54b05086940d85af136a62069292',
+  'openspec-propose': '2a154d5b27d3d3599e8328ccd197d415fb2aa64f344816e2200a0ba06d687193',
 };
 
 function stableStringify(value: unknown): string {
@@ -167,6 +167,21 @@ describe('skill templates split parity', () => {
       expect(content, dirName).toContain(guardText);
       expect(content, dirName).not.toContain('openspec/changes/<name>');
       expect(content, dirName).not.toContain('mv openspec/changes');
+    }
+  });
+
+  it('uses generic progress-tracking guidance for propose and fast-forward workflows', () => {
+    const templates = [
+      getOpsxProposeSkillTemplate(),
+      getOpsxProposeCommandTemplate(),
+      getFfChangeSkillTemplate(),
+      getOpsxFfCommandTemplate(),
+    ];
+
+    for (const template of templates) {
+      const content = 'instructions' in template ? template.instructions : template.content;
+      expect(content).not.toContain('TodoWrite tool');
+      expect(content).toContain('native planning or checklist mechanism');
     }
   });
 });


### PR DESCRIPTION
## Summary
- replace TodoWrite-specific progress tracking instructions in propose and fast-forward workflows
- use runtime-neutral guidance for native planning or visible checklists
- add template coverage to keep TodoWrite references out of those workflows

## Why
The generated fast-forward/propose prompts can reference a tool that is not available in some Claude Code environments. The workflow only needs progress tracking, so generic wording is enough and works across adapters.

Fixes #643.

## Validation
- pnpm exec vitest run test/core/templates/skill-templates-parity.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced artifact creation progress tracking during workflow operations. The agent now uses its native planning and checklist mechanism to display progress, providing clearer visibility into the artifact creation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->