### PR TITLE
fix: use skill references for adapterless tools

### DIFF
--- a/src/core/init.ts
+++ b/src/core/init.ts
@@ -49,6 +49,7 @@ import { getGlobalConfig, type Delivery, type Profile } from './global-config.js
 import { getProfileWorkflows, CORE_WORKFLOWS, ALL_WORKFLOWS } from './profiles.js';
 import { getAvailableTools } from './available-tools.js';
 import { migrateIfNeeded } from './migration.js';
+import { WORKFLOW_TO_SKILL_DIR } from './profile-sync-drift.js';
 
 const require = createRequire(import.meta.url);
 const { version: OPENSPEC_VERSION } = require('../../package.json');

--- a/src/core/init.ts
+++ b/src/core/init.ts
@@ -11,7 +11,11 @@ import ora from 'ora';
 import * as fs from 'fs';
 import { createRequire } from 'module';
 import { FileSystemUtils } from '../utils/file-system.js';
-import { transformToHyphenCommands } from '../utils/command-references.js';
+import {
+  getSkillReferencePrefix,
+  transformToHyphenCommands,
+  transformToToolSkillReferences,
+} from '../utils/command-references.js';
 import {
   AI_TOOLS,
   OPENSPEC_DIR_NAME,
@@ -73,6 +77,29 @@ const WORKFLOW_TO_SKILL_DIR: Record<string, string> = {
   'onboard': 'openspec-onboard',
   'propose': 'openspec-propose',
 };
+
+function getSkillInstructionTransformer(
+  toolId: string,
+  hasCommandAdapter: boolean
+): ((instructions: string) => string) | undefined {
+  if (toolId === 'opencode' || toolId === 'pi') {
+    return transformToHyphenCommands;
+  }
+  if (!hasCommandAdapter) {
+    return (instructions: string) => transformToToolSkillReferences(instructions, toolId);
+  }
+  return undefined;
+}
+
+function formatSkillGettingStarted(workflowId: 'propose' | 'new', tools: Array<{ value: string }>): string {
+  const skillName = WORKFLOW_TO_SKILL_DIR[workflowId];
+  const prefixedTool = tools.find((tool) => getSkillReferencePrefix(tool.value));
+  const prefix = prefixedTool ? getSkillReferencePrefix(prefixedTool.value) : '';
+  if (prefix) {
+    return `${prefix}${skillName} "your idea"`;
+  }
+  return `${skillName} skill for "your idea"`;
+}
 
 // -----------------------------------------------------------------------------
 // Types
@@ -535,10 +562,10 @@ export class InitCommand {
           for (const { template, dirName } of skillTemplates) {
             const skillDir = path.join(skillsDir, dirName);
             const skillFile = path.join(skillDir, 'SKILL.md');
+            const hasCommandAdapter = CommandAdapterRegistry.has(tool.value);
 
             // Generate SKILL.md content with YAML frontmatter including generatedBy
-            // Use hyphen-based command references for tools where filename = command name
-            const transformer = (tool.value === 'opencode' || tool.value === 'pi') ? transformToHyphenCommands : undefined;
+            const transformer = getSkillInstructionTransformer(tool.value, hasCommandAdapter);
             const skillContent = generateSkillContent(template, OPENSPEC_VERSION, transformer);
 
             // Write the skill file
@@ -657,7 +684,8 @@ export class InitCommand {
       const workflows = getProfileWorkflows(profile, globalConfig.workflows);
       const toolDirs = [...new Set(successfulTools.map((t) => t.skillsDir))].join(', ');
       const skillCount = delivery !== 'commands' ? getSkillTemplates(workflows).length : 0;
-      const commandCount = delivery !== 'skills' ? getCommandContents(workflows).length : 0;
+      const hasCommandCapableTool = successfulTools.some((tool) => CommandAdapterRegistry.has(tool.value));
+      const commandCount = delivery !== 'skills' && hasCommandCapableTool ? getCommandContents(workflows).length : 0;
       if (skillCount > 0 && commandCount > 0) {
         console.log(`${skillCount} skills and ${commandCount} commands in ${toolDirs}/`);
       } else if (skillCount > 0) {
@@ -700,13 +728,20 @@ export class InitCommand {
     const globalCfg = getGlobalConfig();
     const activeProfile: Profile = (this.profileOverride as Profile) ?? globalCfg.profile ?? 'core';
     const activeWorkflows = [...getProfileWorkflows(activeProfile, globalCfg.workflows)];
+    const hasCommandCapableTool = successfulTools.some((tool) => CommandAdapterRegistry.has(tool.value));
     console.log();
     if (activeWorkflows.includes('propose')) {
       console.log(chalk.bold('Getting started:'));
-      console.log('  Start your first change: /opsx:propose "your idea"');
+      const startCommand = hasCommandCapableTool
+        ? '/opsx:propose "your idea"'
+        : formatSkillGettingStarted('propose', successfulTools);
+      console.log(`  Start your first change: ${startCommand}`);
     } else if (activeWorkflows.includes('new')) {
       console.log(chalk.bold('Getting started:'));
-      console.log('  Start your first change: /opsx:new "your idea"');
+      const startCommand = hasCommandCapableTool
+        ? '/opsx:new "your idea"'
+        : formatSkillGettingStarted('new', successfulTools);
+      console.log(`  Start your first change: ${startCommand}`);
     } else {
       console.log("Done. Run 'openspec config profile' to configure your workflows.");
     }

--- a/src/core/init.ts
+++ b/src/core/init.ts
@@ -12,9 +12,9 @@ import * as fs from 'fs';
 import { createRequire } from 'module';
 import { FileSystemUtils } from '../utils/file-system.js';
 import {
+  WORKFLOW_TO_SKILL_REFERENCE,
+  getSkillInstructionTransformer,
   getSkillReferencePrefix,
-  transformToHyphenCommands,
-  transformToToolSkillReferences,
 } from '../utils/command-references.js';
 import {
   AI_TOOLS,
@@ -64,35 +64,8 @@ const PROGRESS_SPINNER = {
   frames: ['░░░', '▒░░', '▒▒░', '▒▒▒', '▓▒▒', '▓▓▒', '▓▓▓', '▒▓▓', '░▒▓'],
 };
 
-const WORKFLOW_TO_SKILL_DIR: Record<string, string> = {
-  'explore': 'openspec-explore',
-  'new': 'openspec-new-change',
-  'continue': 'openspec-continue-change',
-  'apply': 'openspec-apply-change',
-  'ff': 'openspec-ff-change',
-  'sync': 'openspec-sync-specs',
-  'archive': 'openspec-archive-change',
-  'bulk-archive': 'openspec-bulk-archive-change',
-  'verify': 'openspec-verify-change',
-  'onboard': 'openspec-onboard',
-  'propose': 'openspec-propose',
-};
-
-function getSkillInstructionTransformer(
-  toolId: string,
-  hasCommandAdapter: boolean
-): ((instructions: string) => string) | undefined {
-  if (toolId === 'opencode' || toolId === 'pi') {
-    return transformToHyphenCommands;
-  }
-  if (!hasCommandAdapter) {
-    return (instructions: string) => transformToToolSkillReferences(instructions, toolId);
-  }
-  return undefined;
-}
-
 function formatSkillGettingStarted(workflowId: 'propose' | 'new', tools: Array<{ value: string }>): string {
-  const skillName = WORKFLOW_TO_SKILL_DIR[workflowId];
+  const skillName = WORKFLOW_TO_SKILL_REFERENCE[workflowId];
   const prefixedTool = tools.find((tool) => getSkillReferencePrefix(tool.value));
   const prefix = prefixedTool ? getSkillReferencePrefix(prefixedTool.value) : '';
   if (prefix) {

--- a/src/core/profile-sync-drift.ts
+++ b/src/core/profile-sync-drift.ts
@@ -5,25 +5,14 @@ import type { Delivery } from './global-config.js';
 import { ALL_WORKFLOWS } from './profiles.js';
 import { CommandAdapterRegistry } from './command-generation/index.js';
 import { COMMAND_IDS, getConfiguredTools } from './shared/index.js';
+import { WORKFLOW_TO_SKILL_REFERENCE } from '../utils/command-references.js';
 
 type WorkflowId = (typeof ALL_WORKFLOWS)[number];
 
 /**
  * Maps workflow IDs to their skill directory names.
  */
-export const WORKFLOW_TO_SKILL_DIR: Record<WorkflowId, string> = {
-  'explore': 'openspec-explore',
-  'new': 'openspec-new-change',
-  'continue': 'openspec-continue-change',
-  'apply': 'openspec-apply-change',
-  'ff': 'openspec-ff-change',
-  'sync': 'openspec-sync-specs',
-  'archive': 'openspec-archive-change',
-  'bulk-archive': 'openspec-bulk-archive-change',
-  'verify': 'openspec-verify-change',
-  'onboard': 'openspec-onboard',
-  'propose': 'openspec-propose',
-};
+export const WORKFLOW_TO_SKILL_DIR = WORKFLOW_TO_SKILL_REFERENCE as Record<WorkflowId, string>;
 
 function toKnownWorkflows(workflows: readonly string[]): WorkflowId[] {
   return workflows.filter(

--- a/src/core/update.ts
+++ b/src/core/update.ts
@@ -319,27 +319,36 @@ export class UpdateCommand {
     const tools = toolIds
       .map((toolId) => AI_TOOLS.find((tool) => tool.value === toolId))
       .filter((tool): tool is NonNullable<typeof tool> => tool != null);
-    const hasCommandCapableTool = tools.some((tool) => CommandAdapterRegistry.has(tool.value));
+    const commandCapableTools = tools.filter((tool) => CommandAdapterRegistry.has(tool.value));
+    const skillOnlyTools = tools.filter((tool) => !CommandAdapterRegistry.has(tool.value));
+    const workflowSet = new Set(desiredWorkflows);
 
     console.log();
     console.log(chalk.bold('Getting started:'));
 
-    if (hasCommandCapableTool) {
+    if (commandCapableTools.length > 0) {
+      if (skillOnlyTools.length > 0) {
+        console.log(chalk.dim('  Slash commands:'));
+      }
       console.log('  /opsx:new       Start a new change');
       console.log('  /opsx:continue  Create the next artifact');
       console.log('  /opsx:apply     Implement tasks');
-    } else {
-      const workflowSet = new Set(desiredWorkflows);
+    }
+
+    for (const tool of skillOnlyTools) {
+      if (commandCapableTools.length > 0 || skillOnlyTools.length > 1) {
+        console.log(chalk.dim(`  ${tool.name} skills:`));
+      }
       if (workflowSet.has('propose')) {
-        console.log(`  ${formatSkillReference('propose', tools)}  Start a new change`);
+        console.log(`  ${formatSkillReference('propose', [tool])}  Start a new change`);
       } else if (workflowSet.has('new')) {
-        console.log(`  ${formatSkillReference('new', tools)}  Start a new change`);
+        console.log(`  ${formatSkillReference('new', [tool])}  Start a new change`);
       }
       if (workflowSet.has('continue')) {
-        console.log(`  ${formatSkillReference('continue', tools)}  Create the next artifact`);
+        console.log(`  ${formatSkillReference('continue', [tool])}  Create the next artifact`);
       }
       if (workflowSet.has('apply')) {
-        console.log(`  ${formatSkillReference('apply', tools)}  Implement tasks`);
+        console.log(`  ${formatSkillReference('apply', [tool])}  Implement tasks`);
       }
     }
 

--- a/src/core/update.ts
+++ b/src/core/update.ts
@@ -13,6 +13,8 @@ import { createRequire } from 'module';
 import { FileSystemUtils } from '../utils/file-system.js';
 import {
   getSkillInstructionTransformer,
+  getSkillReferencePrefix,
+  WORKFLOW_TO_SKILL_REFERENCE,
 } from '../utils/command-references.js';
 import { AI_TOOLS, OPENSPEC_DIR_NAME } from './config.js';
 import {
@@ -53,6 +55,13 @@ import {
 const require = createRequire(import.meta.url);
 const { version: OPENSPEC_VERSION } = require('../../package.json');
 const OLD_CORE_WORKFLOWS = ['propose', 'explore', 'apply', 'archive'] as const;
+
+function formatSkillReference(workflowId: string, tools: Array<{ value: string }>): string {
+  const skillName = WORKFLOW_TO_SKILL_REFERENCE[workflowId];
+  const prefixedTool = tools.find((tool) => getSkillReferencePrefix(tool.value));
+  const prefix = prefixedTool ? getSkillReferencePrefix(prefixedTool.value) : '';
+  return skillName ? `${prefix}${skillName}` : workflowId;
+}
 
 /**
  * Options for the update command.
@@ -270,13 +279,7 @@ export class UpdateCommand {
 
     // 12. Show onboarding message for newly configured tools from legacy upgrade
     if (newlyConfiguredTools.length > 0) {
-      console.log();
-      console.log(chalk.bold('Getting started:'));
-      console.log('  /opsx:new       Start a new change');
-      console.log('  /opsx:continue  Create the next artifact');
-      console.log('  /opsx:apply     Implement tasks');
-      console.log();
-      console.log(`Learn more: ${chalk.cyan('https://github.com/Fission-AI/OpenSpec')}`);
+      this.displayLegacyUpgradeGettingStarted(newlyConfiguredTools, desiredWorkflows);
     }
 
     const configuredAndNewTools = [...new Set([...configuredTools, ...newlyConfiguredTools])];
@@ -307,6 +310,41 @@ export class UpdateCommand {
     console.log(chalk.dim(`  Tools: ${toolNames.join(', ')}`));
     console.log();
     console.log(chalk.dim('Use --force to refresh files anyway.'));
+  }
+
+  private displayLegacyUpgradeGettingStarted(
+    toolIds: string[],
+    desiredWorkflows: readonly (typeof ALL_WORKFLOWS)[number][]
+  ): void {
+    const tools = toolIds
+      .map((toolId) => AI_TOOLS.find((tool) => tool.value === toolId))
+      .filter((tool): tool is NonNullable<typeof tool> => tool != null);
+    const hasCommandCapableTool = tools.some((tool) => CommandAdapterRegistry.has(tool.value));
+
+    console.log();
+    console.log(chalk.bold('Getting started:'));
+
+    if (hasCommandCapableTool) {
+      console.log('  /opsx:new       Start a new change');
+      console.log('  /opsx:continue  Create the next artifact');
+      console.log('  /opsx:apply     Implement tasks');
+    } else {
+      const workflowSet = new Set(desiredWorkflows);
+      if (workflowSet.has('propose')) {
+        console.log(`  ${formatSkillReference('propose', tools)}  Start a new change`);
+      } else if (workflowSet.has('new')) {
+        console.log(`  ${formatSkillReference('new', tools)}  Start a new change`);
+      }
+      if (workflowSet.has('continue')) {
+        console.log(`  ${formatSkillReference('continue', tools)}  Create the next artifact`);
+      }
+      if (workflowSet.has('apply')) {
+        console.log(`  ${formatSkillReference('apply', tools)}  Implement tasks`);
+      }
+    }
+
+    console.log();
+    console.log(`Learn more: ${chalk.cyan('https://github.com/Fission-AI/OpenSpec')}`);
   }
 
   /**

--- a/src/core/update.ts
+++ b/src/core/update.ts
@@ -12,8 +12,7 @@ import * as fs from 'fs';
 import { createRequire } from 'module';
 import { FileSystemUtils } from '../utils/file-system.js';
 import {
-  transformToHyphenCommands,
-  transformToToolSkillReferences,
+  getSkillInstructionTransformer,
 } from '../utils/command-references.js';
 import { AI_TOOLS, OPENSPEC_DIR_NAME } from './config.js';
 import {
@@ -54,19 +53,6 @@ import {
 const require = createRequire(import.meta.url);
 const { version: OPENSPEC_VERSION } = require('../../package.json');
 const OLD_CORE_WORKFLOWS = ['propose', 'explore', 'apply', 'archive'] as const;
-
-function getSkillInstructionTransformer(
-  toolId: string,
-  hasCommandAdapter: boolean
-): ((instructions: string) => string) | undefined {
-  if (toolId === 'opencode' || toolId === 'pi') {
-    return transformToHyphenCommands;
-  }
-  if (!hasCommandAdapter) {
-    return (instructions: string) => transformToToolSkillReferences(instructions, toolId);
-  }
-  return undefined;
-}
 
 /**
  * Options for the update command.

--- a/src/core/update.ts
+++ b/src/core/update.ts
@@ -11,7 +11,10 @@ import ora from 'ora';
 import * as fs from 'fs';
 import { createRequire } from 'module';
 import { FileSystemUtils } from '../utils/file-system.js';
-import { transformToHyphenCommands } from '../utils/command-references.js';
+import {
+  transformToHyphenCommands,
+  transformToToolSkillReferences,
+} from '../utils/command-references.js';
 import { AI_TOOLS, OPENSPEC_DIR_NAME } from './config.js';
 import {
   generateCommands,
@@ -51,6 +54,19 @@ import {
 const require = createRequire(import.meta.url);
 const { version: OPENSPEC_VERSION } = require('../../package.json');
 const OLD_CORE_WORKFLOWS = ['propose', 'explore', 'apply', 'archive'] as const;
+
+function getSkillInstructionTransformer(
+  toolId: string,
+  hasCommandAdapter: boolean
+): ((instructions: string) => string) | undefined {
+  if (toolId === 'opencode' || toolId === 'pi') {
+    return transformToHyphenCommands;
+  }
+  if (!hasCommandAdapter) {
+    return (instructions: string) => transformToToolSkillReferences(instructions, toolId);
+  }
+  return undefined;
+}
 
 /**
  * Options for the update command.
@@ -195,9 +211,9 @@ export class UpdateCommand {
           for (const { template, dirName } of skillTemplates) {
             const skillDir = path.join(skillsDir, dirName);
             const skillFile = path.join(skillDir, 'SKILL.md');
+            const hasCommandAdapter = CommandAdapterRegistry.has(tool.value);
 
-            // Use hyphen-based command references for OpenCode
-            const transformer = (tool.value === 'opencode' || tool.value === 'pi') ? transformToHyphenCommands : undefined;
+            const transformer = getSkillInstructionTransformer(tool.value, hasCommandAdapter);
             const skillContent = generateSkillContent(template, OPENSPEC_VERSION, transformer);
             await FileSystemUtils.writeFile(skillFile, skillContent);
           }
@@ -689,9 +705,9 @@ export class UpdateCommand {
           for (const { template, dirName } of skillTemplates) {
             const skillDir = path.join(skillsDir, dirName);
             const skillFile = path.join(skillDir, 'SKILL.md');
+            const hasCommandAdapter = CommandAdapterRegistry.has(tool.value);
 
-            // Use hyphen-based command references for OpenCode
-            const transformer = (tool.value === 'opencode' || tool.value === 'pi') ? transformToHyphenCommands : undefined;
+            const transformer = getSkillInstructionTransformer(tool.value, hasCommandAdapter);
             const skillContent = generateSkillContent(template, OPENSPEC_VERSION, transformer);
             await FileSystemUtils.writeFile(skillFile, skillContent);
           }

--- a/src/utils/command-references.ts
+++ b/src/utils/command-references.ts
@@ -19,7 +19,7 @@ export function transformToHyphenCommands(text: string): string {
   return text.replace(/\/opsx:/g, '/opsx-');
 }
 
-const WORKFLOW_TO_SKILL_REFERENCE: Record<string, string> = {
+export const WORKFLOW_TO_SKILL_REFERENCE: Record<string, string> = {
   explore: 'openspec-explore',
   new: 'openspec-new-change',
   continue: 'openspec-continue-change',
@@ -52,4 +52,17 @@ export function getSkillReferencePrefix(toolId: string): string {
 
 export function transformToToolSkillReferences(text: string, toolId: string): string {
   return transformToSkillReferences(text, getSkillReferencePrefix(toolId));
+}
+
+export function getSkillInstructionTransformer(
+  toolId: string,
+  hasCommandAdapter: boolean
+): ((instructions: string) => string) | undefined {
+  if (toolId === 'opencode' || toolId === 'pi') {
+    return transformToHyphenCommands;
+  }
+  if (!hasCommandAdapter) {
+    return (instructions: string) => transformToToolSkillReferences(instructions, toolId);
+  }
+  return undefined;
 }

--- a/src/utils/command-references.ts
+++ b/src/utils/command-references.ts
@@ -18,3 +18,38 @@
 export function transformToHyphenCommands(text: string): string {
   return text.replace(/\/opsx:/g, '/opsx-');
 }
+
+const WORKFLOW_TO_SKILL_REFERENCE: Record<string, string> = {
+  explore: 'openspec-explore',
+  new: 'openspec-new-change',
+  continue: 'openspec-continue-change',
+  apply: 'openspec-apply-change',
+  ff: 'openspec-ff-change',
+  sync: 'openspec-sync-specs',
+  archive: 'openspec-archive-change',
+  'bulk-archive': 'openspec-bulk-archive-change',
+  verify: 'openspec-verify-change',
+  onboard: 'openspec-onboard',
+  propose: 'openspec-propose',
+};
+
+/**
+ * Transforms generated slash-command references to Agent Skill references.
+ *
+ * Adapterless tools can receive skills without matching command files. In that
+ * mode, `/opsx:*` guidance points users at commands that were never generated.
+ */
+export function transformToSkillReferences(text: string, prefix = ''): string {
+  return text.replace(/\/opsx:([a-z-]+)/g, (match, workflow: string) => {
+    const skillReference = WORKFLOW_TO_SKILL_REFERENCE[workflow];
+    return skillReference ? `${prefix}${skillReference}` : match;
+  });
+}
+
+export function getSkillReferencePrefix(toolId: string): string {
+  return toolId === 'kimi' ? '/skill:' : '';
+}
+
+export function transformToToolSkillReferences(text: string, toolId: string): string {
+  return transformToSkillReferences(text, getSkillReferencePrefix(toolId));
+}

--- a/test/core/init.test.ts
+++ b/test/core/init.test.ts
@@ -180,16 +180,47 @@ describe('InitCommand', () => {
 
       const skillFile = path.join(testDir, '.kimi', 'skills', 'openspec-explore', 'SKILL.md');
       expect(await fileExists(skillFile)).toBe(true);
+      const proposeSkillFile = path.join(testDir, '.kimi', 'skills', 'openspec-propose', 'SKILL.md');
+      const proposeSkill = await fs.readFile(proposeSkillFile, 'utf-8');
+      expect(proposeSkill).not.toContain('/opsx:');
+      expect(proposeSkill).toContain('/skill:openspec-apply-change');
 
       const commandsDir = path.join(testDir, '.kimi', 'commands');
       expect(await directoryExists(commandsDir)).toBe(false);
 
       const logCalls = (console.log as unknown as { mock: { calls: unknown[][] } }).mock.calls.flat().map(String);
+      expect(logCalls.some((entry) => entry.includes('skills in .kimi/'))).toBe(true);
+      expect(logCalls.some((entry) => entry.includes('skills and') && entry.includes('commands in .kimi/'))).toBe(false);
+      expect(logCalls.some((entry) => entry.includes('/skill:openspec-propose "your idea"'))).toBe(true);
       expect(
         logCalls.some(
           (entry) => entry.includes('Commands skipped for: kimi') && entry.includes('(no adapter)'),
         ),
       ).toBe(true);
+    });
+
+    it('should avoid slash-command references for Vibe adapterless skills', async () => {
+      saveGlobalConfig({
+        featureFlags: {},
+        profile: 'core',
+        delivery: 'both',
+      });
+
+      const initCommand = new InitCommand({ tools: 'vibe', force: true });
+      await initCommand.execute(testDir);
+
+      const proposeSkillFile = path.join(testDir, '.vibe', 'skills', 'openspec-propose', 'SKILL.md');
+      const proposeSkill = await fs.readFile(proposeSkillFile, 'utf-8');
+      expect(proposeSkill).not.toContain('/opsx:');
+      expect(proposeSkill).toContain('openspec-apply-change');
+
+      const commandsDir = path.join(testDir, '.vibe', 'commands');
+      expect(await directoryExists(commandsDir)).toBe(false);
+
+      const logCalls = (console.log as unknown as { mock: { calls: unknown[][] } }).mock.calls.flat().map(String);
+      expect(logCalls.some((entry) => entry.includes('skills in .vibe/'))).toBe(true);
+      expect(logCalls.some((entry) => entry.includes('skills and') && entry.includes('commands in .vibe/'))).toBe(false);
+      expect(logCalls.some((entry) => entry.includes('openspec-propose skill for "your idea"'))).toBe(true);
     });
 
     it('should create skills for multiple tools at once', async () => {

--- a/test/core/update.test.ts
+++ b/test/core/update.test.ts
@@ -1186,6 +1186,39 @@ More user content after markers.
       consoleSpy.mockRestore();
     });
 
+    it('should split mixed legacy-upgraded command and skill-only guidance', async () => {
+      await fs.mkdir(path.join(testDir, '.claude', 'commands', 'openspec'), { recursive: true });
+      await fs.writeFile(
+        path.join(testDir, '.claude', 'commands', 'openspec', 'proposal.md'),
+        'content'
+      );
+
+      await fs.mkdir(path.join(testDir, '.cursor', 'commands'), { recursive: true });
+      await fs.writeFile(
+        path.join(testDir, '.cursor', 'commands', 'openspec-proposal.md'),
+        'content'
+      );
+
+      const { CommandAdapterRegistry } = await import('../../src/core/command-generation/index.js');
+      vi.spyOn(CommandAdapterRegistry, 'has').mockImplementation((toolId) => toolId === 'claude');
+      const consoleSpy = vi.spyOn(console, 'log');
+
+      const forceUpdateCommand = new UpdateCommand({ force: true });
+      await forceUpdateCommand.execute(testDir);
+
+      const calls = consoleSpy.mock.calls.map(call =>
+        call.map(arg => String(arg)).join(' ')
+      );
+      expect(calls.some(call => call.includes('Getting started'))).toBe(true);
+      expect(calls.some(call => call.includes('Slash commands'))).toBe(true);
+      expect(calls.some(call => call.includes('  /opsx:new'))).toBe(true);
+      expect(calls.some(call => call.includes('Cursor skills'))).toBe(true);
+      expect(calls.some(call => call.includes('openspec-propose') && call.includes('Start a new change'))).toBe(true);
+      expect(calls.some(call => call.includes('openspec-apply-change') && call.includes('Implement tasks'))).toBe(true);
+
+      consoleSpy.mockRestore();
+    });
+
     it('should upgrade multiple legacy tools with --force', async () => {
       // Create legacy command directories for Claude and Cursor
       await fs.mkdir(path.join(testDir, '.claude', 'commands', 'openspec'), { recursive: true });

--- a/test/core/update.test.ts
+++ b/test/core/update.test.ts
@@ -1157,6 +1157,35 @@ More user content after markers.
       consoleSpy.mockRestore();
     });
 
+    it('should show skill references for legacy-upgraded tools without command adapters', async () => {
+      // Create legacy slash command directory (no skills exist yet)
+      const legacyCommandDir = path.join(testDir, '.claude', 'commands', 'openspec');
+      await fs.mkdir(legacyCommandDir, { recursive: true });
+      await fs.writeFile(
+        path.join(legacyCommandDir, 'proposal.md'),
+        'old command content'
+      );
+
+      const { CommandAdapterRegistry } = await import('../../src/core/command-generation/index.js');
+      vi.spyOn(CommandAdapterRegistry, 'has').mockReturnValue(false);
+      const consoleSpy = vi.spyOn(console, 'log');
+
+      const forceUpdateCommand = new UpdateCommand({ force: true });
+      await forceUpdateCommand.execute(testDir);
+
+      const calls = consoleSpy.mock.calls.map(call =>
+        call.map(arg => String(arg)).join(' ')
+      );
+      expect(calls.some(call => call.includes('Getting started'))).toBe(true);
+      expect(calls.some(call => call.includes('openspec-propose') && call.includes('Start a new change'))).toBe(true);
+      expect(calls.some(call => call.includes('openspec-apply-change') && call.includes('Implement tasks'))).toBe(true);
+      expect(calls.some(call => call.includes('  /opsx:new'))).toBe(false);
+      expect(calls.some(call => call.includes('  /opsx:continue'))).toBe(false);
+      expect(calls.some(call => call.includes('  /opsx:apply'))).toBe(false);
+
+      consoleSpy.mockRestore();
+    });
+
     it('should upgrade multiple legacy tools with --force', async () => {
       // Create legacy command directories for Claude and Cursor
       await fs.mkdir(path.join(testDir, '.claude', 'commands', 'openspec'), { recursive: true });

--- a/test/utils/command-references.test.ts
+++ b/test/utils/command-references.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { transformToHyphenCommands } from '../../src/utils/command-references.js';
+import {
+  getSkillReferencePrefix,
+  transformToHyphenCommands,
+  transformToSkillReferences,
+  transformToToolSkillReferences,
+} from '../../src/utils/command-references.js';
 
 describe('transformToHyphenCommands', () => {
   describe('basic transformations', () => {
@@ -79,5 +84,37 @@ Finally /opsx-apply to implement`;
         expect(transformToHyphenCommands(`/opsx:${cmd}`)).toBe(`/opsx-${cmd}`);
       });
     }
+  });
+});
+
+describe('transformToSkillReferences', () => {
+  it('should transform command references to skill names', () => {
+    expect(transformToSkillReferences('/opsx:apply')).toBe('openspec-apply-change');
+  });
+
+  it('should apply an optional skill invocation prefix', () => {
+    expect(transformToSkillReferences('Run /opsx:propose', '/skill:')).toBe(
+      'Run /skill:openspec-propose'
+    );
+  });
+
+  it('should transform multiple workflow references', () => {
+    const input = 'Use /opsx:new, then /opsx:continue and /opsx:archive';
+    const expected = 'Use openspec-new-change, then openspec-continue-change and openspec-archive-change';
+    expect(transformToSkillReferences(input)).toBe(expected);
+  });
+
+  it('should leave unknown command references unchanged', () => {
+    expect(transformToSkillReferences('/opsx:unknown')).toBe('/opsx:unknown');
+  });
+
+  it('should use Kimi skill invocation prefix for tool-specific references', () => {
+    expect(getSkillReferencePrefix('kimi')).toBe('/skill:');
+    expect(transformToToolSkillReferences('/opsx:apply', 'kimi')).toBe('/skill:openspec-apply-change');
+  });
+
+  it('should use plain skill names for tools without a specific prefix', () => {
+    expect(getSkillReferencePrefix('vibe')).toBe('');
+    expect(transformToToolSkillReferences('/opsx:apply', 'vibe')).toBe('openspec-apply-change');
   });
 });


### PR DESCRIPTION
Fixes #1155.

## What changed

- Transform generated `/opsx:*` references into skill references for tools that do not have a command adapter.
- Use Kimi CLI-specific `/skill:openspec-*` invocations while keeping Mistral Vibe on plain `openspec-*` skill names.
- Avoid reporting generated command counts when commands are skipped for adapterless tools.
- Show skill-based getting-started guidance when init only creates skills.
- Apply the same transformation during `openspec update` skill regeneration.

## Validation

- `pnpm exec vitest run test/utils/command-references.test.ts test/core/init.test.ts test/core/update.test.ts`
- `pnpm run build`

Note: local build prints the existing Node engine warning because this machine has Node 20.11.1 and the package asks for >=20.19.0, but the build completed successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added capability-aware instruction/skill-reference transformation that rewrites `/opsx:<workflow>` references into the correct skill references, including tool-specific `/skill:` prefixes.
  * Enhanced “getting started” messaging to use slash-style prompts when command-capable tools are available, otherwise workflow skill instructions.

* **Refactor**
  * Unified “SKILL.md” and reference generation across setup and update flows to reflect command-adapter availability.
  * Centralized workflow-to-skill reference mapping for consistent output.

* **Bug Fixes**
  * Corrected command success-message counting to report zero when commands aren’t actually enabled.

* **Tests**
  * Expanded adapterless “skills-only” coverage and added legacy-upgrade scenarios to ensure correct guidance and absence/presence of `/opsx:` commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->