### PR TITLE
docs: add vibe to CLI tool id list

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -107,7 +107,7 @@ openspec init [path] [options]
 
 `--profile custom` uses whatever workflows are currently selected in global config (`openspec config profile`).
 
-**Supported tool IDs (`--tools`):** `amazon-q`, `antigravity`, `auggie`, `bob`, `claude`, `cline`, `codex`, `forgecode`, `codebuddy`, `continue`, `costrict`, `crush`, `cursor`, `factory`, `gemini`, `github-copilot`, `iflow`, `junie`, `kilocode`, `kimi`, `kiro`, `opencode`, `pi`, `qoder`, `lingma`, `qwen`, `roocode`, `trae`, `windsurf`
+**Supported tool IDs (`--tools`):** `amazon-q`, `antigravity`, `auggie`, `bob`, `claude`, `cline`, `codex`, `forgecode`, `codebuddy`, `continue`, `costrict`, `crush`, `cursor`, `factory`, `gemini`, `github-copilot`, `iflow`, `junie`, `kilocode`, `kimi`, `kiro`, `lingma`, `opencode`, `pi`, `qoder`, `qwen`, `roocode`, `trae`, `vibe`, `windsurf`
 
 **Examples:**
 


### PR DESCRIPTION
## Summary

Adds `vibe` to the `openspec init --tools` list in `docs/cli.md`, matching `src/core/config.ts` and `docs/supported-tools.md`.

I left `agents` out because it is currently marked `available: false` in `AI_TOOLS`, so it does not look like a user-facing `--tools` option yet.

Fixes #1213.

## Validation

- `pnpm run build`
- `pnpm vitest run test/core/available-tools.test.ts`
- `git diff --check`

Prepared with AI assistance and manually reviewed before submission.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `openspec init` command's `--tools` documentation to reflect the current list of supported tools, including the addition of `vibe` and removal of `lingma`.
  * Corrected the spelling of the `windsurf` tool ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->