### PR TITLE
fix(view): count nested task files

### DIFF
--- a/src/utils/task-progress.ts
+++ b/src/utils/task-progress.ts
@@ -25,13 +25,35 @@ export function countTasksFromContent(content: string): TaskProgress {
 }
 
 export async function getTaskProgressForChange(changesDir: string, changeName: string): Promise<TaskProgress> {
-  const tasksPath = path.join(changesDir, changeName, 'tasks.md');
+  const changeDir = path.join(changesDir, changeName);
   try {
-    const content = await fs.readFile(tasksPath, 'utf-8');
-    return countTasksFromContent(content);
+    const taskFiles = await findTaskFiles(changeDir);
+    const progress = { total: 0, completed: 0 };
+    for (const taskFile of taskFiles) {
+      const content = await fs.readFile(taskFile, 'utf-8');
+      const fileProgress = countTasksFromContent(content);
+      progress.total += fileProgress.total;
+      progress.completed += fileProgress.completed;
+    }
+    return progress;
   } catch {
     return { total: 0, completed: 0 };
   }
+}
+
+async function findTaskFiles(dir: string): Promise<string[]> {
+  const taskFiles: string[] = [];
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      taskFiles.push(...await findTaskFiles(entryPath));
+    }
+    else if (entry.isFile() && entry.name === 'tasks.md') {
+      taskFiles.push(entryPath);
+    }
+  }
+  return taskFiles.sort();
 }
 
 export function formatTaskStatus(progress: TaskProgress): string {
@@ -39,5 +61,4 @@ export function formatTaskStatus(progress: TaskProgress): string {
   if (progress.completed === progress.total) return '✓ Complete';
   return `${progress.completed}/${progress.total} tasks`;
 }
-
 

--- a/test/core/view.test.ts
+++ b/test/core/view.test.ts
@@ -125,5 +125,29 @@ describe('ViewCommand', () => {
       'gamma-change'
     ]);
   });
-});
 
+  it('counts nested tasks files when rendering change progress', async () => {
+    const changesDir = path.join(tempDir, 'openspec', 'changes');
+    const changeDir = path.join(changesDir, 'layered-change');
+    await fs.mkdir(path.join(changeDir, 'backend'), { recursive: true });
+    await fs.mkdir(path.join(changeDir, 'frontend'), { recursive: true });
+
+    await fs.writeFile(
+      path.join(changeDir, 'backend', 'tasks.md'),
+      '- [x] Add backend endpoint\n- [ ] Add backend tests\n'
+    );
+    await fs.writeFile(
+      path.join(changeDir, 'frontend', 'tasks.md'),
+      '- [ ] Wire frontend view\n'
+    );
+
+    const viewCommand = new ViewCommand();
+    await viewCommand.execute(tempDir);
+
+    const output = logOutput.map(stripAnsi).join('\n');
+
+    expect(output).toContain('Active Changes');
+    expect(output).toContain('Task Progress: 1/3 (33% complete)');
+    expect(output).toContain('◉ layered-change');
+  });
+});


### PR DESCRIPTION
Fixes #1202

## Summary
- count every `tasks.md` under a change directory when computing task progress
- keep root `tasks.md` behavior intact while supporting layered schemas such as `backend/tasks.md` and `frontend/tasks.md`
- add a `view` regression test for nested task files

## Verification
- `pnpm vitest run test/core/view.test.ts`
- `pnpm vitest run test/core/list.test.ts test/core/archive.test.ts test/core/view.test.ts`
- `pnpm run build`
- `pnpm run lint`
- `git diff --check`

I used OpenAI Codex to help implement and check this change, and reviewed the diff and test results before submitting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task progress tracking now aggregates information from multiple task files within nested directory structures.

* **Tests**
  * Added test coverage to verify task progress calculation correctly handles nested directory scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->