### PR TITLE
Add ZCode tool support (#1242)

### DIFF
--- a/src/core/command-generation/adapters/index.ts
+++ b/src/core/command-generation/adapters/index.ts
@@ -30,3 +30,4 @@ export { lingmaAdapter } from './lingma.js';
 export { qwenAdapter } from './qwen.js';
 export { roocodeAdapter } from './roocode.js';
 export { windsurfAdapter } from './windsurf.js';
+export { zcodeAdapter } from './zcode.js';

--- a/src/core/command-generation/adapters/zcode.ts
+++ b/src/core/command-generation/adapters/zcode.ts
@@ -1,0 +1,34 @@
+/**
+ * ZCode Command Adapter
+ *
+ * Formats commands for ZCode under its project-local command directory.
+ */
+
+import path from 'path';
+import type { CommandContent, ToolCommandAdapter } from '../types.js';
+
+/**
+ * ZCode adapter for command generation.
+ * File path: .zcode/commands/opsx/<id>.md
+ * Frontmatter: name, description, category, tags
+ */
+export const zcodeAdapter: ToolCommandAdapter = {
+  toolId: 'zcode',
+
+  getFilePath(commandId: string): string {
+    return path.join('.zcode', 'commands', 'opsx', `${commandId}.md`);
+  },
+
+  formatFile(content: CommandContent): string {
+    const tagsStr = content.tags.join(', ');
+    return `---
+name: ${content.name}
+description: ${content.description}
+category: ${content.category}
+tags: [${tagsStr}]
+---
+
+${content.body}
+`;
+  },
+};

--- a/src/core/command-generation/registry.ts
+++ b/src/core/command-generation/registry.ts
@@ -32,6 +32,7 @@ import { lingmaAdapter } from './adapters/lingma.js';
 import { qwenAdapter } from './adapters/qwen.js';
 import { roocodeAdapter } from './adapters/roocode.js';
 import { windsurfAdapter } from './adapters/windsurf.js';
+import { zcodeAdapter } from './adapters/zcode.js';
 
 /**
  * Registry for looking up tool command adapters.
@@ -67,6 +68,7 @@ export class CommandAdapterRegistry {
     CommandAdapterRegistry.register(qwenAdapter);
     CommandAdapterRegistry.register(roocodeAdapter);
     CommandAdapterRegistry.register(windsurfAdapter);
+    CommandAdapterRegistry.register(zcodeAdapter);
   }
 
   /**

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -49,5 +49,6 @@ export const AI_TOOLS: AIToolOption[] = [
   { name: 'RooCode', value: 'roocode', available: true, successLabel: 'RooCode', skillsDir: '.roo' },
   { name: 'Trae', value: 'trae', available: true, successLabel: 'Trae', skillsDir: '.trae' },
   { name: 'Windsurf', value: 'windsurf', available: true, successLabel: 'Windsurf', skillsDir: '.windsurf' },
+  { name: 'ZCode', value: 'zcode', available: true, successLabel: 'ZCode', skillsDir: '.zcode' },
   { name: 'AGENTS.md (works with Amp, VS Code, …)', value: 'agents', available: false, successLabel: 'your AGENTS.md-compatible assistant' }
 ];

--- a/test/core/available-tools.test.ts
+++ b/test/core/available-tools.test.ts
@@ -163,5 +163,16 @@ describe('available-tools', () => {
       expect(vibeTool?.name).toBe('Mistral Vibe');
       expect(vibeTool?.skillsDir).toBe('.vibe');
     });
+
+    it('should detect ZCode when .zcode directory exists', async () => {
+      await fs.mkdir(path.join(testDir, '.zcode'), { recursive: true });
+
+      const tools = getAvailableTools(testDir);
+      const zcodeTool = tools.find((t) => t.value === 'zcode');
+
+      expect(zcodeTool).toBeDefined();
+      expect(zcodeTool?.name).toBe('ZCode');
+      expect(zcodeTool?.skillsDir).toBe('.zcode');
+    });
   });
 });

--- a/test/core/command-generation/adapters.test.ts
+++ b/test/core/command-generation/adapters.test.ts
@@ -24,6 +24,7 @@ import { qoderAdapter } from '../../../src/core/command-generation/adapters/qode
 import { qwenAdapter } from '../../../src/core/command-generation/adapters/qwen.js';
 import { roocodeAdapter } from '../../../src/core/command-generation/adapters/roocode.js';
 import { windsurfAdapter } from '../../../src/core/command-generation/adapters/windsurf.js';
+import { zcodeAdapter } from '../../../src/core/command-generation/adapters/zcode.js';
 import type { CommandContent } from '../../../src/core/command-generation/types.js';
 
 describe('command-generation/adapters', () => {
@@ -116,6 +117,28 @@ describe('command-generation/adapters', () => {
     it('should format file similar to Claude format', () => {
       const output = windsurfAdapter.formatFile(sampleContent);
 
+      expect(output).toContain('---\n');
+      expect(output).toContain('name: OpenSpec Explore');
+      expect(output).toContain('description: Enter explore mode for thinking');
+      expect(output).toContain('category: Workflow');
+      expect(output).toContain('tags: [workflow, explore, experimental]');
+      expect(output).toContain('---\n\n');
+      expect(output).toContain('This is the command body.');
+    });
+  });
+
+  describe('zcodeAdapter', () => {
+    it('should have correct toolId', () => {
+      expect(zcodeAdapter.toolId).toBe('zcode');
+    });
+
+    it('should generate correct file path with nested opsx folder', () => {
+      const filePath = zcodeAdapter.getFilePath('explore');
+      expect(filePath).toBe(path.join('.zcode', 'commands', 'opsx', 'explore.md'));
+    });
+
+    it('should format file with name, description, category, and tags', () => {
+      const output = zcodeAdapter.formatFile(sampleContent);
       expect(output).toContain('---\n');
       expect(output).toContain('name: OpenSpec Explore');
       expect(output).toContain('description: Enter explore mode for thinking');
@@ -698,7 +721,7 @@ describe('command-generation/adapters', () => {
         codexAdapter, codebuddyAdapter, continueAdapter, costrictAdapter,
         crushAdapter, factoryAdapter, geminiAdapter, githubCopilotAdapter,
         iflowAdapter, kilocodeAdapter, opencodeAdapter, piAdapter, qoderAdapter,
-        qwenAdapter, roocodeAdapter
+        qwenAdapter, roocodeAdapter, zcodeAdapter
       ];
       for (const adapter of adapters) {
         const filePath = adapter.getFilePath('test');

--- a/test/core/command-generation/registry.test.ts
+++ b/test/core/command-generation/registry.test.ts
@@ -27,6 +27,12 @@ describe('command-generation/registry', () => {
       expect(adapter?.toolId).toBe('junie');
     });
 
+    it('should return ZCode adapter for "zcode"', () => {
+      const adapter = CommandAdapterRegistry.get('zcode');
+      expect(adapter).toBeDefined();
+      expect(adapter?.toolId).toBe('zcode');
+    });
+
     it('should return undefined for unregistered tool', () => {
       const adapter = CommandAdapterRegistry.get('unknown-tool');
       expect(adapter).toBeUndefined();
@@ -52,6 +58,7 @@ describe('command-generation/registry', () => {
       expect(toolIds).toContain('claude');
       expect(toolIds).toContain('cursor');
       expect(toolIds).toContain('windsurf');
+      expect(toolIds).toContain('zcode');
     });
   });
 
@@ -61,6 +68,7 @@ describe('command-generation/registry', () => {
       expect(CommandAdapterRegistry.has('cursor')).toBe(true);
       expect(CommandAdapterRegistry.has('windsurf')).toBe(true);
       expect(CommandAdapterRegistry.has('junie')).toBe(true);
+      expect(CommandAdapterRegistry.has('zcode')).toBe(true);
     });
 
     it('should return false for unregistered tools', () => {
@@ -78,6 +86,7 @@ describe('command-generation/registry', () => {
       expect(claudeAdapter?.getFilePath('test')).toContain('.claude');
       expect(cursorAdapter?.getFilePath('test')).toContain('.cursor');
       expect(windsurfAdapter?.getFilePath('test')).toContain('.windsurf');
+      expect(CommandAdapterRegistry.get('zcode')?.getFilePath('test')).toContain('.zcode');
     });
 
     it('registered adapters should have working formatFile', () => {

--- a/test/core/init.test.ts
+++ b/test/core/init.test.ts
@@ -168,6 +168,22 @@ describe('InitCommand', () => {
       expect(await fileExists(skillFile)).toBe(true);
     });
 
+    it('should create ZCode skills and commands', async () => {
+      const initCommand = new InitCommand({ tools: 'zcode', force: true });
+
+      await initCommand.execute(testDir);
+
+      const skillFile = path.join(testDir, '.zcode', 'skills', 'openspec-explore', 'SKILL.md');
+      expect(await fileExists(skillFile)).toBe(true);
+
+      const commandFile = path.join(testDir, '.zcode', 'commands', 'opsx', 'explore.md');
+      expect(await fileExists(commandFile)).toBe(true);
+
+      const commandContent = await fs.readFile(commandFile, 'utf-8');
+      expect(commandContent).toContain('name: OPSX: Explore');
+      expect(commandContent).toContain('description: Enter explore mode');
+    });
+
     it('should support Kimi CLI as an adapterless skills-only tool', async () => {
       saveGlobalConfig({
         featureFlags: {},


### PR DESCRIPTION
## Issue Summary

  #1242 reports that OpenSpec does not recognize or handle zcode. The actual behavior is that zcode cannot be used as a tool ID. The expected behavior is to support ZCode or clearly document that it is
  unsupported. The affected areas are openspec init --tools zcode, tool auto-detection, and command/skill generation.

  ## Selected Fix

  I chose to implement ZCode support. The issue is clear and narrowly scoped: add tool registration, a command adapter, a registry entry, and test coverage. I avoided #1222 and #1226 because you noted they
  were already fixed.

  ## Root Cause

  zcode was missing from AI_TOOLS, and there was no ZCode adapter in the command adapter registry, so the CLI could not recognize it or generate .zcode skills/commands.

  ## Implementation

  1. OpenSpec: No OpenSpec process files were created or modified. No OpenSpec files were included in the commit.
  2. Code: Added zcode tool registration with skillsDir: '.zcode'; added zcodeAdapter, which generates .zcode/commands/opsx/<id>.md; registered and exported the adapter.
  3. Tests: Added/updated adapter, registry, available tools, and init tests covering --tools zcode skill and command generation.
  4. Verification: Ran focused tests, pnpm run lint, pnpm test, and pnpm run build; all passed.

  ## Commit

  Commit: e4fc0cb

  Message: Add ZCode tool support (#1242)

  The commit does not include any OpenSpec-related files; it only includes source and test files.

  Summary

  This switched the local repo to the feature_0623 branch and added ZCode support for #1242.

  Previously, zcode was not a valid tool ID, and OpenSpec did not detect .zcode or generate ZCode skills or commands.

  This adds ZCode registration and command generation so openspec init --tools zcode can create .zcode/skills/.../SKILL.md and .zcode/commands/opsx/<id>.md.

  Changes

  - Added zcode to AI_TOOLS.
  - Added src/core/command-generation/adapters/zcode.ts.
  - Registered and exported the ZCode command adapter.
  - Added adapter, registry, auto-detection, and init generation tests.

  Verification

  - pnpm exec vitest run test/core/command-generation/adapters.test.ts test/core/command-generation/registry.test.ts test/core/available-tools.test.ts test/core/init.test.ts
  - pnpm run lint
  - pnpm test
  - pnpm run build

  Summary by CodeRabbit

  Bug Fixes

  - ZCode is now recognized as a supported OpenSpec tool and can receive generated skills and commands.

  Documentation

  - No documentation files were changed in this commit.

  Tests

  - Added coverage for ZCode adapter formatting, registry lookup, .zcode detection, and init --tools zcode generation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * ZCode is now available as a new tool option for command generation and initialization, enabling structured command file creation with metadata support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->