### PR TITLE
fix(ci+installers): harden permission checks and guard completion/profile writes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '20.19.0'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -116,7 +116,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '20.19.0'
           cache: 'pnpm'
 
       - name: Print environment diagnostics
@@ -155,7 +155,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '20.19.0'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -277,7 +277,7 @@ jobs:
         if: steps.changed-changesets.outputs.has_changesets == 'true'
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '20.19.0'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/src/core/completions/installers/bash-installer.ts
+++ b/src/core/completions/installers/bash-installer.ts
@@ -240,6 +240,10 @@ export class BashInstaller {
         console.debug(`Unable to read existing completion file at ${targetPath}: ${error.message}`);
       }
 
+      if (!(await FileSystemUtils.canWriteFile(targetPath))) {
+        throw new Error(`Path is not writable: ${targetPath}`);
+      }
+
       // Ensure the directory exists
       const targetDir = path.dirname(targetPath);
       await fs.mkdir(targetDir, { recursive: true });

--- a/src/core/completions/installers/fish-installer.ts
+++ b/src/core/completions/installers/fish-installer.ts
@@ -141,8 +141,8 @@ export class FishInstaller {
       }
 
       const targetDir = path.dirname(targetPath);
-      if (!(await FileSystemUtils.canWriteFile(targetPath)) || !(await FileSystemUtils.canWriteFile(targetDir))) {
-        throw new Error(`Path is not writable: ${targetPath}`);
+      if (!(await FileSystemUtils.canWriteFile(targetDir))) {
+        throw new Error(`Path is not writable: ${targetDir}`);
       }
 
       // Remove the completion script

--- a/src/core/completions/installers/fish-installer.ts
+++ b/src/core/completions/installers/fish-installer.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from 'fs';
 import path from 'path';
 import os from 'os';
+import { FileSystemUtils } from '../../../utils/file-system.js';
 import { InstallationResult } from '../factory.js';
 
 /**
@@ -76,6 +77,10 @@ export class FishInstaller {
         console.debug(`Unable to read existing completion file at ${targetPath}: ${error.message}`);
       }
 
+      if (!(await FileSystemUtils.canWriteFile(targetPath))) {
+        throw new Error(`Path is not writable: ${targetPath}`);
+      }
+
       // Ensure the directory exists
       const targetDir = path.dirname(targetPath);
       await fs.mkdir(targetDir, { recursive: true });
@@ -133,6 +138,11 @@ export class FishInstaller {
           success: false,
           message: 'Completion script is not installed',
         };
+      }
+
+      const targetDir = path.dirname(targetPath);
+      if (!(await FileSystemUtils.canWriteFile(targetPath)) || !(await FileSystemUtils.canWriteFile(targetDir))) {
+        throw new Error(`Path is not writable: ${targetPath}`);
       }
 
       // Remove the completion script

--- a/src/core/completions/installers/powershell-installer.ts
+++ b/src/core/completions/installers/powershell-installer.ts
@@ -170,9 +170,23 @@ export class PowerShellInstaller {
 
     for (const profilePath of profilePaths) {
       try {
-        // Create profile file if it doesn't exist
         const profileDir = path.dirname(profilePath);
-        await fs.mkdir(profileDir, { recursive: true });
+        let profileExists = false;
+        try {
+          await fs.access(profilePath);
+          profileExists = true;
+        } catch (err: any) {
+          if (err?.code !== 'ENOENT') {
+            throw err;
+          }
+        }
+
+        if (!profileExists) {
+          if (!(await FileSystemUtils.canWriteFile(profilePath))) {
+            throw new Error(`Path is not writable: ${profilePath}`);
+          }
+          await fs.mkdir(profileDir, { recursive: true });
+        }
 
         let profileContent = '';
         let fileEncoding: BufferEncoding = 'utf-8';
@@ -413,8 +427,8 @@ export class PowerShellInstaller {
       }
 
       const targetDir = path.dirname(targetPath);
-      if (!(await FileSystemUtils.canWriteFile(targetPath)) || !(await FileSystemUtils.canWriteFile(targetDir))) {
-        throw new Error(`Path is not writable: ${targetPath}`);
+      if (!(await FileSystemUtils.canWriteFile(targetDir))) {
+        throw new Error(`Path is not writable: ${targetDir}`);
       }
 
       // Remove the completion script

--- a/src/core/completions/installers/powershell-installer.ts
+++ b/src/core/completions/installers/powershell-installer.ts
@@ -209,6 +209,9 @@ export class PowerShellInstaller {
         ].join('\n');
 
         const newContent = profileContent + openspecBlock;
+        if (!(await FileSystemUtils.canWriteFile(profilePath))) {
+          throw new Error(`Path is not writable: ${profilePath}`);
+        }
         await this.writeProfileFile(profilePath, newContent, fileEncoding, fileBom);
         anyConfigured = true;
       } catch (error) {
@@ -271,6 +274,9 @@ export class PowerShellInstaller {
         // Clean up extra newlines
         const newContent = (beforeBlock.trimEnd() + '\n' + afterBlock.trimStart()).trim() + '\n';
 
+        if (!(await FileSystemUtils.canWriteFile(profilePath))) {
+          throw new Error(`Path is not writable: ${profilePath}`);
+        }
         await this.writeProfileFile(profilePath, newContent, fileEncoding, fileBom);
         anyRemoved = true;
       } catch (error) {
@@ -312,6 +318,10 @@ export class PowerShellInstaller {
       } catch (error: any) {
         // File doesn't exist or can't be read, proceed with installation
         console.debug(`Unable to read existing completion file at ${targetPath}: ${error.message}`);
+      }
+
+      if (!(await FileSystemUtils.canWriteFile(targetPath))) {
+        throw new Error(`Path is not writable: ${targetPath}`);
       }
 
       // Ensure the directory exists
@@ -400,6 +410,11 @@ export class PowerShellInstaller {
           success: false,
           message: 'Completion script is not installed',
         };
+      }
+
+      const targetDir = path.dirname(targetPath);
+      if (!(await FileSystemUtils.canWriteFile(targetPath)) || !(await FileSystemUtils.canWriteFile(targetDir))) {
+        throw new Error(`Path is not writable: ${targetPath}`);
       }
 
       // Remove the completion script

--- a/src/core/completions/installers/zsh-installer.ts
+++ b/src/core/completions/installers/zsh-installer.ts
@@ -256,6 +256,10 @@ export class ZshInstaller {
         console.debug(`Unable to read existing completion file at ${targetPath}: ${error.message}`);
       }
 
+      if (!(await FileSystemUtils.canWriteFile(targetPath))) {
+        throw new Error(`Path is not writable: ${targetPath}`);
+      }
+
       // Ensure the directory exists
       const targetDir = path.dirname(targetPath);
       await fs.mkdir(targetDir, { recursive: true });

--- a/src/core/file-state.ts
+++ b/src/core/file-state.ts
@@ -120,7 +120,11 @@ export async function acquireFileLock(
   options: FileLockOptions
 ): Promise<nodeFs.promises.FileHandle> {
   const { lockPath, errorFor } = options;
-  await FileSystemUtils.createDirectory(path.dirname(lockPath));
+  const lockDir = path.dirname(lockPath);
+  await FileSystemUtils.createDirectory(lockDir);
+  if (!(await FileSystemUtils.canWriteFile(lockDir))) {
+    throw errorFor('create-failed', { lockPath, cause: 'EACCES' });
+  }
   const deadline = Date.now() + LOCK_DEADLINE_MS;
 
   while (true) {

--- a/src/utils/file-system.ts
+++ b/src/utils/file-system.ts
@@ -4,6 +4,30 @@ import path from 'path';
 const fs = nodeFs.promises;
 const { constants: fsConstants } = nodeFs;
 
+function hasOwnerGroupOrOtherWriteBit(stats: nodeFs.Stats): boolean {
+  return (stats.mode & 0o222) !== 0;
+}
+
+async function hasWritableModeAndAccess(targetPath: string): Promise<boolean> {
+  try {
+    const stats = await fs.stat(targetPath);
+
+    // POSIX root can often write despite mode bits, but OpenSpec should respect
+    // explicit read-only file/directory modes when deciding whether an install
+    // path is user-writable. This also keeps permission checks deterministic in
+    // root-run CI containers. On Windows, chmod mode bits are not authoritative,
+    // so rely on fs.access below.
+    if (process.platform !== 'win32' && !hasOwnerGroupOrOtherWriteBit(stats)) {
+      return false;
+    }
+
+    await fs.access(targetPath, fsConstants.W_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function isMarkerOnOwnLine(content: string, markerIndex: number, markerLength: number): boolean {
   let leftIndex = markerIndex - 1;
   while (leftIndex >= 0 && content[leftIndex] !== '\n') {
@@ -152,18 +176,15 @@ export class FileSystemUtils {
     try {
       const stats = await fs.stat(filePath);
 
+      if (stats.isDirectory()) {
+        return hasWritableModeAndAccess(filePath);
+      }
+
       if (!stats.isFile()) {
         return true;
       }
 
-      // On Windows, stats.mode doesn't reliably indicate write permissions.
-      // Use fs.access with W_OK to check actual write permissions cross-platform.
-      try {
-        await fs.access(filePath, fsConstants.W_OK);
-        return true;
-      } catch {
-        return false;
-      }
+      return hasWritableModeAndAccess(filePath);
     } catch (error: any) {
       if (error.code === 'ENOENT') {
         // File doesn't exist - find first existing parent directory and check its permissions
@@ -175,13 +196,8 @@ export class FileSystemUtils {
           return false;
         }
 
-        // Check if the existing parent directory is writable
-        try {
-          await fs.access(existingDir, fsConstants.W_OK);
-          return true;
-        } catch {
-          return false;
-        }
+        // Check if the existing parent directory is writable.
+        return hasWritableModeAndAccess(existingDir);
       }
 
       console.debug(`Unable to determine write permissions for ${filePath}: ${error.message}`);

--- a/src/utils/file-system.ts
+++ b/src/utils/file-system.ts
@@ -8,6 +8,10 @@ function hasOwnerGroupOrOtherWriteBit(stats: nodeFs.Stats): boolean {
   return (stats.mode & 0o222) !== 0;
 }
 
+function hasOwnerGroupOrOtherExecuteBit(stats: nodeFs.Stats): boolean {
+  return (stats.mode & 0o111) !== 0;
+}
+
 async function hasWritableModeAndAccess(targetPath: string): Promise<boolean> {
   try {
     const stats = await fs.stat(targetPath);
@@ -20,8 +24,14 @@ async function hasWritableModeAndAccess(targetPath: string): Promise<boolean> {
     if (process.platform !== 'win32' && !hasOwnerGroupOrOtherWriteBit(stats)) {
       return false;
     }
+    if (process.platform !== 'win32' && stats.isDirectory() && !hasOwnerGroupOrOtherExecuteBit(stats)) {
+      return false;
+    }
 
-    await fs.access(targetPath, fsConstants.W_OK);
+    const accessMode = stats.isDirectory()
+      ? fsConstants.W_OK | fsConstants.X_OK
+      : fsConstants.W_OK;
+    await fs.access(targetPath, accessMode);
     return true;
   } catch {
     return false;

--- a/test/core/completions/installers/bash-installer.test.ts
+++ b/test/core/completions/installers/bash-installer.test.ts
@@ -151,6 +151,23 @@ describe('BashInstaller', () => {
       expect(result.message).toContain('Failed to install');
     });
 
+    it.skipIf(process.platform === 'win32')('should return failure when completion directory is not writable', async () => {
+      const targetPath = await installer.getInstallationPath();
+      const targetDir = path.dirname(targetPath);
+      await fs.mkdir(targetDir, { recursive: true });
+      await fs.chmod(targetDir, 0o555);
+
+      let result: Awaited<ReturnType<BashInstaller['install']>> | undefined;
+      try {
+        result = await installer.install(testScript);
+      } finally {
+        await fs.chmod(targetDir, 0o755);
+      }
+
+      expect(result?.success).toBe(false);
+      expect(result?.message).toContain('Failed to install');
+    });
+
     it('should detect already-installed completion with identical content', async () => {
       // First installation
       const firstResult = await installer.install(testScript);

--- a/test/core/completions/installers/bash-installer.test.ts
+++ b/test/core/completions/installers/bash-installer.test.ts
@@ -166,6 +166,7 @@ describe('BashInstaller', () => {
 
       expect(result?.success).toBe(false);
       expect(result?.message).toContain('Failed to install');
+      expect(result?.message).toContain(`Path is not writable: ${targetPath}`);
     });
 
     it('should detect already-installed completion with identical content', async () => {

--- a/test/core/completions/installers/fish-installer.test.ts
+++ b/test/core/completions/installers/fish-installer.test.ts
@@ -286,6 +286,23 @@ complete -c openspec -a 'init'
       expect(result.message).toBe('Completion script uninstalled successfully');
     });
 
+    it.skipIf(process.platform === 'win32')('should uninstall read-only file when parent directory is writable', async () => {
+      await installer.install(mockCompletionScript);
+      const targetPath = path.join(testHomeDir, '.config', 'fish', 'completions', 'openspec.fish');
+      await fs.chmod(targetPath, 0o444);
+
+      let result: Awaited<ReturnType<FishInstaller['uninstall']>> | undefined;
+      try {
+        result = await installer.uninstall();
+      } finally {
+        await fs.chmod(targetPath, 0o644).catch(() => undefined);
+      }
+
+      const fileExists = await fs.access(targetPath).then(() => true).catch(() => false);
+      expect(result?.success).toBe(true);
+      expect(fileExists).toBe(false);
+    });
+
     // Skip on Windows: fs.chmod() on directories doesn't restrict write access on Windows
     // Windows uses ACLs which Node.js chmod doesn't control
     it.skipIf(process.platform === 'win32')('should return failure on permission error', async () => {

--- a/test/core/completions/installers/powershell-installer.test.ts
+++ b/test/core/completions/installers/powershell-installer.test.ts
@@ -11,6 +11,14 @@ describe('PowerShellInstaller', () => {
   let originalPlatform: NodeJS.Platform;
   let originalEnv: NodeJS.ProcessEnv;
 
+  const restoreEnvValue = (key: string, value: string | undefined): void => {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  };
+
   beforeEach(async () => {
     testHomeDir = path.join(os.tmpdir(), `openspec-powershell-test-${randomUUID()}`);
     await fs.mkdir(testHomeDir, { recursive: true });
@@ -259,7 +267,7 @@ describe('PowerShellInstaller', () => {
     });
 
     it.skipIf(process.platform === 'win32')('should not create profile directory when parent is not writable', async () => {
-      delete process.env.OPENSPEC_NO_AUTO_CONFIG;
+      const originalNoAutoConfig = process.env.OPENSPEC_NO_AUTO_CONFIG;
       const restrictedHome = path.join(testHomeDir, 'restricted-home');
       await fs.mkdir(restrictedHome);
       await fs.chmod(restrictedHome, 0o555);
@@ -268,8 +276,10 @@ describe('PowerShellInstaller', () => {
 
       let result = true;
       try {
+        delete process.env.OPENSPEC_NO_AUTO_CONFIG;
         result = await restrictedInstaller.configureProfile(mockScriptPath);
       } finally {
+        restoreEnvValue('OPENSPEC_NO_AUTO_CONFIG', originalNoAutoConfig);
         await fs.chmod(restrictedHome, 0o755);
       }
 
@@ -788,15 +798,17 @@ Register-ArgumentCompleter -CommandName openspec -ScriptBlock $openspecCompleter
     });
 
     it.skipIf(process.platform === 'win32')('should uninstall read-only completion script when parent directory is writable', async () => {
-      delete process.env.OPENSPEC_NO_AUTO_CONFIG;
-      await installer.install(mockCompletionScript);
+      const originalNoAutoConfig = process.env.OPENSPEC_NO_AUTO_CONFIG;
       const targetPath = installer.getInstallationPath();
-      await fs.chmod(targetPath, 0o444);
-
       let result: Awaited<ReturnType<PowerShellInstaller['uninstall']>> | undefined;
+
       try {
+        delete process.env.OPENSPEC_NO_AUTO_CONFIG;
+        await installer.install(mockCompletionScript);
+        await fs.chmod(targetPath, 0o444);
         result = await installer.uninstall();
       } finally {
+        restoreEnvValue('OPENSPEC_NO_AUTO_CONFIG', originalNoAutoConfig);
         await fs.chmod(targetPath, 0o644).catch(() => undefined);
       }
 

--- a/test/core/completions/installers/powershell-installer.test.ts
+++ b/test/core/completions/installers/powershell-installer.test.ts
@@ -257,6 +257,26 @@ describe('PowerShellInstaller', () => {
 
       expect(result).toBe(false);
     });
+
+    it.skipIf(process.platform === 'win32')('should not create profile directory when parent is not writable', async () => {
+      delete process.env.OPENSPEC_NO_AUTO_CONFIG;
+      const restrictedHome = path.join(testHomeDir, 'restricted-home');
+      await fs.mkdir(restrictedHome);
+      await fs.chmod(restrictedHome, 0o555);
+      const restrictedInstaller = new PowerShellInstaller(restrictedHome);
+      const profileDir = path.dirname(restrictedInstaller.getProfilePath());
+
+      let result = true;
+      try {
+        result = await restrictedInstaller.configureProfile(mockScriptPath);
+      } finally {
+        await fs.chmod(restrictedHome, 0o755);
+      }
+
+      const profileDirExists = await fs.access(profileDir).then(() => true).catch(() => false);
+      expect(result).toBe(false);
+      expect(profileDirExists).toBe(false);
+    });
   });
 
   describe('removeProfileConfig', () => {
@@ -765,6 +785,24 @@ Register-ArgumentCompleter -CommandName openspec -ScriptBlock $openspecCompleter
 
       expect(result.success).toBe(true);
       expect(result.message).toBe('Completion script uninstalled successfully');
+    });
+
+    it.skipIf(process.platform === 'win32')('should uninstall read-only completion script when parent directory is writable', async () => {
+      delete process.env.OPENSPEC_NO_AUTO_CONFIG;
+      await installer.install(mockCompletionScript);
+      const targetPath = installer.getInstallationPath();
+      await fs.chmod(targetPath, 0o444);
+
+      let result: Awaited<ReturnType<PowerShellInstaller['uninstall']>> | undefined;
+      try {
+        result = await installer.uninstall();
+      } finally {
+        await fs.chmod(targetPath, 0o644).catch(() => undefined);
+      }
+
+      const scriptExists = await fs.access(targetPath).then(() => true).catch(() => false);
+      expect(result?.success).toBe(true);
+      expect(scriptExists).toBe(false);
     });
 
     it('should handle both script and config removal', async () => {

--- a/test/core/completions/installers/zsh-installer.test.ts
+++ b/test/core/completions/installers/zsh-installer.test.ts
@@ -194,15 +194,15 @@ describe('ZshInstaller', () => {
       }
     });
 
-    it('should handle installation errors gracefully', async () => {
-      // Create installer with non-existent/invalid home directory
-      // Use a path that will fail on both Unix and Windows
-      const invalidPath = process.platform === 'win32'
-        ? 'Z:\\nonexistent\\invalid\\path'  // Non-existent drive letter on Windows
-        : '/root/invalid/nonexistent/path';  // Permission-denied path on Unix
-      const invalidInstaller = new ZshInstaller(invalidPath);
+    it.skipIf(process.platform === 'win32')('should handle installation errors gracefully', async () => {
+      const restrictedHome = path.join(testHomeDir, 'restricted-home');
+      await fs.mkdir(restrictedHome, { recursive: true });
+      await fs.chmod(restrictedHome, 0o555);
+      const invalidInstaller = new ZshInstaller(restrictedHome);
 
       const result = await invalidInstaller.install(testScript);
+
+      await fs.chmod(restrictedHome, 0o755);
 
       expect(result.success).toBe(false);
       expect(result.message).toContain('Failed to install');
@@ -506,15 +506,15 @@ describe('ZshInstaller', () => {
       }
     });
 
-    it('should handle write permission errors gracefully', async () => {
-      // Create installer with path that can't be written
-      // Use a path that will fail on both Unix and Windows
-      const invalidPath = process.platform === 'win32'
-        ? 'Z:\\nonexistent\\invalid\\path'  // Non-existent drive letter on Windows
-        : '/root/invalid/path';  // Permission-denied path on Unix
-      const invalidInstaller = new ZshInstaller(invalidPath);
+    it.skipIf(process.platform === 'win32')('should handle write permission errors gracefully', async () => {
+      const restrictedHome = path.join(testHomeDir, 'restricted-home');
+      await fs.mkdir(restrictedHome, { recursive: true });
+      await fs.chmod(restrictedHome, 0o555);
+      const invalidInstaller = new ZshInstaller(restrictedHome);
 
       const result = await invalidInstaller.configureZshrc(completionsDir);
+
+      await fs.chmod(restrictedHome, 0o755);
 
       expect(result).toBe(false);
     });

--- a/test/utils/file-system.test.ts
+++ b/test/utils/file-system.test.ts
@@ -236,6 +236,21 @@ describe('FileSystemUtils', () => {
       expect(canWrite).toBe(true);
     });
 
+    it.skipIf(process.platform === 'win32')('should return false for directory without search permission', async () => {
+      const dirPath = path.join(testDir, 'write-only-dir');
+      await fs.mkdir(dirPath);
+      await fs.chmod(dirPath, 0o222);
+
+      let canWrite = false;
+      try {
+        canWrite = await FileSystemUtils.canWriteFile(dirPath);
+      } finally {
+        await fs.chmod(dirPath, 0o755);
+      }
+
+      expect(canWrite).toBe(false);
+    });
+
     it('should traverse multiple non-existent parent directories', async () => {
       const filePath = path.join(testDir, 'a', 'b', 'c', 'd', 'e', 'file.txt');
 


### PR DESCRIPTION
### Motivation
- Tests that simulate permission-denied behavior were flaking when run as root because `fs.access(..., W_OK)` can report writable for root, causing permission-sensitive tests and lock-create logic to pass unexpectedly.
- Completion installers and state-file locks mutate user files (`.zshrc`, PowerShell profile, completion scripts, lock files) without pre-validating writability, which can hide errors or produce confusing diagnostics in CI.
- CI Node version `20` is ambiguous; pin to the package-engine floor `20.19.0` to avoid platform/engine differences when reproducing failures.

### Description
- Make write checks deterministic: add POSIX mode-bit validation plus `fs.access` via `hasWritableModeAndAccess()` and update `FileSystemUtils.canWriteFile()` to prefer mode-bit checks on POSIX, preserving Windows behavior (file: `src/utils/file-system.ts`).
- Validate lock directory writability before creating locks in `acquireFileLock()` so permission errors produce the correct `create-failed` diagnostic (file: `src/core/file-state.ts`).
- Guard completion install/uninstall and profile edits by checking `FileSystemUtils.canWriteFile()` before mutating files or unlinking, for Fish, PowerShell and Zsh installers (files: `src/core/completions/installers/fish-installer.ts`, `src/core/completions/installers/powershell-installer.ts`, `src/core/completions/installers/zsh-installer.ts`).
- Make Zsh permission-error tests deterministic in CI by using local read-only temp fixtures instead of relying on `/root` paths (file: `test/core/completions/installers/zsh-installer.test.ts`).
- Pin Node in CI workflow to `20.19.0` for all Node setup steps in `.github/workflows/ci.yml` to reduce CI variability.

### Testing
- Ran focused unit suites: `corepack pnpm@9 exec vitest run test/core/completions/installers/bash-installer.test.ts test/core/completions/installers/zsh-installer.test.ts test/core/completions/installers/fish-installer.test.ts test/core/completions/installers/powershell-installer.test.ts test/core/file-state.test.ts` and observed all focused tests pass (permission-related failures are fixed).
- Built and type-checked: `corepack pnpm@9 run build && corepack pnpm@9 exec tsc --noEmit && corepack pnpm@9 lint` succeeded; lint reports one preexisting warning in `src/core/references.ts`.
- Full suite: `corepack pnpm@9 test` was exercised during investigation; earlier full runs in this constrained environment still exhibited unrelated, long-running e2e/timeouts (environment/order-sensitive) but the root permission-related failures addressed here no longer repro in focused coverage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b375d311883228491ace64f4a1543)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Completion install/uninstall now performs upfront write-permission checks for target paths (and relevant parent directories), failing early with clearer “Path is not writable” errors.
  * File locking now verifies the lock directory is writable before creating it.
  * Writability detection is more consistent across platforms using unified permission logic for files and directories.
* **Tests**
  * Updated and added permission-focused installer and filesystem tests for determinism, with Windows skips where needed.
* **Chores**
  * Updated CI workflow Node.js version across multiple jobs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->