### PR TITLE
fix #1238 workspace update commands

### DIFF
--- a/src/commands/workspace.ts
+++ b/src/commands/workspace.ts
@@ -319,6 +319,12 @@ function formatWorkspaceSkillRemovedResult(result: { name: string; workflow_ids?
   return `${result.name} (${workflowLabel} removed)`;
 }
 
+function formatWorkspaceCommandAgentResult(result: { name: string; workflow_ids?: string[] }): string {
+  const workflowCount = result.workflow_ids?.length ?? 0;
+  const workflowLabel = workflowCount === 1 ? '1 workflow' : `${workflowCount} workflows`;
+  return `${result.name} (${workflowLabel})`;
+}
+
 function printWorkspaceSkillReportHuman(report: WorkspaceSkillInstallationReport): void {
   console.log('Agent skills:');
   console.log(`  Profile: ${report.profile}`);
@@ -357,13 +363,35 @@ function printWorkspaceSkillReportHuman(report: WorkspaceSkillInstallationReport
     );
   }
 
+  if (report.commands_generated.length > 0) {
+    console.log(`  Commands generated: ${report.commands_generated.map(formatWorkspaceCommandAgentResult).join(', ')}`);
+  }
+
+  if (report.commands_refreshed.length > 0) {
+    console.log(`  Commands refreshed: ${report.commands_refreshed.map(formatWorkspaceCommandAgentResult).join(', ')}`);
+  }
+
+  if (report.commands_skipped.length > 0) {
+    for (const skipped of report.commands_skipped) {
+      console.log(`  Commands skipped: ${skipped.name}: ${skipped.message}`);
+    }
+  }
+
+  if (report.commands_failed.length > 0) {
+    console.log(
+      chalk.red(
+        `  Commands failed: ${report.commands_failed.map((failure) => `${failure.name} (${failure.error})`).join(', ')}`
+      )
+    );
+  }
+
   if (report.delivery_notice) {
     console.log(chalk.dim(`  ${report.delivery_notice}`));
   }
 }
 
 function hasWorkspaceSkillFailures(report: WorkspaceSkillInstallationReport): boolean {
-  return report.failed.length > 0;
+  return report.failed.length > 0 || report.commands_failed.length > 0;
 }
 
 function setWorkspaceSkillFailureExitCode(report: WorkspaceSkillInstallationReport): void {

--- a/src/core/workspace/skills.ts
+++ b/src/core/workspace/skills.ts
@@ -24,6 +24,7 @@ import type { WorkspaceSkillState } from './foundation.js';
 const require = createRequire(import.meta.url);
 const { version: OPENSPEC_VERSION } = require('../../../package.json');
 const fs = nodeFs.promises;
+const MANAGED_COMMAND_MARKER = 'OpenSpec managed command';
 
 export interface WorkspaceSkillAgentResult {
   tool_id: string;
@@ -310,6 +311,67 @@ function resolveWorkspaceCommandFilePath(workspaceRoot: string, commandPath: str
     : FileSystemUtils.joinPath(workspaceRoot, commandPath);
 }
 
+function normalizeCommandContent(content: string): string {
+  return content.replace(/\r\n/g, '\n');
+}
+
+function markWorkspaceCommandContent(commandPath: string, content: string): string {
+  if (content.includes(MANAGED_COMMAND_MARKER)) {
+    return content;
+  }
+
+  const yamlFrontmatterMatch = content.match(/^---\r?\n/);
+  if (yamlFrontmatterMatch) {
+    return content.replace(
+      /^---(\r?\n)/,
+      `---$1# ${MANAGED_COMMAND_MARKER} ${OPENSPEC_VERSION}$1`
+    );
+  }
+
+  if (commandPath.endsWith('.toml')) {
+    return `# ${MANAGED_COMMAND_MARKER} ${OPENSPEC_VERSION}\n${content}`;
+  }
+
+  return `<!-- ${MANAGED_COMMAND_MARKER} ${OPENSPEC_VERSION} -->\n${content}`;
+}
+
+function isOpenSpecManagedCommandContent(content: string): boolean {
+  return content.includes(MANAGED_COMMAND_MARKER);
+}
+
+function matchesGeneratedCommandContent(content: string, expectedContent: string | undefined): boolean {
+  return expectedContent !== undefined &&
+    normalizeCommandContent(content) === normalizeCommandContent(expectedContent);
+}
+
+async function isOpenSpecManagedCommandFile(
+  commandFile: string,
+  expectedContent?: string
+): Promise<boolean> {
+  try {
+    const content = await fs.readFile(commandFile, 'utf-8');
+    return isOpenSpecManagedCommandContent(content) ||
+      matchesGeneratedCommandContent(content, expectedContent);
+  } catch {
+    return false;
+  }
+}
+
+async function assertCanWriteWorkspaceCommandFile(
+  commandFile: string,
+  expectedContent: string
+): Promise<boolean> {
+  if (!nodeFs.existsSync(commandFile)) {
+    return false;
+  }
+
+  if (!(await isOpenSpecManagedCommandFile(commandFile, expectedContent))) {
+    throw new Error(`Refusing to overwrite unmanaged command file: ${commandFile}`);
+  }
+
+  return true;
+}
+
 function makeCommandAgentResult(
   workspaceRoot: string,
   tool: WorkspaceSkillCapableTool,
@@ -396,6 +458,9 @@ async function removeManagedWorkflowCommandFiles(
   }
 
   const desiredSet = new Set(desiredWorkflowIds);
+  const commandContentsById = new Map(
+    getCommandContents(ALL_WORKFLOWS).map((content) => [content.id, content])
+  );
   let removed = 0;
 
   for (const workflowId of ALL_WORKFLOWS) {
@@ -407,9 +472,14 @@ async function removeManagedWorkflowCommandFiles(
       workspaceRoot,
       adapter.getFilePath(workflowId)
     );
+    const commandContent = commandContentsById.get(workflowId);
+    const expectedContent = commandContent ? adapter.formatFile(commandContent) : undefined;
 
     try {
-      if (nodeFs.existsSync(commandFile)) {
+      if (
+        nodeFs.existsSync(commandFile) &&
+        await isOpenSpecManagedCommandFile(commandFile, expectedContent)
+      ) {
         await fs.unlink(commandFile);
         removed++;
       }
@@ -638,13 +708,21 @@ export async function updateWorkspaceAgentSkills(
 
       try {
         const generatedCommands = generateCommands(commandContents, adapter);
-        const hadExistingCommand = generatedCommands.some((command) =>
-          nodeFs.existsSync(resolveWorkspaceCommandFilePath(workspaceRoot, command.path))
-        );
+        let hadExistingCommand = false;
 
         for (const command of generatedCommands) {
           const commandFile = resolveWorkspaceCommandFilePath(workspaceRoot, command.path);
-          await FileSystemUtils.writeFile(commandFile, command.fileContent);
+          hadExistingCommand =
+            (await assertCanWriteWorkspaceCommandFile(commandFile, command.fileContent)) ||
+            hadExistingCommand;
+        }
+
+        for (const command of generatedCommands) {
+          const commandFile = resolveWorkspaceCommandFilePath(workspaceRoot, command.path);
+          await FileSystemUtils.writeFile(
+            commandFile,
+            markWorkspaceCommandContent(command.path, command.fileContent)
+          );
         }
 
         const result = makeCommandAgentResult(workspaceRoot, tool, profileContext.workflowIds);

--- a/src/core/workspace/skills.ts
+++ b/src/core/workspace/skills.ts
@@ -1,13 +1,19 @@
 import * as nodeFs from 'node:fs';
 import { createRequire } from 'node:module';
+import path from 'node:path';
 
 import { FileSystemUtils } from '../../utils/file-system.js';
 import { transformToHyphenCommands } from '../../utils/command-references.js';
 import { AI_TOOLS, type AIToolOption } from '../config.js';
 import { getGlobalConfig, type Delivery, type Profile } from '../global-config.js';
-import { getProfileWorkflows } from '../profiles.js';
+import { ALL_WORKFLOWS, getProfileWorkflows } from '../profiles.js';
+import {
+  generateCommands,
+  CommandAdapterRegistry,
+} from '../command-generation/index.js';
 import {
   generateSkillContent,
+  getCommandContents,
   getSkillTemplates,
   getToolSkillStatus,
   getToolsWithSkillsDir,
@@ -43,12 +49,32 @@ export interface WorkspaceSkillFailedResult {
   error: string;
 }
 
+export interface WorkspaceCommandAgentResult {
+  tool_id: string;
+  name: string;
+  commands_path: string;
+  workflow_ids: string[];
+}
+
+export interface WorkspaceCommandSkippedResult {
+  tool_id: string;
+  name: string;
+  reason: string;
+  message: string;
+}
+
+export interface WorkspaceCommandFailedResult {
+  tool_id: string;
+  name: string;
+  error: string;
+}
+
 export interface WorkspaceSkillInstallationReport {
   profile: Profile;
   delivery: Delivery;
   workflow_ids: string[];
   selected_agents: string[];
-  skills_only: true;
+  skills_only: boolean;
   delivery_notice: string | null;
   generated: WorkspaceSkillAgentResult[];
   added: WorkspaceSkillAgentResult[];
@@ -56,6 +82,10 @@ export interface WorkspaceSkillInstallationReport {
   removed: WorkspaceSkillRemovedResult[];
   skipped: WorkspaceSkillSkippedResult[];
   failed: WorkspaceSkillFailedResult[];
+  commands_generated: WorkspaceCommandAgentResult[];
+  commands_refreshed: WorkspaceCommandAgentResult[];
+  commands_skipped: WorkspaceCommandSkippedResult[];
+  commands_failed: WorkspaceCommandFailedResult[];
 }
 
 interface WorkspaceSkillProfileContext {
@@ -63,17 +93,26 @@ interface WorkspaceSkillProfileContext {
   delivery: Delivery;
   workflowIds: string[];
   deliveryNotice: string | null;
+  commandGenerationEnabled: boolean;
+}
+
+interface ResolveWorkspaceSkillProfileContextOptions {
+  deliveryOverride?: Delivery;
+  commandGenerationEnabled?: boolean;
 }
 
 type WorkspaceSkillCapableTool = AIToolOption & { skillsDir: string };
 
-function resolveWorkspaceSkillProfileContext(): WorkspaceSkillProfileContext {
+function resolveWorkspaceSkillProfileContext(
+  options: ResolveWorkspaceSkillProfileContextOptions = {}
+): WorkspaceSkillProfileContext {
   const globalConfig = getGlobalConfig();
   const profile = globalConfig.profile ?? 'core';
-  const delivery = globalConfig.delivery ?? 'both';
+  const delivery = options.deliveryOverride ?? globalConfig.delivery ?? 'both';
   const workflowIds = [...getProfileWorkflows(profile, globalConfig.workflows)];
+  const commandGenerationEnabled = options.commandGenerationEnabled ?? false;
   const deliveryNotice =
-    delivery === 'skills'
+    delivery === 'skills' || commandGenerationEnabled
       ? null
       : 'Workspace setup installs skills only; workspace command generation is not part of this slice.';
 
@@ -82,6 +121,7 @@ function resolveWorkspaceSkillProfileContext(): WorkspaceSkillProfileContext {
     delivery,
     workflowIds,
     deliveryNotice,
+    commandGenerationEnabled,
   };
 }
 
@@ -127,7 +167,6 @@ export function hasWorkspaceSkillProfileDrift(
 
   return (
     workspaceSkills.last_applied_profile !== current.profile ||
-    workspaceSkills.last_applied_delivery !== current.delivery ||
     !arraysEqual(workspaceSkills.last_applied_workflow_ids, current.workflow_ids)
   );
 }
@@ -141,7 +180,7 @@ function makeBaseWorkspaceSkillReport(
     delivery: profileContext.delivery,
     workflow_ids: profileContext.workflowIds,
     selected_agents: selectedAgentIds,
-    skills_only: true,
+    skills_only: profileContext.delivery === 'skills' || !profileContext.commandGenerationEnabled,
     delivery_notice: profileContext.deliveryNotice,
     generated: [],
     added: [],
@@ -149,6 +188,10 @@ function makeBaseWorkspaceSkillReport(
     removed: [],
     skipped: [],
     failed: [],
+    commands_generated: [],
+    commands_refreshed: [],
+    commands_skipped: [],
+    commands_failed: [],
   };
 }
 
@@ -261,6 +304,31 @@ function makeAgentResult(
   };
 }
 
+function resolveWorkspaceCommandFilePath(workspaceRoot: string, commandPath: string): string {
+  return path.isAbsolute(commandPath)
+    ? commandPath
+    : FileSystemUtils.joinPath(workspaceRoot, commandPath);
+}
+
+function makeCommandAgentResult(
+  workspaceRoot: string,
+  tool: WorkspaceSkillCapableTool,
+  workflowIds: string[]
+): WorkspaceCommandAgentResult {
+  const adapter = CommandAdapterRegistry.get(tool.value);
+  const sampleWorkflowId = workflowIds[0] ?? 'propose';
+  const commandPath = adapter
+    ? resolveWorkspaceCommandFilePath(workspaceRoot, adapter.getFilePath(sampleWorkflowId))
+    : workspaceRoot;
+
+  return {
+    tool_id: tool.value,
+    name: tool.name,
+    commands_path: path.dirname(commandPath),
+    workflow_ids: workflowIds,
+  };
+}
+
 function getManagedWorkspaceSkillEntries(): Array<{ workflowId: string; dirName: string }> {
   return getSkillTemplates().map(({ workflowId, dirName }) => ({ workflowId, dirName }));
 }
@@ -315,6 +383,42 @@ async function removeManagedWorkflowSkillDirs(
     ...makeAgentResult(workspaceRoot, tool, removedWorkflowIds),
     reason,
   };
+}
+
+async function removeManagedWorkflowCommandFiles(
+  workspaceRoot: string,
+  tool: WorkspaceSkillCapableTool,
+  desiredWorkflowIds: readonly string[]
+): Promise<number> {
+  const adapter = CommandAdapterRegistry.get(tool.value);
+  if (!adapter) {
+    return 0;
+  }
+
+  const desiredSet = new Set(desiredWorkflowIds);
+  let removed = 0;
+
+  for (const workflowId of ALL_WORKFLOWS) {
+    if (desiredSet.has(workflowId)) {
+      continue;
+    }
+
+    const commandFile = resolveWorkspaceCommandFilePath(
+      workspaceRoot,
+      adapter.getFilePath(workflowId)
+    );
+
+    try {
+      if (nodeFs.existsSync(commandFile)) {
+        await fs.unlink(commandFile);
+        removed++;
+      }
+    } catch {
+      // Keep update best-effort, matching repo-local command cleanup behavior.
+    }
+  }
+
+  return removed;
 }
 
 export async function generateWorkspaceAgentSkills(
@@ -385,7 +489,10 @@ export async function updateWorkspaceAgentSkills(
   selectedAgentIds: string[],
   previousSkillState?: WorkspaceSkillState
 ): Promise<WorkspaceSkillInstallationReport> {
-  const profileContext = resolveWorkspaceSkillProfileContext();
+  const profileContext = resolveWorkspaceSkillProfileContext({
+    deliveryOverride: previousSkillState?.last_applied_delivery,
+    commandGenerationEnabled: true,
+  });
   const report = makeBaseWorkspaceSkillReport(selectedAgentIds, profileContext);
   const previousSelectedAgentIds = previousSkillState?.selected_agents ?? [];
   const previousSelectedSet = new Set(previousSelectedAgentIds);
@@ -408,6 +515,9 @@ export async function updateWorkspaceAgentSkills(
       );
       if (removed) {
         report.removed.push(removed);
+      }
+      if (profileContext.delivery !== 'skills') {
+        await removeManagedWorkflowCommandFiles(workspaceRoot, tool, []);
       }
     } catch (error) {
       report.failed.push({
@@ -442,6 +552,9 @@ export async function updateWorkspaceAgentSkills(
         );
         if (removed) {
           report.removed.push(removed);
+        }
+        if (profileContext.delivery !== 'skills') {
+          await removeManagedWorkflowCommandFiles(workspaceRoot, tool, []);
         }
       } catch (error) {
         report.failed.push({
@@ -483,6 +596,13 @@ export async function updateWorkspaceAgentSkills(
       if (removed) {
         report.removed.push(removed);
       }
+      if (profileContext.delivery !== 'skills') {
+        await removeManagedWorkflowCommandFiles(
+          workspaceRoot,
+          tool,
+          profileContext.workflowIds
+        );
+      }
 
       const result = makeAgentResult(workspaceRoot, tool, profileContext.workflowIds);
       if (previousSelectedSet.has(toolId)) {
@@ -496,6 +616,50 @@ export async function updateWorkspaceAgentSkills(
         name: tool.name,
         error: error instanceof Error ? error.message : String(error),
       });
+    }
+  }
+
+  if (profileContext.delivery !== 'skills' && profileContext.workflowIds.length > 0) {
+    const commandContents = getCommandContents(profileContext.workflowIds);
+
+    for (const toolId of selectedAgentIds) {
+      const tool = getWorkspaceSkillTool(toolId);
+      const adapter = CommandAdapterRegistry.get(tool.value);
+
+      if (!adapter) {
+        report.commands_skipped.push({
+          tool_id: tool.value,
+          name: tool.name,
+          reason: 'commands_not_supported',
+          message: `${tool.name} does not support OpenSpec command generation.`,
+        });
+        continue;
+      }
+
+      try {
+        const generatedCommands = generateCommands(commandContents, adapter);
+        const hadExistingCommand = generatedCommands.some((command) =>
+          nodeFs.existsSync(resolveWorkspaceCommandFilePath(workspaceRoot, command.path))
+        );
+
+        for (const command of generatedCommands) {
+          const commandFile = resolveWorkspaceCommandFilePath(workspaceRoot, command.path);
+          await FileSystemUtils.writeFile(commandFile, command.fileContent);
+        }
+
+        const result = makeCommandAgentResult(workspaceRoot, tool, profileContext.workflowIds);
+        if (hadExistingCommand) {
+          report.commands_refreshed.push(result);
+        } else {
+          report.commands_generated.push(result);
+        }
+      } catch (error) {
+        report.commands_failed.push({
+          tool_id: tool.value,
+          name: tool.name,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
     }
   }
 

--- a/test/commands/workspace.test.ts
+++ b/test/commands/workspace.test.ts
@@ -350,6 +350,7 @@ describe('workspace command', () => {
   it('updates stored workspace skills from the current workspace and clears profile drift', async () => {
     const api = mkdir('repos/api');
     const linkedEntriesBefore = fs.readdirSync(api).sort();
+    const codexHome = path.join(tempDir, 'profile-sync-codex-home');
     writeGlobalConfig({
       profile: 'custom',
       delivery: 'commands',
@@ -383,7 +384,10 @@ describe('workspace command', () => {
 
     const update = await runCLI(['workspace', 'update', '--json'], {
       cwd: workspaceRoot,
-      env,
+      env: {
+        ...env,
+        CODEX_HOME: codexHome,
+      },
     });
     expect(update.exitCode).toBe(0);
     const payload = parseJson(update);
@@ -395,8 +399,8 @@ describe('workspace command', () => {
         delivery: 'commands',
         workflow_ids: ['propose', 'explore', 'apply', 'sync', 'archive'],
         selected_agents: ['codex'],
-        skills_only: true,
-        delivery_notice: expect.stringContaining('skills only'),
+        skills_only: false,
+        delivery_notice: null,
         refreshed: [
           expect.objectContaining({
             tool_id: 'codex',
@@ -410,6 +414,14 @@ describe('workspace command', () => {
             workflow_ids: ['verify'],
           }),
         ],
+        commands_generated: [
+          expect.objectContaining({
+            tool_id: 'codex',
+            workflow_ids: ['propose', 'explore', 'apply', 'sync', 'archive'],
+          }),
+        ],
+        commands_refreshed: [],
+        commands_failed: [],
         failed: [],
       })
     );
@@ -420,6 +432,25 @@ describe('workspace command', () => {
     expect(fs.existsSync(path.join(workspaceRoot, '.codex', 'skills', 'openspec-verify-change'))).toBe(false);
     expect(fs.existsSync(path.join(customSkillDir, 'README.md'))).toBe(true);
     expect(fs.existsSync(path.join(workspaceRoot, '.codex', 'prompts'))).toBe(false);
+    expect(fs.existsSync(path.join(codexHome, 'prompts', 'opsx-propose.md'))).toBe(true);
+    expect(fs.existsSync(path.join(codexHome, 'prompts', 'opsx-explore.md'))).toBe(true);
+    expect(fs.existsSync(path.join(codexHome, 'prompts', 'opsx-apply.md'))).toBe(true);
+    expect(fs.existsSync(path.join(codexHome, 'prompts', 'opsx-sync.md'))).toBe(true);
+    expect(fs.existsSync(path.join(codexHome, 'prompts', 'opsx-archive.md'))).toBe(true);
+    expect(fs.existsSync(path.join(codexHome, 'prompts', 'opsx-verify.md'))).toBe(false);
+    fs.writeFileSync(path.join(codexHome, 'prompts', 'opsx-verify.md'), 'stale verify command\n');
+    fs.writeFileSync(path.join(codexHome, 'prompts', 'user-note.md'), 'user command\n');
+
+    const secondUpdate = await runCLI(['workspace', 'update', '--json'], {
+      cwd: workspaceRoot,
+      env: {
+        ...env,
+        CODEX_HOME: codexHome,
+      },
+    });
+    expect(secondUpdate.exitCode).toBe(0);
+    expect(fs.existsSync(path.join(codexHome, 'prompts', 'opsx-verify.md'))).toBe(false);
+    expect(fs.existsSync(path.join(codexHome, 'prompts', 'user-note.md'))).toBe(true);
     expect(fs.readdirSync(api).sort()).toEqual(linkedEntriesBefore);
     expect(fs.existsSync(path.join(api, '.codex'))).toBe(false);
     expect(readWorkspaceState(workspaceRoot).workspace_skills).toEqual(

--- a/test/commands/workspace.test.ts
+++ b/test/commands/workspace.test.ts
@@ -438,7 +438,12 @@ describe('workspace command', () => {
     expect(fs.existsSync(path.join(codexHome, 'prompts', 'opsx-sync.md'))).toBe(true);
     expect(fs.existsSync(path.join(codexHome, 'prompts', 'opsx-archive.md'))).toBe(true);
     expect(fs.existsSync(path.join(codexHome, 'prompts', 'opsx-verify.md'))).toBe(false);
+    expect(fs.existsSync(path.join(codexHome, 'prompts', 'opsx-onboard.md'))).toBe(false);
     fs.writeFileSync(path.join(codexHome, 'prompts', 'opsx-verify.md'), 'stale verify command\n');
+    fs.writeFileSync(
+      path.join(codexHome, 'prompts', 'opsx-onboard.md'),
+      '<!-- OpenSpec managed command 1.4.1 -->\nstale onboard command\n'
+    );
     fs.writeFileSync(path.join(codexHome, 'prompts', 'user-note.md'), 'user command\n');
 
     const secondUpdate = await runCLI(['workspace', 'update', '--json'], {
@@ -449,7 +454,10 @@ describe('workspace command', () => {
       },
     });
     expect(secondUpdate.exitCode).toBe(0);
-    expect(fs.existsSync(path.join(codexHome, 'prompts', 'opsx-verify.md'))).toBe(false);
+    expect(fs.readFileSync(path.join(codexHome, 'prompts', 'opsx-verify.md'), 'utf-8')).toBe(
+      'stale verify command\n'
+    );
+    expect(fs.existsSync(path.join(codexHome, 'prompts', 'opsx-onboard.md'))).toBe(false);
     expect(fs.existsSync(path.join(codexHome, 'prompts', 'user-note.md'))).toBe(true);
     expect(fs.readdirSync(api).sort()).toEqual(linkedEntriesBefore);
     expect(fs.existsSync(path.join(api, '.codex'))).toBe(false);
@@ -470,6 +478,45 @@ describe('workspace command', () => {
     expect(parseJson(clean).workspace.status).not.toContainEqual(
       expect.objectContaining({
         code: 'workspace_skills_out_of_sync',
+      })
+    );
+  });
+
+  it('does not overwrite unmanaged workspace command files', async () => {
+    const api = mkdir('repos/api');
+    const codexHome = path.join(tempDir, 'unmanaged-command-codex-home');
+    writeGlobalConfig({
+      profile: 'custom',
+      delivery: 'commands',
+      workflows: ['apply'],
+    });
+    const setup = await setupWorkspace('unmanaged-command', [`api=${api}`], ['--tools', 'codex']);
+    const workspaceRoot = setup.workspace.root;
+    const commandFile = path.join(codexHome, 'prompts', 'opsx-apply.md');
+    fs.mkdirSync(path.dirname(commandFile), { recursive: true });
+    fs.writeFileSync(commandFile, 'user-owned apply command\n');
+
+    const update = await runCLI(['workspace', 'update', '--json'], {
+      cwd: workspaceRoot,
+      env: {
+        ...env,
+        CODEX_HOME: codexHome,
+      },
+    });
+
+    expect(update.exitCode).toBe(1);
+    expect(parseJson(update).workspace_skills.commands_failed).toEqual([
+      expect.objectContaining({
+        tool_id: 'codex',
+        error: expect.stringContaining('Refusing to overwrite unmanaged command file'),
+      }),
+    ]);
+    expect(fs.readFileSync(commandFile, 'utf-8')).toBe('user-owned apply command\n');
+    expect(readWorkspaceState(workspaceRoot).workspace_skills).toEqual(
+      expect.objectContaining({
+        selected_agents: ['codex'],
+        last_applied_profile: 'custom',
+        last_applied_workflow_ids: ['apply'],
       })
     );
   });

--- a/test/core/workspace/skills.test.ts
+++ b/test/core/workspace/skills.test.ts
@@ -9,8 +9,10 @@ import {
   getWorkspaceSkillToolIds,
   hasWorkspaceSkillProfileDrift,
   parseWorkspaceSkillToolsValue,
+  updateWorkspaceAgentSkills,
 } from '../../../src/core/workspace/skills.js';
 import { CORE_WORKFLOWS } from '../../../src/core/profiles.js';
+import { saveGlobalConfig } from '../../../src/core/global-config.js';
 
 function withDefaultGlobalConfig<T>(callback: () => T): T {
   const previousConfigHome = process.env.XDG_CONFIG_HOME;
@@ -65,5 +67,59 @@ describe('workspace skill helpers', () => {
         })
       ).toBe(false);
     });
+  });
+
+  it('generates workspace commands when the stored delivery includes commands', async () => {
+    const previousConfigHome = process.env.XDG_CONFIG_HOME;
+    const configHome = fs.mkdtempSync(path.join(os.tmpdir(), 'openspec-workspace-commands-config-'));
+    const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'openspec-workspace-commands-'));
+
+    process.env.XDG_CONFIG_HOME = configHome;
+
+    try {
+      saveGlobalConfig({
+        featureFlags: {},
+        profile: 'custom',
+        delivery: 'skills',
+        workflows: ['apply'],
+      });
+
+      const report = await updateWorkspaceAgentSkills(
+        workspaceRoot,
+        ['claude'],
+        {
+          selected_agents: ['claude'],
+          last_applied_profile: 'custom',
+          last_applied_delivery: 'both',
+          last_applied_workflow_ids: ['apply'],
+        }
+      );
+
+      expect(report).toEqual(
+        expect.objectContaining({
+          delivery: 'both',
+          skills_only: false,
+          delivery_notice: null,
+          commands_generated: [
+            expect.objectContaining({
+              tool_id: 'claude',
+              workflow_ids: ['apply'],
+            }),
+          ],
+          commands_failed: [],
+        })
+      );
+      expect(
+        fs.existsSync(path.join(workspaceRoot, '.claude', 'commands', 'opsx', 'apply.md'))
+      ).toBe(true);
+    } finally {
+      if (previousConfigHome === undefined) {
+        delete process.env.XDG_CONFIG_HOME;
+      } else {
+        process.env.XDG_CONFIG_HOME = previousConfigHome;
+      }
+      fs.rmSync(configHome, { recursive: true, force: true });
+      fs.rmSync(workspaceRoot, { recursive: true, force: true });
+    }
   });
 });

--- a/test/core/workspace/skills.test.ts
+++ b/test/core/workspace/skills.test.ts
@@ -112,6 +112,58 @@ describe('workspace skill helpers', () => {
       expect(
         fs.existsSync(path.join(workspaceRoot, '.claude', 'commands', 'opsx', 'apply.md'))
       ).toBe(true);
+      expect(
+        fs.readFileSync(path.join(workspaceRoot, '.claude', 'commands', 'opsx', 'apply.md'), 'utf-8')
+      ).toContain('OpenSpec managed command');
+    } finally {
+      if (previousConfigHome === undefined) {
+        delete process.env.XDG_CONFIG_HOME;
+      } else {
+        process.env.XDG_CONFIG_HOME = previousConfigHome;
+      }
+      fs.rmSync(configHome, { recursive: true, force: true });
+      fs.rmSync(workspaceRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses to overwrite unmanaged workspace commands', async () => {
+    const previousConfigHome = process.env.XDG_CONFIG_HOME;
+    const configHome = fs.mkdtempSync(path.join(os.tmpdir(), 'openspec-workspace-command-conflict-config-'));
+    const workspaceRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'openspec-workspace-command-conflict-'));
+
+    process.env.XDG_CONFIG_HOME = configHome;
+
+    try {
+      saveGlobalConfig({
+        featureFlags: {},
+        profile: 'custom',
+        delivery: 'commands',
+        workflows: ['apply'],
+      });
+      const commandFile = path.join(workspaceRoot, '.claude', 'commands', 'opsx', 'apply.md');
+      fs.mkdirSync(path.dirname(commandFile), { recursive: true });
+      fs.writeFileSync(commandFile, 'user-owned command\n');
+
+      const report = await updateWorkspaceAgentSkills(
+        workspaceRoot,
+        ['claude'],
+        {
+          selected_agents: ['claude'],
+          last_applied_profile: 'custom',
+          last_applied_delivery: 'commands',
+          last_applied_workflow_ids: ['apply'],
+        }
+      );
+
+      expect(report.commands_generated).toEqual([]);
+      expect(report.commands_refreshed).toEqual([]);
+      expect(report.commands_failed).toEqual([
+        expect.objectContaining({
+          tool_id: 'claude',
+          error: expect.stringContaining('Refusing to overwrite unmanaged command file'),
+        }),
+      ]);
+      expect(fs.readFileSync(commandFile, 'utf-8')).toBe('user-owned command\n');
     } finally {
       if (previousConfigHome === undefined) {
         delete process.env.XDG_CONFIG_HOME;

--- a/test/helpers/run-cli.ts
+++ b/test/helpers/run-cli.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'child_process';
-import { existsSync } from 'fs';
+import { existsSync, readdirSync, statSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -8,6 +8,7 @@ const __dirname = path.dirname(__filename);
 
 const projectRoot = path.resolve(__dirname, '..', '..');
 const cliEntry = path.join(projectRoot, 'dist', 'cli', 'index.js');
+const cliSourceRoots = ['src', 'bin'];
 
 let buildPromise: Promise<void> | undefined;
 
@@ -53,8 +54,45 @@ function runCommand(command: string, args: string[], options: RunCommandOptions 
   });
 }
 
+function getNewestMtimeMs(targetPath: string): number {
+  if (!existsSync(targetPath)) {
+    return 0;
+  }
+
+  const stat = statSync(targetPath);
+  if (!stat.isDirectory()) {
+    return stat.mtimeMs;
+  }
+
+  let newest = stat.mtimeMs;
+  for (const entry of readdirSync(targetPath, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === 'dist') {
+      continue;
+    }
+    newest = Math.max(newest, getNewestMtimeMs(path.join(targetPath, entry.name)));
+  }
+
+  return newest;
+}
+
+function isCliBuildFresh(): boolean {
+  if (!existsSync(cliEntry)) {
+    return false;
+  }
+
+  const cliBuildTime = statSync(cliEntry).mtimeMs;
+  const newestSourceTime = Math.max(
+    ...cliSourceRoots.map((sourceRoot) => getNewestMtimeMs(path.join(projectRoot, sourceRoot))),
+    getNewestMtimeMs(path.join(projectRoot, 'package.json')),
+    getNewestMtimeMs(path.join(projectRoot, 'tsconfig.json')),
+    getNewestMtimeMs(path.join(projectRoot, 'build.js'))
+  );
+
+  return cliBuildTime >= newestSourceTime;
+}
+
 export async function ensureCliBuilt() {
-  if (existsSync(cliEntry)) {
+  if (isCliBuildFresh()) {
     return;
   }
 


### PR DESCRIPTION
Summary
  Fixed GitHub issue #1238 on feature_0623_3: openspec workspace update now respects stored workspace delivery when it includes commands.

  Previously, workspace update always treated workspace generation as skills-only and showed the “workspace command generation is not part of this slice” notice even when
  workspace_skills.last_applied_delivery was commands or both.

  This adds/changes/fixes workspace update so it:

  - Reuses the stored last_applied_delivery for update runs.
  - Generates or refreshes command files when stored delivery is commands or both.
  - Removes deselected managed workflow command files while preserving user command files.
  - Reports command generation results and treats command write failures as update failures.

  Changes

  - Updated src/core/workspace/skills.ts to generate workspace commands via existing command adapters.
  - Updated src/commands/workspace.ts to print command update results and include command failures in exit-code handling.
  - Updated test/commands/workspace.test.ts for Codex command generation and stale command cleanup.
  - Updated test/core/workspace/skills.test.ts for stored both delivery command generation.

  Verification

  - pnpm run build
  - pnpm run lint
  - pnpm exec vitest run test/core/workspace/skills.test.ts test/commands/workspace.test.ts
  - pnpm exec vitest run test/commands/config-profile.test.ts
  - pnpm exec vitest run test/commands/validate.test.ts
  - pnpm test

  Summary by CodeRabbit

  Bug Fixes

  - workspace update now honors recorded command delivery for workspaces and no longer incorrectly warns that commands are unsupported for recorded commands/both delivery.

  Documentation

  - No OpenSpec or documentation files were changed.

  Tests

  - Added coverage for workspace command generation from stored delivery.
  - Added CLI coverage for Codex prompt generation and stale managed command cleanup.

  Commit

  - 202afbb0bb9ba348ee1d067fbf4ce7262a842ae0
  - Message: fix #1238 workspace update commands
  - Commit contains only source and test files; no OpenSpec files are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace updates now include OpenSpec command-generation results alongside skill installation status.
  * Updates can generate, refresh, skip, or fail managed command files for supported tools.

* **Bug Fixes**
  * CLI exit status now reflects both skill failures and command-generation failures.
  * Managed command files are cleaned up appropriately; stale files are refreshed without overwriting user-owned content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->