### PR TITLE
fix: count nested tasks in progress (#1202)

### DIFF
--- a/src/utils/task-progress.ts
+++ b/src/utils/task-progress.ts
@@ -24,14 +24,45 @@ export function countTasksFromContent(content: string): TaskProgress {
   return { total, completed };
 }
 
-export async function getTaskProgressForChange(changesDir: string, changeName: string): Promise<TaskProgress> {
-  const tasksPath = path.join(changesDir, changeName, 'tasks.md');
+async function collectTaskFiles(dir: string): Promise<string[]> {
+  let entries;
   try {
-    const content = await fs.readFile(tasksPath, 'utf-8');
-    return countTasksFromContent(content);
+    entries = await fs.readdir(dir, { withFileTypes: true });
   } catch {
-    return { total: 0, completed: 0 };
+    return [];
   }
+
+  const taskFiles: string[] = [];
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      taskFiles.push(...await collectTaskFiles(entryPath));
+    } else if (entry.isFile() && entry.name === 'tasks.md') {
+      taskFiles.push(entryPath);
+    }
+  }
+  return taskFiles;
+}
+
+export async function getTaskProgressForChange(changesDir: string, changeName: string): Promise<TaskProgress> {
+  const changeDir = path.join(changesDir, changeName);
+  const taskFiles = await collectTaskFiles(changeDir);
+
+  let total = 0;
+  let completed = 0;
+  for (const tasksPath of taskFiles.sort()) {
+    let content;
+    try {
+      content = await fs.readFile(tasksPath, 'utf-8');
+    } catch {
+      continue;
+    }
+    const progress = countTasksFromContent(content);
+    total += progress.total;
+    completed += progress.completed;
+  }
+
+  return { total, completed };
 }
 
 export function formatTaskStatus(progress: TaskProgress): string {

--- a/test/core/view.test.ts
+++ b/test/core/view.test.ts
@@ -125,5 +125,31 @@ describe('ViewCommand', () => {
       'gamma-change'
     ]);
   });
+
+  it('uses nested tasks.md files when classifying change progress', async () => {
+    const changesDir = path.join(tempDir, 'openspec', 'changes');
+    const changeDir = path.join(changesDir, 'layered-change');
+    await fs.mkdir(path.join(changeDir, 'backend'), { recursive: true });
+    await fs.mkdir(path.join(changeDir, 'frontend'), { recursive: true });
+    await fs.writeFile(
+      path.join(changeDir, 'backend', 'tasks.md'),
+      '- [x] Backend task\n- [ ] Backend follow-up\n'
+    );
+    await fs.writeFile(
+      path.join(changeDir, 'frontend', 'tasks.md'),
+      '- [ ] Frontend task\n'
+    );
+
+    const viewCommand = new ViewCommand();
+    await viewCommand.execute(tempDir);
+
+    const output = logOutput.map(stripAnsi).join('\n');
+    expect(output).toContain('Active Changes');
+    expect(output).toContain('layered-change');
+    expect(output).toContain('33%');
+
+    const draftSection = output.split('Draft Changes')[1]?.split('Active Changes')[0] ?? '';
+    expect(draftSection).not.toContain('layered-change');
+  });
 });
 


### PR DESCRIPTION
Summary
  Fixed GitHub issue #1202 on feature_0623_4: openspec view now counts nested tasks.md files such as backend/tasks.md and frontend/tasks.md.

  Previously, openspec view only read openspec/changes/<change>/tasks.md, so changes using layered task files were classified as Draft even when they had task progress.

  This fixes shared task progress detection by recursively aggregating every tasks.md under a change directory.

  Changes

  - Updated src/utils/task-progress.ts to recursively collect and count nested tasks.md files.
  - Added test/core/view.test.ts coverage for a change with backend/tasks.md and frontend/tasks.md, verifying it appears as Active with progress instead of Draft.

  Verification

  - pnpm exec vitest run test/core/view.test.ts --reporter=dot
  - pnpm exec tsc --noEmit
  - pnpm exec vitest run test/core/view.test.ts test/core/list.test.ts test/core/archive.test.ts --reporter=dot
  - pnpm run lint
  - pnpm run build

  Commit

  - 521ced8 fix: count nested tasks in progress (#1202)
  - Commit contains only source and test files: src/utils/task-progress.ts, test/core/view.test.ts.
  - No OpenSpec related files were committed.

  Summary by CodeRabbit

  Bug Fixes

  - openspec view now recognizes task progress from nested task files and no longer incorrectly shows layered changes as Draft.

  Documentation

  - No documentation or OpenSpec process files were changed.

  Tests

  - Added regression coverage for nested task files under one change directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Change progress now reflects tasks found in nested folders, giving a more accurate completion percentage.
* **Bug Fixes**
  * Fixed change status reporting so changes with multiple task lists are classified correctly in the active changes view.
  * Improved resilience when some task files can’t be read; other available task progress is still included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->