### PR TITLE
docs: clarify change name format

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -620,6 +620,13 @@ Create a change directory and optional checked-in metadata in the resolved OpenS
 openspec new change <name> [options]
 ```
 
+Change names must use lowercase kebab-case. They start with a lowercase letter,
+then contain lowercase letters, numbers, and single hyphens. They cannot start
+with a number, contain spaces, underscores, uppercase letters, consecutive
+hyphens, or leading/trailing hyphens. When including an external ticket ID,
+prefix it with a word, for example `ticket-123-add-notifications` instead of
+`123-add-notifications`.
+
 **Options:**
 
 | Option | Description |


### PR DESCRIPTION
This documents the change name validation already enforced by validateChangeName in src/utils/change-utils.ts. The public docs currently show kebab-case examples but do not state that change names must start with a lowercase letter, so names that begin with ticket numbers fail unexpectedly in commands like openspec status --change. This PR clarifies the accepted format and uses a neutral ticket-ID example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the required naming format for new change entries.
  * Added rules for valid lowercase kebab-case names, including allowed characters and hyphen placement.
  * Explained how to include an external ticket ID in a change name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->