### PR TITLE
chore: add changeset for stores beta and config JSON parsing

### DIFF
--- a/.changeset/stores-beta-config-parse.md
+++ b/.changeset/stores-beta-config-parse.md
@@ -9,5 +9,3 @@
 ### Bug Fixes
 
 - **Config parsing** — Configuration values wrapped in JSON containers are now parsed correctly.
-</content>
-</invoke>

--- a/.changeset/stores-beta-config-parse.md
+++ b/.changeset/stores-beta-config-parse.md
@@ -1,0 +1,13 @@
+---
+"@fission-ai/openspec": minor
+---
+
+### New Features
+
+- **Stores (very early beta)** — Introduces stores as a simpler way to organize specs and changes, replacing the workspace and initiative model. This feature is in very early beta — expect rough edges and breaking changes in upcoming releases.
+
+### Bug Fixes
+
+- **Config parsing** — Configuration values wrapped in JSON containers are now parsed correctly.
+</content>
+</invoke>


### PR DESCRIPTION
Adds a `minor` changeset for user-facing changes merged to `main` since v1.4.1 that did not yet have one.

## Changes covered

### New Features
- **Stores (very early beta)** (#1190) — Introduces stores as a simpler way to organize specs and changes, replacing the workspace and initiative model. Flagged as very early beta — expect rough edges and breaking changes in upcoming releases.

### Bug Fixes
- **Config parsing** (#1244) — Configuration values wrapped in JSON containers are now parsed correctly.

## Not included (by design)
- `#1240` carriage-return escaping — already has a changeset (in release PR #1248).
- Docs overhaul (#1237), CI/installer hardening (#1247), dependency lock refresh (#1249) — docs/internal, follow the normal release cadence.

## Effect on the release
Once merged, the Changesets action will regenerate release PR #1248, recomputing the version to **1.5.0** and folding in all three changelog entries. Merging #1248 then publishes to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added early beta support for Stores, introducing a simpler spec organization model.

* **Bug Fixes**
  * Fixed configuration parsing so values wrapped in JSON containers are now handled correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->