### PR TITLE
Fix #1264: bug skipping sync

### DIFF
--- a/.changeset/fix-config-set-workflows-array.md
+++ b/.changeset/fix-config-set-workflows-array.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+Fix `openspec config set workflows` so JSON array values are stored as workflow arrays instead of being rejected as strings.

--- a/.changeset/fix-yaml-carriage-return-escaping.md
+++ b/.changeset/fix-yaml-carriage-return-escaping.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+Fix YAML frontmatter command generation so carriage returns are escaped consistently across adapters.

--- a/openspec/changes/fix-config-set-workflows-array/design.md
+++ b/openspec/changes/fix-config-set-workflows-array/design.md
@@ -1,0 +1,38 @@
+## Context
+
+`GlobalConfigSchema` defines `workflows` as `string[] | undefined`, and `validateConfigKeyPath()` explicitly allows `workflows` as a known top-level key. The `config set` command currently calls `coerceValue(value, --string)` without considering the key being set, so JSON array input remains a string and fails schema validation.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Let users configure `workflows` non-interactively with a JSON array value.
+- Keep validation responsible for rejecting malformed or schema-incompatible values.
+- Preserve existing coercion behavior for scalar config keys.
+- Keep the implementation extensible for future known structured config keys.
+
+**Non-Goals:**
+
+- Add a new CLI flag such as `--json`.
+- Add repeatable workflow flags or append/remove workflow subcommands.
+- Validate workflow IDs beyond the existing schema contract in this change.
+- Parse arbitrary JSON for all config keys.
+
+## Decisions
+
+1. Add a key-aware coercion helper for config writes.
+
+   The helper will accept the config key path, raw string value, and `forceString` flag. If `forceString` is true, it returns the raw string exactly as today.
+
+2. Parse JSON only for known structured keys.
+
+   For this change, `workflows` is the only known array-typed settable key. The helper will attempt `JSON.parse()` for `workflows` and return the parsed value. Schema validation will then enforce that the parsed value is an array of strings.
+
+3. Preserve fallback scalar coercion for all other keys.
+
+   Existing `coerceValue()` behavior remains available and unchanged for booleans, numbers, and strings. `config set` will use the new key-aware helper, which delegates to scalar coercion when no structured coercion applies.
+
+## Risks / Trade-offs
+
+- Quoting JSON arrays differs by shell. This is already true for JSON-like CLI arguments, so tests should exercise command behavior through direct argument passing rather than shell-specific quoting.
+- Parsing only `workflows` is intentionally narrow. Future structured config keys can be added to the same explicit list when they become settable.

--- a/openspec/changes/fix-config-set-workflows-array/proposal.md
+++ b/openspec/changes/fix-config-set-workflows-array/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+`openspec config set` advertises automatic type coercion and accepts `workflows` as a known top-level key, but it currently cannot set `workflows` because the value always remains a string. Users who need to configure a custom workflow profile non-interactively must either use the interactive picker or edit the global config JSON by hand.
+
+This breaks scriptable setup for custom profiles and can leave the global config in a confusing partial state when `profile` is already set to `custom` but `workflows` cannot be written.
+
+## What Changes
+
+Teach `openspec config set workflows <value>` to accept a JSON array value and store it as an array of strings after schema validation.
+
+Keep existing scalar coercion behavior for other keys, including booleans, numbers, strings, and `--string`.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `cli-config`: `config set` can set the array-typed `workflows` key from a JSON array value.
+
+## Impact
+
+- `src/core/config-schema.ts` - add targeted coercion for known array-typed config keys.
+- `src/commands/config.ts` - use key-aware coercion for `config set`.
+- `test/core/config-schema.test.ts` and/or `test/commands/config.test.ts` - cover JSON-array workflow setting and invalid values.

--- a/openspec/changes/fix-config-set-workflows-array/specs/cli-config/spec.md
+++ b/openspec/changes/fix-config-set-workflows-array/specs/cli-config/spec.md
@@ -1,0 +1,42 @@
+## MODIFIED Requirements
+
+### Requirement: Config Set
+The config command SHALL set configuration values with automatic type coercion, including supported structured values for known structured config keys.
+
+#### Scenario: Set string value
+- **WHEN** user executes `openspec config set <key> <value>`
+- **AND** value does not match boolean, number, or supported structured value patterns for that key
+- **THEN** store value as a string
+- **AND** display confirmation message
+
+#### Scenario: Set boolean value
+- **WHEN** user executes `openspec config set <key> true` or `openspec config set <key> false`
+- **THEN** store value as boolean (not string)
+- **AND** display confirmation message
+
+#### Scenario: Set numeric value
+- **WHEN** user executes `openspec config set <key> <value>`
+- **AND** value is a valid number (integer or float)
+- **THEN** store value as number (not string)
+
+#### Scenario: Set workflows array value
+- **WHEN** user executes `openspec config set workflows '["new","ff","apply","archive"]'`
+- **THEN** store `workflows` as an array of strings
+- **AND** subsequent `openspec config get workflows` output SHALL be valid JSON for that array
+- **AND** display confirmation message
+
+#### Scenario: Reject invalid workflows array value
+- **WHEN** user executes `openspec config set workflows not-json`
+- **THEN** display a descriptive schema validation error
+- **AND** do not modify the config file
+- **AND** exit with code 1
+
+#### Scenario: Force string with --string flag
+- **WHEN** user executes `openspec config set <key> <value> --string`
+- **THEN** store value as string regardless of content
+- **AND** this allows storing literal "true" or "123" as strings when allowed by the target config key
+
+#### Scenario: Set nested key
+- **WHEN** user executes `openspec config set featureFlags.newFlag true`
+- **THEN** create intermediate objects if they don't exist
+- **AND** set the value at the nested path

--- a/openspec/changes/fix-config-set-workflows-array/tasks.md
+++ b/openspec/changes/fix-config-set-workflows-array/tasks.md
@@ -1,0 +1,18 @@
+## 1. Specification
+
+- [x] 1.1 Capture the issue contract in a `cli-config` delta spec
+- [x] 1.2 Document the narrow key-aware parsing design
+
+## 2. Implementation
+
+- [x] 2.1 Add key-aware config value coercion for `workflows`
+- [x] 2.2 Wire `openspec config set` to use key-aware coercion
+- [x] 2.3 Keep `--string` and scalar key behavior unchanged
+
+## 3. Verification
+
+- [x] 3.1 Add unit coverage for key-aware workflow array coercion
+- [x] 3.2 Add config command coverage for successful `workflows` array setting
+- [x] 3.3 Add config command coverage for invalid `workflows` values that must not save
+- [x] 3.4 Run targeted config/schema tests
+- [x] 3.5 Add patch changeset for the user-visible CLI fix

--- a/openspec/changes/fix-yaml-carriage-return-escaping/design.md
+++ b/openspec/changes/fix-yaml-carriage-return-escaping/design.md
@@ -1,0 +1,36 @@
+## Context
+
+Command adapters for Bob, Claude, Cursor, Pi, and Windsurf emit YAML frontmatter and shared the same local `escapeYamlValue()` implementation. The helper regex includes `\r`, so carriage returns already trigger double quoting, but the escape chain only handles backslashes, double quotes, and `\n`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Provide one reusable YAML scalar escaping helper for command generation.
+- Preserve existing quoting behavior for ordinary scalars and existing escaped characters.
+- Escape carriage returns as `\\r` whenever a YAML scalar is double quoted.
+- Keep adapter output formats otherwise unchanged.
+
+**Non-Goals:**
+
+- Replace all frontmatter generation with a YAML serializer.
+- Change TOML or markdown-only adapters.
+- Broaden command adapter behavior beyond scalar escaping.
+
+## Decisions
+
+1. Add `src/core/command-generation/utils/yaml.ts`.
+
+   The utility owns the existing detection regex and escaping chain so future YAML-frontmatter adapters can reuse the same behavior.
+
+2. Escape carriage returns after line feeds.
+
+   The helper continues escaping backslashes and double quotes first, then emits visible `\\n` and `\\r` sequences for control characters inside double-quoted scalars.
+
+3. Update all current YAML-frontmatter adapters with the duplicated helper.
+
+   The current repository still uses YAML helpers in Bob, Claude, Cursor, Pi, and Windsurf. Qwen now emits TOML and is outside this change.
+
+## Risks / Trade-offs
+
+- A dedicated YAML serializer would handle more edge cases but would be a larger behavioral change for generated files. This change intentionally preserves the existing formatting contract and fixes the known control-character gap.

--- a/openspec/changes/fix-yaml-carriage-return-escaping/proposal.md
+++ b/openspec/changes/fix-yaml-carriage-return-escaping/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Several command adapters duplicate the same YAML frontmatter scalar escaping helper. The duplicated helper detects carriage returns as requiring quoted YAML, but only escapes line feeds. A description, category, name, or tag containing `\r` can therefore be emitted with a raw carriage return inside a double-quoted scalar.
+
+This produces inconsistent YAML escaping across generated command files and makes the helper harder to fix consistently.
+
+## What Changes
+
+Move the shared YAML scalar escaping behavior into one command-generation utility and make it escape carriage returns as `\r` when emitting double-quoted YAML scalars.
+
+Update the YAML-frontmatter adapters that use this behavior to call the shared utility.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `command-generation`: YAML frontmatter scalar values escape carriage returns consistently.
+
+## Impact
+
+- `src/core/command-generation/utils/yaml.ts` - add shared YAML scalar escaping utility.
+- YAML-frontmatter command adapters - import the shared utility instead of local copies.
+- `test/core/command-generation/yaml-utils.test.ts` and adapter tests - cover carriage-return escaping.

--- a/openspec/changes/fix-yaml-carriage-return-escaping/specs/command-generation/spec.md
+++ b/openspec/changes/fix-yaml-carriage-return-escaping/specs/command-generation/spec.md
@@ -1,0 +1,14 @@
+## MODIFIED Requirements
+
+### Requirement: YAML frontmatter scalar escaping
+Command adapters that emit YAML frontmatter SHALL render scalar field values without unescaped control characters.
+
+#### Scenario: Escape carriage returns in YAML frontmatter
+- **WHEN** a generated YAML frontmatter scalar value contains a carriage return character
+- **THEN** the emitted scalar SHALL be double quoted
+- **AND** the carriage return SHALL be represented as the escaped `\r` sequence
+- **AND** the generated YAML frontmatter SHALL not contain the raw carriage return inside the scalar value
+
+#### Scenario: Preserve existing YAML scalar escaping
+- **WHEN** a generated YAML frontmatter scalar value contains existing supported special characters such as a colon, double quote, backslash, or line feed
+- **THEN** the emitted scalar SHALL preserve the existing double-quoted escaping behavior

--- a/openspec/changes/fix-yaml-carriage-return-escaping/tasks.md
+++ b/openspec/changes/fix-yaml-carriage-return-escaping/tasks.md
@@ -1,0 +1,17 @@
+## 1. Specification
+
+- [x] 1.1 Capture YAML frontmatter carriage-return escaping in a `command-generation` delta spec
+- [x] 1.2 Document the shared utility design
+
+## 2. Implementation
+
+- [x] 2.1 Add shared YAML scalar escaping utility
+- [x] 2.2 Escape carriage returns in quoted YAML scalar values
+- [x] 2.3 Update YAML-frontmatter adapters to use the shared utility
+
+## 3. Verification
+
+- [x] 3.1 Add unit coverage for the shared YAML utility
+- [x] 3.2 Add adapter coverage for carriage-return escaping in generated frontmatter
+- [x] 3.3 Run targeted command-generation tests
+- [x] 3.4 Validate the OpenSpec change

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -13,7 +13,7 @@ import {
   getNestedValue,
   setNestedValue,
   deleteNestedValue,
-  coerceValue,
+  coerceConfigValue,
   formatValueYaml,
   validateConfigKeyPath,
   validateConfig,
@@ -365,7 +365,7 @@ export function registerConfigCommand(program: Command): void {
       }
 
       const config = getGlobalConfig() as Record<string, unknown>;
-      const coercedValue = coerceValue(value, options.string || false);
+      const coercedValue = coerceConfigValue(key, value, options.string || false);
 
       // Create a copy to validate before saving
       const newConfig = JSON.parse(JSON.stringify(config));
@@ -384,7 +384,7 @@ export function registerConfigCommand(program: Command): void {
       saveGlobalConfig(config as GlobalConfig);
 
       const displayValue =
-        typeof coercedValue === 'string' ? `"${coercedValue}"` : String(coercedValue);
+        typeof coercedValue === 'string' ? `"${coercedValue}"` : JSON.stringify(coercedValue);
       console.log(`Set ${key} = ${displayValue}`);
     });
 

--- a/src/core/command-generation/adapters/bob.ts
+++ b/src/core/command-generation/adapters/bob.ts
@@ -8,21 +8,7 @@
 import path from 'path';
 import type { CommandContent, ToolCommandAdapter } from '../types.js';
 import { transformToHyphenCommands } from '../../../utils/command-references.js';
-
-/**
- * Escapes a string value for safe YAML output.
- * Quotes the string if it contains special YAML characters.
- */
-function escapeYamlValue(value: string): string {
-  // Check if value needs quoting (contains special YAML characters or starts/ends with whitespace)
-  const needsQuoting = /[:\n\r#{}[\],&*!|>'"%@`]|^\s|\s$/.test(value);
-  if (needsQuoting) {
-    // Use double quotes and escape internal double quotes and backslashes
-    const escaped = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n');
-    return `"${escaped}"`;
-  }
-  return value;
-}
+import { escapeYamlValue } from '../utils/yaml.js';
 
 /**
  * Bob Shell adapter for command generation.

--- a/src/core/command-generation/adapters/claude.ts
+++ b/src/core/command-generation/adapters/claude.ts
@@ -6,21 +6,7 @@
 
 import path from 'path';
 import type { CommandContent, ToolCommandAdapter } from '../types.js';
-
-/**
- * Escapes a string value for safe YAML output.
- * Quotes the string if it contains special YAML characters.
- */
-function escapeYamlValue(value: string): string {
-  // Check if value needs quoting (contains special YAML characters or starts/ends with whitespace)
-  const needsQuoting = /[:\n\r#{}[\],&*!|>'"%@`]|^\s|\s$/.test(value);
-  if (needsQuoting) {
-    // Use double quotes and escape internal double quotes and backslashes
-    const escaped = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n');
-    return `"${escaped}"`;
-  }
-  return value;
-}
+import { escapeYamlValue } from '../utils/yaml.js';
 
 /**
  * Formats a tags array as a YAML array with proper escaping.

--- a/src/core/command-generation/adapters/cursor.ts
+++ b/src/core/command-generation/adapters/cursor.ts
@@ -7,21 +7,7 @@
 
 import path from 'path';
 import type { CommandContent, ToolCommandAdapter } from '../types.js';
-
-/**
- * Escapes a string value for safe YAML output.
- * Quotes the string if it contains special YAML characters.
- */
-function escapeYamlValue(value: string): string {
-  // Check if value needs quoting (contains special YAML characters or starts/ends with whitespace)
-  const needsQuoting = /[:\n\r#{}[\],&*!|>'"%@`]|^\s|\s$/.test(value);
-  if (needsQuoting) {
-    // Use double quotes and escape internal double quotes and backslashes
-    const escaped = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n');
-    return `"${escaped}"`;
-  }
-  return value;
-}
+import { escapeYamlValue } from '../utils/yaml.js';
 
 /**
  * Cursor adapter for command generation.

--- a/src/core/command-generation/adapters/pi.ts
+++ b/src/core/command-generation/adapters/pi.ts
@@ -8,6 +8,7 @@
 import path from 'path';
 import type { CommandContent, ToolCommandAdapter } from '../types.js';
 import { transformToHyphenCommands } from '../../../utils/command-references.js';
+import { escapeYamlValue } from '../utils/yaml.js';
 
 const PI_INPUT_HEADING = /^\*\*Input\*\*:[^\n]*$/m;
 
@@ -20,21 +21,6 @@ function injectPiArgs(body: string): string {
     PI_INPUT_HEADING,
     (heading) => `${heading}\n**Provided arguments**: $@`
   );
-}
-
-/**
- * Escapes a string value for safe YAML output.
- * Quotes the string if it contains special YAML characters.
- */
-function escapeYamlValue(value: string): string {
-  // Check if value needs quoting (contains special YAML characters or starts/ends with whitespace)
-  const needsQuoting = /[:\n\r#{}[\],&*!|>'"%@`]|^\s|\s$/.test(value);
-  if (needsQuoting) {
-    // Use double quotes and escape internal double quotes and backslashes
-    const escaped = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n');
-    return `"${escaped}"`;
-  }
-  return value;
 }
 
 /**

--- a/src/core/command-generation/adapters/windsurf.ts
+++ b/src/core/command-generation/adapters/windsurf.ts
@@ -7,21 +7,7 @@
 
 import path from 'path';
 import type { CommandContent, ToolCommandAdapter } from '../types.js';
-
-/**
- * Escapes a string value for safe YAML output.
- * Quotes the string if it contains special YAML characters.
- */
-function escapeYamlValue(value: string): string {
-  // Check if value needs quoting (contains special YAML characters or starts/ends with whitespace)
-  const needsQuoting = /[:\n\r#{}[\],&*!|>'"%@`]|^\s|\s$/.test(value);
-  if (needsQuoting) {
-    // Use double quotes and escape internal double quotes and backslashes
-    const escaped = value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n');
-    return `"${escaped}"`;
-  }
-  return value;
-}
+import { escapeYamlValue } from '../utils/yaml.js';
 
 /**
  * Formats a tags array as a YAML array with proper escaping.

--- a/src/core/command-generation/utils/yaml.ts
+++ b/src/core/command-generation/utils/yaml.ts
@@ -1,0 +1,16 @@
+/**
+ * Escapes a string value for safe YAML output.
+ * Quotes the string if it contains special YAML characters.
+ */
+export function escapeYamlValue(value: string): string {
+  const needsQuoting = /[:\n\r#{}[\],&*!|>'"%@`]|^\s|\s$/.test(value);
+  if (needsQuoting) {
+    const escaped = value
+      .replace(/\\/g, '\\\\')
+      .replace(/"/g, '\\"')
+      .replace(/\n/g, '\\n')
+      .replace(/\r/g, '\\r');
+    return `"${escaped}"`;
+  }
+  return value;
+}

--- a/src/core/config-schema.ts
+++ b/src/core/config-schema.ts
@@ -175,6 +175,34 @@ export function coerceValue(value: string, forceString: boolean = false): string
 }
 
 /**
+ * Coerce a config value using the destination key path when structured values
+ * are only valid for specific known keys.
+ */
+export function coerceConfigValue(
+  path: string,
+  value: string,
+  forceString: boolean = false
+): string | number | boolean | unknown[] {
+  if (forceString) {
+    return value;
+  }
+
+  if (path === 'workflows') {
+    try {
+      const parsed: unknown = JSON.parse(value);
+      if (Array.isArray(parsed)) {
+        return parsed;
+      }
+    } catch {
+      // Fall through to scalar coercion so schema validation produces the
+      // same user-facing error path as other invalid config values.
+    }
+  }
+
+  return coerceValue(value, forceString);
+}
+
+/**
  * Format a value for YAML-like display.
  *
  * @param value - The value to format

--- a/src/core/templates/workflows/archive-change.ts
+++ b/src/core/templates/workflows/archive-change.ts
@@ -59,7 +59,13 @@ export function getArchiveChangeSkillTemplate(): SkillTemplate {
    Use \`artifactPaths.specs.existingOutputPaths\` from status JSON to check for delta specs. If none exist, proceed without sync prompt.
 
    **If delta specs exist:**
-   - Compare each delta spec with its corresponding main spec at \`openspec/specs/<capability>/spec.md\`
+   - For each delta spec, check whether its corresponding main spec exists at \`openspec/specs/<capability>/spec.md\`
+   - If the corresponding main spec exists, compare the delta spec with that main spec
+   - If the corresponding main spec does not exist, assess by delta operation:
+     - ADDED requirements -> include in sync as creation of a new main spec
+     - MODIFIED / RENAMED requirements -> warn that they are not allowed without an existing main spec and stop before archiving
+     - REMOVED requirements -> warn that they have no target main spec and do not require sync
+   - Do not treat a missing main spec as "already synced" or "no sync needed"
    - Determine what changes would be applied (adds, modifications, removals, renames)
    - Show a combined summary before prompting
 
@@ -177,7 +183,13 @@ export function getOpsxArchiveCommandTemplate(): CommandTemplate {
    Use \`artifactPaths.specs.existingOutputPaths\` from status JSON to check for delta specs. If none exist, proceed without sync prompt.
 
    **If delta specs exist:**
-   - Compare each delta spec with its corresponding main spec at \`openspec/specs/<capability>/spec.md\`
+   - For each delta spec, check whether its corresponding main spec exists at \`openspec/specs/<capability>/spec.md\`
+   - If the corresponding main spec exists, compare the delta spec with that main spec
+   - If the corresponding main spec does not exist, assess by delta operation:
+     - ADDED requirements -> include in sync as creation of a new main spec
+     - MODIFIED / RENAMED requirements -> warn that they are not allowed without an existing main spec and stop before archiving
+     - REMOVED requirements -> warn that they have no target main spec and do not require sync
+   - Do not treat a missing main spec as "already synced" or "no sync needed"
    - Determine what changes would be applied (adds, modifications, removals, renames)
    - Show a combined summary before prompting
 

--- a/test/commands/config.test.ts
+++ b/test/commands/config.test.ts
@@ -2,12 +2,22 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
+import { Command } from 'commander';
+
+async function runConfigCommand(args: string[]): Promise<void> {
+  const { registerConfigCommand } = await import('../../src/commands/config.js');
+  const program = new Command();
+  registerConfigCommand(program);
+  await program.parseAsync(['node', 'openspec', 'config', ...args]);
+}
 
 describe('config command integration', () => {
   // These tests use real file system operations with XDG_CONFIG_HOME override
   let tempDir: string;
   let originalEnv: NodeJS.ProcessEnv;
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let originalExitCode: number | undefined;
 
   beforeEach(() => {
     // Create unique temp directory for each test
@@ -20,6 +30,9 @@ describe('config command integration', () => {
 
     // Spy on console.error
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    originalExitCode = process.exitCode;
+    process.exitCode = undefined;
   });
 
   afterEach(() => {
@@ -31,6 +44,8 @@ describe('config command integration', () => {
 
     // Restore spies
     consoleErrorSpy.mockRestore();
+    consoleLogSpy.mockRestore();
+    process.exitCode = originalExitCode;
 
     // Reset module cache to pick up new XDG_CONFIG_HOME
     vi.resetModules();
@@ -88,6 +103,38 @@ describe('config command integration', () => {
     // Should return defaults
     expect(config.featureFlags).toEqual({});
     expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid JSON'));
+  });
+
+  it('should set workflows from a JSON array value', async () => {
+    await runConfigCommand(['set', 'profile', 'custom']);
+    await runConfigCommand(['set', 'workflows', '["new","ff","apply","archive"]']);
+
+    const { getGlobalConfig } = await import('../../src/core/global-config.js');
+    const config = getGlobalConfig();
+
+    expect(process.exitCode).toBeUndefined();
+    expect(config.profile).toBe('custom');
+    expect(config.workflows).toEqual(['new', 'ff', 'apply', 'archive']);
+    expect(consoleLogSpy).toHaveBeenCalledWith('Set workflows = ["new","ff","apply","archive"]');
+  });
+
+  it('should reject invalid workflows values without saving', async () => {
+    const { getGlobalConfig, saveGlobalConfig } = await import('../../src/core/global-config.js');
+    saveGlobalConfig({
+      featureFlags: {},
+      profile: 'custom',
+      delivery: 'both',
+      workflows: ['explore'],
+    });
+
+    await runConfigCommand(['set', 'workflows', 'not-json']);
+
+    const config = getGlobalConfig();
+    expect(process.exitCode).toBe(1);
+    expect(config.workflows).toEqual(['explore']);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Error: Invalid configuration - workflows:')
+    );
   });
 });
 

--- a/test/core/command-generation/adapters.test.ts
+++ b/test/core/command-generation/adapters.test.ts
@@ -239,6 +239,16 @@ describe('command-generation/adapters', () => {
       expect(output).toContain('description: "Line 1\\nLine 2"');
     });
 
+    it('should escape carriage returns in description', () => {
+      const contentWithCarriageReturn: CommandContent = {
+        ...sampleContent,
+        description: 'Line 1\rLine 2',
+      };
+      const output = bobAdapter.formatFile(contentWithCarriageReturn);
+      expect(output).toContain('description: "Line 1\\rLine 2"');
+      expect(output).not.toContain('Line 1\rLine 2');
+    });
+
     it('should handle empty description', () => {
       const contentEmptyDesc: CommandContent = {
         ...sampleContent,
@@ -651,6 +661,16 @@ describe('command-generation/adapters', () => {
       };
       const output = piAdapter.formatFile(contentWithNewline);
       expect(output).toContain('description: "Line 1\\nLine 2"');
+    });
+
+    it('should escape carriage returns in description', () => {
+      const contentWithCarriageReturn: CommandContent = {
+        ...sampleContent,
+        description: 'Line 1\rLine 2',
+      };
+      const output = piAdapter.formatFile(contentWithCarriageReturn);
+      expect(output).toContain('description: "Line 1\\rLine 2"');
+      expect(output).not.toContain('Line 1\rLine 2');
     });
   });
 

--- a/test/core/command-generation/yaml-utils.test.ts
+++ b/test/core/command-generation/yaml-utils.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { escapeYamlValue } from '../../../src/core/command-generation/utils/yaml.js';
+
+describe('command-generation/yaml utils', () => {
+  it('leaves plain scalar values unquoted', () => {
+    expect(escapeYamlValue('OpenSpec Explore')).toBe('OpenSpec Explore');
+  });
+
+  it('escapes YAML double-quoted scalars', () => {
+    expect(escapeYamlValue('Fix: "auth"\\path')).toBe('"Fix: \\"auth\\"\\\\path"');
+  });
+
+  it('escapes line feed and carriage return characters', () => {
+    expect(escapeYamlValue('Line 1\nLine 2\rLine 3')).toBe('"Line 1\\nLine 2\\rLine 3"');
+  });
+});

--- a/test/core/config-schema.test.ts
+++ b/test/core/config-schema.test.ts
@@ -5,6 +5,7 @@ import {
   setNestedValue,
   deleteNestedValue,
   coerceValue,
+  coerceConfigValue,
   formatValueYaml,
   validateConfig,
   GlobalConfigSchema,
@@ -179,6 +180,35 @@ describe('config-schema', () => {
     });
   });
 
+  describe('coerceConfigValue', () => {
+    it('should coerce workflows JSON arrays to arrays', () => {
+      expect(coerceConfigValue('workflows', '["new","ff","apply","archive"]')).toEqual([
+        'new',
+        'ff',
+        'apply',
+        'archive',
+      ]);
+    });
+
+    it('should leave invalid workflows JSON for schema validation', () => {
+      expect(coerceConfigValue('workflows', 'not-json')).toBe('not-json');
+    });
+
+    it('should leave non-array workflows JSON for schema validation', () => {
+      expect(coerceConfigValue('workflows', '{"new":true}')).toBe('{"new":true}');
+    });
+
+    it('should preserve force string behavior for workflows', () => {
+      expect(coerceConfigValue('workflows', '["new"]', true)).toBe('["new"]');
+    });
+
+    it('should preserve scalar coercion for other keys', () => {
+      expect(coerceConfigValue('featureFlags.test', 'true')).toBe(true);
+      expect(coerceConfigValue('someFutureKey', '42')).toBe(42);
+      expect(coerceConfigValue('profile', 'custom')).toBe('custom');
+    });
+  });
+
   describe('formatValueYaml', () => {
     it('should format null as "null"', () => {
       expect(formatValueYaml(null)).toBe('null');
@@ -317,6 +347,16 @@ describe('config-schema', () => {
       const result = validateConfig(config);
       expect(result.success).toBe(true);
       expect((config.featureFlags as Record<string, unknown>).experimental).toBe(false);
+    });
+
+    it('should accept setting workflows from a JSON array', () => {
+      const config: Record<string, unknown> = { featureFlags: {}, profile: 'custom' };
+      const value = coerceConfigValue('workflows', '["new","ff","apply","archive"]');
+      setNestedValue(config, 'workflows', value);
+
+      const result = validateConfig(config);
+      expect(result.success).toBe(true);
+      expect(config.workflows).toEqual(['new', 'ff', 'apply', 'archive']);
     });
   });
 

--- a/test/core/templates/skill-templates-parity.test.ts
+++ b/test/core/templates/skill-templates-parity.test.ts
@@ -42,11 +42,11 @@ const EXPECTED_FUNCTION_HASHES: Record<string, string> = {
   getOpsxContinueCommandTemplate: '62f8863edda2bfe4e210f8bc3095fd4369aaaaf7772a5cba9602d0f0bca1d0c9',
   getOpsxApplyCommandTemplate: '812feefd32a4d9d468e03e456d06e3d2d08d1118d29cce4911f0be59cdd30bfc',
   getOpsxFfCommandTemplate: 'f775b242bcfd56594c431c7f31a0129208a1bacfdb2427074d412543072ef7ca',
-  getArchiveChangeSkillTemplate: 'bdf022ae2cdef1feef4d641a068bef3a7fc5d98a323f7ce9f77ac578fe8d20c6',
+  getArchiveChangeSkillTemplate: '6333f3f372ce13a6486baea72e176220a13de57c93c168f3d885b86a670f39c2',
   getBulkArchiveChangeSkillTemplate: 'fdb1715804e86de85be96222b8efeb9d5b350c6d5c19e343e244655deff8e62b',
   getOpsxSyncCommandTemplate: '4c8118afaea79ff4fed3d946c88e6a7abbba904a5fbf643e4372da1e3735a467',
   getVerifyChangeSkillTemplate: '3c5dda8b49ba00f50b5bae7f04763dd00cc00a05e5f1d8a2068ad7fb701d8165',
-  getOpsxArchiveCommandTemplate: '5181ec2f59c9f0f3376e61d952ed4be976cbd01595b6b0d5e67466c8bd6bac6d',
+  getOpsxArchiveCommandTemplate: '68294096d50f850373ceac9ca6880267f08ade52d4fe52b9854dc0baa09c492e',
   getOpsxOnboardCommandTemplate: '57c1f3e2590bda8f47818bab1d528456c1b8a9a7501f63ab9e2115e0cfaf6f35',
   getOpsxBulkArchiveCommandTemplate: 'b76c421023ccb5a12867c349f27cdb186234b692c1811980fb94127567bdabda',
   getOpsxVerifyCommandTemplate: '9a7a3f9e5bc3d0c0878b1a4493efbbb38729597d9b9be78f63284cc2da7c20c3',
@@ -62,7 +62,7 @@ const EXPECTED_GENERATED_SKILL_CONTENT_HASHES: Record<string, string> = {
   'openspec-apply-change': 'd849442efd925b9247651e254a5cd696945321610cca5a9432ad420430554548',
   'openspec-ff-change': '9d9b1995b6f4adb3da570676f7d11fee4cd1cf6c5df8ec83c033e02783a544df',
   'openspec-sync-specs': '2e0f67ec6fadffc6107b4b1a28eef23a99a6649e5fae706897ea1dd9deb852a8',
-  'openspec-archive-change': '8d14af2c8b2e4358308ac9fc14f75db42a4b41a07e175825035852a82479793e',
+  'openspec-archive-change': '50f0cb57bb37059e448c9f93c3f87820e3125c0b0861e3d7fdc40f16a2099d3d',
   'openspec-bulk-archive-change': '16207683996b1952559cd4e33463f28fb097761f2c5d912107733d01a90d3f2f',
   'openspec-verify-change': 'a2acecd0c2b4e57080a314e5e7a093e0688293c37e446eb45d378f5050058550',
   'openspec-onboard': 'b924ea3c97543ebb7ee82c5f194afe7ce87a521c32b85616f445240ab33a02ab',
@@ -167,6 +167,21 @@ describe('skill templates split parity', () => {
       expect(content, dirName).toContain(guardText);
       expect(content, dirName).not.toContain('openspec/changes/<name>');
       expect(content, dirName).not.toContain('mv openspec/changes');
+    }
+  });
+
+  it('guides archive sync assessment when the main spec is missing', () => {
+    const archiveSurfaces = [
+      ['openspec-archive-change', getArchiveChangeSkillTemplate().instructions],
+      ['opsx-archive-command', getOpsxArchiveCommandTemplate().content],
+    ] as const;
+
+    for (const [name, content] of archiveSurfaces) {
+      expect(content, name).toContain('If the corresponding main spec does not exist');
+      expect(content, name).toContain('ADDED requirements -> include in sync as creation of a new main spec');
+      expect(content, name).toContain('MODIFIED / RENAMED requirements -> warn that they are not allowed without an existing main spec');
+      expect(content, name).toContain('REMOVED requirements -> warn that they have no target main spec and do not require sync');
+      expect(content, name).toContain('Do not treat a missing main spec as "already synced" or "no sync needed"');
     }
   });
 });


### PR DESCRIPTION
Source issue: https://github.com/Fission-AI/OpenSpec/issues/1264

  This changes the archive workflow prompt to explicitly handle missing main specs: ADDED creates a new main spec during sync, MODIFIED / RENAMED stops with a warning,
  and REMOVED warns that there is no target.

  Changes

  - Updated archive skill and /opsx:archive command template in src/core/templates/workflows/archive-change.ts.
  - Added regression coverage and updated intentional template hashes in test/core/templates/skill-templates-parity.test.ts.

  Verification

  - pnpm exec vitest run test/core/templates/skill-templates-parity.test.ts
  - pnpm run build

  Bug Fixes

  - Prevents generated archive instructions from treating a missing main spec as “already synced” or “no sync needed.”

  Tests

  - Added template assertions covering both generated archive surfaces.

  Suggested commit message:

  Fix archive prompt handling for missing main specs