### PR TITLE
feat(schema): add one-sentence-per-line convention for artifact prose

### DIFF
--- a/schemas/spec-driven/schema.yaml
+++ b/schemas/spec-driven/schema.yaml
@@ -25,6 +25,9 @@ artifacts:
       implementation details belong in design.md.
 
       This is the foundation - specs, design, and tasks all build on this.
+
+      In prose paragraphs, write each sentence on its own line and never wrap a sentence across multiple lines.
+      This keeps diffs clean and reviewable.
     requires: []
 
   - id: specs
@@ -79,6 +82,9 @@ artifacts:
       ```
 
       Specs should be testable - each scenario is a potential test case.
+
+      In prose paragraphs, write each sentence on its own line and never wrap a sentence across multiple lines.
+      This keeps diffs clean and reviewable.
     requires:
       - proposal
 
@@ -107,6 +113,9 @@ artifacts:
       Reference the proposal for motivation and specs for requirements.
 
       Good design docs explain the "why" behind technical decisions.
+
+      In prose paragraphs, write each sentence on its own line and never wrap a sentence across multiple lines.
+      This keeps diffs clean and reviewable.
     requires:
       - proposal
 
@@ -141,6 +150,9 @@ artifacts:
 
       Reference specs for what needs to be built, design for how to build it.
       Each task should be verifiable - you know when it's done.
+
+      In prose paragraphs, write each sentence on its own line and never wrap a sentence across multiple lines.
+      This keeps diffs clean and reviewable.
     requires:
       - specs
       - design


### PR DESCRIPTION
## Summary

Adds a one-sentence-per-line authoring convention to the bundled spec-driven schema, telling agents to put each sentence of artifact prose on its own line.

## Why

OpenSpec artifacts are version controlled, so they should diff cleanly.
A paragraph kept on one line marks the whole paragraph as changed for any edit, so the diff can't pinpoint which sentence was touched.
One sentence per line confines each edit to a single line, keeping reviews and blame precise.

## What changed

Appends the convention to the four prose-bearing artifacts in `schemas/spec-driven/schema.yaml`: proposal, specs, design, and tasks.
The apply phase is excluded because it executes tasks rather than authoring prose.
The convention affects prose paragraphs only.

## Testing

Ran the schema and instruction-loader suites; all passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated writing instructions across multiple workflow phases to enforce consistent prose formatting.
  * Guidance now requires one sentence per line and prevents sentence wrapping onto multiple lines.
  * This helps keep diffs clean and review changes more easily.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->