### PR TITLE
fix(doctor): note when a store checkout is behind its upstream ref

### DIFF
--- a/docs/agent-contract.md
+++ b/docs/agent-contract.md
@@ -72,7 +72,7 @@ Success: `{ "change": { "id", "path", "metadataPath", "schema" }, "root" }`. Fai
 Success: `{ "archive": { "change", "archivedAs": "YYYY-MM-DD-name", "path", "specsUpdated", "totals"? }, "root" }`. Failure: `{ "archive": null, "root"?, "status": [d] }`, exit 1. JSON mode is strictly non-interactive: every prompt point becomes an `archive_*` code.
 
 ### 4.9 `doctor --json`
-`{ "root": { "path", "source", "store_id"?, "healthy", "status": [] }, "store": { "id", "metadata": {present,valid,remote?}, "origin_url"?, "status": [] } | null, "references": [...], "status": [] }`. Health findings of any severity exit 0. Failure payload: `{ "root": null, "store": null, "references": [], "status": [d] }`, exit 1.
+`{ "root": { "path", "source", "store_id"?, "healthy", "status": [] }, "store": { "id", "metadata": {present,valid,remote?}, "origin_url"?, "drift"?: {ahead,behind}, "status": [] } | null, "references": [...], "status": [] }`. `drift` (present only for a git-backed store checkout that has an upstream tracking ref) is ahead/behind counts against the last-fetched upstream, not the live remote. Health findings of any severity exit 0. Failure payload: `{ "root": null, "store": null, "references": [], "status": [d] }`, exit 1.
 
 ### 4.10 `context --json`
 `{ "root": { "path", "source", "store_id"?, "role": "openspec_root" }, "members": [ { "role": "referenced_store", "id", "path"?, "remote"?, "fetch"?, "status": [] } ], "status": [] }`. AVAILABLE = path present AND status empty. `--code-workspace <path>` writes `{folders:[{name,path}]}` (available referenced stores only, `ref:` prefixes); in JSON mode the write runs before printing so stdout holds exactly one document even on write failure. Failure: `{ "root": null, "members": [], "status": [d] }`, exit 1.
@@ -107,7 +107,7 @@ setup/register: `{ "store": {id, root, metadata_path?}, "registry": {path, regis
 `store_setup_id_required`, `store_setup_path_required`, `store_setup_path_not_directory`, `store_setup_inside_git_repo`, `store_setup_non_empty_directory`, `store_setup_cancelled`, `store_path_required`, `store_path_missing`, `store_path_not_directory`, `store_root_pointer_declared`, `store_register_root_unhealthy`, `store_register_identity_confirmation_required`, `store_register_cancelled`, `store_remote_empty`, `store_remote_requires_hand_edit`, `store_remove_confirmation_required`, `store_remove_cancelled`, `store_remove_path_not_directory`, `store_remove_metadata_missing`, `store_root_missing` (warning in remove, error in doctor), `store_root_not_directory`.
 
 ### Store git
-`store_git_init_failed`, `store_git_identity_missing`, `store_git_commit_failed`, `store_git_no_commits` (warning), `store_clone_fragile_directories` (warning), `store_remote_divergence` (info, doctor).
+`store_git_init_failed`, `store_git_identity_missing`, `store_git_commit_failed`, `store_git_no_commits` (warning), `store_clone_fragile_directories` (warning), `store_remote_divergence` (info, doctor), `store_checkout_drift` (info, doctor).
 
 ### References (warning)
 `reference_invalid_id`, `reference_registry_unreadable`, `reference_unresolved`, `reference_root_unhealthy`, `reference_index_truncated`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -332,7 +332,7 @@ One read-only question, one place: is the OpenSpec root healthy, and are the sto
 openspec doctor [--store <id>] [--json]
 ```
 
-The report separates root health, store metadata health (including a note when the recorded remote and the checkout's origin diverge), and reference health (the same diagnostics instructions show, with clone fixes for unresolved references). Health findings of any severity exit 0 — agents read the `status` arrays; only command failures (no root, unknown store) exit 1. Doctor never clones, syncs, or repairs. To get the assembled set itself rather than its health, use `openspec context`.
+The report separates root health, store metadata health (including a note when the recorded remote and the checkout's origin diverge, and a note when the store checkout has drifted behind its last-fetched upstream tracking ref), and reference health (the same diagnostics instructions show, with clone fixes for unresolved references). Health findings of any severity exit 0 — agents read the `status` arrays; only command failures (no root, unknown store) exit 1. Doctor never clones, syncs, or repairs. To get the assembled set itself rather than its health, use `openspec context`.
 
 ## Working context (the assembled set)
 

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -10,7 +10,7 @@ import {
   type ResolvedOpenSpecRoot,
 } from '../core/root-selection.js';
 import { readOptionalStoreMetadataState } from '../core/store/foundation.js';
-import { gitOriginUrl, isGitRepositoryAtRoot } from '../core/store/git.js';
+import { gitOriginUrl, gitTrackingDrift, isGitRepositoryAtRoot } from '../core/store/git.js';
 import {
   classifyOpenSpecDir,
   readProjectConfig,
@@ -59,14 +59,17 @@ async function gatherHealth(
   if (root.storeId) {
     const metadata = await readOptionalStoreMetadataState(root.path).catch(() => null);
     // git -C walks UP the tree: probing a non-repo store nested inside
-    // another repo would record the ENCLOSING repo's origin.
-    const originUrl = (await isGitRepositoryAtRoot(root.path)) ? await gitOriginUrl(root.path) : null;
+    // another repo would record the ENCLOSING repo's origin (and drift).
+    const isRepo = await isGitRepositoryAtRoot(root.path);
+    const originUrl = isRepo ? await gitOriginUrl(root.path) : null;
+    const drift = isRepo ? await gitTrackingDrift(root.path) : null;
     input.storeFacts = {
       id: root.storeId,
       metadataPresent: metadata !== null,
       metadataValid: metadata !== null,
       ...(metadata?.remote ? { canonicalRemote: metadata.remote } : {}),
       ...(originUrl ? { originUrl } : {}),
+      ...(drift ? { drift } : {}),
     };
   }
 

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -61,8 +61,9 @@ async function gatherHealth(
     // git -C walks UP the tree: probing a non-repo store nested inside
     // another repo would record the ENCLOSING repo's origin (and drift).
     const isRepo = await isGitRepositoryAtRoot(root.path);
-    const originUrl = isRepo ? await gitOriginUrl(root.path) : null;
-    const drift = isRepo ? await gitTrackingDrift(root.path) : null;
+    const [originUrl, drift] = isRepo
+      ? await Promise.all([gitOriginUrl(root.path), gitTrackingDrift(root.path)])
+      : [null, null];
     input.storeFacts = {
       id: root.storeId,
       metadataPresent: metadata !== null,

--- a/src/core/relationship-health.ts
+++ b/src/core/relationship-health.ts
@@ -24,6 +24,7 @@ export interface RelationshipHealth {
     id: string;
     metadata: { present: boolean; valid: boolean; remote?: string };
     origin_url?: string;
+    drift?: { ahead: number; behind: number };
     status: StoreDiagnostic[];
   } | null;
   references: ReferenceIndexEntry[];
@@ -41,6 +42,7 @@ export interface InspectRelationshipsInput {
     metadataValid: boolean;
     canonicalRemote?: string;
     originUrl?: string;
+    drift?: { ahead: number; behind: number };
   };
   referenceEntries: ReferenceIndexEntry[];
   registryUnreadable: boolean;
@@ -117,6 +119,25 @@ export function inspectRelationships(input: InspectRelationshipsInput): Relation
         )
       );
     }
+    // Checkout behind its upstream tracking ref: a read-only staleness
+    // signal, not a version pin — OpenSpec never syncs stores, so this
+    // compares against the local upstream ref, not the live remote.
+    // Behind means teammates on newer commits may resolve different specs.
+    // Ahead-only is normal (OpenSpec never pushes stores), so it stays quiet.
+    const drift = input.storeFacts.drift;
+    if (drift && drift.behind > 0) {
+      const behindCommits = `${drift.behind} commit${drift.behind === 1 ? '' : 's'}`;
+      storeStatus.push(
+        makeStoreDiagnostic(
+          'info',
+          'store_checkout_drift',
+          drift.ahead > 0
+            ? `This store checkout has diverged from its upstream tracking branch (${drift.behind} behind, ${drift.ahead} ahead); teammates on newer commits may resolve different specs.`
+            : `This store checkout is ${behindCommits} behind its upstream tracking branch; teammates on newer commits may resolve different specs.`,
+          { target: 'store.git' }
+        )
+      );
+    }
     store = {
       id: input.storeFacts.id,
       metadata: {
@@ -127,6 +148,7 @@ export function inspectRelationships(input: InspectRelationshipsInput): Relation
           : {}),
       },
       ...(input.storeFacts.originUrl ? { origin_url: input.storeFacts.originUrl } : {}),
+      ...(drift ? { drift } : {}),
       status: storeStatus,
     };
   }

--- a/src/core/store/git.ts
+++ b/src/core/store/git.ts
@@ -169,6 +169,34 @@ export async function gitOriginUrl(storeRoot: string): Promise<string | null> {
   return url ? url : null;
 }
 
+export interface GitTrackingDrift {
+  ahead: number;
+  behind: number;
+}
+
+/**
+ * Ahead/behind counts of HEAD against its configured upstream tracking
+ * ref, read from local refs only — no fetch, no network. The comparison
+ * is therefore against the current local upstream ref (typically last
+ * updated by fetch, but it may be a local branch), not the live remote.
+ * Null when there is no repository, no upstream, a detached HEAD, or Git
+ * is unavailable: the absence of a comparison is not drift.
+ */
+export async function gitTrackingDrift(storeRoot: string): Promise<GitTrackingDrift | null> {
+  const stdout = await gitProbe(storeRoot, [
+    'rev-list',
+    '--left-right',
+    '--count',
+    '@{upstream}...HEAD',
+  ]);
+  if (stdout === null) return null;
+  const match = stdout.trim().match(/^(\d+)\s+(\d+)$/);
+  if (!match) return null;
+  // `--left-right` orders the counts by side of the `...`: left is @{upstream}
+  // (commits we lack = behind), right is HEAD (commits upstream lacks = ahead).
+  return { behind: Number(match[1]), ahead: Number(match[2]) };
+}
+
 export async function gitDirectoryHasTrackedFiles(
   storeRoot: string,
   relativeDir: string

--- a/test/commands/doctor.test.ts
+++ b/test/commands/doctor.test.ts
@@ -8,6 +8,7 @@ import { runCLI, type RunCLIResult } from '../helpers/run-cli.js';
 import { createOpenSpecRoot, writeSpec } from '../helpers/openspec-fixtures.js';
 import { snapshotDirectory as snapshot } from '../helpers/fs-snapshot.js';
 import { cleanupTempPath } from '../helpers/temp-cleanup.js';
+import { isolatedGitEnv } from '../helpers/store-git.js';
 
 describe('openspec doctor (3.6)', () => {
   let tempDir: string;
@@ -223,6 +224,102 @@ describe('openspec doctor (3.6)', () => {
       expect.objectContaining({ severity: 'info', code: 'store_remote_divergence' })
     );
     expect(result.exitCode).toBe(0);
+  });
+
+  it('notes an upstream-behind store checkout as info drift', async () => {
+    const { execFileSync } = await import('node:child_process');
+    const gitEnv = { ...process.env, ...isolatedGitEnv(tempDir) };
+    const git = (args: string[]) =>
+      execFileSync('git', args, { cwd: storeRoot, env: gitEnv, stdio: 'ignore' });
+    git(['init']);
+    git(['add', '-A']);
+    git(['commit', '-m', 'shared base']);
+    const head = execFileSync('git', ['branch', '--show-current'], { cwd: storeRoot })
+      .toString()
+      .trim();
+
+    // A tracking branch that advances one commit past HEAD, then set it as
+    // HEAD's upstream — HEAD is now one commit behind, no network involved.
+    git(['branch', 'tracking']);
+    git(['checkout', 'tracking']);
+    fs.writeFileSync(path.join(storeRoot, 'ahead.txt'), 'newer\n');
+    git(['add', '-A']);
+    git(['commit', '-m', 'advance upstream']);
+    git(['checkout', head]);
+    git(['branch', `--set-upstream-to=tracking`, head]);
+
+    const result = await runCLI(['doctor', '--json', '--store', 'team-context'], {
+      cwd: tempDir,
+      env,
+    });
+    expect(result.exitCode).toBe(0);
+    const store = parseJson(result).store;
+    expect(store.drift).toEqual({ ahead: 0, behind: 1 });
+    expect(store.status[0]).toEqual(
+      expect.objectContaining({ severity: 'info', code: 'store_checkout_drift' })
+    );
+    expect(store.status[0].message).toContain('1 commit behind its upstream tracking branch');
+
+    const human = await runCLI(['doctor', '--store', 'team-context'], { cwd: tempDir, env });
+    expect(human.stdout).toContain('behind its upstream tracking branch');
+  });
+
+  it('reports diverged drift when the checkout is both ahead and behind', async () => {
+    const { execFileSync } = await import('node:child_process');
+    const gitEnv = { ...process.env, ...isolatedGitEnv(tempDir) };
+    const git = (args: string[]) =>
+      execFileSync('git', args, { cwd: storeRoot, env: gitEnv, stdio: 'ignore' });
+    git(['init']);
+    git(['add', '-A']);
+    git(['commit', '-m', 'shared base']);
+    const head = execFileSync('git', ['branch', '--show-current'], { cwd: storeRoot })
+      .toString()
+      .trim();
+
+    // Upstream advances one commit; HEAD then adds its own — the two have
+    // diverged (1 behind, 1 ahead) off a common base.
+    git(['branch', 'tracking']);
+    git(['checkout', 'tracking']);
+    fs.writeFileSync(path.join(storeRoot, 'upstream.txt'), 'theirs\n');
+    git(['add', '-A']);
+    git(['commit', '-m', 'advance upstream']);
+    git(['checkout', head]);
+    git(['branch', `--set-upstream-to=tracking`, head]);
+    fs.writeFileSync(path.join(storeRoot, 'local.txt'), 'mine\n');
+    git(['add', '-A']);
+    git(['commit', '-m', 'local work']);
+
+    const result = await runCLI(['doctor', '--json', '--store', 'team-context'], {
+      cwd: tempDir,
+      env,
+    });
+    expect(result.exitCode).toBe(0);
+    const store = parseJson(result).store;
+    expect(store.drift).toEqual({ ahead: 1, behind: 1 });
+    expect(store.status[0]).toEqual(
+      expect.objectContaining({ severity: 'info', code: 'store_checkout_drift' })
+    );
+    expect(store.status[0].message).toContain('diverged');
+    expect(store.status[0].message).toContain('1 behind, 1 ahead');
+  });
+
+  it('reports no drift for a store checkout with no upstream tracking branch', async () => {
+    const { execFileSync } = await import('node:child_process');
+    const gitEnv = { ...process.env, ...isolatedGitEnv(tempDir) };
+    const git = (args: string[]) =>
+      execFileSync('git', args, { cwd: storeRoot, env: gitEnv, stdio: 'ignore' });
+    git(['init']);
+    git(['add', '-A']);
+    git(['commit', '-m', 'base']);
+
+    const result = await runCLI(['doctor', '--json', '--store', 'team-context'], {
+      cwd: tempDir,
+      env,
+    });
+    expect(result.exitCode).toBe(0);
+    const store = parseJson(result).store;
+    expect('drift' in store).toBe(false);
+    expect(store.status).toEqual([]);
   });
 
   it('fails with the null-shape payload on command failures', async () => {

--- a/test/commands/doctor.test.ts
+++ b/test/commands/doctor.test.ts
@@ -55,7 +55,7 @@ describe('openspec doctor (3.6)', () => {
     git(['init']);
     git(['add', '-A']);
     git(['commit', '-m', 'base']);
-    const head = execFileSync('git', ['branch', '--show-current'], { cwd: storeRoot })
+    const head = execFileSync('git', ['branch', '--show-current'], { cwd: storeRoot, env: gitEnv })
       .toString()
       .trim();
     return { git, head };

--- a/test/commands/doctor.test.ts
+++ b/test/commands/doctor.test.ts
@@ -45,6 +45,22 @@ describe('openspec doctor (3.6)', () => {
     return dir;
   }
 
+  // Git-backed store with one base commit, isolated from host gitconfig.
+  // Returns the git runner and the base branch name for upstream setup.
+  async function initGitStore() {
+    const { execFileSync } = await import('node:child_process');
+    const gitEnv = { ...process.env, ...isolatedGitEnv(tempDir) };
+    const git = (args: string[]) =>
+      execFileSync('git', args, { cwd: storeRoot, env: gitEnv, stdio: 'ignore' });
+    git(['init']);
+    git(['add', '-A']);
+    git(['commit', '-m', 'base']);
+    const head = execFileSync('git', ['branch', '--show-current'], { cwd: storeRoot })
+      .toString()
+      .trim();
+    return { git, head };
+  }
+
   it('reports ok everywhere for a healthy store-backed root, all session shapes', async () => {
     // A resolvable reference.
     const upstream = path.join(tempDir, 'upstream-context');
@@ -227,16 +243,7 @@ describe('openspec doctor (3.6)', () => {
   });
 
   it('notes an upstream-behind store checkout as info drift', async () => {
-    const { execFileSync } = await import('node:child_process');
-    const gitEnv = { ...process.env, ...isolatedGitEnv(tempDir) };
-    const git = (args: string[]) =>
-      execFileSync('git', args, { cwd: storeRoot, env: gitEnv, stdio: 'ignore' });
-    git(['init']);
-    git(['add', '-A']);
-    git(['commit', '-m', 'shared base']);
-    const head = execFileSync('git', ['branch', '--show-current'], { cwd: storeRoot })
-      .toString()
-      .trim();
+    const { git, head } = await initGitStore();
 
     // A tracking branch that advances one commit past HEAD, then set it as
     // HEAD's upstream — HEAD is now one commit behind, no network involved.
@@ -265,16 +272,7 @@ describe('openspec doctor (3.6)', () => {
   });
 
   it('reports diverged drift when the checkout is both ahead and behind', async () => {
-    const { execFileSync } = await import('node:child_process');
-    const gitEnv = { ...process.env, ...isolatedGitEnv(tempDir) };
-    const git = (args: string[]) =>
-      execFileSync('git', args, { cwd: storeRoot, env: gitEnv, stdio: 'ignore' });
-    git(['init']);
-    git(['add', '-A']);
-    git(['commit', '-m', 'shared base']);
-    const head = execFileSync('git', ['branch', '--show-current'], { cwd: storeRoot })
-      .toString()
-      .trim();
+    const { git, head } = await initGitStore();
 
     // Upstream advances one commit; HEAD then adds its own — the two have
     // diverged (1 behind, 1 ahead) off a common base.
@@ -304,13 +302,7 @@ describe('openspec doctor (3.6)', () => {
   });
 
   it('reports no drift for a store checkout with no upstream tracking branch', async () => {
-    const { execFileSync } = await import('node:child_process');
-    const gitEnv = { ...process.env, ...isolatedGitEnv(tempDir) };
-    const git = (args: string[]) =>
-      execFileSync('git', args, { cwd: storeRoot, env: gitEnv, stdio: 'ignore' });
-    git(['init']);
-    git(['add', '-A']);
-    git(['commit', '-m', 'base']);
+    await initGitStore();
 
     const result = await runCLI(['doctor', '--json', '--store', 'team-context'], {
       cwd: tempDir,

--- a/test/core/relationship-health.test.ts
+++ b/test/core/relationship-health.test.ts
@@ -97,6 +97,57 @@ describe('relationship health composition (3.6)', () => {
     expect(absent.store?.metadata.remote).toBeUndefined();
   });
 
+  it('notes an upstream-behind checkout as info, but stays quiet when ahead-only', () => {
+    const facts = { id: 'team-context', metadataPresent: true, metadataValid: true };
+
+    const behind = inspectRelationships({
+      ...baseInput(),
+      storeFacts: { ...facts, drift: { ahead: 0, behind: 3 } },
+    });
+    expect(behind.store?.status[0]).toEqual(
+      expect.objectContaining({ severity: 'info', code: 'store_checkout_drift' })
+    );
+    expect(behind.store?.status[0].message).toContain('3 commits behind');
+    expect(behind.store?.drift).toEqual({ ahead: 0, behind: 3 });
+
+    // Singular when exactly one commit behind.
+    const one = inspectRelationships({
+      ...baseInput(),
+      storeFacts: { ...facts, drift: { ahead: 0, behind: 1 } },
+    });
+    expect(one.store?.status[0].message).toContain('1 commit behind');
+    expect(one.store?.status[0].message).not.toContain('1 commits');
+
+    const diverged = inspectRelationships({
+      ...baseInput(),
+      storeFacts: { ...facts, drift: { ahead: 2, behind: 3 } },
+    });
+    expect(diverged.store?.status[0].message).toContain('diverged');
+    expect(diverged.store?.status[0].message).toContain('3 behind, 2 ahead');
+
+    // Ahead-only is the normal steady state for a never-pushed store.
+    const ahead = inspectRelationships({
+      ...baseInput(),
+      storeFacts: { ...facts, drift: { ahead: 4, behind: 0 } },
+    });
+    expect(ahead.store?.status).toEqual([]);
+    expect(ahead.store?.drift).toEqual({ ahead: 4, behind: 0 });
+
+    // In sync: counts surface in JSON (a consumer can tell "in sync" apart
+    // from "no upstream"), but nothing is reported.
+    const synced = inspectRelationships({
+      ...baseInput(),
+      storeFacts: { ...facts, drift: { ahead: 0, behind: 0 } },
+    });
+    expect(synced.store?.status).toEqual([]);
+    expect(synced.store?.drift).toEqual({ ahead: 0, behind: 0 });
+
+    // No drift fact at all: nothing added, nothing reported.
+    const none = inspectRelationships({ ...baseInput(), storeFacts: facts });
+    expect(none.store?.status).toEqual([]);
+    expect(none.store?.drift).toBeUndefined();
+  });
+
   it('passes reference entries through untouched', () => {
     const entries = [
       { store_id: 'up', root: '/up', status: [] },


### PR DESCRIPTION
## Why

Stores have no commit pin, so two teammates on different commits of the
same store silently resolve different specs (#1273). `openspec doctor`
already reports store health, but only checks recorded-remote vs origin —
it never looks at commit drift, so nothing surfaces the mismatch.

## What

Adds a read-only `info` diagnostic, `store_checkout_drift`, to
`openspec doctor`. For a git-backed store checkout it reports how far HEAD
is ahead/behind its upstream tracking ref:

- Fires only when **behind** — ahead-only is normal for a store (OpenSpec
  never pushes them), so it stays quiet.
- Calls out a **diverged** checkout (both ahead and behind) in the message.
- Surfaces the counts in `doctor --json` as `store.drift`.

It mirrors the existing `store_remote_divergence` info diagnostic in
severity and shape, and leaves the exit code unchanged.

## Scope

Not a commit pin, and it doesn't touch the "OpenSpec never
clones/pulls/pushes" contract. The comparison is against the *local*
upstream ref (`@{upstream}`), so it flags drift already known locally — it
can't see a remote that advanced before you fetched. A true reproducible
pin (an expected store commit per code repo) is a separate design question;
happy to open a proposal for that rather than fold it in here.

`agent-contract.md` (§4.9 shape, §6 catalog) and `cli.md` are updated to match.

## Tests

- `relationship-health.test.ts`: behind / diverged / ahead-only-quiet /
  in-sync / no-drift composition.
- `doctor.test.ts`: real-git fixtures (isolated via `isolatedGitEnv`) for
  behind, diverged, and no-upstream — asserting JSON and human output.

No changeset yet — happy to add one if you'd like.

Refs #1273


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added store checkout drift reporting to `openspec doctor`, including optional JSON `store.drift` (ahead/behind) when an upstream tracking branch is available.
  * Added an informational diagnostic (`store_checkout_drift`) when the store checkout is behind or diverged.
* **Bug Fixes**
  * Improved drift messaging for correct behind/diverged wording and singular/plural commit counts.
* **Documentation**
  * Updated `doctor --json` and relationship-health documentation to describe the new drift output.
* **Tests**
  * Added coverage for behind, diverged, in-sync, ahead-only, and no-upstream scenarios across JSON and human output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->