### PR TITLE
feat(schema): resolve symlinked schema directories

### DIFF
--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -8,6 +8,7 @@ import {
   getProjectSchemasDir,
   getUserSchemasDir,
   getPackageSchemasDir,
+  isSchemaDir,
   listSchemas,
 } from '../core/artifact-graph/resolver.js';
 import { parseSchema, SchemaValidationError } from '../core/artifact-graph/schema.js';
@@ -437,7 +438,7 @@ export function registerSchemaCommand(program: Command): void {
           let anyInvalid = false;
 
           for (const entry of entries) {
-            if (!entry.isDirectory()) continue;
+            if (!isSchemaDir(projectSchemasDir, entry)) continue;
 
             const schemaDir = path.join(projectSchemasDir, entry.name);
             const schemaPath = path.join(schemaDir, 'schema.yaml');

--- a/src/core/artifact-graph/resolver.ts
+++ b/src/core/artifact-graph/resolver.ts
@@ -46,6 +46,34 @@ export function getProjectSchemasDir(projectRoot: string): string {
 }
 
 /**
+ * Determines whether a directory entry represents a schema directory candidate.
+ *
+ * Returns true for real directories and for symlinks whose target is a
+ * directory. `fs.Dirent.isDirectory()` reports the raw entry type, so a symlink
+ * (even one pointing at a directory) has `isDirectory() === false`; we
+ * dereference such entries via `fs.statSync` to admit symlinked schema dirs
+ * while still rejecting symlinks-to-files and broken/dangling symlinks.
+ *
+ * @param parentDir - The directory containing the entry
+ * @param entry - The directory entry from `fs.readdirSync(..., { withFileTypes: true })`
+ */
+export function isSchemaDir(parentDir: string, entry: fs.Dirent): boolean {
+  if (entry.isDirectory()) {
+    return true;
+  }
+  if (entry.isSymbolicLink()) {
+    try {
+      // statSync follows the link; isDirectory() reflects the target type.
+      return fs.statSync(path.join(parentDir, entry.name)).isDirectory();
+    } catch {
+      // Broken symlink (dangling target) — statSync throws; treat as non-dir.
+      return false;
+    }
+  }
+  return false;
+}
+
+/**
  * Resolves a schema name to its directory path.
  *
  * Resolution order (when projectRoot is provided):
@@ -165,7 +193,7 @@ export function listSchemas(projectRoot?: string): string[] {
   const packageDir = getPackageSchemasDir();
   if (fs.existsSync(packageDir)) {
     for (const entry of fs.readdirSync(packageDir, { withFileTypes: true })) {
-      if (entry.isDirectory()) {
+      if (isSchemaDir(packageDir, entry)) {
         const schemaPath = path.join(packageDir, entry.name, 'schema.yaml');
         if (fs.existsSync(schemaPath)) {
           schemas.add(entry.name);
@@ -178,7 +206,7 @@ export function listSchemas(projectRoot?: string): string[] {
   const userDir = getUserSchemasDir();
   if (fs.existsSync(userDir)) {
     for (const entry of fs.readdirSync(userDir, { withFileTypes: true })) {
-      if (entry.isDirectory()) {
+      if (isSchemaDir(userDir, entry)) {
         const schemaPath = path.join(userDir, entry.name, 'schema.yaml');
         if (fs.existsSync(schemaPath)) {
           schemas.add(entry.name);
@@ -192,7 +220,7 @@ export function listSchemas(projectRoot?: string): string[] {
     const projectDir = getProjectSchemasDir(projectRoot);
     if (fs.existsSync(projectDir)) {
       for (const entry of fs.readdirSync(projectDir, { withFileTypes: true })) {
-        if (entry.isDirectory()) {
+        if (isSchemaDir(projectDir, entry)) {
           const schemaPath = path.join(projectDir, entry.name, 'schema.yaml');
           if (fs.existsSync(schemaPath)) {
             schemas.add(entry.name);
@@ -230,7 +258,7 @@ export function listSchemasWithInfo(projectRoot?: string): SchemaInfo[] {
     const projectDir = getProjectSchemasDir(projectRoot);
     if (fs.existsSync(projectDir)) {
       for (const entry of fs.readdirSync(projectDir, { withFileTypes: true })) {
-        if (entry.isDirectory()) {
+        if (isSchemaDir(projectDir, entry)) {
           const schemaPath = path.join(projectDir, entry.name, 'schema.yaml');
           if (fs.existsSync(schemaPath)) {
             try {
@@ -255,7 +283,7 @@ export function listSchemasWithInfo(projectRoot?: string): SchemaInfo[] {
   const userDir = getUserSchemasDir();
   if (fs.existsSync(userDir)) {
     for (const entry of fs.readdirSync(userDir, { withFileTypes: true })) {
-      if (entry.isDirectory() && !seenNames.has(entry.name)) {
+      if (isSchemaDir(userDir, entry) && !seenNames.has(entry.name)) {
         const schemaPath = path.join(userDir, entry.name, 'schema.yaml');
         if (fs.existsSync(schemaPath)) {
           try {
@@ -279,7 +307,7 @@ export function listSchemasWithInfo(projectRoot?: string): SchemaInfo[] {
   const packageDir = getPackageSchemasDir();
   if (fs.existsSync(packageDir)) {
     for (const entry of fs.readdirSync(packageDir, { withFileTypes: true })) {
-      if (entry.isDirectory() && !seenNames.has(entry.name)) {
+      if (isSchemaDir(packageDir, entry) && !seenNames.has(entry.name)) {
         const schemaPath = path.join(packageDir, entry.name, 'schema.yaml');
         if (fs.existsSync(schemaPath)) {
           try {

--- a/test/core/artifact-graph/resolver.test.ts
+++ b/test/core/artifact-graph/resolver.test.ts
@@ -11,6 +11,7 @@ import {
   getPackageSchemasDir,
   getUserSchemasDir,
   getProjectSchemasDir,
+  isSchemaDir,
 } from '../../../src/core/artifact-graph/resolver.js';
 
 describe('artifact-graph/resolver', () => {
@@ -646,6 +647,128 @@ artifacts:
       expect(sharedSchema).toBeDefined();
       expect(sharedSchema!.source).toBe('project');
       expect(sharedSchema!.description).toBe('Project shared'); // project version wins
+    });
+  });
+
+  // =========================================================================
+  // Symlinked schema directory tests
+  // =========================================================================
+
+  describe('isSchemaDir', () => {
+    it('should return true for a real directory', () => {
+      const dir = path.join(tempDir, 'real-dir');
+      fs.mkdirSync(dir);
+      const [entry] = fs.readdirSync(tempDir, { withFileTypes: true });
+      expect(isSchemaDir(tempDir, entry)).toBe(true);
+    });
+
+    it('should return true for a symlink pointing at a directory', () => {
+      const target = path.join(tempDir, 'target-dir');
+      fs.mkdirSync(target);
+      const link = path.join(tempDir, 'linked-dir');
+      fs.symlinkSync(target, link, 'dir');
+
+      const entry = fs
+        .readdirSync(tempDir, { withFileTypes: true })
+        .find(e => e.name === 'linked-dir')!;
+      expect(entry.isDirectory()).toBe(false); // sanity: Dirent sees the link, not the target
+      expect(entry.isSymbolicLink()).toBe(true);
+      expect(isSchemaDir(tempDir, entry)).toBe(true);
+    });
+
+    it('should return false for a symlink pointing at a file', () => {
+      const targetFile = path.join(tempDir, 'target-file');
+      fs.writeFileSync(targetFile, 'contents');
+      const link = path.join(tempDir, 'linked-file');
+      fs.symlinkSync(targetFile, link, 'file');
+
+      const entry = fs
+        .readdirSync(tempDir, { withFileTypes: true })
+        .find(e => e.name === 'linked-file')!;
+      expect(isSchemaDir(tempDir, entry)).toBe(false);
+    });
+
+    it('should return false for a broken symlink', () => {
+      const link = path.join(tempDir, 'broken-link');
+      fs.symlinkSync(path.join(tempDir, 'does-not-exist'), link, 'dir');
+
+      const entry = fs
+        .readdirSync(tempDir, { withFileTypes: true })
+        .find(e => e.name === 'broken-link')!;
+      expect(isSchemaDir(tempDir, entry)).toBe(false);
+    });
+
+    it('should return false for a regular file', () => {
+      const file = path.join(tempDir, 'plain-file');
+      fs.writeFileSync(file, 'contents');
+      const entry = fs
+        .readdirSync(tempDir, { withFileTypes: true })
+        .find(e => e.name === 'plain-file')!;
+      expect(isSchemaDir(tempDir, entry)).toBe(false);
+    });
+  });
+
+  describe('listSchemas with symlinked directories', () => {
+    it('should include a user schema that is a symlink to a directory', () => {
+      process.env.XDG_DATA_HOME = tempDir;
+      const userSchemasBase = path.join(tempDir, 'openspec', 'schemas');
+      fs.mkdirSync(userSchemasBase, { recursive: true });
+
+      // Real schema dir stored elsewhere, linked into the user schemas dir.
+      const realSchemaDir = path.join(tempDir, 'shared', 'linked-schema');
+      fs.mkdirSync(realSchemaDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(realSchemaDir, 'schema.yaml'),
+        'name: linked\nversion: 1\nartifacts: []'
+      );
+      fs.symlinkSync(realSchemaDir, path.join(userSchemasBase, 'linked-schema'), 'dir');
+
+      const schemas = listSchemas();
+      expect(schemas).toContain('linked-schema');
+    });
+
+    it('should not include a symlink pointing at a schema file', () => {
+      process.env.XDG_DATA_HOME = tempDir;
+      const userSchemasBase = path.join(tempDir, 'openspec', 'schemas');
+      fs.mkdirSync(userSchemasBase, { recursive: true });
+
+      // A symlink whose target is a file, not a directory.
+      const targetFile = path.join(tempDir, 'schema.yaml');
+      fs.writeFileSync(targetFile, 'name: nope\nversion: 1\nartifacts: []');
+      fs.symlinkSync(targetFile, path.join(userSchemasBase, 'file-link'), 'file');
+
+      const schemas = listSchemas();
+      expect(schemas).not.toContain('file-link');
+    });
+  });
+
+  describe('listSchemasWithInfo with symlinked directories', () => {
+    it('should include a symlinked user schema with source: user', () => {
+      process.env.XDG_DATA_HOME = tempDir;
+      const userSchemasBase = path.join(tempDir, 'openspec', 'schemas');
+      fs.mkdirSync(userSchemasBase, { recursive: true });
+
+      const realSchemaDir = path.join(tempDir, 'shared', 'linked-info');
+      fs.mkdirSync(realSchemaDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(realSchemaDir, 'schema.yaml'),
+        `name: linked-info
+version: 1
+description: Linked info
+artifacts:
+  - id: a
+    generates: a.md
+    description: A
+    template: a.md
+`
+      );
+      fs.symlinkSync(realSchemaDir, path.join(userSchemasBase, 'linked-info'), 'dir');
+
+      const schemas = listSchemasWithInfo();
+      const linked = schemas.find(s => s.name === 'linked-info');
+      expect(linked).toBeDefined();
+      expect(linked!.source).toBe('user');
+      expect(linked!.description).toBe('Linked info');
     });
   });
 });


### PR DESCRIPTION
## Summary

P0 of the performance audit. Vercel Speed Insights showed perf 85 with FCP 2.76s / LCP 3.42s / TTFB 0.85s all amber. Root cause: every public page used the cookie-bound Supabase client, forcing per-request dynamic SSR with no caching — and the existing `revalidateTag` calls invalidated nothing because no cached read attached tags.

This branch decouples public reads from the auth client and adopts **Cache Components** (`cacheComponents: true`) for the public surface.

## What changed

- **Cookie-less public client** (`src/lib/auth/public.ts`) for anonymous published-content reads — no `cookies()`, so routes are no longer forced dynamic.
- **`use cache` + `cacheTag` + `cacheLife`** on `listPublishedPosts` / `getPublishedPost` / `getAllTags` / `getAllCategories` (tagged `posts-list` + `post-${slug}`) and public `getRef`. The existing `revalidateTag` calls in the post/ref Server Actions now actually invalidate.
- **React `cache()`** wraps the per-slug post read so `generateMetadata` + body share one query per request.
- **`generateStaticParams` + ISR** on `/blog/[slug]` (build-time pre-warm, ISR fallback for new slugs — not frozen).
- **Partial Prerendering** on the home page — static hero paints immediately, Recent Writing streams behind `<Suspense>`.
- **Shared `Skeleton` primitive** (`src/components/ui/skeleton.tsx`) replacing ~9 duplicated inline skeletons.
- **Error strategy**: public `use cache` reads throw `DatabaseError` — verified against Next docs that throws are *not* written to cache (no poisoning) and the `DbUnavailable` fallbacks stay live.
- **Suspense fallbacks** reserve header/footer/admin-nav heights to prevent layout shift.
- ADR 0003 documents the decision; full spec under `openspec/changes/public-read-caching-perf/`.

## Route shape (build output)

- `/` ○ static + ISR (15m/1h), Recent Writing streamed
- `/blog/[slug]` ◐ PPR + ISR
- all `/admin/*` ◐ PPR behind auth guard (unchanged `src/proxy.ts`)

## Verification

- ✅ `pnpm build` passes, warning-clean (32 pages)
- ✅ 167/167 tests green
- ⏳ Post-deploy on this preview: owner-edit → public-refresh round-trip (task 8.2), re-check Speed Insights for perf ≥90 (task 8.4)

See ADR `docs/adr/0003-cache-components-public-content-delivery.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Schema validation now correctly recognizes schema directories even when they are symlinks.
  * Schema discovery now includes symlinked directories and ignores broken or file-based symlinks.
  * User-provided schemas discovered through symlinks now appear with the expected source and details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->