### PR TITLE
Fix `archive` exit code on validation failure

### DIFF
--- a/.changeset/fix-archive-exit-code.md
+++ b/.changeset/fix-archive-exit-code.md
@@ -1,0 +1,7 @@
+---
+"@fission-ai/openspec": patch
+---
+
+### Bug Fixes
+
+- **`archive` exits non-zero when blocked in human mode** — `openspec archive <change> -y` (and any non-`--json` invocation) no longer returns exit code 0 when validation fails and nothing is archived. The three blocking paths in human mode — delta-spec validation failure, spec rebuild failure, and rebuilt-spec validation failure — now set `process.exitCode = 1`, matching the existing `--json` behavior. Previously the command printed "Validation failed" (or "Aborted. No files were changed.") and exited 0, letting scripts and CI believe the archive succeeded. Aligns `archive` with the same exit-code guarantee already approved for `apply` instructions (#1250).

--- a/src/core/archive.ts
+++ b/src/core/archive.ts
@@ -306,6 +306,7 @@ export class ArchiveCommand {
         }
         console.log(chalk.red('\nValidation failed. Please fix the errors before archiving.'));
         console.log(chalk.yellow('To skip validation (not recommended), use --no-validate flag.'));
+        process.exitCode = 1;
         return null;
       }
     } else if (json) {
@@ -428,6 +429,7 @@ export class ArchiveCommand {
             }
             console.log(String(err.message || err));
             console.log('Aborted. No files were changed.');
+            process.exitCode = 1;
             return null;
           }
 
@@ -451,6 +453,7 @@ export class ArchiveCommand {
                   else if (issue.level === 'WARNING') console.log(chalk.yellow(`  ⚠ ${issue.message}`));
                 }
                 console.log('Aborted. No files were changed.');
+                process.exitCode = 1;
                 return null;
               }
             }

--- a/test/core/archive.test.ts
+++ b/test/core/archive.test.ts
@@ -15,6 +15,7 @@ describe('ArchiveCommand', () => {
   let tempDir: string;
   let archiveCommand: ArchiveCommand;
   const originalConsoleLog = console.log;
+  const originalExitCode = process.exitCode;
   const originalXdgDataHome = process.env.XDG_DATA_HOME;
 
   beforeEach(async () => {
@@ -38,12 +39,19 @@ describe('ArchiveCommand', () => {
     // Suppress console.log during tests
     console.log = vi.fn();
 
+    // Isolate process.exitCode so a failing run can't leak into the next
+    // test or skew the vitest process exit status.
+    process.exitCode = undefined;
+
     archiveCommand = new ArchiveCommand();
   });
 
   afterEach(async () => {
     // Restore console.log
     console.log = originalConsoleLog;
+
+    // Restore process.exitCode (clear anything a test set)
+    process.exitCode = originalExitCode;
 
     if (originalXdgDataHome === undefined) {
       delete process.env.XDG_DATA_HOME;
@@ -823,6 +831,92 @@ E1 updated`);
       expect(console.log).toHaveBeenCalledWith(
         expect.stringContaining('Totals: + 1, ~ 1, - 0, → 1')
       );
+    });
+  });
+
+  describe('exit code on blocked archive (human mode)', () => {
+    // Regression for the silent-exit-0 bug: when archive is blocked in
+    // human mode it must set a non-zero exit code so scripts/CI can detect
+    // the failure, mirroring the JSON-mode behavior.
+    it('sets exit code 1 when delta spec validation fails', async () => {
+      const changeName = 'exit-delta-fail';
+      const changeDir = path.join(tempDir, 'openspec', 'changes', changeName);
+      const changeSpecDir = path.join(changeDir, 'specs', 'bad-capability');
+      await fs.mkdir(changeSpecDir, { recursive: true });
+
+      // Delta spec missing required SHALL/MUST keyword -> validation error
+      const specContent = `# Bad Capability - Changes
+
+## ADDED Requirements
+
+### Requirement: Logging Feature
+
+The system will log all events.
+
+#### Scenario: Event recorded
+- **WHEN** an event occurs
+- **THEN** it is captured`;
+      await fs.writeFile(path.join(changeSpecDir, 'spec.md'), specContent);
+      await fs.writeFile(path.join(changeDir, 'tasks.md'), '- [x] Task 1\n');
+
+      await archiveCommand.execute(changeName, { yes: true, skipSpecs: true });
+
+      expect(process.exitCode).toBe(1);
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining('Validation failed')
+      );
+
+      // Change must NOT have been archived
+      const archiveDir = path.join(tempDir, 'openspec', 'changes', 'archive');
+      const archives = await fs.readdir(archiveDir);
+      expect(archives.some(a => a.includes(changeName))).toBe(false);
+    });
+
+    it('sets exit code 1 when spec rebuild fails (MODIFIED on new spec)', async () => {
+      const changeName = 'exit-rebuild-fail';
+      const changeDir = path.join(tempDir, 'openspec', 'changes', changeName);
+      const changeSpecDir = path.join(changeDir, 'specs', 'new-capability');
+      await fs.mkdir(changeSpecDir, { recursive: true });
+
+      // MODIFIED on a non-existent target spec aborts the rebuild
+      const specContent = `# New Capability - Changes
+
+## ADDED Requirements
+
+### Requirement: New Feature
+New feature description.
+
+## MODIFIED Requirements
+
+### Requirement: Existing Feature
+Modified content.`;
+      await fs.writeFile(path.join(changeSpecDir, 'spec.md'), specContent);
+
+      await archiveCommand.execute(changeName, { yes: true, noValidate: true });
+
+      expect(process.exitCode).toBe(1);
+      expect(console.log).toHaveBeenCalledWith('Aborted. No files were changed.');
+
+      const mainSpecPath = path.join(tempDir, 'openspec', 'specs', 'new-capability', 'spec.md');
+      await expect(fs.access(mainSpecPath)).rejects.toThrow();
+
+      const archiveDir = path.join(tempDir, 'openspec', 'changes', 'archive');
+      const archives = await fs.readdir(archiveDir);
+      expect(archives.some(a => a.includes(changeName))).toBe(false);
+    });
+
+    it('leaves exit code 0 on successful archive (no leak from prior test)', async () => {
+      const changeName = 'exit-ok';
+      const changeDir = path.join(tempDir, 'openspec', 'changes', changeName);
+      await fs.mkdir(changeDir, { recursive: true });
+
+      await archiveCommand.execute(changeName, { yes: true });
+
+      expect(process.exitCode).toBeUndefined();
+
+      const archiveDir = path.join(tempDir, 'openspec', 'changes', 'archive');
+      const archives = await fs.readdir(archiveDir);
+      expect(archives.some(a => a.includes(changeName))).toBe(true);
     });
   });
 

--- a/test/core/archive.test.ts
+++ b/test/core/archive.test.ts
@@ -905,6 +905,85 @@ Modified content.`;
       expect(archives.some(a => a.includes(changeName))).toBe(false);
     });
 
+    it('sets exit code 1 when rebuilt spec fails validateSpecContent', async () => {
+      // Spot 3 is defensive: spot 1 (validateChangeDeltaSpecs) already
+      // enforces SHALL/MUST/scenario rules on the delta, and buildUpdatedSpec
+      // pre-validates target structure, so a real delta almost never reaches
+      // this branch. Spy on validateSpecContent (the existing --no-validate
+      // test uses the same spy pattern) to force the rebuilt spec invalid
+      // while buildUpdatedSpec runs for real — exercising the exit-code fix.
+      const changeName = 'exit-rebuilt-validate-fail';
+      const changeDir = path.join(tempDir, 'openspec', 'changes', changeName);
+      const changeSpecDir = path.join(changeDir, 'specs', 'rebuilt-capability');
+      await fs.mkdir(changeSpecDir, { recursive: true });
+
+      // Existing main spec so MODIFIED targets a real spec and buildUpdatedSpec
+      // succeeds (does not throw).
+      const mainSpecDir = path.join(tempDir, 'openspec', 'specs', 'rebuilt-capability');
+      await fs.mkdir(mainSpecDir, { recursive: true });
+      const mainContent = `# rebuilt-capability Specification
+
+## Purpose
+Rebuilt capability purpose.
+
+## Requirements
+
+### Requirement: Existing Feature
+The system SHALL do the thing.
+
+#### Scenario: works
+- **WHEN** x
+- **THEN** y`;
+      await fs.writeFile(path.join(mainSpecDir, 'spec.md'), mainContent);
+
+      // Valid MODIFIED delta (passes spot 1 delta validation).
+      const deltaContent = `# Rebuilt Capability - Changes
+
+## MODIFIED Requirements
+
+### Requirement: Existing Feature
+The system SHALL do the thing differently.
+
+#### Scenario: works
+- **WHEN** x
+- **THEN** z`;
+      await fs.writeFile(path.join(changeSpecDir, 'spec.md'), deltaContent);
+      await fs.writeFile(path.join(changeDir, 'tasks.md'), '- [x] Task 1\n');
+
+      const specContentSpy = vi
+        .spyOn(Validator.prototype, 'validateSpecContent')
+        .mockResolvedValue({
+          valid: false,
+          issues: [
+            { level: 'ERROR', path: 'requirements[0]', message: 'mocked rebuilt-spec failure' },
+          ],
+          summary: { errors: 1, warnings: 0, info: 0 },
+        });
+
+      try {
+        await archiveCommand.execute(changeName, { yes: true });
+
+        expect(process.exitCode).toBe(1);
+        // buildUpdatedSpec ran for real and the spy made its output "invalid"
+        expect(specContentSpy).toHaveBeenCalled();
+        expect(console.log).toHaveBeenCalledWith(
+          expect.stringContaining('Validation errors in rebuilt spec for rebuilt-capability')
+        );
+        expect(console.log).toHaveBeenCalledWith('Aborted. No files were changed.');
+
+        // Main spec must be unchanged (no writes happened)
+        const still = await fs.readFile(path.join(mainSpecDir, 'spec.md'), 'utf-8');
+        expect(still).toBe(mainContent);
+
+        // Change must NOT have been archived
+        const archiveDir = path.join(tempDir, 'openspec', 'changes', 'archive');
+        const archives = await fs.readdir(archiveDir);
+        expect(archives.some(a => a.includes(changeName))).toBe(false);
+      } finally {
+        specContentSpy.mockRestore();
+      }
+    });
+
     it('leaves exit code 0 on successful archive (no leak from prior test)', async () => {
       const changeName = 'exit-ok';
       const changeDir = path.join(tempDir, 'openspec', 'changes', changeName);


### PR DESCRIPTION
## Summary

In human (non-`--json`) mode, `openspec archive <change> -y` returned exit code 0 when validation failed and nothing was archived. The command printed "Validation failed" (or "Aborted. No files were changed.") and exited cleanly, so scripts and CI could not distinguish a blocked archive from a successful one.

The `--json` path was already correct — it throws `ArchiveBlockedError`, caught by `printJsonFailure`, which sets `process.exitCode = 1`. This was an asymmetry between the two modes for the same failure class.

Reproduced in a clean sandbox against 1.5.0: `openspec archive bad-change -y` with a delta spec missing the SHALL/MUST keyword → printed "Validation failed", exited 0, `changes/archive/` was never created.

## Changes

Set `process.exitCode = 1` at the three human-mode abort points in `ArchiveCommand.run()` before `return null`:

- delta-spec validation failure
- spec rebuild failure (`buildUpdatedSpec` threw)
- rebuilt-spec validation failure

This mirrors what `printJsonFailure` already does in the same file for the JSON path. Legitimate user cancellations (no change selected, declining a confirmation prompt) remain exit 0 by design.
## Related

- Aligns `archive` with the same exit-code guarantee already approved for `apply` instructions in #1250 — same class of silent-exit-0 bug, same fix philosophy.
- References #498 (adjacent: validate passes while archive fails — a validator divergence, separate from this exit-code fix, but worth keeping in mind).
## Testing

- New regression tests in `test/core/archive.test.ts` covering both blocking paths reachable in human mode (delta validation failure, spec rebuild failure) plus a success path asserting exit code stays unset.
- Test setup now saves/restores `process.exitCode` to prevent leakage between tests.
- `pnpm exec vitest run` — 99 files / 1811 tests passing.
- `pnpm run lint` — 0 errors.
- Manual sandbox repro now exits 1 and does not archive.

## Notes

The third abort path (rebuilt-spec validation failure) got the same one-line fix but is defensively hard to trigger in isolation — the delta-spec validator catches most malformed deltas first. I kept the dedicated test for the two reachable paths rather than contriving validator internals to hit the third.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Archive commands now return a non-zero exit code when an archive is blocked by validation or rebuild failures in normal output mode.
  * Successful archives continue to exit normally.
  * Blocked archive attempts no longer leave changes partially archived.
  * Added regression coverage to ensure the correct exit-code behavior in human (non-JSON) mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->