### PR TITLE
fix(archive): keep an existing date prefix instead of stacking a new one

### DIFF
--- a/.changeset/fix-archive-date-prefix-dedup.md
+++ b/.changeset/fix-archive-date-prefix-dedup.md
@@ -1,0 +1,7 @@
+---
+"@fission-ai/openspec": patch
+---
+
+### Bug Fixes
+
+- **`archive` no longer stacks a second date prefix** — archiving a change whose name already starts with a `YYYY-MM-DD-` prefix (a common authoring convention) keeps the name as-is instead of prepending today's date. Previously `openspec archive 2026-07-04-voice-copilot-v1 --yes` produced `2026-07-06-2026-07-04-voice-copilot-v1`, and when run on a later day the folder sorted under a day on which the change did not happen. Names without a full date prefix (including partial dates like `2026-07-feature`) are dated as before, and the naming is now idempotent.

--- a/openspec/specs/cli-archive/spec.md
+++ b/openspec/specs/cli-archive/spec.md
@@ -52,7 +52,7 @@ The archive operation SHALL follow a structured process to safely move changes t
 - **WHEN** archiving a change
 - **THEN** execute these steps:
   1. Create archive/ directory if it doesn't exist
-  2. Generate target name as `YYYY-MM-DD-[change-name]` using current date
+  2. Generate target name as `YYYY-MM-DD-[change-name]` using current date, keeping the name as-is when it already starts with a `YYYY-MM-DD-` prefix
   3. Check if target directory already exists
   4. Update main specs from the change's future state specs (see Spec Update Process below)
   5. Move the entire change directory to the archive location
@@ -203,7 +203,7 @@ The archive command SHALL validate changes before applying them to ensure data i
 
 **Interactive selection**: Reduces typing and helps users see available changes
 **Task checking**: Prevents accidental archiving of incomplete work
-**Date prefixing**: Maintains chronological order and prevents naming conflicts
+**Date prefixing**: Maintains chronological order and prevents naming conflicts; a name that already carries a date prefix keeps it, so archived names never stack dates
 **No overwrite**: Preserves historical archives and prevents data loss
 **Spec updates before archiving**: Specs in the main directory represent current reality; when a change is deployed and archived, its future state specs become the new reality and must replace the main specs
 **Confirmation for spec updates**: Provides visibility into what will change, prevents accidental overwrites, and ensures users understand the impact before specs are modified

--- a/src/core/archive.ts
+++ b/src/core/archive.ts
@@ -30,6 +30,13 @@ function isMissingPathError(error: unknown): boolean {
   );
 }
 
+/**
+ * Matches the `YYYY-MM-DD-` prefix that archiving prepends to a change name.
+ * A change whose name already starts with one (a common authoring convention)
+ * is archived under its existing name so the prefix is never stacked (#1309).
+ */
+const ARCHIVE_DATE_PREFIX_PATTERN = /^\d{4}-\d{2}-\d{2}-/;
+
 async function listActiveChangeNames(changesDir: string): Promise<string[]> {
   try {
     const entries = await fs.readdir(changesDir, { withFileTypes: true });
@@ -482,8 +489,13 @@ export class ArchiveCommand {
       }
     }
 
-    // Create archive directory with date prefix
-    const archiveName = `${formatLocalDate()}-${changeName}`;
+    // Create archive directory with date prefix. Names that already carry
+    // one keep it: re-prefixing would stutter the name, and when the archive
+    // runs on a later day the folder would sort under a day on which the
+    // change did not happen (#1309).
+    const archiveName = ARCHIVE_DATE_PREFIX_PATTERN.test(changeName)
+      ? changeName
+      : `${formatLocalDate()}-${changeName}`;
     const archivePath = path.join(archiveDir, archiveName);
 
     // Check if archive already exists

--- a/test/core/archive.test.ts
+++ b/test/core/archive.test.ts
@@ -137,6 +137,41 @@ describe('ArchiveCommand', () => {
       await expect(fs.readdir(archiveDir)).resolves.toEqual([`2026-01-05-${changeName}`]);
     });
 
+    it('keeps an existing YYYY-MM-DD- prefix instead of stacking a new one (#1309)', async () => {
+      const changeName = '2026-07-04-voice-copilot-v1';
+      const changeDir = path.join(tempDir, 'openspec', 'changes', changeName);
+      await fs.mkdir(changeDir, { recursive: true });
+      await fs.writeFile(path.join(changeDir, 'tasks.md'), '- [x] Task 1');
+
+      await archiveCommand.execute(changeName, { yes: true });
+
+      const archiveDir = path.join(tempDir, 'openspec', 'changes', 'archive');
+      const archives = await fs.readdir(archiveDir);
+
+      // Archived under its own name: no second date prefix, and the folder
+      // keeps sorting under the change's own day even when archived later.
+      expect(archives).toEqual([changeName]);
+      await expect(fs.access(changeDir)).rejects.toThrow();
+    });
+
+    it('still adds the date prefix when a name only starts with a partial date', async () => {
+      const changeName = '2026-07-feature';
+      const changeDir = path.join(tempDir, 'openspec', 'changes', changeName);
+      await fs.mkdir(changeDir, { recursive: true });
+      await fs.writeFile(path.join(changeDir, 'tasks.md'), '- [x] Task 1');
+
+      await archiveCommand.execute(changeName, { yes: true });
+
+      const archiveDir = path.join(tempDir, 'openspec', 'changes', 'archive');
+      const archives = await fs.readdir(archiveDir);
+
+      // `2026-07-` is not a full YYYY-MM-DD- prefix, so the name is dated
+      // as usual. Asserted as a pattern rather than an exact date to avoid
+      // a UTC-midnight race between execute() and the expectation.
+      expect(archives.length).toBe(1);
+      expect(archives[0]).toMatch(new RegExp(`^\\d{4}-\\d{2}-\\d{2}-${changeName}$`));
+    });
+
     it('should warn about incomplete tasks', async () => {
       const changeName = 'incomplete-feature';
       const changeDir = path.join(tempDir, 'openspec', 'changes', changeName);


### PR DESCRIPTION
## Summary

`openspec archive` unconditionally prepends today's date to the change name. A change already named with the common `YYYY-MM-DD-` convention comes out double-dated, and when archived on a later day the folder sorts under a day on which the change did not happen.

Reproduced in a clean sandbox against main: `openspec archive 2026-07-04-voice-copilot-v1 --yes` → `archived as '2026-07-07-2026-07-04-voice-copilot-v1'`.

## Changes

- Detect a full `^YYYY-MM-DD-` prefix in `ArchiveCommand` and archive the change under its own name; names without one (including partial dates like `2026-07-feature`) keep the current behavior. This also makes the naming idempotent, per the issue's expectation.
- Nothing in `src/` parses the date back out of archive folder names — the prefix only drives human chronological sorting — so keeping the original date is the minimal, non-breaking choice.
- Updated the two `openspec/specs/cli-archive/spec.md` lines that describe target-name generation and the date-prefixing rationale to match (direct spec edits alongside `src/` follow the precedent of #966).
- Added a patch changeset.

## Testing

- Two new cases in `test/core/archive.test.ts`: an existing-prefix name is archived as-is; a partial-date name (`2026-07-feature`) still gets today's prefix (asserted as a pattern to avoid a UTC-midnight race). The existing first case covers plain names.
- `vitest run`: 1813 passed, 1 pre-existing environment-dependent failure in `test/commands/workset.test.ts` (fails identically on pristine main when a real `claude` binary is on PATH); `eslint src/` 0 errors (1 pre-existing warning); `tsc --noEmit` and `node build.js` clean.
- Manual sandbox: `2026-07-04-voice-copilot-v1` now archives under its own name; `plain-feature` archives as `2026-07-07-plain-feature`.

## Notes

- Open question: an alternative was to **replace** an existing prefix with today's date. I went with keep-as-is because it's what #1309 asks for, it's idempotent, and it avoids the archived folder sorting under the wrong day; happy to switch if maintainers prefer archive-date semantics.
- Adjacent same-class issue, deliberately not touched here: the agent workflow templates instruct a literal `mv` to `archive/YYYY-MM-DD-<name>` (`src/core/templates/workflows/archive-change.ts:87,205`, `bulk-archive-change.ts:135,384`, `onboard.ts:450`), so the opsx workflow path can still stack a prefix. Happy to file a follow-up issue.
- Small semantic change: re-archiving a same-named date-prefixed change on a different day previously produced distinct folders; it now fails with "Archive already exists". That's arguably more correct (the spec's no-overwrite rationale), but it does touch the "prevents naming conflicts" reasoning — flagging for awareness.

Fixes #1309

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `openspec archive` to avoid stacking an extra `YYYY-MM-DD-` prefix when the provided change name already begins with a full date prefix, preventing incorrect archive folder names and sorting.
* **Documentation**
  * Updated the “Performing archive” steps and rationale to clarify the naming behavior for fully date-prefixed vs non-prefixed change names.
* **Tests**
  * Added regression tests covering both full `YYYY-MM-DD-` and partial date-like prefixes to ensure the archive target folder name is generated correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->