### PR TITLE
chore: remove scheduled docs workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -2,14 +2,14 @@ name: Docs site
 
 # The documentation site (website/) mirrors docs/*.md via scripts/sync-docs.mjs,
 # which runs as the first step of `pnpm run build`. This workflow rebuilds that
-# mirror and deploys the static export to Cloudflare Pages:
-#   - on every push to main that touches docs/ or website/ (deploy immediately),
-#   - on a daily schedule (re-mirror the latest docs even if nothing pushed),
+# mirror:
+#   - on every push to main that touches docs/ or website/,
 #   - manually via the Actions tab,
 #   - and as a build-only check on pull requests.
 #
-# Deploys require two repository secrets: CLOUDFLARE_API_TOKEN and
-# CLOUDFLARE_ACCOUNT_ID. Set the site's public URL via the DOCS_SITE_URL
+# The Cloudflare Pages deploy step is temporarily disabled until setup is ready.
+# When re-enabled, deploys require two repository secrets: CLOUDFLARE_API_TOKEN
+# and CLOUDFLARE_ACCOUNT_ID. Set the site's public URL via the DOCS_SITE_URL
 # repository variable (used for OG/sitemap absolute URLs).
 
 on:
@@ -24,18 +24,18 @@ on:
       - 'docs/**'
       - 'website/**'
       - '.github/workflows/deploy-docs.yml'
-  schedule:
-    # Daily at 06:00 UTC — picks up any docs changes merged since the last run.
-    - cron: '0 6 * * *'
   workflow_dispatch:
 
-# Never run two deploys at once; let an in-flight deploy finish.
+# Never run two docs site jobs at once; let an in-flight job finish.
 concurrency:
   group: deploy-docs
   cancel-in-progress: false
 
 jobs:
   build-and-deploy:
+    # Keep enabled forks from spending CI on their own copy of this workflow.
+    # PRs from forks into Fission-AI/OpenSpec still run in the base repository.
+    if: ${{ github.repository == 'Fission-AI/OpenSpec' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

- remove the daily cron trigger from the docs-site workflow
- update workflow comments so they no longer describe daily docs runs or active deploys
- add a canonical-repository guard so enabled forks do not spend CI on their own copy of the docs workflow

## Why

The Cloudflare deploy step was commented out, but the workflow still had an active `schedule` trigger. That meant forks with the workflow enabled could still run the docs build on their own cron and notify the scheduled workflow actor, even though nothing deployed.

Docs changes already trigger the workflow through `push` path filters, and PRs still get build-only validation, so the scheduled run was redundant noise.

## Validation

- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-docs.yml"); puts "YAML parsed"'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment notes to clarify the current docs hosting status and the settings needed when redeploying is re-enabled.
* **Chores**
  * Adjusted the docs deployment workflow so it no longer runs on a daily schedule, and now only runs through manual or source-change triggers in the main repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->