### PR TITLE
fix(schemas): include spec content guidance from concepts docs in specs instructions

### DIFF
--- a/schemas/spec-driven/schema.yaml
+++ b/schemas/spec-driven/schema.yaml
@@ -34,6 +34,23 @@ artifacts:
     instruction: |
       Create specification files that define WHAT the system should do.
 
+      A spec is a behavior contract, not an implementation plan.
+
+      Good spec content:
+      - Observable behavior users or downstream systems rely on
+      - Inputs, outputs, and error conditions
+      - External constraints (security, privacy, reliability, compatibility)
+      - Scenarios that can be tested or explicitly validated
+
+      Avoid in specs:
+      - Internal class/function names
+      - Library or framework choices
+      - Step-by-step implementation details
+      - Detailed execution plans (those belong in design.md or tasks.md)
+
+      Quick test: if the implementation can change without changing externally
+      visible behavior, it likely does not belong in the spec.
+
       Create one spec file per capability listed in the proposal's Capabilities section.
       - New capabilities: use the exact kebab-case name from the proposal (specs/<capability>/spec.md).
       - Modified capabilities: use the existing spec folder name from openspec/specs/<capability>/ when creating the delta spec at specs/<capability>/spec.md.


### PR DESCRIPTION
Closes #1289

**What was missing:** `docs/concepts.md` explains that a spec is a behavior contract — what belongs in one (observable behavior, inputs/outputs, constraints, testable scenarios) and what doesn't (class names, framework choices, implementation steps). But that guidance never reached agents: the `specs` instructions shipped with OpenSpec don't include it, so agents only follow it when a user pastes it in by hand (as reported in #1289).

**What this does:** Adds that guidance, verbatim from `docs/concepts.md`, to the `specs` artifact instruction in `schemas/spec-driven/schema.yaml`. Every agent authoring specs now sees it via `openspec instructions specs`, in new and existing projects alike (the built-in schema resolves from the package, so no migration is needed).

**Proof it works:** `openspec instructions specs` on a fresh project now emits the guidance inside the `<instruction>` block; resolver, instruction-loader, and skill-template parity tests pass.

**Notes:** Deliberately narrow — one file, +17 lines, no skill template changes (the broader rewrite in #1284 was closed in favor of surgical fixes).

> [!NOTE]
> **For the reviewer:** one path is intentionally not covered — the `sync-specs` skill carries its own inline delta-format guidance and doesn't go through `openspec instructions specs`, so it won't show this guidance. Covering it means touching skill templates (and their golden hashes), so I left it as a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)