### PR TITLE
fix(stores): allow empty store registration

### DIFF
--- a/docs/agent-contract.md
+++ b/docs/agent-contract.md
@@ -97,13 +97,13 @@ setup/register: `{ "store": {id, root, metadata_path?}, "registry": {path, regis
 `no_openspec_root`, `no_root_with_registered_stores`, `no_registered_stores`, `unknown_store`, `store_identity_mismatch`, `unhealthy_store_root`, `store_path_not_supported`, `invalid_store_pointer`, `initiative_option_removed`, `areas_option_removed`; pass-through: `invalid_store_id`, `invalid_store_registry`, `invalid_store_metadata`.
 
 ### OpenSpec-root health (error, no fix)
-`openspec_store_root_missing`, `openspec_root_missing`, `openspec_config_missing`, `openspec_specs_missing`, `openspec_changes_missing`, `openspec_archive_missing`, plus `_not_directory` variants of each.
+`openspec_store_root_missing`, `openspec_store_root_not_directory`, `openspec_root_missing`, `openspec_root_not_directory`, `openspec_config_missing`, `openspec_config_not_file`, `openspec_specs_not_directory`, `openspec_changes_not_directory`, `openspec_archive_not_directory`. During the stores beta, `openspec/specs/`, `openspec/changes/`, and `openspec/changes/archive/` may be absent in a healthy root; they are only health errors when present but not directories.
 
 ### Store registry/identity/state
 `invalid_store_id`, `invalid_store_registry`, `invalid_store_metadata`, `store_registry_busy`, `store_not_found`, `no_store_registry`, `store_registry_changed`, `store_metadata_missing`, `store_metadata_id_mismatch`, `store_metadata_invalid`, `store_id_conflict`, `store_path_conflict`, `store_already_registered` (info).
 
 ### Store setup/register/remove
-`store_setup_id_required`, `store_setup_path_required`, `store_setup_path_not_directory`, `store_setup_inside_git_repo`, `store_setup_non_empty_directory`, `store_setup_cancelled`, `store_path_required`, `store_path_missing`, `store_path_not_directory`, `store_register_root_unhealthy`, `store_register_identity_confirmation_required`, `store_register_cancelled`, `store_remote_empty`, `store_remote_requires_hand_edit`, `store_remove_confirmation_required`, `store_remove_cancelled`, `store_remove_path_not_directory`, `store_remove_metadata_missing`, `store_root_missing` (warning in remove, error in doctor), `store_root_not_directory`.
+`store_setup_id_required`, `store_setup_path_required`, `store_setup_path_not_directory`, `store_setup_inside_git_repo`, `store_setup_non_empty_directory`, `store_setup_cancelled`, `store_path_required`, `store_path_missing`, `store_path_not_directory`, `store_root_pointer_declared`, `store_register_root_unhealthy`, `store_register_identity_confirmation_required`, `store_register_cancelled`, `store_remote_empty`, `store_remote_requires_hand_edit`, `store_remove_confirmation_required`, `store_remove_cancelled`, `store_remove_path_not_directory`, `store_remove_metadata_missing`, `store_root_missing` (warning in remove, error in doctor), `store_root_not_directory`.
 
 ### Store git
 `store_git_init_failed`, `store_git_identity_missing`, `store_git_commit_failed`, `store_git_no_commits` (warning), `store_clone_fragile_directories` (warning), `store_remote_divergence` (info, doctor).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -215,7 +215,12 @@ openspec store setup team-context --path ~/openspec/team-context --no-init-git -
 
 ### `openspec store register`
 
-Register an existing local store folder.
+Register an existing local store folder. During the stores beta, a root may be
+registered before any changes exist, specs have been applied, or changes have
+been archived; in that case `openspec/changes/`, `openspec/specs/`, and
+`openspec/changes/archive/` may be absent until normal commands create them.
+A config-only repo that declares `store: <id>` remains a pointer to another
+store and is not registered as a store root unless that pointer is removed.
 
 ```bash
 openspec store register [path] [options]

--- a/docs/stores-beta/user-guide.md
+++ b/docs/stores-beta/user-guide.md
@@ -308,6 +308,14 @@ tells you which case you're in.
 - **No sync, ever — by design.** OpenSpec never clones, pulls, or pushes.
   A stale checkout shows stale specs until *you* pull; references are
   indexed live from whatever is on disk.
+- **Empty planning folders can be absent.** A new store may not have
+  `openspec/changes/`, `openspec/specs/`, or `openspec/changes/archive/` in Git
+  yet. That is accepted during the beta; those folders appear once normal
+  commands create files for them.
+- **Pointer repos stay pointers.** A config-only repo whose
+  `openspec/config.yaml` declares `store: <id>` is treated as externalized
+  planning, not as a store checkout to register. Remove the `store:` line first
+  if you intentionally want to convert that repo into a local store root.
 - **Some commands stay where they are.** `view`, `templates`, `schemas`,
   and the deprecated noun forms (`openspec change show`, ...) act on the
   current directory only — no `--store`.

--- a/src/core/archive.ts
+++ b/src/core/archive.ts
@@ -19,6 +19,15 @@ import {
   type SpecUpdate,
 } from './specs-apply.js';
 
+function isMissingPathError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as NodeJS.ErrnoException).code === 'ENOENT'
+  );
+}
+
 async function listActiveChangeNames(changesDir: string): Promise<string[]> {
   try {
     const entries = await fs.readdir(changesDir, { withFileTypes: true });
@@ -26,7 +35,8 @@ async function listActiveChangeNames(changesDir: string): Promise<string[]> {
       .filter((entry) => entry.isDirectory() && entry.name !== 'archive')
       .map((entry) => entry.name)
       .sort();
-  } catch {
+  } catch (error) {
+    if (!isMissingPathError(error)) throw error;
     return [];
   }
 }
@@ -191,13 +201,6 @@ export class ArchiveCommand {
     const changesDir = root.changesDir;
     const archiveDir = root.archiveDir;
     const mainSpecsDir = root.specsDir;
-
-    // Check if changes directory exists
-    try {
-      await fs.access(changesDir);
-    } catch {
-      throw new Error("No OpenSpec changes directory found. Run 'openspec init' first.");
-    }
 
     // Get change name interactively if not provided
     if (!changeName) {
@@ -523,12 +526,7 @@ export class ArchiveCommand {
 
   private async selectChange(changesDir: string): Promise<string | null> {
     const { select } = await import('@inquirer/prompts');
-    // Get all directories in changes (excluding archive)
-    const entries = await fs.readdir(changesDir, { withFileTypes: true });
-    const changeDirs = entries
-      .filter(entry => entry.isDirectory() && entry.name !== 'archive')
-      .map(entry => entry.name)
-      .sort();
+    const changeDirs = await listActiveChangeNames(changesDir);
 
     if (changeDirs.length === 0) {
       console.log('No active changes found.');

--- a/src/core/list.ts
+++ b/src/core/list.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'fs';
 import path from 'path';
 import { getTaskProgressForChange, formatTaskStatus } from '../utils/task-progress.js';
-import { readFileSync } from 'fs';
+import { readFileSync, type Dirent } from 'fs';
 import { join } from 'path';
 import { MarkdownParser } from './parsers/markdown-parser.js';
 import type { RootOutput } from './root-selection.js';
@@ -17,6 +17,24 @@ interface ListOptions {
   sort?: 'recent' | 'name';
   json?: boolean;
   root?: RootOutput;
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as NodeJS.ErrnoException).code === 'ENOENT'
+  );
+}
+
+async function readChangeDirectoryEntries(changesDir: string): Promise<Dirent[]> {
+  try {
+    return await fs.readdir(changesDir, { withFileTypes: true });
+  } catch (error) {
+    if (isMissingPathError(error)) return [];
+    throw error;
+  }
 }
 
 /**
@@ -83,15 +101,8 @@ export class ListCommand {
     if (mode === 'changes') {
       const changesDir = path.join(targetPath, 'openspec', 'changes');
 
-      // Check if changes directory exists
-      try {
-        await fs.access(changesDir);
-      } catch {
-        throw new Error("No OpenSpec changes directory found. Run 'openspec init' first.");
-      }
-
       // Get all directories in changes (excluding archive)
-      const entries = await fs.readdir(changesDir, { withFileTypes: true });
+      const entries = await readChangeDirectoryEntries(changesDir);
       const changeDirs = entries
         .filter(entry => entry.isDirectory() && entry.name !== 'archive')
         .map(entry => entry.name);

--- a/src/core/openspec-root.ts
+++ b/src/core/openspec-root.ts
@@ -17,8 +17,8 @@ export const OPENSPEC_ARCHIVE_DIR = 'openspec/changes/archive';
 export const DEFAULT_OPENSPEC_SCHEMA = 'spec-driven';
 export const DIRECTORY_ANCHOR_FILE_NAME = '.gitkeep';
 
-// Git cannot track empty directories, so clones of a fresh store would lose
-// these and fail root-health checks. Anchored at setup time.
+// Git cannot track empty directories, so setup anchors otherwise-empty
+// conventional store directories for teammates who clone the repo later.
 export const ANCHORED_OPENSPEC_DIRS = [OPENSPEC_SPECS_DIR, OPENSPEC_ARCHIVE_DIR] as const;
 
 type PathKind = 'missing' | 'directory' | 'file' | 'other';
@@ -99,6 +99,28 @@ function missingDirectoryDiagnostic(
   return makeStoreDiagnostic('error', code, message, { target });
 }
 
+type OptionalPlanningDirectoryKey = 'specs' | 'changes' | 'archive';
+
+async function inspectOptionalPlanningDirectory(
+  inspection: OpenSpecRootInspection,
+  storeRoot: string,
+  key: OptionalPlanningDirectoryKey,
+  relativePath: string,
+  notDirectoryCode: string,
+  target: string
+): Promise<PathKind> {
+  const kind = await pathKind(path.join(storeRoot, relativePath));
+  inspection[key] = { present: kind === 'directory' };
+  if (kind === 'directory' || kind === 'missing') return kind;
+
+  inspection.diagnostics.push(missingDirectoryDiagnostic(
+    notDirectoryCode,
+    `${relativePath}/ exists but is not a directory.`,
+    target
+  ));
+  return kind;
+}
+
 export async function inspectOpenSpecRoot(storeRoot: string): Promise<OpenSpecRootInspection> {
   const rootKind = await pathKind(storeRoot);
   const inspection = unresolvedInspection();
@@ -166,28 +188,39 @@ export async function inspectOpenSpecRoot(storeRoot: string): Promise<OpenSpecRo
     }
   }
 
-  for (const [key, relativePath, code, message, target] of [
-    ['specs', OPENSPEC_SPECS_DIR, 'openspec_specs_missing', 'Missing openspec/specs/.', 'openspec.specs'],
-    ['changes', OPENSPEC_CHANGES_DIR, 'openspec_changes_missing', 'Missing openspec/changes/.', 'openspec.changes'],
-    ['archive', OPENSPEC_ARCHIVE_DIR, 'openspec_archive_missing', 'Missing openspec/changes/archive/.', 'openspec.archive'],
-  ] as const) {
-    const kind = await pathKind(path.join(storeRoot, relativePath));
-    inspection[key] = { present: kind === 'directory' };
-    if (kind === 'directory') continue;
-
-    inspection.diagnostics.push(missingDirectoryDiagnostic(
-      kind === 'missing' ? code : code.replace('_missing', '_not_directory'),
-      kind === 'missing' ? message : `${relativePath}/ exists but is not a directory.`,
-      target
-    ));
+  await inspectOptionalPlanningDirectory(
+    inspection,
+    storeRoot,
+    'specs',
+    OPENSPEC_SPECS_DIR,
+    'openspec_specs_not_directory',
+    'openspec.specs'
+  );
+  const changesKind = await inspectOptionalPlanningDirectory(
+    inspection,
+    storeRoot,
+    'changes',
+    OPENSPEC_CHANGES_DIR,
+    'openspec_changes_not_directory',
+    'openspec.changes'
+  );
+  if (changesKind === 'directory') {
+    await inspectOptionalPlanningDirectory(
+      inspection,
+      storeRoot,
+      'archive',
+      OPENSPEC_ARCHIVE_DIR,
+      'openspec_archive_not_directory',
+      'openspec.archive'
+    );
+  } else {
+    inspection.archive = { present: false };
   }
 
   inspection.healthy =
     inspection.present === true &&
     inspection.config.present === true &&
-    inspection.specs.present === true &&
-    inspection.changes.present === true &&
-    inspection.archive.present === true;
+    inspection.diagnostics.length === 0;
 
   return inspection;
 }

--- a/src/core/store/operations.ts
+++ b/src/core/store/operations.ts
@@ -6,6 +6,10 @@ import { promisify } from 'node:util';
 
 import { FileSystemUtils } from '../../utils/file-system.js';
 import {
+  classifyOpenSpecDir,
+  storePointerProblem,
+} from '../project-config.js';
+import {
   ANCHORED_OPENSPEC_DIRS,
   DIRECTORY_ANCHOR_FILE_NAME,
   OPENSPEC_ROOT_DIR,
@@ -218,6 +222,33 @@ function alreadyRegisteredDiagnostic(id: string): StoreDiagnostic {
       target: 'store.registry',
     }
   );
+}
+
+function assertNotConfigOnlyPointerRoot(storeRoot: string): void {
+  const { hasPlanningShape, pointer } = classifyOpenSpecDir(storeRoot);
+  if (hasPlanningShape || pointer.filePath === null) return;
+
+  if (pointer.malformed) {
+    throw new StoreError(
+      `The store declaration in ${pointer.filePath} is invalid (${storePointerProblem(pointer.malformed)}).`,
+      'invalid_store_pointer',
+      {
+        target: 'store.pointer',
+        fix: `Fix or remove the store: line in ${pointer.filePath} before registering this path as a store.`,
+      }
+    );
+  }
+
+  if (pointer.value !== undefined) {
+    throw new StoreError(
+      `This repo's planning is externalized to store '${pointer.value}' (${pointer.filePath}); it is not itself a store root.`,
+      'store_root_pointer_declared',
+      {
+        target: 'store.pointer',
+        fix: 'Register the checkout for the declared store, or remove the store: line first to convert this repo into a local store root.',
+      }
+    );
+  }
 }
 
 function createdPath(relativePath: string, absolutePath: string, kind: CreatedPathLedgerEntry['kind']): CreatedPathLedgerEntry {
@@ -459,6 +490,7 @@ async function prepareSetupPlan(
   let backend: StoreGitBackendConfig | undefined;
 
   if (kind === 'directory') {
+    assertNotConfigOnlyPointerRoot(storeRoot);
     metadata = await readStoreMetadataForOperation(storeRoot);
 
     if (metadata) {
@@ -730,6 +762,7 @@ export async function registerExistingStore(
     );
   }
 
+  assertNotConfigOnlyPointerRoot(storeRoot);
   const openspecRoot = await inspectOpenSpecRoot(storeRoot);
   if (!openspecRoot.healthy) {
     const problems =

--- a/test/commands/store-git.test.ts
+++ b/test/commands/store-git.test.ts
@@ -196,6 +196,102 @@ describe('store git lifecycle', () => {
     expect(fs.existsSync(path.join(cloneRoot, 'workspace.yaml'))).toBe(false);
   });
 
+  it('registers a clone before any changes exist', async () => {
+    const storeRoot = mkdir('empty-team-context');
+    const cloneRoot = path.join(tempDir, 'empty-team-clone');
+    const gitEnv = { ...env, ...isolatedGitEnv(tempDir) };
+    const gitExecEnv = { ...process.env, ...gitEnv };
+    const teammateEnv = {
+      ...gitEnv,
+      XDG_DATA_HOME: path.join(tempDir, 'empty-teammate-data'),
+      XDG_CONFIG_HOME: path.join(tempDir, 'empty-teammate-config'),
+    };
+    fs.mkdirSync(path.join(storeRoot, 'openspec'), { recursive: true });
+    fs.writeFileSync(path.join(storeRoot, 'openspec', 'config.yaml'), 'schema: spec-driven\n');
+    await writeStoreMetadataState(storeRoot, { version: 1, id: 'empty-team-context' });
+    execFileSync('git', ['init'], { cwd: storeRoot, stdio: 'ignore' });
+    execFileSync('git', ['add', '-A'], { cwd: storeRoot, env: gitExecEnv });
+    execFileSync('git', ['commit', '-m', 'initialize empty store'], {
+      cwd: storeRoot,
+      env: gitExecEnv,
+      stdio: 'ignore',
+    });
+
+    execFileSync('git', ['clone', storeRoot, cloneRoot], {
+      env: gitExecEnv,
+      stdio: 'ignore',
+    });
+    expect(fs.existsSync(path.join(cloneRoot, 'openspec', 'changes'))).toBe(false);
+    expect(fs.existsSync(path.join(cloneRoot, 'openspec', 'specs'))).toBe(false);
+
+    const registered = await runCLI(['store', 'register', cloneRoot, '--json'], {
+      cwd: tempDir,
+      env: teammateEnv,
+    });
+    expect(registered.exitCode).toBe(0);
+    expect(parseJson(registered).store.id).toBe('empty-team-context');
+  });
+
+  it('registers a clone with active changes before specs or archive exist', async () => {
+    const storeRoot = mkdir('planned-context');
+    const cloneRoot = path.join(tempDir, 'planned-clone');
+    const gitEnv = { ...env, ...isolatedGitEnv(tempDir) };
+    const gitExecEnv = { ...process.env, ...gitEnv };
+    const teammateEnv = {
+      ...gitEnv,
+      XDG_DATA_HOME: path.join(tempDir, 'teammate-data'),
+      XDG_CONFIG_HOME: path.join(tempDir, 'teammate-config'),
+    };
+    fs.mkdirSync(path.join(storeRoot, 'openspec', 'changes', 'add-widget'), { recursive: true });
+    fs.writeFileSync(path.join(storeRoot, 'openspec', 'config.yaml'), 'schema: spec-driven\n');
+    fs.writeFileSync(
+      path.join(storeRoot, 'openspec', 'changes', 'add-widget', 'proposal.md'),
+      '# Proposal\n'
+    );
+    fs.writeFileSync(
+      path.join(storeRoot, 'openspec', 'changes', 'add-widget', 'tasks.md'),
+      '# Tasks\n'
+    );
+    await writeStoreMetadataState(storeRoot, { version: 1, id: 'planned-context' });
+    execFileSync('git', ['init'], { cwd: storeRoot, stdio: 'ignore' });
+    execFileSync('git', ['add', '-A'], { cwd: storeRoot, env: gitExecEnv });
+    execFileSync('git', ['commit', '-m', 'draft changes'], {
+      cwd: storeRoot,
+      env: gitExecEnv,
+      stdio: 'ignore',
+    });
+
+    const committedFiles = execFileSync('git', ['show', '--name-only', '--format=', 'HEAD'], {
+      cwd: storeRoot,
+    })
+      .toString()
+      .trim()
+      .split('\n')
+      .sort();
+    expect(committedFiles).toEqual([
+      '.openspec-store/store.yaml',
+      'openspec/changes/add-widget/proposal.md',
+      'openspec/changes/add-widget/tasks.md',
+      'openspec/config.yaml',
+    ]);
+    expect(committedFiles).not.toContain('openspec/specs/.gitkeep');
+    expect(committedFiles).not.toContain('openspec/changes/archive/.gitkeep');
+
+    execFileSync('git', ['clone', storeRoot, cloneRoot], {
+      env: gitExecEnv,
+      stdio: 'ignore',
+    });
+    expect(fs.existsSync(path.join(cloneRoot, 'openspec', 'specs'))).toBe(false);
+    expect(fs.existsSync(path.join(cloneRoot, 'openspec', 'changes', 'archive'))).toBe(false);
+
+    const registered = await runCLI(['store', 'register', cloneRoot, '--json'], {
+      cwd: tempDir,
+      env: teammateEnv,
+    });
+    expect(registered.exitCode).toBe(0);
+    expect(parseJson(registered).store.id).toBe('planned-context');
+  });
+
   it('keeps pre-staged user files out of the setup commit', async () => {
     const storeRoot = mkdir('staged-context');
     const gitEnv = { ...env, ...isolatedGitEnv(tempDir) };

--- a/test/commands/store-root-selection.test.ts
+++ b/test/commands/store-root-selection.test.ts
@@ -181,6 +181,37 @@ describe('store root selection for normal commands', () => {
       expect(json.root.store_id).toBe('team-context');
     });
 
+    it('lists an empty team store before any changes exist', async () => {
+      const blankStoreRoot = path.join(tempDir, 'stores', 'blank-context');
+      fs.mkdirSync(path.join(blankStoreRoot, 'openspec'), { recursive: true });
+      fs.writeFileSync(
+        path.join(blankStoreRoot, 'openspec', 'config.yaml'),
+        'schema: spec-driven\n'
+      );
+      await writeStoreMetadataState(blankStoreRoot, {
+        version: 1,
+        id: 'blank-context',
+      });
+      const registered = await runCLI(
+        ['store', 'register', blankStoreRoot, '--json'],
+        { cwd: appRepo, env }
+      );
+      expect(registered.exitCode).toBe(0);
+
+      const result = await runCLI(['list', '--json', '--store', 'blank-context'], {
+        cwd: appRepo,
+        env,
+      });
+      expect(result.exitCode).toBe(0);
+      const json = parseJson(result);
+      expect(json.changes).toEqual([]);
+      expect(json.root).toEqual({
+        path: fs.realpathSync.native(blankStoreRoot),
+        source: 'store',
+        store_id: 'blank-context',
+      });
+    });
+
     it('reads, validates, shows, and reports status in the selected store', async () => {
       createChange(storeRoot, 'store-change');
 
@@ -504,6 +535,37 @@ describe('store root selection for normal commands', () => {
       const json = parseJson(result);
       expect(json.archive).toBeNull();
       expect(json.status[0].code).toBe('archive_change_name_required');
+    });
+
+    it('reports no active changes for a selected empty store without init guidance', async () => {
+      const blankStoreRoot = path.join(tempDir, 'stores', 'archive-blank-context');
+      fs.mkdirSync(path.join(blankStoreRoot, 'openspec'), { recursive: true });
+      fs.writeFileSync(
+        path.join(blankStoreRoot, 'openspec', 'config.yaml'),
+        'schema: spec-driven\n'
+      );
+      await writeStoreMetadataState(blankStoreRoot, {
+        version: 1,
+        id: 'archive-blank-context',
+      });
+      const registered = await runCLI(
+        ['store', 'register', blankStoreRoot, '--json'],
+        { cwd: appRepo, env }
+      );
+      expect(registered.exitCode).toBe(0);
+
+      const result = await runCLI(
+        ['archive', 'missing-change', '--store', 'archive-blank-context', '--json', '--yes'],
+        { cwd: appRepo, env }
+      );
+
+      expect(result.exitCode).toBe(1);
+      const json = parseJson(result);
+      expect(json.archive).toBeNull();
+      expect(json.status[0]).toEqual(expect.objectContaining({
+        code: 'archive_change_not_found',
+        message: "Change 'missing-change' not found. No active changes exist in this root.",
+      }));
     });
 
     it('reports validation failures as diagnostics without stdout prose', async () => {

--- a/test/commands/store.test.ts
+++ b/test/commands/store.test.ts
@@ -370,6 +370,50 @@ describe('store command', () => {
     expect(fs.existsSync(getStoreMetadataPath(storeRoot))).toBe(false);
   });
 
+  it('refuses to convert a config-only store pointer repo into a store', async () => {
+    const pointerRoot = mkdir('app-repo');
+    fs.mkdirSync(path.join(pointerRoot, 'openspec'), { recursive: true });
+    fs.writeFileSync(path.join(pointerRoot, 'openspec', 'config.yaml'), 'store: team-context\n');
+
+    const setup = await runCLI(
+      ['store', 'setup', 'app-context', '--path', pointerRoot, '--no-init-git', '--json'],
+      { cwd: tempDir, env }
+    );
+    const register = await runCLI(
+      ['store', 'register', pointerRoot, '--yes', '--json'],
+      { cwd: tempDir, env }
+    );
+
+    expect(setup.exitCode).toBe(1);
+    expect(parseJson(setup).status[0]).toEqual(expect.objectContaining({
+      code: 'store_root_pointer_declared',
+    }));
+    expect(register.exitCode).toBe(1);
+    expect(parseJson(register).status[0]).toEqual(expect.objectContaining({
+      code: 'store_root_pointer_declared',
+    }));
+    expect(fs.existsSync(path.join(pointerRoot, 'openspec', 'specs'))).toBe(false);
+    expect(fs.existsSync(path.join(pointerRoot, 'openspec', 'changes'))).toBe(false);
+    expect(fs.existsSync(getStoreMetadataPath(pointerRoot))).toBe(false);
+  });
+
+  it('refuses malformed config-only store pointer repos before registering', async () => {
+    const pointerRoot = mkdir('bad-app-repo');
+    fs.mkdirSync(path.join(pointerRoot, 'openspec'), { recursive: true });
+    fs.writeFileSync(path.join(pointerRoot, 'openspec', 'config.yaml'), 'store: [team-context]\n');
+
+    const result = await runCLI(
+      ['store', 'register', pointerRoot, '--yes', '--json'],
+      { cwd: tempDir, env }
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(parseJson(result).status[0]).toEqual(expect.objectContaining({
+      code: 'invalid_store_pointer',
+    }));
+    expect(fs.existsSync(getStoreMetadataPath(pointerRoot))).toBe(false);
+  });
+
   it('rejects explicit setup paths inside an existing Git repo in non-interactive mode', async () => {
     const repoRoot = mkdir('repo');
     execFileSync('git', ['init'], { cwd: repoRoot, stdio: 'ignore' });
@@ -513,6 +557,55 @@ describe('store command', () => {
     expect(payload.registry.registered).toBe(true);
     expect(payload.created_files).toEqual([]);
     expect(fs.readFileSync(path.join(storeRoot, 'openspec', 'specs', 'note.md'), 'utf-8')).toBe('keep\n');
+  });
+
+  it('registers a team store before any changes exist', async () => {
+    const storeRoot = mkdir('team-context');
+    fs.mkdirSync(path.join(storeRoot, 'openspec'), { recursive: true });
+    fs.writeFileSync(
+      path.join(storeRoot, 'openspec', 'config.yaml'),
+      `schema: ${DEFAULT_OPENSPEC_SCHEMA}\n`
+    );
+    await writeStoreMetadataState(storeRoot, { version: 1, id: 'team-context' });
+
+    const result = await runCLI(
+      ['store', 'register', storeRoot, '--json'],
+      { cwd: tempDir, env }
+    );
+
+    expect(result.exitCode).toBe(0);
+    const payload = parseJson(result);
+    expect(payload.store.id).toBe('team-context');
+    expect(payload.created_files).toEqual([]);
+    expect(fs.existsSync(path.join(storeRoot, 'openspec', 'changes'))).toBe(false);
+    expect(fs.existsSync(path.join(storeRoot, 'openspec', 'specs'))).toBe(false);
+    expect(fs.existsSync(path.join(storeRoot, 'openspec', 'changes', 'archive'))).toBe(false);
+  });
+
+  it('registers a store with active changes before specs or archive exist', async () => {
+    const storeRoot = mkdir('team-context');
+    fs.mkdirSync(path.join(storeRoot, 'openspec', 'changes', 'add-widget'), { recursive: true });
+    fs.writeFileSync(
+      path.join(storeRoot, 'openspec', 'changes', 'add-widget', 'proposal.md'),
+      '# Proposal\n'
+    );
+    fs.writeFileSync(
+      path.join(storeRoot, 'openspec', 'config.yaml'),
+      `schema: ${DEFAULT_OPENSPEC_SCHEMA}\n`
+    );
+    await writeStoreMetadataState(storeRoot, { version: 1, id: 'team-context' });
+
+    const result = await runCLI(
+      ['store', 'register', storeRoot, '--json'],
+      { cwd: tempDir, env }
+    );
+
+    expect(result.exitCode).toBe(0);
+    const payload = parseJson(result);
+    expect(payload.store.id).toBe('team-context');
+    expect(payload.created_files).toEqual([]);
+    expect(fs.existsSync(path.join(storeRoot, 'openspec', 'specs'))).toBe(false);
+    expect(fs.existsSync(path.join(storeRoot, 'openspec', 'changes', 'archive'))).toBe(false);
   });
 
   it('requires confirmation before registering a healthy root without identity', async () => {
@@ -979,6 +1072,7 @@ describe('store command', () => {
     const storeRoot = mkdir('team-context');
     fs.mkdirSync(path.join(storeRoot, 'openspec', 'specs'), { recursive: true });
     fs.mkdirSync(path.join(storeRoot, 'openspec', 'changes'), { recursive: true });
+    fs.writeFileSync(path.join(storeRoot, 'openspec', 'changes', 'archive'), 'not a dir\n');
     fs.writeFileSync(path.join(storeRoot, 'openspec', 'config.yaml'), `schema: ${DEFAULT_OPENSPEC_SCHEMA}\n`);
     await writeStoreMetadataState(storeRoot, { version: 1, id: 'team-context' });
     await writeStoreRegistryState(
@@ -1006,10 +1100,10 @@ describe('store command', () => {
     expect(store.openspec_root.archive.present).toBe(false);
     expect(store.openspec_root.status[0]).toEqual(
       expect.objectContaining({
-        code: 'openspec_archive_missing',
+        code: 'openspec_archive_not_directory',
       })
     );
-    expect(fs.existsSync(path.join(storeRoot, 'openspec', 'changes', 'archive'))).toBe(false);
+    expect(fs.readFileSync(path.join(storeRoot, 'openspec', 'changes', 'archive'), 'utf-8')).toBe('not a dir\n');
   });
 
   it('register errors are terminal: one-checkout rule, no circular fix texts', async () => {

--- a/test/core/archive.test.ts
+++ b/test/core/archive.test.ts
@@ -1078,13 +1078,13 @@ The system SHALL do the thing differently.
   });
 
   describe('error handling', () => {
-    it('should throw error when openspec directory does not exist', async () => {
+    it('should report no active changes when openspec directory does not exist', async () => {
       // Remove openspec directory
       await fs.rm(path.join(tempDir, 'openspec'), { recursive: true });
       
       await expect(
         archiveCommand.execute('any-change', { yes: true })
-      ).rejects.toThrow("No OpenSpec changes directory found. Run 'openspec init' first.");
+      ).rejects.toThrow("Change 'any-change' not found. No active changes exist in this root.");
     });
   });
 

--- a/test/core/list.test.ts
+++ b/test/core/list.test.ts
@@ -31,12 +31,12 @@ describe('ListCommand', () => {
   });
 
   describe('execute', () => {
-    it('should handle missing openspec/changes directory', async () => {
+    it('should treat a missing openspec/changes directory as no active changes', async () => {
       const listCommand = new ListCommand();
-      
-      await expect(listCommand.execute(tempDir, 'changes')).rejects.toThrow(
-        "No OpenSpec changes directory found. Run 'openspec init' first."
-      );
+
+      await listCommand.execute(tempDir, 'changes');
+
+      expect(logOutput).toEqual(['No active changes found.']);
     });
 
     it('should handle empty changes directory', async () => {
@@ -47,6 +47,16 @@ describe('ListCommand', () => {
       await listCommand.execute(tempDir, 'changes');
 
       expect(logOutput).toEqual(['No active changes found.']);
+    });
+
+    it('should not report a malformed openspec/changes path as empty', async () => {
+      await fs.mkdir(path.join(tempDir, 'openspec'), { recursive: true });
+      await fs.writeFile(path.join(tempDir, 'openspec', 'changes'), 'not a directory\n');
+
+      const listCommand = new ListCommand();
+
+      await expect(listCommand.execute(tempDir, 'changes')).rejects.toThrow();
+      expect(logOutput).toEqual([]);
     });
 
     it('should exclude archive directory', async () => {

--- a/test/core/openspec-root.test.ts
+++ b/test/core/openspec-root.test.ts
@@ -64,10 +64,40 @@ describe('OpenSpec root helper', () => {
     expect(inspection.healthy).toBe(false);
     expect(inspection.diagnostics.map((diagnostic) => diagnostic.code)).toEqual([
       'openspec_config_missing',
-      'openspec_specs_missing',
-      'openspec_archive_missing',
     ]);
     expect(fs.existsSync(path.join(root, 'openspec', 'changes', 'archive'))).toBe(false);
+  });
+
+  it('accepts roots before changes, applied specs, or archives exist', async () => {
+    const root = path.join(tempDir, 'store');
+    fs.mkdirSync(path.join(root, 'openspec'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'openspec', 'config.yaml'), `schema: ${DEFAULT_OPENSPEC_SCHEMA}\n`);
+
+    const inspection = await inspectOpenSpecRoot(root);
+
+    expect(inspection).toEqual(expect.objectContaining({
+      healthy: true,
+      specs: { present: false },
+      changes: { present: false },
+      archive: { present: false },
+      diagnostics: [],
+    }));
+  });
+
+  it('reports malformed optional planning paths without throwing', async () => {
+    const root = path.join(tempDir, 'store');
+    fs.mkdirSync(path.join(root, 'openspec'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'openspec', 'config.yaml'), `schema: ${DEFAULT_OPENSPEC_SCHEMA}\n`);
+    fs.writeFileSync(path.join(root, 'openspec', 'changes'), 'not a directory\n');
+
+    const inspection = await inspectOpenSpecRoot(root);
+
+    expect(inspection.healthy).toBe(false);
+    expect(inspection.changes).toEqual({ present: false });
+    expect(inspection.archive).toEqual({ present: false });
+    expect(inspection.diagnostics.map((diagnostic) => diagnostic.code)).toEqual([
+      'openspec_changes_not_directory',
+    ]);
   });
 
   it('ensures the default root shape and records created paths', async () => {


### PR DESCRIPTION
## Summary

- Allow store roots to be registered before `openspec/changes/`, `openspec/specs/`, or `openspec/changes/archive/` exist.
- Treat missing changes directories as an empty active-change set for list/archive flows without hiding malformed filesystem paths.
- Keep config-only `store:` pointer repos from being accidentally converted or registered as stores.

## Root Cause

Fresh team store checkouts could contain only committed config and store metadata because Git does not track empty directories. The root-health check still required the conventional empty planning folders, so teammates could not run `openspec store register` until someone had created/applied/archive-backed content.

## Validation

- `pnpm run build`
- `pnpm run lint` (passes with the existing `src/core/references.ts` warning)
- `pnpm test` (100 files, 1875 tests)
- Built CLI repro: config-only store clone registers and lists zero changes; config-only pointer repo rejects with `store_root_pointer_declared`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Store registration and setup now support freshly created repositories with only minimal OpenSpec structure.
  * Listing changes and archiving now handle empty or not-yet-created planning folders more gracefully.

* **Bug Fixes**
  * Improved health checks for OpenSpec roots when optional folders are missing or not directories.
  * Prevented registering config-only pointer repositories as local stores.
  * Updated archive behavior to report “no active changes” instead of init guidance in empty stores.

* **Documentation**
  * Clarified beta-era store setup, registration, and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->