### PR TITLE
fix(archive): contain archive path to changes dir (prevents escape + data loss)

### DIFF
--- a/src/core/archive.ts
+++ b/src/core/archive.ts
@@ -221,6 +221,23 @@ export class ArchiveCommand {
 
     const changeDir = path.join(changesDir, changeName);
 
+    // Guard against path traversal: a crafted change name (e.g. "../../x") must
+    // not let archive move/recursively-delete a directory outside the changes
+    // directory. A containment check (rather than a strict name pattern) closes
+    // the hole while preserving support for names the CLI already archives today,
+    // e.g. date-prefixed changes (see #1308).
+    const resolvedChangeDir = path.resolve(changeDir);
+    const changesDirBase = path.resolve(changesDir);
+    if (
+      resolvedChangeDir !== changesDirBase &&
+      !resolvedChangeDir.startsWith(changesDirBase + path.sep)
+    ) {
+      throw new ArchiveBlockedError(
+        'archive_change_name_invalid',
+        `Invalid change name '${changeName}': resolves outside the changes directory.`
+      );
+    }
+
     // Verify change exists
     try {
       const stat = await fs.stat(changeDir);
@@ -490,6 +507,19 @@ export class ArchiveCommand {
     // Create archive directory with date prefix
     const archiveName = `${this.getArchiveDate()}-${changeName}`;
     const archivePath = path.join(archiveDir, archiveName);
+
+    // Defense-in-depth: the destination must also stay within the archive dir.
+    const resolvedArchivePath = path.resolve(archivePath);
+    const archiveDirBase = path.resolve(archiveDir);
+    if (
+      resolvedArchivePath !== archiveDirBase &&
+      !resolvedArchivePath.startsWith(archiveDirBase + path.sep)
+    ) {
+      throw new ArchiveBlockedError(
+        'archive_change_name_invalid',
+        `Invalid change name '${changeName}': archive path resolves outside the archive directory.`
+      );
+    }
 
     // Check if archive already exists
     let archiveExists = false;

--- a/test/core/archive.test.ts
+++ b/test/core/archive.test.ts
@@ -323,6 +323,34 @@ New feature description.
       ).rejects.toThrow("Change 'non-existent-change' not found.");
     });
 
+    it('rejects a path-traversal change name without touching anything outside the changes dir', async () => {
+      // A crafted change name that resolves outside changes/ (e.g. "../../<name>")
+      // must be blocked BEFORE any move/recursive-delete runs. Plant a sentinel
+      // directory outside changes/ that the traversal would target, prove the
+      // command is blocked with the invalid-change-name diagnostic, and prove the
+      // sentinel is left fully intact.
+      const sentinelDir = path.join(tempDir, 'sentinel');
+      const sentinelFile = path.join(sentinelDir, 'keep.txt');
+      await fs.mkdir(sentinelDir, { recursive: true });
+      await fs.writeFile(sentinelFile, 'do not touch');
+
+      // openspec/changes/../../sentinel === tempDir/sentinel (outside changes/).
+      const traversalName = path.join('..', '..', 'sentinel');
+
+      await expect(
+        archiveCommand.execute(traversalName, { yes: true })
+      ).rejects.toThrow(/resolves outside the changes directory/);
+
+      // Sentinel directory and its contents must be untouched (not moved/deleted).
+      await expect(fs.access(sentinelFile)).resolves.not.toThrow();
+      expect(await fs.readFile(sentinelFile, 'utf-8')).toBe('do not touch');
+
+      // Nothing should have been archived.
+      const archiveDir = path.join(tempDir, 'openspec', 'changes', 'archive');
+      const archives = await fs.readdir(archiveDir);
+      expect(archives.length).toBe(0);
+    });
+
     it('should throw error if archive already exists', async () => {
       const changeName = 'duplicate-feature';
       const changeDir = path.join(tempDir, 'openspec', 'changes', changeName);


### PR DESCRIPTION
### Problem

`openspec archive <name>` doesn't validate the change name before resolving and moving the change directory. A crafted name escapes `openspec/changes`:

- `path.join(changesDir, '../../../x')` collapses the `..`, so the resolved source is **outside** the changes tree.
- The normal path then moves that directory out via `moveDirectory`.
- On the Windows / cross-device (`EXDEV`) rename fallback, `moveDirectory` recursively deletes the source with `fs.rm(src, { recursive, force })` — i.e. **data loss** on a directory the user didn't intend to touch.

Every other destructive command already guards the change name; `archive` is the one that skips it.

This is a **local CLI-arg footgun**, not a remote exploit — it bites via copy-pasted commands, scripts, or programmatic callers, not untrusted network input. Flagging that honestly.

### Relation to #1308

#1308 reports the *same* missing validation in `archive`, but as a UX inconsistency (archive accepts names that `--change` rejects). This PR addresses the **data-loss angle** of that same gap, which isn't connected in the issue.

### Why not just call `validateChangeName`?

That was the obvious fix, but it **rejects legitimate date-prefixed change names** (the very names #1308 is about). So instead of name-shape validation, this adds a **path-containment** check: resolve the target and verify it stays inside the changes directory, before any `stat` / move / `rm`. Legit names (including date-prefixed) pass; escapes are blocked.

### Test

Adds a regression test that plants a sentinel file **outside** `changes/`, runs `archive` with an escaping name, and asserts (a) the command rejects, and (b) the sentinel is still present with unchanged contents. Fails against the pre-fix code.

Co-authored-by: Sōren Vale <soren@tessara.us>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added stronger validation for archive names to block path traversal attempts.
  * Prevented archive destinations from escaping the expected archive location.
  * Improved error handling with a clear, machine-readable failure when an invalid name is used.

* **Tests**
  * Added a regression test covering malicious archive names to confirm files outside the intended area are left untouched and no archive is created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->