### PR TITLE
fix(command-generation): escape YAML frontmatter name in codebuddy/crush/lingma/qoder

### DIFF
--- a/src/core/command-generation/adapters/codebuddy.ts
+++ b/src/core/command-generation/adapters/codebuddy.ts
@@ -6,6 +6,7 @@
 
 import path from 'path';
 import type { CommandContent, ToolCommandAdapter } from '../types.js';
+import { escapeYamlValue } from '../yaml.js';
 
 /**
  * CodeBuddy adapter for command generation.
@@ -21,8 +22,8 @@ export const codebuddyAdapter: ToolCommandAdapter = {
 
   formatFile(content: CommandContent): string {
     return `---
-name: ${content.name}
-description: "${content.description}"
+name: ${escapeYamlValue(content.name)}
+description: ${escapeYamlValue(content.description)}
 argument-hint: "[command arguments]"
 ---
 

--- a/src/core/command-generation/adapters/crush.ts
+++ b/src/core/command-generation/adapters/crush.ts
@@ -6,6 +6,7 @@
 
 import path from 'path';
 import type { CommandContent, ToolCommandAdapter } from '../types.js';
+import { escapeYamlValue } from '../yaml.js';
 
 /**
  * Crush adapter for command generation.
@@ -20,11 +21,11 @@ export const crushAdapter: ToolCommandAdapter = {
   },
 
   formatFile(content: CommandContent): string {
-    const tagsStr = content.tags.join(', ');
+    const tagsStr = content.tags.map(escapeYamlValue).join(', ');
     return `---
-name: ${content.name}
-description: ${content.description}
-category: ${content.category}
+name: ${escapeYamlValue(content.name)}
+description: ${escapeYamlValue(content.description)}
+category: ${escapeYamlValue(content.category)}
 tags: [${tagsStr}]
 ---
 

--- a/src/core/command-generation/adapters/lingma.ts
+++ b/src/core/command-generation/adapters/lingma.ts
@@ -6,6 +6,7 @@
 
 import path from 'path';
 import type { CommandContent, ToolCommandAdapter } from '../types.js';
+import { escapeYamlValue } from '../yaml.js';
 
 /**
  * Lingma adapter for command generation.
@@ -20,11 +21,11 @@ export const lingmaAdapter: ToolCommandAdapter = {
   },
 
   formatFile(content: CommandContent): string {
-    const tagsStr = content.tags.join(', ');
+    const tagsStr = content.tags.map(escapeYamlValue).join(', ');
     return `---
-name: ${content.name}
-description: ${content.description}
-category: ${content.category}
+name: ${escapeYamlValue(content.name)}
+description: ${escapeYamlValue(content.description)}
+category: ${escapeYamlValue(content.category)}
 tags: [${tagsStr}]
 ---
 

--- a/src/core/command-generation/adapters/qoder.ts
+++ b/src/core/command-generation/adapters/qoder.ts
@@ -6,6 +6,7 @@
 
 import path from 'path';
 import type { CommandContent, ToolCommandAdapter } from '../types.js';
+import { escapeYamlValue } from '../yaml.js';
 
 /**
  * Qoder adapter for command generation.
@@ -20,11 +21,11 @@ export const qoderAdapter: ToolCommandAdapter = {
   },
 
   formatFile(content: CommandContent): string {
-    const tagsStr = content.tags.join(', ');
+    const tagsStr = content.tags.map(escapeYamlValue).join(', ');
     return `---
-name: ${content.name}
-description: ${content.description}
-category: ${content.category}
+name: ${escapeYamlValue(content.name)}
+description: ${escapeYamlValue(content.description)}
+category: ${escapeYamlValue(content.category)}
 tags: [${tagsStr}]
 ---
 

--- a/test/core/command-generation/adapters.test.ts
+++ b/test/core/command-generation/adapters.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { parse as parseYaml } from 'yaml';
 import os from 'os';
 import path from 'path';
 import { amazonQAdapter } from '../../../src/core/command-generation/adapters/amazon-q.js';
@@ -18,6 +19,7 @@ import { geminiAdapter } from '../../../src/core/command-generation/adapters/gem
 import { githubCopilotAdapter } from '../../../src/core/command-generation/adapters/github-copilot.js';
 import { iflowAdapter } from '../../../src/core/command-generation/adapters/iflow.js';
 import { kilocodeAdapter } from '../../../src/core/command-generation/adapters/kilocode.js';
+import { lingmaAdapter } from '../../../src/core/command-generation/adapters/lingma.js';
 import { ohMyPiAdapter } from '../../../src/core/command-generation/adapters/oh-my-pi.js';
 import { opencodeAdapter } from '../../../src/core/command-generation/adapters/opencode.js';
 import { piAdapter } from '../../../src/core/command-generation/adapters/pi.js';
@@ -339,7 +341,9 @@ describe('command-generation/adapters', () => {
       const output = codebuddyAdapter.formatFile(sampleContent);
       expect(output).toContain('---\n');
       expect(output).toContain('name: OpenSpec Explore');
-      expect(output).toContain('description: "Enter explore mode for thinking"');
+      // escapeYamlValue only quotes when a value contains YAML-special chars; a
+      // safe scalar is emitted unquoted (valid YAML, consistent with claude/crush/lingma).
+      expect(output).toContain('description: Enter explore mode for thinking');
       expect(output).toContain('argument-hint: "[command arguments]"');
       expect(output).toContain('---\n\n');
       expect(output).toContain('This is the command body.');
@@ -835,6 +839,44 @@ describe('command-generation/adapters', () => {
       const output = traeAdapter.formatFile(contentWithCR);
       expect(output).toContain('description: "Line 1\\r\\nLine 2"');
     });
+  });
+
+  describe('frontmatter YAML validity for colon-bearing fields', () => {
+    // Real command names carry a colon (e.g. "OPSX: Explore"). Adapters that emit
+    // YAML frontmatter must route interpolated fields through escapeYamlValue so a
+    // colon does not produce a broken `key: value: rest` mapping. Before the fix
+    // these adapters interpolated the raw name and produced INVALID YAML; here we
+    // parse the emitted frontmatter with a real YAML parser to prove it round-trips.
+    const yamlFrontmatterAdapters = [
+      { name: 'codebuddy', adapter: codebuddyAdapter },
+      { name: 'crush', adapter: crushAdapter },
+      { name: 'lingma', adapter: lingmaAdapter },
+      { name: 'qoder', adapter: qoderAdapter },
+    ];
+
+    const extractFrontmatter = (output: string): string => {
+      const match = output.match(/^---\n([\s\S]*?)\n---\n/);
+      if (!match) {
+        throw new Error('No YAML frontmatter block found in adapter output');
+      }
+      return match[1];
+    };
+
+    for (const { name, adapter } of yamlFrontmatterAdapters) {
+      it(`${name} emits parseable YAML frontmatter when the name contains a colon`, () => {
+        const contentWithColon: CommandContent = {
+          ...sampleContent,
+          name: 'OPSX: Explore',
+        };
+
+        const output = adapter.formatFile(contentWithColon);
+        const frontmatter = extractFrontmatter(output);
+
+        // Must parse without throwing and preserve the exact name (colon intact).
+        const parsed = parseYaml(frontmatter) as Record<string, unknown>;
+        expect(parsed.name).toBe('OPSX: Explore');
+      });
+    }
   });
 
   describe('cross-platform path handling', () => {


### PR DESCRIPTION
### Problem

The `codebuddy`, `crush`, `lingma`, and `qoder` adapters interpolate `name: ${content.name}` **raw** into command frontmatter. Every OPSX command name contains a colon (`OPSX: Explore`, `OPSX: Apply`, …), so the emitted frontmatter is:

```yaml
name: OPSX: Explore
```

which is invalid YAML — parsers throw `mapping values are not allowed here` (reproduced). On a default `openspec init` for any of those 4 tools, the generated slash-commands ship **broken** into the user's repo.

### Fix

Route the field through the existing `escapeYamlValue` helper — the same one `claude` / `windsurf` / `trae` already use. `OPSX: Explore` → `"OPSX: Explore"`, valid YAML, value preserved.

The prior `escapeYamlValue` refactor (#1204 / #1205) wired the helper into `pi` / `claude` / `qwen` but didn't reach these 4 adapters.

### Test

Adds tests that feed a colon-bearing name through each of the 4 adapters, extract the frontmatter, parse it with the real `yaml` library, and assert the name round-trips.

### Note on scope (follow-up, not in this PR)

This PR fixes the field that actually breaks today — `name`, because it's the one carrying a colon. For completeness: ~11 other adapters still interpolate `description: ${content.description}` raw (amazon-q, antigravity, auggie, codex, continue, factory, github-copilot, iflow, junie, kiro, opencode), and `iflow` also emits `category: ${content.category}` raw. None break today (no current description/category value contains a colon), so it's a latent instance of the same class rather than a live bug. Happy to follow up with a sweep if you'd like it in one pass.

Co-authored-by: Sōren Vale <soren@tessara.us>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated command files so titles, descriptions, categories, and tags are safely escaped in YAML.
  * Fixed cases where special characters like colons could break command metadata rendering.
* **Tests**
  * Added coverage to verify generated command metadata remains valid YAML.
  * Updated expectations to match the new escaping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->