### PR TITLE
fix(parser): classify delta operation by earliest keyword, hyphen-safe

### DIFF
--- a/src/core/parsers/markdown-parser.ts
+++ b/src/core/parsers/markdown-parser.ts
@@ -196,15 +196,25 @@ export class MarkdownParser {
         
         let operation: DeltaOperation = 'MODIFIED';
         const lowerDesc = description.toLowerCase();
-        
-        // Use word boundaries to avoid false matches (e.g., "address" matching "add")
-        // Check RENAMED first since it's more specific than patterns containing "new"
-        if (/\brename(s|d|ing)?\b/.test(lowerDesc) || /\brenamed\s+(to|from)\b/.test(lowerDesc)) {
-          operation = 'RENAMED';
-        } else if (/\badd(s|ed|ing)?\b/.test(lowerDesc) || /\bcreate(s|d|ing)?\b/.test(lowerDesc) || /\bnew\b/.test(lowerDesc)) {
-          operation = 'ADDED';
-        } else if (/\bremove(s|d|ing)?\b/.test(lowerDesc) || /\bdelete(s|d|ing)?\b/.test(lowerDesc)) {
-          operation = 'REMOVED';
+
+        // Classify by the FIRST operation keyword that appears, not a fixed
+        // type priority. Otherwise an incidental later keyword outranks the
+        // actual verb — e.g. "Remove the add-ons page" matched ADDED because
+        // ADDED was tested before REMOVED. The (?<![\w-])/(?![\w-]) boundaries
+        // also exclude hyphen-joined words so "add-ons"/"new-user" no longer
+        // match "add"/"new".
+        const opPatterns: Array<{ op: DeltaOperation; re: RegExp }> = [
+          { op: 'RENAMED', re: /(?<![\w-])rename(s|d|ing)?(?![\w-])/ },
+          { op: 'REMOVED', re: /(?<![\w-])(remove(s|d|ing)?|delete(s|d|ing)?)(?![\w-])/ },
+          { op: 'ADDED', re: /(?<![\w-])(add(s|ed|ing)?|create(s|d|ing)?|new)(?![\w-])/ },
+        ];
+        let bestIndex = Infinity;
+        for (const { op, re } of opPatterns) {
+          const match = lowerDesc.match(re);
+          if (match && match.index !== undefined && match.index < bestIndex) {
+            bestIndex = match.index;
+            operation = op;
+          }
         }
         
         deltas.push({

--- a/test/core/parsers/markdown-parser.test.ts
+++ b/test/core/parsers/markdown-parser.test.ts
@@ -199,6 +199,38 @@ We need to implement user authentication to secure the application and protect u
       expect(change.deltas[2].operation).toBe('REMOVED');
     });
 
+    it('classifies deltas by the first operation keyword, ignoring hyphen-joined words', () => {
+      // Each of these was previously misclassified: a fixed type-priority let an
+      // incidental later keyword outrank the real verb, and unbounded matching let
+      // "add-ons"/"new-user" match "add"/"new".
+      //   - "Remove the add-ons page..." -> REMOVED (not ADDED via "add-ons")
+      //   - "Add a rename button..."      -> ADDED   (not RENAMED via "rename")
+      //   - "Remove the new-user flow..." -> REMOVED (not ADDED via "new-user")
+      const content = `# Reclassify Deltas
+
+## Why
+We need to confirm delta operations are classified by the leading verb, not by an incidental keyword appearing later in the sentence.
+
+## What Changes
+- **settings:** Remove the add-ons page from settings
+- **toolbar:** Add a rename button to the toolbar
+- **onboarding:** Remove the new-user onboarding flow`;
+
+      const parser = new MarkdownParser(content);
+      const change = parser.parseChange('reclassify-deltas');
+
+      expect(change.deltas).toHaveLength(3);
+
+      expect(change.deltas[0].spec).toBe('settings');
+      expect(change.deltas[0].operation).toBe('REMOVED');
+
+      expect(change.deltas[1].spec).toBe('toolbar');
+      expect(change.deltas[1].operation).toBe('ADDED');
+
+      expect(change.deltas[2].spec).toBe('onboarding');
+      expect(change.deltas[2].operation).toBe('REMOVED');
+    });
+
     it('should throw error for missing why section', () => {
       const content = `# Test Change
 


### PR DESCRIPTION
### Problem

`parseDeltas` classifies each delta bullet's operation (ADDED / MODIFIED / REMOVED / RENAMED) by scanning the description against a fixed keyword priority using `\b` word boundaries. Two issues compound:

1. `\b` matches **inside hyphenated words** — `add` matches inside `add-ons`, `new` inside `new-user`.
2. Fixed type-priority lets that false match win over the real leading verb.

So `"Remove the add-ons page"` classifies as **ADDED** instead of REMOVED.

### Fix

Select the operation by **earliest keyword position** in the description, and use **hyphen-safe boundaries** so `add-ons` / `new-user` no longer trigger a false ADDED. The leading verb wins by position.

This also corrects a latent case: `"Remove the rename button"` previously classified as RENAMED (priority) and now correctly resolves to REMOVED (earliest).

### Test

Adds coverage for the reported case plus ADDED / REMOVED controls, asserting the parsed `operation` on real markdown deltas.

Co-authored-by: Sōren Vale <soren@tessara.us>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved change-detection so the app classifies delta actions based on the first meaningful keyword in a description.
  * Reduced false matches from partial words, making ambiguous change text more reliable.

* **Tests**
  * Added coverage for descriptions with overlapping or misleading keywords to verify the correct action is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->