### PR TITLE
fix: use colon syntax for Cursor slash commands

### DIFF
--- a/openspec/specs/command-generation/spec.md
+++ b/openspec/specs/command-generation/spec.md
@@ -40,7 +40,7 @@ The system SHALL define a `ToolCommandAdapter` interface for per-tool formatting
 #### Scenario: Cursor adapter formatting
 
 - **WHEN** formatting a command for Cursor
-- **THEN** the adapter SHALL output YAML frontmatter with `name` as `/opsx-<id>`, `id`, `category`, `description` fields
+- **THEN** the adapter SHALL output YAML frontmatter with `name` as `/opsx:<id>`, `id`, `category`, `description` fields
 - **AND** file path SHALL follow pattern `.cursor/commands/opsx-<id>.md`
 
 #### Scenario: Windsurf adapter formatting

--- a/src/core/command-generation/adapters/cursor.ts
+++ b/src/core/command-generation/adapters/cursor.ts
@@ -12,7 +12,7 @@ import { escapeYamlValue } from '../yaml.js';
 /**
  * Cursor adapter for command generation.
  * File path: .cursor/commands/opsx-<id>.md
- * Frontmatter: name (as /opsx-<id>), id, category, description
+ * Frontmatter: name (as /opsx:<id>), id, category, description
  */
 export const cursorAdapter: ToolCommandAdapter = {
   toolId: 'cursor',
@@ -23,7 +23,7 @@ export const cursorAdapter: ToolCommandAdapter = {
 
   formatFile(content: CommandContent): string {
     return `---
-name: /opsx-${content.id}
+name: /opsx:${content.id}
 id: opsx-${content.id}
 category: ${escapeYamlValue(content.category)}
 description: ${escapeYamlValue(content.description)}

--- a/test/commands/artifact-workflow.test.ts
+++ b/test/commands/artifact-workflow.test.ts
@@ -761,7 +761,7 @@ artifacts:
       // Verify commands were created with Cursor format
       const commandFile = path.join(tempDir, '.cursor', 'commands', 'opsx-explore.md');
       const content = await fs.readFile(commandFile, 'utf-8');
-      expect(content).toContain('name: /opsx-explore');
+      expect(content).toContain('name: /opsx:explore');
     });
 
     it('creates skills for Windsurf tool', async () => {

--- a/test/core/command-generation/adapters.test.ts
+++ b/test/core/command-generation/adapters.test.ts
@@ -92,7 +92,7 @@ describe('command-generation/adapters', () => {
       const output = cursorAdapter.formatFile(sampleContent);
 
       expect(output).toContain('---\n');
-      expect(output).toContain('name: /opsx-explore');
+      expect(output).toContain('name: /opsx:explore');
       expect(output).toContain('id: opsx-explore');
       expect(output).toContain('category: Workflow');
       expect(output).toContain('description: Enter explore mode for thinking');

--- a/test/core/command-generation/generator.test.ts
+++ b/test/core/command-generation/generator.test.ts
@@ -29,7 +29,7 @@ describe('command-generation/generator', () => {
 
       expect(result.path).toContain('.cursor');
       expect(result.path).toContain('opsx-explore.md');
-      expect(result.fileContent).toContain('name: /opsx-explore');
+      expect(result.fileContent).toContain('name: /opsx:explore');
       expect(result.fileContent).toContain('id: opsx-explore');
       expect(result.fileContent).toContain('Command body here.');
     });


### PR DESCRIPTION
## Summary
- change Cursor command frontmatter to register `/opsx:<command>` names instead of `/opsx-<command>`
- keep the existing `.cursor/commands/opsx-<command>.md` filenames and ids unchanged
- update command-generation and CLI workflow tests for the Cursor format

Fixes #1307.

## Validation
- `pnpm exec vitest run test/core/command-generation/adapters.test.ts test/core/command-generation/generator.test.ts test/commands/artifact-workflow.test.ts` (179 passed)
- `pnpm run build`
- `pnpm run lint` (passes with one pre-existing warning in `src/core/references.ts` about an unused eslint-disable directive)

I could not verify Cursor's UI command palette locally from this CLI environment, so the local validation covers generated file content and build/lint checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated generated Cursor command frontmatter formatting so the command name now uses the `:` syntax (e.g., `/opsx:<id>`).
  * Updated related tests to match the new Cursor command naming format.
  * Refreshed the Cursor adapter documentation/spec to reflect the updated `name` pattern.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->