### PR TITLE
chore: add missing v1.6.0 release changeset

### DIFF
--- a/.changeset/complete-v1-6-release-coverage.md
+++ b/.changeset/complete-v1-6-release-coverage.md
@@ -1,0 +1,13 @@
+---
+"@fission-ai/openspec": minor
+---
+
+### New Features
+
+- **Oh My Pi support** — Generate native OPSX commands and skills for Oh My Pi projects, including tool detection and the expected `.omp` directory layout.
+- **Update planning artifacts in place** — Use `/opsx:update` to revise an existing change's planning artifacts, reconcile related artifacts, and keep implementation work delegated to `/opsx:apply`.
+
+### Bug Fixes
+
+- **Fresh store registration** — Register and use newly created stores before their empty changes, specs, or archive directories have been committed.
+- **Safer requirement archiving** — Stop stale `MODIFIED` requirements from silently deleting scenarios that were added by an earlier archive.


### PR DESCRIPTION
## Summary

- Add the missing release tracking for two user-facing features and two notable fixes already merged to `main`.
- Keep the proposed release at `@fission-ai/openspec@1.6.0`; the catch-up changeset is a minor bump, matching the existing Version Packages PR.

## Covered merged PRs

- #1276 — Oh My Pi command and skill support
- #1278 — `/opsx:update` planning-artifact workflow
- #1328 — registration and use of fresh stores with empty planning directories
- #1252 — protection against stale archives deleting existing scenarios

## Why

The automated Version Packages PR #1295 currently includes five pending changesets but not these four release-worthy changes. Once this PR merges, the Changesets action should update #1295 rather than create another release PR.

## Validation

- `changeset status` resolves `@fission-ai/openspec` as a minor bump
- `git diff --check` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added native OPSX command and skill generation for Oh My Pi projects, including tool detection and supported directory layouts.
  - Added an `/opsx:update` workflow for revising existing change plans while leaving implementation to `/opsx:apply`.

- **Bug Fixes**
  - Improved handling of newly created stores and their initial artifacts.
  - Prevented requirement archiving from removing scenarios added during earlier archives.

- **Release**
  - Published as a minor release of `@fission-ai/openspec`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->