### PR TITLE
fix(completion): install the right completions for fish users

### DIFF
--- a/.changeset/completion-detect-parent-shell.md
+++ b/.changeset/completion-detect-parent-shell.md
@@ -1,0 +1,8 @@
+---
+"@fission-ai/openspec": patch
+---
+
+Fix `openspec completion install` detecting the wrong shell for fish (and other)
+users whose interactive shell differs from their login shell. Detection now
+consults the parent process before falling back to `$SHELL`, so running the
+command from fish installs fish completions instead of defaulting to bash.

--- a/src/utils/shell-detection.ts
+++ b/src/utils/shell-detection.ts
@@ -1,3 +1,5 @@
+import { execFileSync } from 'node:child_process';
+
 /**
  * Supported shell types for completion generation
  */
@@ -14,25 +16,76 @@ export interface ShellDetectionResult {
 }
 
 /**
- * Detects the current user's shell based on environment variables
+ * Map a raw shell name/path to a supported shell, if any.
+ */
+function matchSupportedShell(name: string): SupportedShell | undefined {
+  const lower = name.toLowerCase();
+  if (lower.includes('zsh')) return 'zsh';
+  if (lower.includes('bash')) return 'bash';
+  if (lower.includes('fish')) return 'fish';
+  return undefined;
+}
+
+/**
+ * Detect the interactive shell from the parent process.
+ *
+ * `process.env.SHELL` is only the login shell, so users whose interactive shell
+ * differs from it (e.g. running fish while their login shell is bash) are
+ * misdetected. Inspecting the parent process reflects the shell that actually
+ * launched openspec. POSIX-only and best-effort — any failure returns undefined
+ * so the caller falls back to `$SHELL`.
+ *
+ * @returns The supported shell running as the parent process, or undefined
+ */
+function detectShellFromParentProcess(): SupportedShell | undefined {
+  // `ps` is POSIX-only; Windows shells are handled via PSModulePath/COMSPEC.
+  if (process.platform === 'win32') {
+    return undefined;
+  }
+
+  const ppid = process.ppid;
+  if (!ppid || ppid <= 1) {
+    return undefined;
+  }
+
+  try {
+    const comm = execFileSync('ps', ['-p', String(ppid), '-o', 'comm='], {
+      encoding: 'utf8',
+      timeout: 1000,
+    }).trim();
+
+    if (!comm) {
+      return undefined;
+    }
+
+    // Only trust the parent process when it maps to a supported shell; an
+    // unrelated parent (node, npm, sudo, a pager) falls through to `$SHELL`.
+    return matchSupportedShell(comm);
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Detects the current user's shell based on the parent process and environment
  *
  * @returns Detection result with supported shell and raw detected name
  */
 export function detectShell(): ShellDetectionResult {
-  // Try SHELL environment variable first (Unix-like systems)
+  // Prefer the actual running shell (parent process) over `$SHELL`, which only
+  // reflects the login shell and misses users whose interactive shell differs.
+  const parentShell = detectShellFromParentProcess();
+  if (parentShell) {
+    return { shell: parentShell, detected: parentShell };
+  }
+
+  // Try SHELL environment variable next (Unix-like systems)
   const shellPath = process.env.SHELL;
 
   if (shellPath) {
-    const shellName = shellPath.toLowerCase();
-
-    if (shellName.includes('zsh')) {
-      return { shell: 'zsh', detected: 'zsh' };
-    }
-    if (shellName.includes('bash')) {
-      return { shell: 'bash', detected: 'bash' };
-    }
-    if (shellName.includes('fish')) {
-      return { shell: 'fish', detected: 'fish' };
+    const supported = matchSupportedShell(shellPath);
+    if (supported) {
+      return { shell: supported, detected: supported };
     }
 
     // Shell detected but not supported

--- a/src/utils/shell-detection.ts
+++ b/src/utils/shell-detection.ts
@@ -19,10 +19,13 @@ export interface ShellDetectionResult {
  * Map a raw shell name/path to a supported shell, if any.
  */
 function matchSupportedShell(name: string): SupportedShell | undefined {
-  const lower = name.toLowerCase();
-  if (lower.includes('zsh')) return 'zsh';
-  if (lower.includes('bash')) return 'bash';
-  if (lower.includes('fish')) return 'fish';
+  // Match the executable basename exactly so lookalikes such as `fish-lsp` or
+  // `bash-language-server` don't get mistaken for the shell itself. Login
+  // shells report a leading dash (e.g. `-zsh`), so strip it first.
+  const executable = name.trim().toLowerCase().split('/').pop()?.replace(/^-/, '');
+  if (executable === 'zsh') return 'zsh';
+  if (executable === 'bash') return 'bash';
+  if (executable === 'fish') return 'fish';
   return undefined;
 }
 

--- a/test/utils/shell-detection.test.ts
+++ b/test/utils/shell-detection.test.ts
@@ -189,6 +189,12 @@ describe('shell-detection', () => {
   });
 
   describe('parent process detection', () => {
+    // Parent-process detection is POSIX-only, so pin the platform to make
+    // these tests exercise the `ps` path even when CI runs on Windows.
+    beforeEach(() => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+    });
+
     it('should detect fish from the parent process even when SHELL is bash', () => {
       // Reproduces #1197: fish user whose login shell ($SHELL) is bash.
       process.env.SHELL = '/bin/bash';
@@ -205,11 +211,25 @@ describe('shell-detection', () => {
       expect(result.shell).toBe('fish');
     });
 
+    it('should detect a login shell reported with a leading dash', () => {
+      process.env.SHELL = '/bin/bash';
+      mockedExecFileSync.mockReturnValue('-zsh\n');
+      const result = detectShell();
+      expect(result.shell).toBe('zsh');
+    });
+
     it('should fall back to SHELL when the parent process is not a shell', () => {
       process.env.SHELL = '/usr/bin/fish';
       mockedExecFileSync.mockReturnValue('node\n');
       const result = detectShell();
       expect(result.shell).toBe('fish');
+    });
+
+    it('should not mistake shell-named tools like fish-lsp for the shell', () => {
+      process.env.SHELL = '/bin/zsh';
+      mockedExecFileSync.mockReturnValue('fish-lsp\n');
+      const result = detectShell();
+      expect(result.shell).toBe('zsh');
     });
 
     it('should fall back to SHELL when reading the parent process fails', () => {

--- a/test/utils/shell-detection.test.ts
+++ b/test/utils/shell-detection.test.ts
@@ -1,5 +1,12 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { execFileSync } from 'node:child_process';
 import { detectShell, SupportedShell } from '../../src/utils/shell-detection.js';
+
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(),
+}));
+
+const mockedExecFileSync = vi.mocked(execFileSync);
 
 describe('shell-detection', () => {
   let originalShell: string | undefined;
@@ -18,6 +25,11 @@ describe('shell-detection', () => {
     delete process.env.SHELL;
     delete process.env.PSModulePath;
     delete process.env.COMSPEC;
+
+    // Default: parent process is not a shell (e.g. the test runner), so
+    // detection falls through to environment-based logic.
+    mockedExecFileSync.mockReset();
+    mockedExecFileSync.mockReturnValue('node\n');
   });
 
   afterEach(() => {
@@ -173,6 +185,48 @@ describe('shell-detection', () => {
       const result = detectShell();
       expect(result.shell).toBeUndefined();
       expect(result.detected).toBeUndefined();
+    });
+  });
+
+  describe('parent process detection', () => {
+    it('should detect fish from the parent process even when SHELL is bash', () => {
+      // Reproduces #1197: fish user whose login shell ($SHELL) is bash.
+      process.env.SHELL = '/bin/bash';
+      mockedExecFileSync.mockReturnValue('fish\n');
+      const result = detectShell();
+      expect(result.shell).toBe('fish');
+      expect(result.detected).toBe('fish');
+    });
+
+    it('should handle full-path comm output from macOS ps', () => {
+      process.env.SHELL = '/bin/bash';
+      mockedExecFileSync.mockReturnValue('/opt/homebrew/bin/fish\n');
+      const result = detectShell();
+      expect(result.shell).toBe('fish');
+    });
+
+    it('should fall back to SHELL when the parent process is not a shell', () => {
+      process.env.SHELL = '/usr/bin/fish';
+      mockedExecFileSync.mockReturnValue('node\n');
+      const result = detectShell();
+      expect(result.shell).toBe('fish');
+    });
+
+    it('should fall back to SHELL when reading the parent process fails', () => {
+      process.env.SHELL = '/bin/zsh';
+      mockedExecFileSync.mockImplementation(() => {
+        throw new Error('ps unavailable');
+      });
+      const result = detectShell();
+      expect(result.shell).toBe('zsh');
+    });
+
+    it('should not shell out to ps on Windows', () => {
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+      process.env.PSModulePath = 'C:\\Program Files\\PowerShell\\Modules';
+      const result = detectShell();
+      expect(result.shell).toBe('powershell');
+      expect(mockedExecFileSync).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
Closes the problem reported in discussion #1197.

## What was wrong
`openspec completion install` detected your shell only from `$SHELL`, which is your **login** shell. If you run fish interactively but your login shell is bash (the default on Fedora Silverblue and many container/immutable setups), the command installed **bash** completions and edited `.bashrc` — silently doing the wrong thing:

```
❯ openspec completion install
⠋ Installing bash completion script...
✓ Completion script installed and .bashrc configured successfully
```

Fish completions were already fully supported — they just never got selected.

## What it does
Detection now looks at the **parent process** (the shell that actually launched openspec) before falling back to `$SHELL`. So running the command from fish installs fish completions.

- Only a parent that maps to a supported shell (bash/zsh/fish) is trusted; `npx`, npm scripts, and other non-shell parents fall back to `$SHELL` exactly as before.
- POSIX-only (`ps`); Windows/PowerShell detection is untouched.
- Best-effort: any failure reading the parent silently falls back to `$SHELL`, so nothing regresses.

## Proof it works
New unit tests cover the fish-on-bash case, macOS full-path `ps` output, and every fallback path. Verified end-to-end against the real `ps` (fish isn't installed locally, so these use bash/zsh to prove the parent shell overrides `$SHELL` — the exact mechanism a fish user needs):

| Parent shell | `$SHELL` (login) | Detected |
|---|---|---|
| bash | `/usr/bin/fish` | **bash** ✓ (parent wins) |
| zsh  | `/bin/bash`      | **zsh** ✓ (mirrors #1197) |
| node (npx-style) | `/bin/bash` | **bash** ✓ (falls back to `$SHELL`) |
| bash | `/bin/bash`      | **bash** ✓ (unchanged) |

## Notes
- Scope is limited to shell **detection**. It does not touch the generated completion scripts (that's the separate open PR #1199).
- Added a `patch` changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed shell completion installation choosing the wrong shell when the interactive shell differs from the login shell.
  * Improved shell detection by preferring the interactive shell derived from the running parent process, with accurate handling for Fish, Bash, and Zsh (including executable-path cases).
  * Strengthened fallback behavior when parent shell detection fails.
  * Preserved Windows PowerShell detection without running Unix-specific detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->