### PR TITLE
docs(readme): show what a spec actually looks like in "See it in action"

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,29 @@ AI:  Archived to openspec/changes/archive/2025-01-23-add-dark-mode/
 ```
 
 <details>
+<summary><strong>What do the specs actually look like?</strong></summary>
+
+Plain Markdown — requirements with concrete scenarios, no special syntax to learn. Here's what goes in the `specs/` folder created above:
+
+```markdown
+## ADDED Requirements
+
+### Requirement: Theme selection
+The app SHALL let users switch between light and dark themes,
+defaulting to the system preference.
+
+#### Scenario: User toggles dark mode
+- **WHEN** the user clicks the theme toggle
+- **THEN** the app switches to dark mode and persists the choice
+```
+
+Your AI writes these; you review the plan before any code is written.
+
+OpenSpec is built with OpenSpec — browse this repo's live [specs](openspec/specs) and in-flight [changes](openspec/changes) for real examples at scale.
+
+</details>
+
+<details>
 <summary><strong>OpenSpec Dashboard</strong></summary>
 
 <p align="center">


### PR DESCRIPTION
**Status:** Ready for review. Docs-only — 23 lines added to README.md, nothing else touched.

**What was missing:** The "See it in action" walkthrough shows `/opsx:propose` creating a `specs/` folder, but the README never shows what a spec actually contains. That is the first thing a newcomer evaluating OpenSpec wants to see — and exactly what discussion #1024 (originally filed as #1022) asks for: *"actual spec powering this example are not seen anywhere … maybe link specs of openspec if you use it on this repo?"*

**What it does:** Adds a collapsible **"What do the specs actually look like?"** block right after the walkthrough transcript, containing:
- a short example spec delta for the walkthrough's dark-mode feature (`## ADDED Requirements` → `### Requirement:` → `#### Scenario:` with WHEN/THEN), matching the real delta format used across this repo's own changes
- links to this repo's live [`openspec/specs`](https://github.com/Fission-AI/OpenSpec/tree/main/openspec/specs) and [`openspec/changes`](https://github.com/Fission-AI/OpenSpec/tree/main/openspec/changes), since OpenSpec is built with OpenSpec — real examples at scale

**Proof:** The example format was checked against real artifacts in this repo (`openspec/changes/simplify-skill-installation/specs/propose-workflow/spec.md`, `openspec/specs/context-injection/spec.md`). Collapsed by default, so the README's above-the-fold flow is unchanged.

**Notes:** Answers discussion #1024. Written with Claude Code using Claude Fable 5 (claude-fable-5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a collapsible README section explaining the contents of the `specs/` folder.
  * Included a Markdown example showing a theme selection requirement and dark mode scenario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->