### PR TITLE
fix(schemas): resolve blocking open questions instead of deferring them to design.md

### DIFF
--- a/schemas/spec-driven/schema.yaml
+++ b/schemas/spec-driven/schema.yaml
@@ -101,7 +101,12 @@ artifacts:
       - **Decisions**: Key technical choices with rationale (why X over Y?). Include alternatives considered for each decision.
       - **Risks / Trade-offs**: Known limitations, things that could go wrong. Format: [Risk] → Mitigation
       - **Migration Plan**: Steps to deploy, rollback strategy (if applicable)
-      - **Open Questions**: Outstanding decisions or unknowns to resolve
+      - **Open Questions**: Unknowns that can safely be answered later without
+        changing the specs, the approach, or the task breakdown. Omit if none.
+
+      Open questions are for genuinely deferrable unknowns, not decisions you
+      skipped. If a question would change the specs, the chosen approach, or
+      the task breakdown, resolve it now - ask the user instead of guessing.
 
       Focus on architecture and approach, not line-by-line implementation.
       Reference the proposal for motivation and specs for requirements.
@@ -116,6 +121,10 @@ artifacts:
     template: tasks.md
     instruction: |
       Create the task list that breaks down the implementation work.
+
+      Before writing tasks, check design.md for Open Questions. If any of them
+      would change what gets built, resolve them with the user first - do not
+      bake an unstated assumption into the task list.
 
       **IMPORTANT: Follow the template below exactly.** The apply phase parses
       checkbox format to track progress. Tasks not using `- [ ]` won't be tracked.


### PR DESCRIPTION
**Status:** Ready for review. One file, +10/-1, instruction text only.

**What was wrong:** The design instruction told agents to end `design.md` with an "Open Questions" section but never said what to do with those questions. Agents dutifully wrote down unresolved decisions and moved straight on to tasks, silently picking answers along the way. Users hit this and don't know whether they're supposed to answer the questions before continuing — that's exactly the confusion in discussion #1296 ("should we address this Open Questions before we proceed... or opsx:continue will handle this?").

**How it was fixed:** Two instruction edits in `schemas/spec-driven/schema.yaml` (read at runtime, no build step):

- **design:** Open Questions is now scoped to unknowns that can safely be answered later; anything that would change the specs, the approach, or the task breakdown must be resolved now — ask the user instead of guessing.
- **tasks:** before writing the task list, check `design.md` for Open Questions and resolve blocking ones with the user, so the check still fires when tasks are generated in a later session (`/opsx:continue`).

**Proof:** YAML parses, and the real CLI emits the new text:

```
$ openspec instructions design --change open-questions-demo
...
- **Open Questions**: Unknowns that can safely be answered later without
  changing the specs, the approach, or the task breakdown. Omit if none.

Open questions are for genuinely deferrable unknowns, not decisions you
skipped. If a question would change the specs, the chosen approach, or
the task breakdown, resolve it now - ask the user instead of guessing.
```

`vitest run test/commands/schema.test.ts test/core/artifact-graph/resolver.test.ts test/commands/artifact-workflow.test.ts test/core/view.test.ts` — 123 tests passed.

**Notes:** Touches a different hunk of the same file as #1326 (specs instruction), so the two won't conflict. No changeset, matching #1326.

Closes the question raised in discussion #1296.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated workflow guidance to ensure open questions are deferred only when they do not affect specifications, implementation approach, or task planning.
  * Added instructions to resolve design-impacting questions before creating the task list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->