### PR TITLE
feat: add native support for Kurama

### DIFF
--- a/src/core/command-generation/adapters/index.ts
+++ b/src/core/command-generation/adapters/index.ts
@@ -15,6 +15,7 @@ export { codebuddyAdapter } from './codebuddy.js';
 export { continueAdapter } from './continue.js';
 export { costrictAdapter } from './costrict.js';
 export { crushAdapter } from './crush.js';
+export { kuramaAdapter } from './kurama.js';
 export { cursorAdapter } from './cursor.js';
 export { factoryAdapter } from './factory.js';
 export { geminiAdapter } from './gemini.js';

--- a/src/core/command-generation/adapters/kurama.ts
+++ b/src/core/command-generation/adapters/kurama.ts
@@ -1,0 +1,34 @@
+/**
+ * Kurama Command Adapter
+ *
+ * Formats commands for Kurama following its frontmatter specification.
+ */
+
+import path from 'path';
+import type { CommandContent, ToolCommandAdapter } from '../types.js';
+
+/**
+ * Kurama adapter for command generation.
+ * File path: .kurama/skills/<id>.md
+ * Frontmatter: name, description, category, tags
+ */
+export const kuramaAdapter: ToolCommandAdapter = {
+  toolId: 'kurama',
+
+  getFilePath(commandId: string): string {
+    return path.join('.kurama', 'skills', `${commandId}.md`);
+  },
+
+  formatFile(content: CommandContent): string {
+    const tagsStr = content.tags.join(', ');
+    return `---
+name: ${content.name}
+description: ${content.description}
+category: ${content.category}
+tags: [${tagsStr}]
+---
+
+${content.body}
+`;
+  },
+};

--- a/src/core/command-generation/registry.ts
+++ b/src/core/command-generation/registry.ts
@@ -17,6 +17,7 @@ import { codebuddyAdapter } from './adapters/codebuddy.js';
 import { continueAdapter } from './adapters/continue.js';
 import { costrictAdapter } from './adapters/costrict.js';
 import { crushAdapter } from './adapters/crush.js';
+import { kuramaAdapter } from './adapters/kurama.js';
 import { cursorAdapter } from './adapters/cursor.js';
 import { factoryAdapter } from './adapters/factory.js';
 import { geminiAdapter } from './adapters/gemini.js';
@@ -54,6 +55,7 @@ export class CommandAdapterRegistry {
     CommandAdapterRegistry.register(continueAdapter);
     CommandAdapterRegistry.register(costrictAdapter);
     CommandAdapterRegistry.register(crushAdapter);
+    CommandAdapterRegistry.register(kuramaAdapter);
     CommandAdapterRegistry.register(cursorAdapter);
     CommandAdapterRegistry.register(factoryAdapter);
     CommandAdapterRegistry.register(geminiAdapter);

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -31,6 +31,7 @@ export const AI_TOOLS: AIToolOption[] = [
   { name: 'Continue', value: 'continue', available: true, successLabel: 'Continue (VS Code / JetBrains / Cli)', skillsDir: '.continue' },
   { name: 'CoStrict', value: 'costrict', available: true, successLabel: 'CoStrict', skillsDir: '.cospec' },
   { name: 'Crush', value: 'crush', available: true, successLabel: 'Crush', skillsDir: '.crush' },
+  { name: 'Kurama', value: 'kurama', available: true, successLabel: 'Kurama', skillsDir: '.kurama' },
   { name: 'Cursor', value: 'cursor', available: true, successLabel: 'Cursor', skillsDir: '.cursor' },
   { name: 'Factory Droid', value: 'factory', available: true, successLabel: 'Factory Droid', skillsDir: '.factory' },
   { name: 'Gemini CLI', value: 'gemini', available: true, successLabel: 'Gemini CLI', skillsDir: '.gemini' },


### PR DESCRIPTION
This PR adds native support for Kurama, mapping it to the `.kurama` directory. It registers the adapter so `openspec init` works perfectly for Kurama projects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kurama as a supported AI tool.
  * Commands can now be generated as Kurama-compatible Markdown skill files.
  * Kurama output is available through the existing command-generation tool selection and registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->