### PR TITLE
fix(completion): make PowerShell tab completion work again

### DIFF
--- a/.changeset/fix-powershell-empty-switch.md
+++ b/.changeset/fix-powershell-empty-switch.md
@@ -1,0 +1,7 @@
+---
+"@fission-ai/openspec": patch
+---
+
+fix(completion): make the PowerShell completion script parse and load again
+
+The generated `OpenSpecCompletion.ps1` contained 18 empty `switch ($positionalIndex) { }` blocks — emitted for commands whose positionals are all `path`-typed (PowerShell completes paths natively, so those cases produce no clauses). A switch with no clauses is a PowerShell parse error ("Missing condition in switch statement clause"), and PowerShell parses the whole file before running it, so the script never loaded and completions never registered. The generator now skips the positional-index block entirely when no positional produces completions, so the script parses clean (18 → 0 errors) and tab completion works.

--- a/src/core/completions/generators/powershell-generator.ts
+++ b/src/core/completions/generators/powershell-generator.ts
@@ -196,6 +196,20 @@ Register-ArgumentCompleter -CommandName openspec -ScriptBlock $openspecCompleter
     firstPositionalTokenIndex: number,
     indent: string
   ): string[] {
+    const caseLines: string[] = [];
+    for (const [index, positional] of positionals.entries()) {
+      const completion = this.generatePositionalCompletion(positional.type, indent + '    ');
+      if (completion.length === 0) continue;
+      caseLines.push(`${indent}    ${index} {`);
+      caseLines.push(...completion);
+      caseLines.push(`${indent}    }`);
+    }
+
+    // A switch with no clauses is a PowerShell parse error, so when no
+    // positional produces completions skip the whole block (it would only
+    // feed the empty switch anyway).
+    if (caseLines.length === 0) return [];
+
     const lines: string[] = [];
     const valueFlags = this.generateValueFlags(flags);
 
@@ -228,15 +242,7 @@ Register-ArgumentCompleter -CommandName openspec -ScriptBlock $openspecCompleter
     lines.push(`${indent}}`);
     lines.push('');
     lines.push(`${indent}switch ($positionalIndex) {`);
-
-    for (const [index, positional] of positionals.entries()) {
-      const completion = this.generatePositionalCompletion(positional.type, indent + '    ');
-      if (completion.length === 0) continue;
-      lines.push(`${indent}    ${index} {`);
-      lines.push(...completion);
-      lines.push(`${indent}    }`);
-    }
-
+    lines.push(...caseLines);
     lines.push(`${indent}}`);
 
     return lines;

--- a/test/core/completions/generators/powershell-generator.test.ts
+++ b/test/core/completions/generators/powershell-generator.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { PowerShellGenerator } from '../../../../src/core/completions/generators/powershell-generator.js';
+import { COMMAND_REGISTRY } from '../../../../src/core/completions/command-registry.js';
 import { CommandDefinition } from '../../../../src/core/completions/types.js';
 
 describe('PowerShellGenerator', () => {
@@ -459,6 +460,36 @@ describe('PowerShellGenerator', () => {
 			expect(script).toContain('--strict');
 			expect(script).toContain('--json');
 			expect(script).toContain('Get-OpenSpecSpecs');
+		});
+
+		it('should not emit an empty switch when no positional produces completions', () => {
+			const commands: CommandDefinition[] = [
+				{
+					name: 'init',
+					description: 'Initialize OpenSpec',
+					flags: [
+						{
+							name: 'tools',
+							description: 'AI tools to configure',
+							takesValue: true,
+						},
+					],
+					positionals: [{ name: 'path', type: 'path', optional: true }],
+				},
+			];
+
+			const script = generator.generate(commands);
+
+			// An empty switch body is a PowerShell parse error that aborts the
+			// entire completion script ("Missing condition in switch statement clause").
+			expect(script).not.toMatch(/switch \(\$positionalIndex\) \{\s*\}/);
+			expect(script).not.toContain('$positionalIndex');
+		});
+
+		it('should not emit empty switch blocks for the real command registry', () => {
+			const script = generator.generate(COMMAND_REGISTRY);
+
+			expect(script).not.toMatch(/switch \(\$positionalIndex\) \{\s*\}/);
 		});
 
 		it('should not emit trailing commas in @() arrays', () => {


### PR DESCRIPTION
**Status:** LGTM — reproduced, fixed, and verified with a real PowerShell 7.5.4 parser (18 parse errors → 0) and live tab completion.

Fixes #1293

## What was wrong

`openspec completion install` generated a PowerShell script that failed to parse, so completions never worked for any PowerShell user. The generator emitted `switch ($positionalIndex) { }` with zero clauses for every command whose positional arguments are all `path`-typed (PowerShell completes paths natively, so those cases produce no clauses) — 18 such blocks in the current registry. An empty switch body is a hard syntax error in PowerShell (`Missing condition in switch statement clause`), and PowerShell parses the whole file before running it, so one bad block aborted the entire script.

## How it was fixed

In `generateIndexedPositionalCompletion`, the case clauses are now built first; when no positional produces any completion, the whole positional-index block (the token-counting loop plus the switch) is skipped — it existed only to feed the switch, so this is behavior-equivalent and leaves no dead code. Commands with real positional completions are unchanged.

## Replication / proof

Generate the script from the real command registry and parse it with PowerShell's own parser:

```
BEFORE fix: parse errors = 18
  first: Missing condition in switch statement clause. (line 106)
AFTER fix:  parse errors = 0
```

Dot-sourcing the fixed script in pwsh 7.5.4 and invoking `TabExpansion2` returns real completions:

```
completions for 'openspec val': validate
completions for 'openspec completion ': generate, install, uninstall
```

Two regression tests added: a unit test for a path-only positional command, and a registry-wide test asserting the generated script never contains an empty `switch ($positionalIndex)` block. Full suite: 1,860 passed; the only failures are the 17 known environment-only `zsh-installer` failures on this machine (local oh-my-zsh; CI unaffected).

## Notes

- bash/zsh/fish generators are untouched — empty case bodies are legal in those shells.
- Pre-existing and out of scope: with an *empty* command list the outer `switch ($command)` would also be empty, but the registry is static and never empty, so it's unreachable in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed PowerShell completion scripts failing to load when commands contained only path-based positional parameters.
  * Prevented generation of invalid empty PowerShell `switch` blocks.
  * Restored tab completion for affected commands.

* **Tests**
  * Added coverage to verify generated scripts omit empty positional completion switches and avoid unnecessary positional-index references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->