### PR TITLE
fix(cli): let --change find change names that exist on disk

### DIFF
--- a/.changeset/change-lookup-accepts-existing-names.md
+++ b/.changeset/change-lookup-accepts-existing-names.md
@@ -1,0 +1,5 @@
+---
+'@fission-ai/openspec': patch
+---
+
+`--change` now accepts any change name that exists on disk (e.g. date-prefixed names like `2026-07-04-voice-copilot-v1`), matching what `list`, `validate`, and `archive` already resolve. Lookup still rejects unsafe names (path separators, `..`, hidden entries); the kebab-case naming rule still applies when creating a change.

--- a/src/commands/workflow/shared.ts
+++ b/src/commands/workflow/shared.ts
@@ -11,7 +11,6 @@ import * as fs from 'fs';
 import { getSchemaDir, listSchemas } from '../../core/artifact-graph/index.js';
 import type { ReferenceIndexEntry } from '../../core/references.js';
 import { isRootSelectionError } from '../../core/root-selection.js';
-import { validateChangeName } from '../../utils/change-utils.js';
 
 // -----------------------------------------------------------------------------
 // Types
@@ -135,6 +134,31 @@ export async function getAvailableChanges(
 }
 
 /**
+ * Validates a change name used to look up an existing change directory.
+ * Lookup accepts any directory name that `getAvailableChanges` could return
+ * (the kebab-case convention in `validateChangeName` applies at creation
+ * time only); it only rejects names that would escape the changes directory
+ * or address hidden entries.
+ *
+ * @returns An error message, or undefined if the name is safe to look up
+ */
+function validateChangeLookupName(changeName: string): string | undefined {
+  if (changeName === '.' || changeName === '..') {
+    return 'Change name cannot be a relative path segment';
+  }
+  if (changeName.includes('/') || changeName.includes('\\')) {
+    return 'Change name cannot contain path separators';
+  }
+  if (changeName.includes('\0')) {
+    return 'Change name cannot contain null characters';
+  }
+  if (changeName.startsWith('.')) {
+    return 'Change name cannot start with a dot';
+  }
+  return undefined;
+}
+
+/**
  * Validates that a change exists and returns available changes if not.
  * Checks directory existence directly to support scaffolded changes (without proposal.md).
  */
@@ -159,9 +183,9 @@ export async function validateChangeExists(
   }
 
   // Validate change name format to prevent path traversal
-  const nameValidation = validateChangeName(changeName);
-  if (!nameValidation.valid) {
-    throw new Error(`Invalid change name '${changeName}': ${nameValidation.error}`);
+  const lookupError = validateChangeLookupName(changeName);
+  if (lookupError) {
+    throw new Error(`Invalid change name '${changeName}': ${lookupError}`);
   }
 
   // Check directory existence directly

--- a/src/commands/workflow/shared.ts
+++ b/src/commands/workflow/shared.ts
@@ -138,7 +138,7 @@ export async function getAvailableChanges(
  * Lookup accepts any directory name that `getAvailableChanges` could return
  * (the kebab-case convention in `validateChangeName` applies at creation
  * time only); it only rejects names that would escape the changes directory
- * or address hidden entries.
+ * or address entries `getAvailableChanges` excludes (hidden dirs, archive).
  *
  * @returns An error message, or undefined if the name is safe to look up
  */
@@ -154,6 +154,9 @@ function validateChangeLookupName(changeName: string): string | undefined {
   }
   if (changeName.startsWith('.')) {
     return 'Change name cannot start with a dot';
+  }
+  if (changeName === 'archive') {
+    return "'archive' is reserved for archived changes";
   }
   return undefined;
 }

--- a/test/commands/artifact-workflow.test.ts
+++ b/test/commands/artifact-workflow.test.ts
@@ -220,6 +220,15 @@ describe('artifact-workflow CLI commands', () => {
       expect(output).toContain('Invalid change name');
     });
 
+    it('rejects the reserved archive directory name', async () => {
+      await fs.mkdir(path.join(changesDir, 'archive'), { recursive: true });
+
+      const result = await runCLI(['status', '--change', 'archive'], { cwd: tempDir });
+      expect(result.exitCode).toBe(1);
+      const output = getOutput(result);
+      expect(output).toContain('Invalid change name');
+    });
+
     it('accepts digit-leading change names that exist on disk (#1308)', async () => {
       await createTestChange('2026-07-04-voice-copilot-v1', ['proposal', 'design']);
 

--- a/test/commands/artifact-workflow.test.ts
+++ b/test/commands/artifact-workflow.test.ts
@@ -212,6 +212,24 @@ describe('artifact-workflow CLI commands', () => {
       const output = getOutput(result);
       expect(output).toContain('Invalid change name');
     });
+
+    it('rejects hidden directory names', async () => {
+      const result = await runCLI(['status', '--change', '.hidden'], { cwd: tempDir });
+      expect(result.exitCode).toBe(1);
+      const output = getOutput(result);
+      expect(output).toContain('Invalid change name');
+    });
+
+    it('accepts digit-leading change names that exist on disk (#1308)', async () => {
+      await createTestChange('2026-07-04-voice-copilot-v1', ['proposal', 'design']);
+
+      const result = await runCLI(['status', '--change', '2026-07-04-voice-copilot-v1'], {
+        cwd: tempDir,
+      });
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('2026-07-04-voice-copilot-v1');
+      expect(result.stdout).toContain('2/4 artifacts complete');
+    });
   });
 
   describe('instructions command', () => {
@@ -289,6 +307,17 @@ describe('artifact-workflow CLI commands', () => {
       const output = getOutput(result);
       expect(output).toContain("Artifact 'unknown-artifact' not found");
       expect(output).toContain('Valid artifacts');
+    });
+
+    it('accepts digit-leading change names that exist on disk (#1308)', async () => {
+      await createTestChange('2026-07-04-voice-copilot-v1', ['proposal']);
+
+      const result = await runCLI(
+        ['instructions', 'design', '--change', '2026-07-04-voice-copilot-v1'],
+        { cwd: tempDir }
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain('<artifact id="design"');
     });
   });
 


### PR DESCRIPTION
Fixes #1308.

## What was wrong

Any command taking `--change` (`status`, `instructions <artifact>`, `instructions apply`) rejected digit-leading change names at parse time:

```
$ openspec status --change 2026-07-04-voice-copilot-v1
✖ Error: Invalid change name '2026-07-04-voice-copilot-v1': Change name must start with a letter
```

Meanwhile `list`, `validate`, and `archive` all handled the same change fine, so a change could live its whole lifecycle while being unaddressable by `--change`. Repos with a date-prefixed naming convention (which the archive flow itself produces) couldn't use the status/instructions workflow at all.

The cause: `validateChangeExists()` reused `validateChangeName()` — the creation-time kebab-case rule — as its path-traversal guard, so the lookup path enforced a naming convention on directories that already exist.

## How it was fixed

Lookup and creation are now separate rules, matching how the rest of the CLI behaves:

- **Lookup** (`--change`) accepts any directory name that `openspec list` could return, and only rejects unsafe names: path separators, `.`/`..`, null bytes, and hidden (dot-leading) entries.
- **Creation** (`openspec new change`) still enforces kebab-case via `validateChangeName()` — this PR takes no position on #1169 (numbered names at creation).

One small function in `src/commands/workflow/shared.ts`; no other call sites touched.

## Replication / proof

Before (repro from the issue, real output):

```
$ openspec status --change 2026-07-04-voice-copilot-v1
✖ Error: Invalid change name '2026-07-04-voice-copilot-v1': Change name must start with a letter
```

After:

```
$ openspec status --change 2026-07-04-voice-copilot-v1
Change: 2026-07-04-voice-copilot-v1
Schema: spec-driven
Progress: 1/4 artifacts complete
...
$ openspec status --change ../foo
✖ Error: Invalid change name '../foo': Change name cannot contain path separators
```

Tests: new cases for digit-leading names on `status` and `instructions`, plus a hidden-name rejection; the existing traversal tests (`../foo`, `/etc/passwd`, `foo/bar`) pass unchanged. Full suite: 1,861 passed (the 17 zsh-installer failures are the known local-environment ones).

## Notes

- Lookup now also accepts other on-disk names the old rule rejected (uppercase, underscores) — intentional, since `list`/`archive` already resolve those directories.
- Includes a patch changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The `--change` option now accepts any safe existing change name on disk, including date- or digit-prefixed names.
  * Change lookup resolution is now consistent with other change-related commands (e.g., list/validate/archive).

* **Bug Fixes**
  * Unsafe names (hidden entries, path separators, relative segments like `.`/`..`, and null characters) are still rejected.
  * The reserved name `archive` is rejected when provided via `--change`.

* **Tests**
  * Expanded CLI coverage for `status` and `instructions` change-name validation and acceptance.

* **Documentation**
  * Updated behavior notes for the `--change` option accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->