### PR TITLE
fix(config): stop warning about rules keys that belong to another schema

### DIFF
--- a/.changeset/config-rules-cross-schema.md
+++ b/.changeset/config-rules-cross-schema.md
@@ -1,0 +1,7 @@
+---
+"@fission-ai/openspec": patch
+---
+
+### Bug Fixes
+
+- Config `rules:` keys are no longer reported as `Unknown artifact ID` when they belong to a different schema. The global rules map is now validated against the union of artifact IDs across every available schema, so multi-schema projects stop seeing spurious warnings on every command (#1322).

--- a/src/core/artifact-graph/instruction-loader.ts
+++ b/src/core/artifact-graph/instruction-loader.ts
@@ -1,6 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { getSchemaDir, resolveSchema } from './resolver.js';
+import { getSchemaDir, resolveSchema, listSchemasWithInfo } from './resolver.js';
 import { ArtifactGraph } from './graph.js';
 import { detectCompleted } from './state.js';
 import { resolveArtifactOutputs } from './outputs.js';
@@ -298,14 +298,14 @@ export function generateInstructions(
     }
   }
 
-  // Validate rules artifact IDs if config has rules (only once per session)
+  // Validate rules artifact IDs if config has rules (only once per session).
+  // The rules map is global while each change can use a different schema, so a
+  // key is only "unknown" when it matches no artifact in ANY available schema.
   if (projectConfig?.rules) {
-    const validArtifactIds = new Set(context.graph.getAllArtifacts().map((a) => a.id));
-    const warnings = validateConfigRules(
-      projectConfig.rules,
-      validArtifactIds,
-      context.schemaName
+    const validArtifactIds = new Set(
+      listSchemasWithInfo(effectiveProjectRoot ?? undefined).flatMap((s) => s.artifacts)
     );
+    const warnings = validateConfigRules(projectConfig.rules, validArtifactIds);
 
     // Show each unique warning only once per session
     for (const warning of warnings) {

--- a/src/core/project-config.ts
+++ b/src/core/project-config.ts
@@ -266,19 +266,18 @@ function configPathForWarnings(projectRoot: string): string {
 }
 
 /**
- * Validate artifact IDs in rules against a schema's artifacts.
- * Called during instruction loading (when schema is known).
- * Returns warnings for unknown artifact IDs.
+ * Validate artifact IDs in rules against the artifacts of every available
+ * schema. The `rules:` map is global, but each change can use a different
+ * schema, so a key is only unknown when it matches no artifact in ANY schema.
+ * Returns warnings for keys that are unknown everywhere.
  *
  * @param rules - The rules object from config
- * @param validArtifactIds - Set of valid artifact IDs from the schema
- * @param schemaName - Name of the schema for error messages
+ * @param validArtifactIds - Set of valid artifact IDs across all schemas
  * @returns Array of warning messages for unknown artifact IDs
  */
 export function validateConfigRules(
   rules: Record<string, string[]>,
-  validArtifactIds: Set<string>,
-  schemaName: string
+  validArtifactIds: Set<string>
 ): string[] {
   const warnings: string[] = [];
 
@@ -287,7 +286,7 @@ export function validateConfigRules(
       const validIds = Array.from(validArtifactIds).sort().join(', ');
       warnings.push(
         `Unknown artifact ID in rules: "${artifactId}". ` +
-          `Valid IDs for schema "${schemaName}": ${validIds}`
+          `It matches no artifact in any available schema. Known artifact IDs: ${validIds}`
       );
     }
   }

--- a/test/core/project-config.test.ts
+++ b/test/core/project-config.test.ts
@@ -577,7 +577,7 @@ rules:
       };
       const validIds = new Set(['proposal', 'specs', 'design', 'tasks']);
 
-      const warnings = validateConfigRules(rules, validIds, 'spec-driven');
+      const warnings = validateConfigRules(rules, validIds);
 
       expect(warnings).toEqual([]);
     });
@@ -590,12 +590,26 @@ rules:
       };
       const validIds = new Set(['proposal', 'specs', 'design', 'tasks']);
 
-      const warnings = validateConfigRules(rules, validIds, 'spec-driven');
+      const warnings = validateConfigRules(rules, validIds);
 
       expect(warnings).toHaveLength(2);
       expect(warnings[0]).toContain('Unknown artifact ID in rules: "testplan"');
-      expect(warnings[0]).toContain('Valid IDs for schema "spec-driven": design, proposal, specs, tasks');
+      expect(warnings[0]).toContain('Known artifact IDs: design, proposal, specs, tasks');
       expect(warnings[1]).toContain('Unknown artifact ID in rules: "documentation"');
+    });
+
+    it('should not warn for keys valid in another schema (union across schemas)', () => {
+      // `issue` is not a spec-driven artifact but is valid for a lighter
+      // schema; the union set contains it, so it must not warn.
+      const rules = {
+        proposal: ['Rule 1'], // spec-driven
+        issue: ['Rule 2'], // another schema
+      };
+      const unionIds = new Set(['proposal', 'specs', 'design', 'tasks', 'issue']);
+
+      const warnings = validateConfigRules(rules, unionIds);
+
+      expect(warnings).toEqual([]);
     });
 
     it('should return warnings for all unknown artifact IDs', () => {
@@ -606,7 +620,7 @@ rules:
       };
       const validIds = new Set(['proposal', 'specs']);
 
-      const warnings = validateConfigRules(rules, validIds, 'spec-driven');
+      const warnings = validateConfigRules(rules, validIds);
 
       expect(warnings).toHaveLength(3);
     });
@@ -615,7 +629,7 @@ rules:
       const rules = {};
       const validIds = new Set(['proposal', 'specs']);
 
-      const warnings = validateConfigRules(rules, validIds, 'spec-driven');
+      const warnings = validateConfigRules(rules, validIds);
 
       expect(warnings).toEqual([]);
     });


### PR DESCRIPTION
**Status:** Ready for review. Surgical fix, verified end-to-end.

## What was wrong
`openspec/config.yaml` has a single global `rules:` map keyed by artifact ID, but each change can use a different schema. The validation only checked keys against the schema of the change currently being loaded, so any rules key that's legitimate for a *different* schema printed:

```
Unknown artifact ID in rules: "issue". Valid IDs for schema "spec-driven": design, proposal, specs, tasks
```

on **every** command in a multi-schema project (e.g. `spec-driven` for features + a lighter schema for fixes). The warning was pure noise — rules are applied per-artifact (`rules?.[artifactId]`), so a cross-schema key is simply unused for that change; nothing was ever misapplied.

## How it's fixed
Validate rules keys against the **union** of artifact IDs across every available schema (built-in, user, and project-local) via the existing `listSchemasWithInfo()`. A key now warns only when it matches no artifact in *any* schema; keys valid for another schema are silent. The warning message drops its single-schema framing accordingly.

Two files, ~15 lines:
- `src/core/artifact-graph/instruction-loader.ts` — build the valid-ID set from all schemas instead of just `context.graph`.
- `src/core/project-config.ts` — `validateConfigRules` no longer takes a `schemaName`; message reworded to "matches no artifact in any available schema."

## Replication / proof
Repro: a project with a project-local `light` schema (artifact `issue`) + `schema: spec-driven`, and a `rules:` map containing `issue`. Before this change, loading any `spec-driven` change warns about `issue`.

End-to-end after the fix (temp project, real `dist/`):

```
schemas seen: light, spec-driven
union IDs: design, issue, proposal, specs, tasks
warnings (1):
  - Unknown artifact ID in rules: "totally-bogus". It matches no artifact in any available schema. Known artifact IDs: design, issue, proposal, specs, tasks
```

`issue` (valid only in `light`) no longer warns; a genuinely-unknown key (`totally-bogus`) still does.

New regression test in `test/core/project-config.test.ts` covers the union case. `npm run build` green; full suite passes (only the 17 documented environment-only `zsh-installer` tests fail locally, CI unaffected).

## Notes
- No config format, output format, or CLI change. Behavior change is limited to which keys warn.
- The `schemaName` parameter of `validateConfigRules` was unused after this change and removed; the one caller and unit tests are updated.

Fixes #1322.

🤖 Generated with [Claude Code](https://claude.com/claude-code)