### PR TITLE
docs: add ADR guidance

### DIFF
--- a/docs/customization.md
+++ b/docs/customization.md
@@ -80,6 +80,23 @@ Tech stack: TypeScript, React, Node.js, PostgreSQL
 - **Context** appears in ALL artifacts
 - **Rules** ONLY appear for the matching artifact
 
+### Existing ADRs and Decision History
+
+OpenSpec does not currently provide native Architecture Decision Record (ADR) support. Keep existing MADR/ADR files and references in their current location; there is no OpenSpec migration or sync step for them. If they should inform future work, make their location and the expected research explicit in your project configuration:
+
+```yaml
+context: |
+  Architectural decision records are in docs/adrs/.
+  For work affected by an earlier decision, review the relevant ADRs, code and Git
+  history, and openspec/changes/archive/ before proposing an approach.
+
+rules:
+  design:
+    - Preserve established ADR references; record the change-specific decision and rationale in design.md.
+```
+
+This is guidance for the coding agent, not an indexer: OpenSpec does not automatically search `docs/adrs/` or `openspec/changes/archive/`. Use `/opsx:explore` or ask the agent to investigate a particular decision when you need its rationale. Teams that want ADRs generated or reviewed as part of their process can add planning artifacts and instructions with a custom schema, while continuing to manage their ADR files with their existing workflow.
+
 ### Schema Resolution Order
 
 When OpenSpec needs a schema, it checks in this order:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -110,6 +110,12 @@ A spec that describes only what's changing, using `ADDED`, `MODIFIED`, and `REMO
 
 To `openspec/changes/archive/YYYY-MM-DD-<name>/`, with all artifacts preserved. Nothing is deleted; the change just moves out of your active list.
 
+### Does OpenSpec support Architecture Decision Records (ADRs)?
+
+Not natively. If you already have MADR or other ADRs—for example in `docs/adrs/`—keep them and their existing links as they are. OpenSpec does not migrate, synchronize, or manage their lifecycle, and adopting OpenSpec does not require changing their format. Treat ADRs as the historical record of _why_ a decision was made; capture the current requirements and change-specific design in OpenSpec's specs and design artifacts.
+
+When an old decision matters, ask the coding agent to research it—`/opsx:explore` is a good starting point—and name the relevant places to inspect: your ADR directory, related code and Git history, and, when applicable, `openspec/changes/archive/`. OpenSpec has no built-in ADR/archive search or default prompt that automatically searches those locations; the agent uses normal repository tools such as `rg`, `git log`, and `git blame`. You can make this expectation persistent with project context or a custom schema; see [Customization](customization.md#existing-adrs-and-decision-history).
+
 ## Configuration and customization
 
 ### How do I tell the AI about my tech stack?


### PR DESCRIPTION
It now clarifies that OpenSpec has no native ADR support: teams should retain existing MADR files and links, explicitly direct agents to ADRs/Git/archive when researching rationale, and use project context or a custom schema for a tailored workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on working with existing Architecture Decision Records (ADRs).
  * Clarified that ADRs remain managed in their existing locations and aren’t automatically migrated, synchronized, or searched.
  * Documented ways to reference historical decisions through repository research and project configuration.
  * Added FAQ coverage explaining ADR support and available research workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->