### PR TITLE
fix(archive): make scenario-drift check multiplicity-aware (#1246)

### DIFF
--- a/src/core/specs-apply.ts
+++ b/src/core/specs-apply.ts
@@ -408,10 +408,27 @@ export function buildSpecSkeleton(specFolderName: string, changeName: string): s
 }
 
 function findMissingCurrentScenarios(current: RequirementBlock, incoming: RequirementBlock): string[] {
-  const incomingScenarioNames = new Set(parseScenarioBlocks(incoming.raw).map((scenario) => scenario.name));
-  return parseScenarioBlocks(current.raw)
-    .filter((scenario) => !incomingScenarioNames.has(scenario.name))
-    .map((scenario) => scenario.name);
+  // Multiplicity-aware: a name present N times in current and M times in
+  // incoming means max(0, N - M) instances are missing. Set membership would
+  // treat N>M as fully covered and let archive silently drop duplicates
+  // (residual #1246 / duplicate-scenario-name blind spot).
+  const remainingIncoming = new Map<string, number>();
+  for (const scenario of parseScenarioBlocks(incoming.raw)) {
+    const name = scenario.name;
+    remainingIncoming.set(name, (remainingIncoming.get(name) ?? 0) + 1);
+  }
+
+  const missing: string[] = [];
+  for (const scenario of parseScenarioBlocks(current.raw)) {
+    const name = scenario.name;
+    const remaining = remainingIncoming.get(name) ?? 0;
+    if (remaining > 0) {
+      remainingIncoming.set(name, remaining - 1);
+    } else {
+      missing.push(name);
+    }
+  }
+  return missing;
 }
 
 function parseScenarioBlocks(requirementRaw: string): ScenarioBlock[] {

--- a/test/core/archive.test.ts
+++ b/test/core/archive.test.ts
@@ -950,6 +950,71 @@ The system SHALL support the shared rule.
       expect(archives.some(a => a.includes(changeB))).toBe(false);
     });
 
+    it('should abort MODIFIED that drops a duplicate-named scenario (issue #1246 multiplicity)', async () => {
+      // Residual blind spot after the original #1246 gate: findMissingCurrentScenarios
+      // used Set membership, so two current scenarios sharing a name were both
+      // considered "present" when the MODIFIED block kept only one of them.
+      const mainSpecDir = path.join(tempDir, 'openspec', 'specs', 'dup-scenario');
+      await fs.mkdir(mainSpecDir, { recursive: true });
+      const mainSpecPath = path.join(mainSpecDir, 'spec.md');
+      await fs.writeFile(
+        mainSpecPath,
+        `# dup-scenario Specification
+
+## Purpose
+Duplicate scenario names within one requirement.
+
+## Requirements
+
+### Requirement: Login
+The system SHALL authenticate.
+
+#### Scenario: Validate
+- **WHEN** input is empty
+- **THEN** reject
+
+#### Scenario: Validate
+- **WHEN** input is malformed
+- **THEN** reject`
+      );
+
+      const changeName = 'drop-one-validate';
+      const changeDir = path.join(tempDir, 'openspec', 'changes', changeName);
+      const changeSpecDir = path.join(changeDir, 'specs', 'dup-scenario');
+      await fs.mkdir(changeSpecDir, { recursive: true });
+      await fs.writeFile(
+        path.join(changeSpecDir, 'spec.md'),
+        `# Drop One Validate - Change
+
+## MODIFIED Requirements
+
+### Requirement: Login
+The system SHALL authenticate.
+
+#### Scenario: Validate
+- **WHEN** input is empty
+- **THEN** reject`
+      );
+
+      await archiveCommand.execute(changeName, { yes: true, noValidate: true });
+
+      const updated = await fs.readFile(mainSpecPath, 'utf-8');
+      // Spec must be untouched — both Validate scenarios preserved
+      expect((updated.match(/#### Scenario: Validate/g) || []).length).toBe(2);
+      expect(updated).toContain('malformed');
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'dup-scenario MODIFIED failed for header "### Requirement: Login" - current spec contains scenario(s) not present in the modified block: "Validate"'
+        )
+      );
+      expect(console.log).toHaveBeenCalledWith('Aborted. No files were changed.');
+
+      await expect(fs.access(changeDir)).resolves.not.toThrow();
+      const archiveDir = path.join(tempDir, 'openspec', 'changes', 'archive');
+      const archives = await fs.readdir(archiveDir);
+      expect(archives.some(a => a.includes(changeName))).toBe(false);
+    });
+
     it('should abort with a structural error when target spec hides requirements outside ## Requirements', async () => {
       const changeName = 'hidden-requirement-target';
       const changeDir = path.join(tempDir, 'openspec', 'changes', changeName);


### PR DESCRIPTION
## Summary

Closes a residual silent-drop path in the #1246 scenario-drift gate.

PR #1252 added `findMissingCurrentScenarios` so a stale `MODIFIED` block
cannot overwrite the canonical requirement when it omits scenarios that
already exist. That gate stored incoming scenario **names** in a `Set` and
filtered by membership. When the current requirement has **N** scenarios
sharing one name and the `MODIFIED` block keeps **M < N**, every current
instance still "matches," `missing` is empty, and archive still succeeds —
dropping the extras with no abort.

This change makes the check **multiplicity-aware**: count occurrences per
scenario name; a current instance is missing when remaining incoming count
for that name is zero. Error message shape is unchanged.

### Credits

- **Issue reporter:** [@stanleykao72](https://github.com/stanleykao72) —
  sequential-archive scenario drop (#1246).
- **Root-cause analysis (duplicate-name blind spot + multiplicity sketch):**
  [@HerbertGao](https://github.com/HerbertGao) — issue comment on #1246.
  Implemented and verified independently against a failing repro on main.

### Related

- Partial fix: #1252 / `7e21cc5` (`fix archive scenario drift for #1246`)
- Issue: #1246

## Changes

- **`src/core/specs-apply.ts`:** `findMissingCurrentScenarios` uses a
  remaining-count `Map` instead of a name `Set`.
- **`test/core/archive.test.ts`:** regression — current has two
  `#### Scenario: Validate` blocks; `MODIFIED` keeps one → archive aborts,
  main spec untouched, change not archived.

## Verification

- [x] Pre-fix repro on unmodified main: `buildUpdatedSpec` succeeded with
      `Scenario: Validate` count 1 and no `malformed` body (silent drop).
- [x] `pnpm exec vitest run test/core/archive.test.ts` — 40/40 passed
- [x] `pnpm run lint` — 0 errors; 1 pre-existing warning in
      `src/core/references.ts` (unused eslint-disable; present on
      `origin/main`)
- [x] `pnpm run build` — passed
- [x] Revert-proof: restore Set-based `findMissingCurrentScenarios`, keep new
      test → FAIL (`expected 1 to be 2` — silent drop); restore fix → PASS
- [x] `pnpm test` — 2014 passed; 13 failed in e2e/config/store/artifact
      files. Same 13 failures reproduce on unmodified `origin/main`
      (NO_COLOR/FORCE_COLOR chalk + stderr noise). Labeled pre-existing;
      not introduced by this change.

## Test plan

- [ ] CI green on this branch
- [ ] Review residual path: duplicate scenario names within one requirement,
      MODIFIED retains fewer copies → abort with
      `scenario(s) not present in the modified block: "…"`
- [ ] Existing distinct-name drift case from #1252 still aborts as before


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spec validation when multiple scenarios share the same name.
  * Archive operations now correctly abort when a modified block omits duplicate scenario occurrences.
  * Prevented partial changes, incorrect archiving, and unintended file updates in these cases.

* **Tests**
  * Added regression coverage for duplicate-named scenarios during archive operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->