### PR TITLE
fix(validate): reject a delta spec at the change's specs/ root

### DIFF
--- a/.changeset/root-level-delta-spec.md
+++ b/.changeset/root-level-delta-spec.md
@@ -1,0 +1,7 @@
+---
+"@fission-ai/openspec": patch
+---
+
+### Fixed
+
+- Stop a delta spec written directly at a change's `specs/` root from being silently dropped. `validate` accepted `specs/spec.md` and counted its deltas, but the apply/archive merge only reads capability folders (`specs/<capability>/spec.md`), so the change could pass validation and be archived while its requirements never reached `openspec/specs/`. `validate` now uses the same discovery rules as the merge path and reports the misplaced file with a fix hint, and `archive` blocks instead of completing.

--- a/src/core/archive.ts
+++ b/src/core/archive.ts
@@ -274,16 +274,14 @@ export class ArchiveCommand {
 
       // Validate delta-formatted spec files under the change directory if present
       const changeSpecsDir = path.join(changeDir, 'specs');
-      let hasDeltaSpecs = false;
-      // The root-level specs/spec.md is not a mergeable delta, but it must
-      // still trigger validation: otherwise a change whose only delta sits
-      // there skips this gate and archives with its requirements dropped
-      // (#1385). Validation reports it as an error and blocks the archive.
-      const deltaCandidates = [
-        ...(await discoverSpecFiles(changeSpecsDir)).map(spec => spec.specFile),
-        path.join(changeSpecsDir, 'spec.md'),
-      ];
-      for (const specFile of deltaCandidates) {
+      // A spec.md at the specs/ root is never merged, so archiving a change
+      // that has one drops its content whether or not it carries delta headers
+      // (#1385). Its existence alone must run validation, which reports it and
+      // blocks the archive. A directory named spec.md is a normal capability
+      // folder, so only a regular file counts.
+      const rootSpecStat = await fs.stat(path.join(changeSpecsDir, 'spec.md')).catch(() => null);
+      let hasDeltaSpecs = rootSpecStat?.isFile() === true;
+      for (const { specFile } of hasDeltaSpecs ? [] : await discoverSpecFiles(changeSpecsDir)) {
         try {
           const content = await fs.readFile(specFile, 'utf-8');
           if (/^##\s+(ADDED|MODIFIED|REMOVED|RENAMED)\s+Requirements/m.test(content)) {

--- a/src/core/archive.ts
+++ b/src/core/archive.ts
@@ -275,7 +275,15 @@ export class ArchiveCommand {
       // Validate delta-formatted spec files under the change directory if present
       const changeSpecsDir = path.join(changeDir, 'specs');
       let hasDeltaSpecs = false;
-      for (const { specFile } of await discoverSpecFiles(changeSpecsDir)) {
+      // The root-level specs/spec.md is not a mergeable delta, but it must
+      // still trigger validation: otherwise a change whose only delta sits
+      // there skips this gate and archives with its requirements dropped
+      // (#1385). Validation reports it as an error and blocks the archive.
+      const deltaCandidates = [
+        ...(await discoverSpecFiles(changeSpecsDir)).map(spec => spec.specFile),
+        path.join(changeSpecsDir, 'spec.md'),
+      ];
+      for (const specFile of deltaCandidates) {
         try {
           const content = await fs.readFile(specFile, 'utf-8');
           if (/^##\s+(ADDED|MODIFIED|REMOVED|RENAMED)\s+Requirements/m.test(content)) {

--- a/src/core/validation/validator.ts
+++ b/src/core/validation/validator.ts
@@ -122,6 +122,7 @@ export class Validator {
     const issues: ValidationIssue[] = [];
     const specsDir = path.join(changeDir, 'specs');
     let totalDeltas = 0;
+    let hasRootLevelSpec = false;
     const missingHeaderSpecs: string[] = [];
     const emptySectionSpecs: Array<{ path: string; sections: string[] }> = [];
 
@@ -136,7 +137,11 @@ export class Validator {
       // A spec.md directly at the specs/ root has no capability folder, so the
       // merge path drops it: without this error the change validates clean and
       // archives while its requirements never reach openspec/specs/ (#1385).
-      if (await FileSystemUtils.fileExists(path.join(specsDir, 'spec.md'))) {
+      // Only a regular file counts — a *directory* named spec.md is a capability
+      // folder like any other, and discoverSpecFiles reads it normally.
+      const rootSpecStat = await fs.stat(path.join(specsDir, 'spec.md')).catch(() => null);
+      hasRootLevelSpec = rootSpecStat?.isFile() === true;
+      if (hasRootLevelSpec) {
         issues.push({
           level: 'ERROR',
           path: 'spec.md',
@@ -318,7 +323,10 @@ export class Validator {
       });
     }
 
-    if (totalDeltas === 0) {
+    // The root-level error already names the file and the fix; adding "No
+    // deltas found" on top would contradict it, since the deltas are sitting in
+    // the file just reported.
+    if (totalDeltas === 0 && !hasRootLevelSpec) {
       issues.push({ level: 'ERROR', path: 'file', message: this.enrichTopLevelError('change', VALIDATION_MESSAGES.CHANGE_NO_DELTAS) });
     }
 

--- a/src/core/validation/validator.ts
+++ b/src/core/validation/validator.ts
@@ -18,6 +18,7 @@ import {
 } from '../parsers/requirement-text.js';
 import { findMainSpecStructureIssues } from '../parsers/spec-structure.js';
 import { FileSystemUtils } from '../../utils/file-system.js';
+import { discoverSpecFiles } from '../../utils/spec-discovery.js';
 
 export class Validator {
   private strictMode: boolean;
@@ -125,11 +126,25 @@ export class Validator {
     const emptySectionSpecs: Array<{ path: string; sections: string[] }> = [];
 
     try {
-      // Discover delta specs at any depth so the nested multi-area layout
-      // (specs/<area>/<capability>/spec.md) is validated, not just the
-      // one-level specs/<capability>/spec.md layout (#1182b). The spec-driven
-      // specs glob is specs/**/*.md; delta files are always named spec.md.
-      const specFiles = await this.findDeltaSpecFiles(specsDir);
+      // Discover delta specs through the same helper the change parser, show,
+      // apply, and archive use, so validate never accepts a layout the merge
+      // path silently skips (#1385). It finds spec.md at any depth, covering
+      // both specs/<capability>/spec.md and the nested multi-area
+      // specs/<area>/<capability>/spec.md layout (#1182b).
+      const specFiles = (await discoverSpecFiles(specsDir)).map(spec => spec.specFile);
+
+      // A spec.md directly at the specs/ root has no capability folder, so the
+      // merge path drops it: without this error the change validates clean and
+      // archives while its requirements never reach openspec/specs/ (#1385).
+      if (await FileSystemUtils.fileExists(path.join(specsDir, 'spec.md'))) {
+        issues.push({
+          level: 'ERROR',
+          path: 'spec.md',
+          message:
+            'Delta spec found at specs/spec.md. Delta specs must live in a capability folder (e.g. specs/<capability>/spec.md) — a file at the specs/ root is ignored when the change is applied or archived.',
+        });
+      }
+
       for (const specFile of specFiles) {
         let content: string | undefined;
         try {
@@ -308,34 +323,6 @@ export class Validator {
     }
 
     return this.createReport(issues);
-  }
-
-  /**
-   * Recursively collect every delta `spec.md` under a change's specs directory,
-   * so both the one-level (specs/<capability>/spec.md) and nested multi-area
-   * (specs/<area>/<capability>/spec.md) layouts are discovered (#1182b).
-   * Returns absolute paths, sorted for deterministic issue ordering.
-   */
-  private async findDeltaSpecFiles(specsDir: string): Promise<string[]> {
-    const results: string[] = [];
-    const walk = async (dir: string): Promise<void> => {
-      let entries;
-      try {
-        entries = await fs.readdir(dir, { withFileTypes: true });
-      } catch {
-        return;
-      }
-      for (const entry of entries) {
-        const full = path.join(dir, entry.name);
-        if (entry.isDirectory()) {
-          await walk(full);
-        } else if (entry.isFile() && entry.name === 'spec.md') {
-          results.push(full);
-        }
-      }
-    };
-    await walk(specsDir);
-    return results.sort();
   }
 
   private convertZodErrors(error: ZodError): ValidationIssue[] {

--- a/test/core/archive.test.ts
+++ b/test/core/archive.test.ts
@@ -1294,6 +1294,38 @@ The system SHALL record request metrics.
       expect(archives.some(a => a.includes(changeName))).toBe(false);
     });
 
+    it('sets exit code 1 for a root-level specs/spec.md without delta headers (#1385)', async () => {
+      const changeName = 'exit-root-plain';
+      const changeDir = path.join(tempDir, 'openspec', 'changes', changeName);
+      const changeSpecsDir = path.join(changeDir, 'specs');
+      await fs.mkdir(changeSpecsDir, { recursive: true });
+
+      // Main-spec shape rather than delta shape: still never merged, so the
+      // gate must trip on the file existing, not on its headers.
+      const specContent = `# Metrics
+
+## Purpose
+Metrics for requests.
+
+## Requirements
+
+### Requirement: Request metrics
+The system SHALL record request metrics.
+
+#### Scenario: Request is counted
+- **WHEN** a request completes
+- **THEN** a counter is incremented`;
+      await fs.writeFile(path.join(changeSpecsDir, 'spec.md'), specContent);
+      await fs.writeFile(path.join(changeDir, 'tasks.md'), '- [x] Task 1\n');
+
+      await archiveCommand.execute(changeName, { yes: true });
+
+      expect(process.exitCode).toBe(1);
+      const archiveDir = path.join(tempDir, 'openspec', 'changes', 'archive');
+      const archives = await fs.readdir(archiveDir);
+      expect(archives.some(a => a.includes(changeName))).toBe(false);
+    });
+
     it('sets exit code 1 when spec rebuild fails (MODIFIED on new spec)', async () => {
       const changeName = 'exit-rebuild-fail';
       const changeDir = path.join(tempDir, 'openspec', 'changes', changeName);

--- a/test/core/archive.test.ts
+++ b/test/core/archive.test.ts
@@ -1263,6 +1263,37 @@ The system will log all events.
       expect(archives.some(a => a.includes(changeName))).toBe(false);
     });
 
+    it('sets exit code 1 when the only delta spec sits at the specs/ root (#1385)', async () => {
+      const changeName = 'exit-root-delta';
+      const changeDir = path.join(tempDir, 'openspec', 'changes', changeName);
+      const changeSpecsDir = path.join(changeDir, 'specs');
+      await fs.mkdir(changeSpecsDir, { recursive: true });
+
+      // No capability folder: the merge path skips this file, so archiving it
+      // used to succeed while dropping the requirement.
+      const specContent = `## ADDED Requirements
+
+### Requirement: Request metrics
+The system SHALL record request metrics.
+
+#### Scenario: Request is counted
+- **WHEN** a request completes
+- **THEN** a counter is incremented`;
+      await fs.writeFile(path.join(changeSpecsDir, 'spec.md'), specContent);
+      await fs.writeFile(path.join(changeDir, 'tasks.md'), '- [x] Task 1\n');
+
+      await archiveCommand.execute(changeName, { yes: true });
+
+      expect(process.exitCode).toBe(1);
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining('Validation failed')
+      );
+
+      const archiveDir = path.join(tempDir, 'openspec', 'changes', 'archive');
+      const archives = await fs.readdir(archiveDir);
+      expect(archives.some(a => a.includes(changeName))).toBe(false);
+    });
+
     it('sets exit code 1 when spec rebuild fails (MODIFIED on new spec)', async () => {
       const changeName = 'exit-rebuild-fail';
       const changeDir = path.join(tempDir, 'openspec', 'changes', changeName);

--- a/test/core/validation.test.ts
+++ b/test/core/validation.test.ts
@@ -532,6 +532,33 @@ The system SHALL record request metrics.
       expect(
         report.issues.some(i => i.message.includes('Delta spec found at specs/spec.md'))
       ).toBe(true);
+      // The precise error replaces the generic one, which would otherwise say
+      // "No deltas found" about a file it just named.
+      expect(report.issues.some(i => i.message.includes('No deltas found'))).toBe(false);
+    });
+
+    it('should accept a capability folder that is literally named spec.md', async () => {
+      const changeDir = path.join(testDir, 'test-change-spec-md-folder');
+      const specsDir = path.join(changeDir, 'specs', 'spec.md');
+      await fs.mkdir(specsDir, { recursive: true });
+
+      const deltaSpec = `## ADDED Requirements
+
+### Requirement: Request metrics
+The system SHALL record request metrics.
+
+#### Scenario: Request is counted
+- **WHEN** a request completes
+- **THEN** a counter is incremented`;
+
+      await fs.writeFile(path.join(specsDir, 'spec.md'), deltaSpec);
+
+      const validator = new Validator(true);
+      const report = await validator.validateChangeDeltaSpecs(changeDir);
+
+      // specs/spec.md is a directory here, so nothing is dropped by the merge.
+      expect(report.valid).toBe(true);
+      expect(report.summary.errors).toBe(0);
     });
 
     it('should still validate a nested capability layout', async () => {

--- a/test/core/validation.test.ts
+++ b/test/core/validation.test.ts
@@ -506,6 +506,57 @@ The system SHALL handle all errors gracefully.
       expect(report.summary.errors).toBe(0);
     });
 
+    it('should fail when a delta spec.md sits directly under specs/', async () => {
+      // #1385: the merge path only reads specs/<capability>/spec.md, so a
+      // root-level file used to validate clean and then archive with its
+      // requirements silently dropped.
+      const changeDir = path.join(testDir, 'test-change-root-delta');
+      const specsDir = path.join(changeDir, 'specs');
+      await fs.mkdir(specsDir, { recursive: true });
+
+      const deltaSpec = `## ADDED Requirements
+
+### Requirement: Request metrics
+The system SHALL record request metrics.
+
+#### Scenario: Request is counted
+- **WHEN** a request completes
+- **THEN** a counter is incremented`;
+
+      await fs.writeFile(path.join(specsDir, 'spec.md'), deltaSpec);
+
+      const validator = new Validator(true);
+      const report = await validator.validateChangeDeltaSpecs(changeDir);
+
+      expect(report.valid).toBe(false);
+      expect(
+        report.issues.some(i => i.message.includes('Delta spec found at specs/spec.md'))
+      ).toBe(true);
+    });
+
+    it('should still validate a nested capability layout', async () => {
+      const changeDir = path.join(testDir, 'test-change-nested-delta');
+      const specsDir = path.join(changeDir, 'specs', 'platform', 'metrics');
+      await fs.mkdir(specsDir, { recursive: true });
+
+      const deltaSpec = `## ADDED Requirements
+
+### Requirement: Request metrics
+The system SHALL record request metrics.
+
+#### Scenario: Request is counted
+- **WHEN** a request completes
+- **THEN** a counter is incremented`;
+
+      await fs.writeFile(path.join(specsDir, 'spec.md'), deltaSpec);
+
+      const validator = new Validator(true);
+      const report = await validator.validateChangeDeltaSpecs(changeDir);
+
+      expect(report.valid).toBe(true);
+      expect(report.summary.errors).toBe(0);
+    });
+
     it('should fail when requirement text lacks SHALL/MUST', async () => {
       const changeDir = path.join(testDir, 'test-change-3');
       const specsDir = path.join(changeDir, 'specs', 'test-spec');


### PR DESCRIPTION
Fixes #1385.

**Status:** LGTM — reproduced on main, fixed, regression-tested.

## What was wrong

If you wrote a change's delta spec at `openspec/changes/<change>/specs/spec.md` — no capability folder — OpenSpec told you it was fine and then threw it away.

`openspec validate <change> --strict` passed and counted the deltas. But everything that actually merges specs (`show`, `apply`, `archive`) only reads `specs/<capability>/spec.md`, so it saw zero deltas. The change archived successfully and the requirement never reached `openspec/specs/`. The only signal was a non-blocking warning that scrolled by.

Two walkers disagreed: the validator had its own recursive scan, while the merge path used the shared `discoverSpecFiles` helper.

## How it's fixed

- The validator now uses `discoverSpecFiles` — the same helper the merge path uses — so it can never accept a layout the merge silently skips.
- A file at `specs/spec.md` is reported as an error that names the fix: `Delta spec found at specs/spec.md. Delta specs must live in a capability folder (e.g. specs/<capability>/spec.md) — a file at the specs/ root is ignored when the change is applied or archived.`
- `archive` trips its validation gate on that file simply existing, so it blocks instead of archiving a change whose content will be dropped. Existence, not delta headers: a root-level file written in main-spec shape (`## Requirements`) is dropped just the same.
- A *directory* named `specs/spec.md` is left alone — that is an ordinary capability folder the merge path reads normally.
- The generic "No deltas found" error is suppressed when the precise error fires, so the output doesn't claim there are no deltas in the file it just named.

Move the file into a capability folder and everything behaves as before. No other layout changes.

## Proof

Before (main), from the issue's repro:

```
$ openspec validate add-metrics --strict
Change 'add-metrics' is valid
$ openspec archive add-metrics --yes
Change 'add-metrics' archived as '2026-07-20-add-metrics'.
$ grep -r "Request metrics" openspec/specs/
(no match — the requirement is gone)
```

After:

```
$ openspec archive add-metrics --yes
Validation errors in change delta specs:
  ✗ Delta spec found at specs/spec.md. Delta specs must live in a capability folder
    (e.g. specs/<capability>/spec.md) — a file at the specs/ root is ignored when the
    change is applied or archived.
Validation failed. Please fix the errors before archiving.
(exit 1, change still active)

$ mkdir -p specs/metrics && mv specs/spec.md specs/metrics/spec.md
$ openspec archive add-metrics --yes
  metrics: create
Change 'add-metrics' archived as '2026-07-20-add-metrics'.
$ grep -rl "Request metrics" openspec/specs/
openspec/specs/metrics/spec.md
```

Behavior matrix, each row exercised against the built CLI:

| Layout | validate | archive |
|---|---|---|
| `specs/spec.md` (delta shape) | error | blocked |
| `specs/spec.md` (main-spec shape) | error | blocked |
| `specs/spec.md` **plus** a valid capability delta | error | blocked |
| `specs/<capability>/spec.md` | pass | archives, merges |
| `specs/<area>/<capability>/spec.md` | pass | archives, merges |
| `specs/spec.md/spec.md` (folder named `spec.md`) | pass | archives, merges |

Five regression tests added across `validation.test.ts` and `archive.test.ts`. Full suite: 2,015 passing; the only failures are the 17 known environment-only `zsh-installer` cases that also fail on unmodified main.

## Notes

- Consolidating on `discoverSpecFiles` also makes the validator skip dot-directories, matching the merge path — a delta hidden in a dot-directory was never merged anyway.
- Direction picked from the two the issue offered: reject the layout rather than teach the merge to accept it, since a root-level file has no capability id to merge into.
- Out of scope, worth a separate issue: delta content in a file **not** named `spec.md` (e.g. `specs/billing.md`) is invisible to both walkers, so it is dropped the same way without any warning. That predates this change and affects a different code path; happy to file it.
- `--no-validate` still archives without these checks. That is the documented opt-out and already warns that it may archive invalid specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed delta spec discovery so misplaced `specs/spec.md` directly under a change’s `specs/` folder is now detected during validation.
  * Validation now reports the issue with guidance to place delta specs under a capability folder (e.g., `specs/<capability>/spec.md`).
  * Archive operations are now correctly blocked when such misplaced delta specs are found.

* **Tests**
  * Added regression coverage ensuring blocked archive behavior and improved validator edge-case handling for both invalid root layouts and valid nested capability layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->