### PR TITLE
fix(templates): stop the bulk archive when the user picks Cancel

### DIFF
--- a/.changeset/bulk-archive-honors-cancel.md
+++ b/.changeset/bulk-archive-honors-cancel.md
@@ -1,0 +1,7 @@
+---
+"@fission-ai/openspec": patch
+---
+
+### Bug Fixes
+
+- **Bulk archive now stops when you pick "Cancel"** — the generated `openspec-bulk-archive-change` skill (and the matching `opsx:bulk-archive` command) offered a "Cancel" option at the confirmation prompt but never told the agent what to do with it, so the next step archived every selected change anyway. The prompt now routes each answer by intent: "Cancel" stops without archiving anything, the archive options proceed (the ready-only option archives just the changes the status table marks `Ready` or `Ready*`), and any other answer re-asks instead of archiving. The single-change archive skill already routes Cancel this way; this brings the bulk variant in line.

--- a/skills/openspec-bulk-archive-change/SKILL.md
+++ b/skills/openspec-bulk-archive-change/SKILL.md
@@ -118,6 +118,13 @@ This skill allows you to batch-archive changes, handling spec conflicts intellig
 
    If there are incomplete changes, make clear they'll be archived with warnings.
 
+   Route on the answer by intent, not by exact label — you wrote these labels,
+   so match what the user picked rather than the wording above:
+   - "Cancel" — stop, do not archive. Report that nothing was archived and skip the remaining steps.
+   - The archive-everything option — proceed with every selected change
+   - The ready-only option — proceed with only the changes the step 6 table marks `Ready` or `Ready*`, and record the rest as Skipped in step 8c. If a `Ready*` change's conflict partner is skipped, re-derive that conflict's resolution using only the changes being archived.
+   - Anything else — ask again rather than archiving
+
 8. **Execute archive for each confirmed change**
 
    Process changes in the determined order (respecting conflict resolution):
@@ -245,6 +252,7 @@ No active changes found. Create a new change to get started.
 - Skip spec sync only when implementation is missing (warn user)
 - Show clear per-change status before confirming
 - Use single confirmation for entire batch
+- Never archive after the user cancels the confirmation — a cancelled batch archives nothing
 - Track and report all outcomes (success/skip/fail)
 - Preserve .openspec.yaml when moving to archive
 - Archive directory target uses current date: YYYY-MM-DD-<name>; a name that already starts with a `YYYY-MM-DD-` prefix is used as-is (never stack a second date)

--- a/src/core/templates/workflows/bulk-archive-change.ts
+++ b/src/core/templates/workflows/bulk-archive-change.ts
@@ -120,6 +120,13 @@ ${STORE_SELECTION_GUIDANCE}
 
    If there are incomplete changes, make clear they'll be archived with warnings.
 
+   Route on the answer by intent, not by exact label — you wrote these labels,
+   so match what the user picked rather than the wording above:
+   - "Cancel" — stop, do not archive. Report that nothing was archived and skip the remaining steps.
+   - The archive-everything option — proceed with every selected change
+   - The ready-only option — proceed with only the changes the step 6 table marks \`Ready\` or \`Ready*\`, and record the rest as Skipped in step 8c. If a \`Ready*\` change's conflict partner is skipped, re-derive that conflict's resolution using only the changes being archived.
+   - Anything else — ask again rather than archiving
+
 8. **Execute archive for each confirmed change**
 
    Process changes in the determined order (respecting conflict resolution):
@@ -247,6 +254,7 @@ No active changes found. Create a new change to get started.
 - Skip spec sync only when implementation is missing (warn user)
 - Show clear per-change status before confirming
 - Use single confirmation for entire batch
+- Never archive after the user cancels the confirmation — a cancelled batch archives nothing
 - Track and report all outcomes (success/skip/fail)
 - Preserve .openspec.yaml when moving to archive
 - Archive directory target uses current date: YYYY-MM-DD-<name>; a name that already starts with a \`YYYY-MM-DD-\` prefix is used as-is (never stack a second date)
@@ -372,6 +380,13 @@ ${STORE_SELECTION_GUIDANCE}
 
    If there are incomplete changes, make clear they'll be archived with warnings.
 
+   Route on the answer by intent, not by exact label — you wrote these labels,
+   so match what the user picked rather than the wording above:
+   - "Cancel" — stop, do not archive. Report that nothing was archived and skip the remaining steps.
+   - The archive-everything option — proceed with every selected change
+   - The ready-only option — proceed with only the changes the step 6 table marks \`Ready\` or \`Ready*\`, and record the rest as Skipped in step 8c. If a \`Ready*\` change's conflict partner is skipped, re-derive that conflict's resolution using only the changes being archived.
+   - Anything else — ask again rather than archiving
+
 8. **Execute archive for each confirmed change**
 
    Process changes in the determined order (respecting conflict resolution):
@@ -499,6 +514,7 @@ No active changes found. Create a new change to get started.
 - Skip spec sync only when implementation is missing (warn user)
 - Show clear per-change status before confirming
 - Use single confirmation for entire batch
+- Never archive after the user cancels the confirmation — a cancelled batch archives nothing
 - Track and report all outcomes (success/skip/fail)
 - Preserve .openspec.yaml when moving to archive
 - Archive directory target uses current date: YYYY-MM-DD-<name>; a name that already starts with a \`YYYY-MM-DD-\` prefix is used as-is (never stack a second date)

--- a/test/core/templates/skill-templates-parity.test.ts
+++ b/test/core/templates/skill-templates-parity.test.ts
@@ -50,12 +50,12 @@ const EXPECTED_FUNCTION_HASHES: Record<string, string> = {
   getOpsxApplyCommandTemplate: 'daeb507206707169de73c828e199648dde5732cbc17791ef2a027adffd028574',
   getOpsxFfCommandTemplate: 'b859b1955cda6012877ae7f9ec6980e468f2e949a3838dfcdebc17209d133749',
   getArchiveChangeSkillTemplate: 'b04eccde2c57af4bc484fa7279fa873ad1d46474eb024467d68e784d8b985c18',
-  getBulkArchiveChangeSkillTemplate: 'f31d17602c274a3fc24d688fb368156618cd31e07762a267d2c506c63b4b4760',
+  getBulkArchiveChangeSkillTemplate: '2b74b1f73380ff32e35f580734780d843c6161a2748c39edb07f1e00453771b4',
   getOpsxSyncCommandTemplate: '98b20e00da5c588ff83ed6e6f0e959dfc540349090fb3f5792ea030d099b8169',
   getVerifyChangeSkillTemplate: 'cab4db01b5d2b1243d63d90c53747d8b39e488c60f76eba3fe8b994467f69267',
   getOpsxArchiveCommandTemplate: '8c113e2a8bca36fecd0e2152ae262fbfbef508e81378838e15d31308fb069b57',
   getOpsxOnboardCommandTemplate: '9430a0fb6530791ab720e068f4b172bc3dfc4e96a1ae29102bee0b92c2afe7b5',
-  getOpsxBulkArchiveCommandTemplate: '22dde4864ec494eee774a46fe5c0c6a68f4ca9ff67272c3177a5d4f5c2be07b7',
+  getOpsxBulkArchiveCommandTemplate: 'da7be1a7318f15b915f5aae8eb638797a8a24a31e5fc7fc0a2bad01bba137686',
   getOpsxVerifyCommandTemplate: 'f01c0c0cef53be0956de52363d955d4ace131b1b2d77adf902f35fead9a1486d',
   getOpsxProposeSkillTemplate: '59197064a46c53264b62925a1c725af4ebe7caf9f0eaed4101990b7c13a40db1',
   getOpsxProposeCommandTemplate: '04f808a36e850b9cdbc4f943ef324a9fd2b1b0cc59b92f127ab6cc452d66cc4e',
@@ -72,7 +72,7 @@ const EXPECTED_GENERATED_SKILL_CONTENT_HASHES: Record<string, string> = {
   'openspec-ff-change': '0c82830cd9bc98f86eb56b63ddaabe2bf5d35fe25b6c40a7059311aee2c8acac',
   'openspec-sync-specs': 'b3f694ab81956d05126b089fe82dea78dec21788978bb9651485f996aee96740',
   'openspec-archive-change': 'b24d326662ef58809de4464960440713748b9a281323357facdca24af52014e7',
-  'openspec-bulk-archive-change': '98c682899a6fd4c83e71b790b27d6d4ccf832e51c0e754119537992a469c75ec',
+  'openspec-bulk-archive-change': '49d410bda408c0411decd584be9c2355335e3b3db760fc6a0adcd82c172a280f',
   'openspec-verify-change': '57693d22940f06080c6cf8d590ac2f48240d4a5e9ce7074dacd0f8d3c9945afa',
   'openspec-onboard': '76225d10352454a304e56566997811d16f91de1b37653816f2bc5d8ec976febc',
   'openspec-propose': '024db4bce28d9a4d7b25fa92525da6fc701a64ac07dfdcf777d286c95b5281b5',
@@ -265,6 +265,51 @@ describe('skill templates split parity', () => {
       // literal archive path the agent copies verbatim. The rule statements
       // only name the prefix, never place it in a path, so they stay legal.
       expect(text, id).not.toMatch(/\/YYYY-MM-DD-/);
+    }
+  });
+
+  // Covers both archive paths, not just the bulk one the fix targeted: the
+  // single-change routing has been correct since #1357 (current wording from
+  // #1394) but was never pinned, so a stale branch could silently reopen the
+  // bug #1381 actually reported.
+  it('honors Cancel at every archive confirmation (#1381)', () => {
+    const variants: Array<[string, string]> = [
+      ['bulk skill', generateSkillContent(getBulkArchiveChangeSkillTemplate(), 'PARITY-BASELINE')],
+      ['bulk opsx command', getOpsxBulkArchiveCommandTemplate().content],
+      ['single skill', generateSkillContent(getArchiveChangeSkillTemplate(), 'PARITY-BASELINE')],
+      ['single opsx command', getOpsxArchiveCommandTemplate().content],
+    ];
+
+    for (const [variant, content] of variants) {
+      // Offering "Cancel" without routing it let an agent fall straight through
+      // to the archive step and move the changes anyway.
+      expect(content, variant).toContain('"Cancel" — stop, do not archive');
+
+      // An unrecognized answer must re-prompt; archiving is never the default.
+      expect(content, variant).toContain('Anything else — ask again rather than archiving');
+    }
+  });
+
+  // The bulk confirmation labels are written by the agent and carry an `N`
+  // placeholder, so routing must match intent — matching the literal labels
+  // would send every legitimate answer down the "ask again" path forever.
+  it('routes the bulk archive confirmation by intent, not by literal label (#1381)', () => {
+    const variants: Array<[string, string]> = [
+      ['bulk skill', generateSkillContent(getBulkArchiveChangeSkillTemplate(), 'PARITY-BASELINE')],
+      ['bulk opsx command', getOpsxBulkArchiveCommandTemplate().content],
+    ];
+
+    for (const [variant, content] of variants) {
+      expect(content, variant).toContain('Route on the answer by intent, not by exact label');
+
+      // The ready-only route has to name where "ready" is decided, or the agent
+      // cannot tell which subset to archive.
+      expect(content, variant).toContain('the changes the step 6 table marks');
+
+      // A cancelled batch must archive nothing, reinforced where agents skim.
+      expect(content, variant).toContain(
+        'Never archive after the user cancels the confirmation'
+      );
     }
   });
 });


### PR DESCRIPTION
**Status:** LGTM — ready for review.

## What was wrong

The generated `openspec-bulk-archive-change` skill (and the matching `opsx:bulk-archive` command) offered you a **Cancel** option at the confirmation prompt:

```
7. **Confirm batch operation**
   - Options might include:
     - "Archive all N changes"
     - "Archive only N ready changes (skip incomplete)"
     - "Cancel"

8. **Execute archive for each confirmed change**
   Process changes in the determined order...
```

Step 7 collected your answer, but nothing ever told the agent what to *do* with it. Step 8 followed immediately and archived every selected change. An agent reading the skill literally would `mv` your changes into `archive/` after you explicitly cancelled — and the only trace of the option was a vague "Skipped: user chose not to archive (if applicable)" bullet three steps later, after the move already happened.

The single-change archive skill had the same hole; it was fixed in #1357 (`46a4d78`) and reworded into its current routing block by #1394. The bulk variant was left behind. Neither has shipped yet — both are post-`v1.6.0`.

## How it was fixed

Both template bodies (skill and `opsx` command) now route the answer:

```
Route on the answer by intent, not by exact label — you wrote these labels,
so match what the user picked rather than the wording above:
- "Cancel" — stop, do not archive. Report that nothing was archived and skip the remaining steps.
- The archive-everything option — proceed with every selected change
- The ready-only option — proceed with only the changes the step 6 table marks `Ready` or `Ready*`, and record the rest as Skipped in step 8c. If a `Ready*` change's conflict partner is skipped, re-derive that conflict's resolution using only the changes being archived.
- Anything else — ask again rather than archiving
```

Four deliberate details, each from an adversarial review finding:

- **Routing is by intent, not by literal label.** Step 7 says options "might include" those labels, and they contain an `N` placeholder the agent fills in ("Archive all 3 changes"). Matching the literal strings would have sent *every* legitimate answer into "Anything else — ask again", trading a destructive bug for an infinite re-prompt.
- **"Ready" is bound to where it's decided** — the step 6 status table, including the conflict-flagged `Ready*` row. Otherwise the agent can't tell which subset to archive.
- **A skipped conflict partner invalidates its recorded resolution.** Ready-only can archive one side of a conflict while its partner stays active; without re-deriving, step 8a's "apply in resolved order" would sync the skipped change's deltas too.
- **The Cancel wording matches the single-change skill verbatim** (`"Cancel" — stop, do not archive`), so one assertion guards all four templates — and "skip the remaining steps" also rules out printing a "Bulk Archive Complete" summary after a cancel.

A guardrail line was added where agents skim: `Never archive after the user cancels the confirmation — a cancelled batch archives nothing`.

## Proof it works

Two regression tests in `test/core/templates/skill-templates-parity.test.ts`:

- `honors Cancel at every archive confirmation (#1381)` — covers **all four** templates (bulk skill, bulk command, single skill, single command). The single-change routing has been correct since #1357 but was never pinned by a test; this closes the whole issue rather than half of it.
- `routes the bulk archive confirmation by intent, not by literal label (#1381)` — pins the intent-based wording, the ready-only binding, and the guardrail.

Both verified failing-then-passing. With the template change reverted:

```
× honors Cancel at every archive confirmation (#1381)
  → bulk skill: expected '---\nname: openspec-bulk-archive-chan…' to contain '"Cancel" — stop, do not archive'
× routes the bulk archive confirmation by intent, not by literal label (#1381)
  → bulk skill: expected '---\nname: openspec-bulk-archive-chan…' to contain 'Route on the answer by intent, not by…'
```

Full suite after `npm run build`: **2029 passed / 2046, 104 of 105 files green**. The sole failing file is `test/core/completions/installers/zsh-installer.test.ts` (17 failures) — the known environment-only oh-my-zsh issue noted in `CLAUDE.md` and tracked in #1321, untouched by this branch and green in CI.

## Notes / nits

- **Instruction text only.** No CLI, parser, schema, or data-model changes; no workflow design or architecture change.
- Golden hashes regenerated for the three affected entries (`getBulkArchiveChangeSkillTemplate`, `getOpsxBulkArchiveCommandTemplate`, `openspec-bulk-archive-change`), plus the committed `skills/openspec-bulk-archive-change/SKILL.md` via `npm run generate:skills`. No other hash drifted.
- **Sequencing:** #1388 touches the same file ~10 lines below this hunk and moves the same three hashes. The text auto-merges, but whichever lands second must rebuild and regenerate the hashes. #1062 has the same hash overlap.
- **Heads-up:** #1367 is ~15 commits stale and its diff still carries `Proceed to archive regardless of choice.` in `archive-change.ts`. Because it edits those same lines, git will raise a conflict rather than silently revert — but resolving that conflict in #1367's favor would reopen #1381. The new four-template test now fails loudly if that happens.
- Not in scope: the bulk template's step 8a still describes the spec sync loosely ("Use the openspec-sync-specs approach") without the inline/wait guardrail #1394 added for single-change archive. Worth a follow-up.

Closes #1381

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bulk archive now properly honors **“Cancel”**—stops the operation and archives nothing.
  * Archive confirmation routing is now **intent-based** (not exact label matching): **Archive everything** archives all selected changes; **Archive only ready** archives only `Ready`/`Ready*`.
  * Non-ready (and other non-selected) changes are recorded as **Skipped**; for `Ready*` conflicts whose partners are skipped, conflict resolution is re-derived from the archived set.
  * Any **unrecognized** confirmation response re-prompts the user instead of proceeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->