### PR TITLE
test(completion): isolate ZshInstaller tests from a real Oh My Zsh install

### DIFF
--- a/test/core/completions/installers/zsh-installer.test.ts
+++ b/test/core/completions/installers/zsh-installer.test.ts
@@ -8,8 +8,14 @@ import { ZshInstaller } from '../../../../src/core/completions/installers/zsh-in
 describe('ZshInstaller', () => {
   let testHomeDir: string;
   let installer: ZshInstaller;
+  let originalZsh: string | undefined;
 
   beforeEach(async () => {
+    // Clear $ZSH (set by a real Oh My Zsh install) so isOhMyZshInstalled()
+    // falls through to the isolated test home directory
+    originalZsh = process.env.ZSH;
+    delete process.env.ZSH;
+
     // Create a temporary home directory for testing
     testHomeDir = path.join(os.tmpdir(), `openspec-zsh-test-${randomUUID()}`);
     await fs.mkdir(testHomeDir, { recursive: true });
@@ -17,6 +23,13 @@ describe('ZshInstaller', () => {
   });
 
   afterEach(async () => {
+    // Restore original environment
+    if (originalZsh !== undefined) {
+      process.env.ZSH = originalZsh;
+    } else {
+      delete process.env.ZSH;
+    }
+
     // Clean up test directory
     await fs.rm(testHomeDir, { recursive: true, force: true });
   });

--- a/test/core/completions/installers/zsh-installer.test.ts
+++ b/test/core/completions/installers/zsh-installer.test.ts
@@ -40,6 +40,14 @@ describe('ZshInstaller', () => {
       expect(isInstalled).toBe(false);
     });
 
+    it('should return true when $ZSH environment variable is set', async () => {
+      // No .oh-my-zsh directory in testHomeDir; detection relies on $ZSH alone
+      process.env.ZSH = path.join(testHomeDir, '.oh-my-zsh');
+
+      const isInstalled = await installer.isOhMyZshInstalled();
+      expect(isInstalled).toBe(true);
+    });
+
     it('should return true when Oh My Zsh directory exists', async () => {
       // Create .oh-my-zsh directory
       const ohMyZshPath = path.join(testHomeDir, '.oh-my-zsh');


### PR DESCRIPTION
Fixes #1321.

**Status:** LGTM — test-only change, no runtime code touched, full suite green.

**What was wrong:** `test/core/completions/installers/zsh-installer.test.ts` failed 17 of 50 tests on any machine with a real Oh My Zsh install. The tests inject an isolated temp home directory, but `isOhMyZshInstalled()` checks `process.env.ZSH` *before* falling back to that directory ([zsh-installer.ts:31-46](https://github.com/Fission-AI/OpenSpec/blob/main/src/core/completions/installers/zsh-installer.ts#L31-L46)). Oh My Zsh exports `$ZSH`, the test runner inherits it, and every standard-Zsh test silently ran down the Oh My Zsh code path. CI containers don't have Oh My Zsh, so CI stayed green while local contributors saw a permanently red suite that could mask real regressions in this file.

**How it was fixed:**

- Clear `$ZSH` in `beforeEach` and restore it in `afterEach` — the same save/clear/restore idiom this file already uses for `OPENSPEC_NO_AUTO_CONFIG` and `shell-detection.test.ts` uses for `SHELL`/`COMSPEC`.
- Add one explicit test that sets `$ZSH` and asserts detection succeeds with no `.oh-my-zsh` directory present. Clearing the variable would otherwise leave that source branch with no coverage anywhere (before this PR it was only ever exercised accidentally, on the machines where the suite failed).

21 lines total, all inside the test file.

**Replication / proof:** On macOS with Oh My Zsh (`$ZSH` set):

```
# before (main)
npx vitest run test/core/completions/installers/zsh-installer.test.ts
#  Tests  17 failed | 33 passed (50)

# after (this branch)
npx vitest run test/core/completions/installers/zsh-installer.test.ts
#  Tests  51 passed (51)

npx vitest run
#  Test Files  105 passed (105)
#       Tests  2045 passed (2045)
```

**Notes:** The fix approach was proposed by @stanleykao72 in #1321 (credited as co-author). No behavior change for users; nothing in `src/` or the published package is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved Zsh installer test isolation by saving the prior `ZSH` environment value, clearing it for each test, and restoring (or removing) it afterward.
  * Added coverage to confirm `isOhMyZshInstalled()` returns `true` when the `ZSH` environment variable is set, independent of an `.oh-my-zsh` directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->