### PR TITLE
fix(schemas): stop design.md from restating the proposal

### DIFF
--- a/.changeset/design-proposal-boundary.md
+++ b/.changeset/design-proposal-boundary.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+Stop `design.md` from restating the proposal. In the default `spec-driven` schema, the design instruction asked for "Background, current state, constraints, stakeholders" and "What this design achieves and excludes" without saying that motivation and scope already live in `proposal.md`, so agents restated the proposal's Why and What Changes instead of adding the design's own value - approach, alternatives, and trade-offs. The instruction and the design template now state the boundary explicitly (the proposal covers why and what, design covers how) and tell the agent to reference those documents rather than repeat them (#1382).

--- a/schemas/spec-driven/schema.yaml
+++ b/schemas/spec-driven/schema.yaml
@@ -127,8 +127,8 @@ artifacts:
 
       Focus on architecture and approach, not line-by-line implementation.
       The proposal covers why and what; design covers how. Reference the
-      proposal for motivation and specs for requirements - if a section
-      would only restate them, point to them instead.
+      proposal for motivation and, once written, the specs for requirements -
+      if a section would only restate them, point to them instead.
 
       Good design docs explain the "why" behind technical decisions.
     requires:

--- a/schemas/spec-driven/schema.yaml
+++ b/schemas/spec-driven/schema.yaml
@@ -113,8 +113,8 @@ artifacts:
       - Ambiguity that benefits from technical decisions before coding
 
       Sections:
-      - **Context**: Background, current state, constraints, stakeholders
-      - **Goals / Non-Goals**: What this design achieves and explicitly excludes
+      - **Context**: Only the current state and constraints needed to explain the approach. Reference the proposal for motivation instead of restating it (e.g., "See proposal.md - Why").
+      - **Goals / Non-Goals**: What this design achieves and explicitly excludes. Don't restate the proposal's scope - add only design-level boundaries.
       - **Decisions**: Key technical choices with rationale (why X over Y?). Include alternatives considered for each decision.
       - **Risks / Trade-offs**: Known limitations, things that could go wrong. Format: [Risk] → Mitigation
       - **Migration Plan**: Steps to deploy, rollback strategy (if applicable)
@@ -126,7 +126,9 @@ artifacts:
       the task breakdown, resolve it now - ask the user instead of guessing.
 
       Focus on architecture and approach, not line-by-line implementation.
-      Reference the proposal for motivation and specs for requirements.
+      The proposal covers why and what; design covers how. Reference the
+      proposal for motivation and specs for requirements - if a section
+      would only restate them, point to them instead.
 
       Good design docs explain the "why" behind technical decisions.
     requires:

--- a/schemas/spec-driven/templates/design.md
+++ b/schemas/spec-driven/templates/design.md
@@ -1,6 +1,6 @@
 ## Context
 
-<!-- Background and current state -->
+<!-- Current state and constraints that shape the approach. See proposal.md for motivation - don't restate it -->
 
 ## Goals / Non-Goals
 
@@ -12,7 +12,7 @@
 
 ## Decisions
 
-<!-- Key design decisions and rationale -->
+<!-- Key design decisions with rationale and alternatives considered -->
 
 ## Risks / Trade-offs
 


### PR DESCRIPTION
**Status:** Ready for review. Guidance-only change to the default `spec-driven` schema - no code paths, no CLI behavior, no schema structure changes.

**What was wrong:** #1382 - in the default schema, `proposal.md` and `design.md` often end up saying the same thing. The design instruction asked for "Background, current state, constraints, stakeholders" and "What this design achieves and excludes" without ever saying that motivation and scope already live in the proposal, so agents dutifully restated the proposal's Why and What Changes instead of adding the design's differentiated value (approach, alternatives, trade-offs). The proposal side already had its boundary line ("implementation details belong in design.md"); the design side had no equivalent.

**How it was fixed:** Two files, wording only:
- `schemas/spec-driven/schema.yaml` (design instruction): Context is scoped to "only the current state and constraints needed to explain the approach," with a cross-reference example ("See proposal.md - Why"); Goals / Non-Goals now says not to restate the proposal's scope; the closing guidance states the boundary explicitly - the proposal covers why and what, design covers how; reference rather than restate.
- `schemas/spec-driven/templates/design.md`: section comments mirror the same boundary, and the Decisions comment now mentions alternatives considered.

The third acceptance criterion in #1382 (alternatives and trade-offs as first-class decision content) was already met by the existing instruction ("Include alternatives considered for each decision") - this PR only surfaces it in the template comment.

**Proof it works:** `schemas/` ships verbatim in the npm package and is parsed at runtime, so there are no compiled copies or golden hashes to regenerate (same shape as #1326 and #1366). Verified:
- `schema.yaml` still parses (artifacts: `proposal,specs,design,tasks`)
- Full suite after `npm run build`: **2,027 passed**; the only 17 failures are the pre-existing environment-only `zsh-installer` ones tracked in #1321 / PR #1400, identical on `main`
- `skill-templates-parity`, `artifact-graph/resolver`, and `instruction-loader` tests all green

**Notes:** Deliberately does not touch the proposal instruction (its boundary line already exists, and #1399 currently has open edits in that section). Design/architecture untouched - this clarifies the schema's existing intent (the instruction already said "Reference the proposal for motivation").

Closes #1382

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated spec-driven design guidance to improve “Context” framing, clarify explicit scope boundaries, and more clearly separate responsibilities between the proposal (“why/what”) and the design (“how”).
  * Revised the design markdown template placeholders to better direct authors to reuse proposal details and include prompts to record “alternatives considered.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->