### PR TITLE
fix(nix): build with Node.js 22 now that nixpkgs marks Node 20 insecure

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -55,7 +55,7 @@
             };
 
             nativeBuildInputs = with pkgs; [
-              nodejs_20
+              nodejs_22
               npmHooks.npmInstallHook
               pnpmConfigHook
               pnpm_9
@@ -97,7 +97,7 @@
         {
           default = pkgs.mkShell {
             buildInputs = with pkgs; [
-              nodejs_20
+              nodejs_22
               pnpm_9
             ];
 


### PR DESCRIPTION
**Status:** Approved by @TabishB; ready to merge.

**What was wrong:** The Nix flake pinned `nodejs_20` in both the package build and the dev shell. Node.js 20 reached end of life on 2026-04-30, and nixpkgs now marks it insecure (NixOS/nixpkgs#511784). Anyone consuming the flake against current nixpkgs — the normal case for downstream flakes that `follows` their own nixpkgs — gets a hard evaluation failure before the build even starts, exactly as reported in #1119.

**How it was fixed:** Both `nodejs_20` references now use `nodejs_22` (maintenance LTS until April 2027). This stays within the package's declared support range (`engines: node >=20.19.0`) and matches the fix the issue suggests.

**Replication / proof:**
- Repro: evaluate the flake against current `nixos-unstable` — nixpkgs refuses `nodejs_20` as insecure (full trace in #1119).
- Proof: the `nix-flake-validate` CI job runs `nix build` on every `flake.nix` change and verifies `result/bin/openspec` exists, so this PR's green check is a real build with Node 22.

**Notes:**
- Per maintainer decision in review, this PR stays on `nodejs_22`; moving the flake to `nodejs_24` (which would outlast nixpkgs' insecure threshold by an extra year) is deferred as a follow-up down the line.
- The broader Node 20 sweep Tabish requested (GitHub Actions runtimes, devcontainer image) landed separately as #1407.
- The committed `flake.lock` still pins nixpkgs from 2026-01-05, which is why in-repo CI kept passing while downstream users broke. This PR deliberately leaves the lock alone to stay surgical; a follow-up `nix flake update` would let CI exercise the same nixpkgs users are on.
- Supersedes #1177, which made the identical change but was closed by its author without a way to verify the build.
- The `nodejs_20` mentions under `openspec/changes/archive/2026-01-07-add-nix-flake-support/` are historical records of that change and are intentionally untouched; no live spec references a Node version.

Fixes #1119

🤖 Generated with [Claude Code](https://claude.com/claude-code)
