### PR TITLE
ci: clear Node 20 deprecation warnings by bumping action runtimes

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "OpenSpec Development",
-  "image": "mcr.microsoft.com/devcontainers/typescript-node:1-20-bookworm",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm",
 
   // Additional tools and features
   "features": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Check for Nix-related changes
         uses: dorny/paths-filter@v4
@@ -71,6 +73,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
@@ -124,6 +127,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
@@ -166,6 +171,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v21
@@ -226,6 +233,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Determine release tracking
         id: changed-changesets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ jobs:
       nix: ${{ steps.filter.outputs.nix }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Check for Nix-related changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -68,15 +68,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20.19.0'
           cache: 'pnpm'
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload test coverage
         if: matrix.os == 'ubuntu-latest'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-report-${{ github.event_name }}
           path: coverage/
@@ -123,13 +123,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20.19.0'
           cache: 'pnpm'
@@ -165,7 +165,7 @@ jobs:
     if: needs.changes.outputs.nix == 'true'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v21
@@ -223,7 +223,7 @@ jobs:
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -245,11 +245,11 @@ jobs:
 
       - name: Setup pnpm
         if: steps.changed-changesets.outputs.has_changesets == 'true'
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
         if: steps.changed-changesets.outputs.has_changesets == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20.19.0'
           cache: 'pnpm'

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -24,19 +24,19 @@ jobs:
       # (GITHUB_TOKEN cannot trigger workflows by design)
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '24' # Node 24 includes npm 11.5.1+ required for OIDC
           cache: 'pnpm'
@@ -70,13 +70,13 @@ jobs:
     if: github.repository == 'Fission-AI/OpenSpec' && github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '24' # Node 24 includes npm 11.5.1+ required for OIDC
           cache: 'pnpm'


### PR DESCRIPTION
**Status:** Ready for review. Follow-up to the sweep suggested by @TabishB in #1406 review. Version-tag bumps plus one review-driven hardening — no workflow logic, job structure, or filenames change.

**What was missing / the motivation:** Every JS action we use except `changesets/action` still declares a Node 20 runtime. GitHub deprecated Node 20 on runners (2025-09-19 changelog): since June 16, 2026 these actions are force-run on Node 24 with the warning quoted in #1406, and on September 16, 2026 Node 20 is removed from runners entirely. The devcontainer also pinned a Node 20 image (Node 20 is EOL since April 2026).

**What it does:** Bumps each action to its current Node 24 major, verified against each action's `action.yml` and release notes before choosing the target:

| Action | From → To | Why this major |
| --- | --- | --- |
| `actions/checkout` | v4 → v5 | Runtime-only bump. v6 also relocates persisted credentials — deliberately avoided near the changesets push path. |
| `actions/setup-node` | v4 → v6 | Caching-default changes in v5/v6 don't apply because every call site sets `cache: 'pnpm'` explicitly. `node-version` and `registry-url` inputs unchanged. |
| `pnpm/action-setup` | v4 → v6 | Resolves pnpm from `packageManager: "pnpm@9.15.9"` exactly as before; no call site passes a `version` input. |
| `actions/upload-artifact` | v4 → v6 | v5 still declares node20. v6 inputs are identical to v4's. |
| `dorny/paths-filter` | v3 → v4 | Inputs identical. |
| `actions/create-github-app-token` | v2 → v3 | v3 only removed custom proxy handling; we use hosted runners, no proxy. |
| `changesets/action` | v1 (unchanged) | Floating v1 already runs on node24. |

Also bumps `.devcontainer` image `typescript-node:1-20-bookworm` → `1-22-bookworm`.

Per CodeRabbit's review, the five `ci.yml` checkouts now set `persist-credentials: false` — safe because every `ci.yml` job is read-only after checkout (the changeset-validation job's `git diff origin/main...HEAD` works off `fetch-depth: 0`, fetched during the checkout action itself). The equivalent restructure in `release-prepare.yml` was deliberately declined there: its persisted App token is intentional (#477/#478 — changesets pushes must trigger CI) and unverifiable from a PR.

**Deliberately untouched:** `node-version: '20.19.0'` in CI (floor-testing the declared `engines: >=20.19.0` support contract — the runtime warnings are about the actions' own runtime, which is orthogonal), `node-version: '24'` in release, `package.json` engines, docs, and the `release-prepare.yml` filename (npm trusted publishing binds to repo + workflow filename, not to action versions inside it).

**Proof it works:** This PR edits `ci.yml`, so the full CI matrix — including `nix-flake-validate` via the paths filter — runs on these exact changes. Caveat: the release-prepare path only executes on the next version PR / beta dispatch; the bumps there are tag-only with inputs verbatim.

**Notes:** The repo has no `.github/dependabot.yml`, which is why six actions aged into deprecation together — happy to add a monthly `github-actions` ecosystem entry in a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the development container to use a newer TypeScript/Node toolchain.
  * Refreshed CI tooling versions for test runs, linting, artifact uploads, and change-detection.
  * Updated the release preparation workflows for improved compatibility and continued reliable execution (including GitHub App token creation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
