### PR TITLE
fix(templates): give explore the project's context and rules

### DIFF
--- a/.changeset/explore-project-context.md
+++ b/.changeset/explore-project-context.md
@@ -2,4 +2,4 @@
 "@fission-ai/openspec": patch
 ---
 
-Explore now reads the project's context and rules from `openspec/config.yaml` at the start of a session, so it reasons with the same tech stack and conventions the artifact-creating workflows already receive.
+Explore now reads the project's context and rules from `openspec/config.yaml` (or `config.yml`) at the start of a session, so it reasons with the same tech stack and conventions the artifact-creating workflows already receive.

--- a/.changeset/explore-project-context.md
+++ b/.changeset/explore-project-context.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+Explore now reads the project's context and rules from `openspec/config.yaml` at the start of a session, so it reasons with the same tech stack and conventions the artifact-creating workflows already receive.

--- a/skills/openspec-explore/SKILL.md
+++ b/skills/openspec-explore/SKILL.md
@@ -93,6 +93,12 @@ This tells you:
 - Their names, schemas, and status
 - What the user might be working on
 
+Then read the project's own context from `<root.path>/openspec/config.yaml` (use the `root.path` returned above; skip this if the file does not exist):
+- `context` describes the project - tech stack, conventions, constraints
+- `rules` lists per-artifact constraints the project expects
+
+Ground your thinking in these. They are background for you, not material to recite back to the user.
+
 ### When no change exists
 
 Think freely. When insights crystallize, you might offer:

--- a/skills/openspec-explore/SKILL.md
+++ b/skills/openspec-explore/SKILL.md
@@ -93,11 +93,11 @@ This tells you:
 - Their names, schemas, and status
 - What the user might be working on
 
-Then read the project's own context from `<root.path>/openspec/config.yaml` (use the `root.path` returned above; skip this if the file does not exist):
-- `context` describes the project - tech stack, conventions, constraints
-- `rules` lists per-artifact constraints the project expects
+Then read the project's own context from the resolved root - `<root.path>/openspec/config.yaml` (or `config.yml`). Use the `root.path` returned above, and skip this if neither file exists:
+- `context`: project background - tech stack, conventions, constraints
+- `rules`: keyed by artifact id - the entries for an artifact apply only when you write that artifact
 
-Ground your thinking in these. They are background for you, not material to recite back to the user.
+Ground your thinking in these. They are constraints for you to follow, not content to reproduce: do NOT copy them into the conversation or into any artifact you create.
 
 ### When no change exists
 

--- a/src/core/templates/workflows/explore.ts
+++ b/src/core/templates/workflows/explore.ts
@@ -95,11 +95,11 @@ This tells you:
 - Their names, schemas, and status
 - What the user might be working on
 
-Then read the project's own context from \`<root.path>/openspec/config.yaml\` (use the \`root.path\` returned above; skip this if the file does not exist):
-- \`context\` describes the project - tech stack, conventions, constraints
-- \`rules\` lists per-artifact constraints the project expects
+Then read the project's own context from the resolved root - \`<root.path>/openspec/config.yaml\` (or \`config.yml\`). Use the \`root.path\` returned above, and skip this if neither file exists:
+- \`context\`: project background - tech stack, conventions, constraints
+- \`rules\`: keyed by artifact id - the entries for an artifact apply only when you write that artifact
 
-Ground your thinking in these. They are background for you, not material to recite back to the user.
+Ground your thinking in these. They are constraints for you to follow, not content to reproduce: do NOT copy them into the conversation or into any artifact you create.
 
 ### When no change exists
 
@@ -398,11 +398,11 @@ This tells you:
 - Their names, schemas, and status
 - What the user might be working on
 
-Then read the project's own context from \`<root.path>/openspec/config.yaml\` (use the \`root.path\` returned above; skip this if the file does not exist):
-- \`context\` describes the project - tech stack, conventions, constraints
-- \`rules\` lists per-artifact constraints the project expects
+Then read the project's own context from the resolved root - \`<root.path>/openspec/config.yaml\` (or \`config.yml\`). Use the \`root.path\` returned above, and skip this if neither file exists:
+- \`context\`: project background - tech stack, conventions, constraints
+- \`rules\`: keyed by artifact id - the entries for an artifact apply only when you write that artifact
 
-Ground your thinking in these. They are background for you, not material to recite back to the user.
+Ground your thinking in these. They are constraints for you to follow, not content to reproduce: do NOT copy them into the conversation or into any artifact you create.
 
 If the user mentioned a specific change name, read its artifacts for context.
 

--- a/src/core/templates/workflows/explore.ts
+++ b/src/core/templates/workflows/explore.ts
@@ -95,6 +95,12 @@ This tells you:
 - Their names, schemas, and status
 - What the user might be working on
 
+Then read the project's own context from \`<root.path>/openspec/config.yaml\` (use the \`root.path\` returned above; skip this if the file does not exist):
+- \`context\` describes the project - tech stack, conventions, constraints
+- \`rules\` lists per-artifact constraints the project expects
+
+Ground your thinking in these. They are background for you, not material to recite back to the user.
+
 ### When no change exists
 
 Think freely. When insights crystallize, you might offer:
@@ -391,6 +397,12 @@ This tells you:
 - If there are active changes
 - Their names, schemas, and status
 - What the user might be working on
+
+Then read the project's own context from \`<root.path>/openspec/config.yaml\` (use the \`root.path\` returned above; skip this if the file does not exist):
+- \`context\` describes the project - tech stack, conventions, constraints
+- \`rules\` lists per-artifact constraints the project expects
+
+Ground your thinking in these. They are background for you, not material to recite back to the user.
 
 If the user mentioned a specific change name, read its artifacts for context.
 

--- a/test/core/templates/explore.test.ts
+++ b/test/core/templates/explore.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getExploreSkillTemplate,
+  getOpsxExploreCommandTemplate,
+} from '../../../src/core/templates/skill-templates.js';
+
+const skill = getExploreSkillTemplate();
+const command = getOpsxExploreCommandTemplate();
+
+// Both delivery surfaces must carry the same contract; every behavioral
+// assertion below runs against each body.
+const bodies: Array<[string, string]> = [
+  ['skill', skill.instructions],
+  ['command', command.content],
+];
+
+describe('explore templates', () => {
+  // Regression for #696: explore never loaded the project's declared
+  // context, so it reasoned without the tech stack, conventions, and
+  // rules every artifact-creating workflow already receives.
+  it('loads project context from config.yaml at startup (#696)', () => {
+    for (const [label, body] of bodies) {
+      expect(body, label).toContain('openspec/config.yaml');
+      expect(body, label).toContain('`context` describes the project');
+      expect(body, label).toContain('`rules` lists per-artifact constraints');
+    }
+  });
+
+  it('resolves config.yaml through the reported root rather than assuming a repo-local path (#696)', () => {
+    for (const [label, body] of bodies) {
+      expect(body, label).toContain('openspec list --json');
+      expect(body, label).toContain('<root.path>/openspec/config.yaml');
+      expect(body, label).toContain('root.path');
+    }
+  });
+
+  it('treats project context as constraints, not content to echo back (#696)', () => {
+    for (const [label, body] of bodies) {
+      expect(body, label).toContain(
+        'They are background for you, not material to recite back to the user.'
+      );
+    }
+  });
+
+  it('tolerates projects with no config.yaml', () => {
+    for (const [label, body] of bodies) {
+      expect(body, label).toContain('skip this if the file does not exist');
+    }
+  });
+});

--- a/test/core/templates/explore.test.ts
+++ b/test/core/templates/explore.test.ts
@@ -19,15 +19,15 @@ describe('explore templates', () => {
   // Regression for #696: explore never loaded the project's declared
   // context, so it reasoned without the tech stack, conventions, and
   // rules every artifact-creating workflow already receives.
-  it('loads project context from config.yaml at startup (#696)', () => {
+  it('loads project context from the OpenSpec config at startup (#696)', () => {
     for (const [label, body] of bodies) {
       expect(body, label).toContain('openspec/config.yaml');
-      expect(body, label).toContain('`context` describes the project');
-      expect(body, label).toContain('`rules` lists per-artifact constraints');
+      expect(body, label).toContain('`context`: project background');
+      expect(body, label).toContain('`rules`: keyed by artifact id');
     }
   });
 
-  it('resolves config.yaml through the reported root rather than assuming a repo-local path (#696)', () => {
+  it('resolves the config through the reported root rather than assuming a repo-local path (#696)', () => {
     for (const [label, body] of bodies) {
       expect(body, label).toContain('openspec list --json');
       expect(body, label).toContain('<root.path>/openspec/config.yaml');
@@ -35,17 +35,34 @@ describe('explore templates', () => {
     }
   });
 
-  it('treats project context as constraints, not content to echo back (#696)', () => {
+  // resolveConfigFilePath() probes config.yaml then config.yml, and
+  // `openspec init` leaves a .yml project on .yml forever - naming only
+  // .yaml would silently skip context for those projects.
+  it('accepts config.yml as well as config.yaml (#696)', () => {
+    for (const [label, body] of bodies) {
+      expect(body, label).toContain('config.yml');
+      expect(body, label).toContain('skip this if neither file exists');
+    }
+  });
+
+  // `rules` is Record<artifactId, string[]>; explore holds no artifact at
+  // startup, so the guidance must not invite blanket application.
+  it('scopes rules to the artifact they are keyed to (#696)', () => {
     for (const [label, body] of bodies) {
       expect(body, label).toContain(
-        'They are background for you, not material to recite back to the user.'
+        'the entries for an artifact apply only when you write that artifact'
       );
     }
   });
 
-  it('tolerates projects with no config.yaml', () => {
+  // House style across instructions.ts and the sibling workflow templates
+  // forbids leaking context/rules into the artifact, not just the chat.
+  it('treats project context as constraints that must not leak into output (#696)', () => {
     for (const [label, body] of bodies) {
-      expect(body, label).toContain('skip this if the file does not exist');
+      expect(body, label).toContain('constraints for you to follow');
+      expect(body, label).toContain(
+        'do NOT copy them into the conversation or into any artifact you create'
+      );
     }
   });
 });

--- a/test/core/templates/skill-templates-parity.test.ts
+++ b/test/core/templates/skill-templates-parity.test.ts
@@ -37,14 +37,14 @@ import {
 import { STORE_SELECTION_GUIDANCE } from '../../../src/core/templates/workflows/store-selection.js';
 
 const EXPECTED_FUNCTION_HASHES: Record<string, string> = {
-  getExploreSkillTemplate: '7d2f54e74fffcb36aaaa4498a4a8b033142bb25945fb9b2de532354acbe76b9c',
+  getExploreSkillTemplate: '7ae26ee2b62dfe005b05adb56602ee27f61e123cd4409290b9ef8e17eb24d4e3',
   getNewChangeSkillTemplate: '39663a6d2037e6697020393a66f6327506e3e3bc573b7a3556dcb7f9457dc51d',
   getContinueChangeSkillTemplate: 'acc07a489a30192b4bf2bbdc587a889478fbf6fffbbc9353c7775c4ca1ec5011',
   getApplyChangeSkillTemplate: '0f5a15fc7fb9ad6059a5643d0e01365d27642637a4aaebf182f9eabb45348197',
   getFfChangeSkillTemplate: '20ebb682ba89809a100cd4985c074908df5bada2bd649ca1b0f4059a63a1c728',
   getSyncSpecsSkillTemplate: 'dc07ea0312687f3edc602329c889dbbab737c6d79327eb7a723553d346b43433',
   getOnboardSkillTemplate: 'bc2216b72724b01c3a733e63b8bf4aff457f561c0e9ff7288bdacc39780a37a7',
-  getOpsxExploreCommandTemplate: '37e53590aae7ac6621d4393aa80a5b8af21881323887fa924ed329199fda27e0',
+  getOpsxExploreCommandTemplate: '7249617e9a467d5cce272a111ba81df91c769355a5c3f1cac411d1e86f04f7a6',
   getOpsxNewCommandTemplate: '57c600cce318d16b9b4308a18d0d983ea3c0673034e606a7cceec07b4c705e87',
   getOpsxContinueCommandTemplate: 'f63964fab7720ede097aa48808baff196c391b962930ca960459205c724800e5',
   getOpsxApplyCommandTemplate: 'daeb507206707169de73c828e199648dde5732cbc17791ef2a027adffd028574',
@@ -65,7 +65,7 @@ const EXPECTED_FUNCTION_HASHES: Record<string, string> = {
 };
 
 const EXPECTED_GENERATED_SKILL_CONTENT_HASHES: Record<string, string> = {
-  'openspec-explore': 'ba099821631ce75ee70af370917bbddbc88d0882ad0e50e91ed687d2185102ef',
+  'openspec-explore': '72f601a1a2c2ec3ad939a6215fb06042aea7d59b5f227d29225350dbef418dc4',
   'openspec-new-change': 'd5b8909bea70a33b7a312b38ce204a91f40b6bb2bff12c4c06b3e11641b6a689',
   'openspec-continue-change': 'bdb8bbb6a768a741b05256effbc284d65ac6a45360b59c24b94198792d3d0ebf',
   'openspec-apply-change': '09c0e1cdf5ccc82416d0969d6bd715cc70616bdbc3531358a5c36057f78be55a',

--- a/test/core/templates/skill-templates-parity.test.ts
+++ b/test/core/templates/skill-templates-parity.test.ts
@@ -37,14 +37,14 @@ import {
 import { STORE_SELECTION_GUIDANCE } from '../../../src/core/templates/workflows/store-selection.js';
 
 const EXPECTED_FUNCTION_HASHES: Record<string, string> = {
-  getExploreSkillTemplate: '7ae26ee2b62dfe005b05adb56602ee27f61e123cd4409290b9ef8e17eb24d4e3',
+  getExploreSkillTemplate: 'a7eb6fabdc05a5b90a4773ba93320a60edffea88e9b27985668a2959dcec2e3d',
   getNewChangeSkillTemplate: '39663a6d2037e6697020393a66f6327506e3e3bc573b7a3556dcb7f9457dc51d',
   getContinueChangeSkillTemplate: 'acc07a489a30192b4bf2bbdc587a889478fbf6fffbbc9353c7775c4ca1ec5011',
   getApplyChangeSkillTemplate: '0f5a15fc7fb9ad6059a5643d0e01365d27642637a4aaebf182f9eabb45348197',
   getFfChangeSkillTemplate: '20ebb682ba89809a100cd4985c074908df5bada2bd649ca1b0f4059a63a1c728',
   getSyncSpecsSkillTemplate: 'dc07ea0312687f3edc602329c889dbbab737c6d79327eb7a723553d346b43433',
   getOnboardSkillTemplate: 'bc2216b72724b01c3a733e63b8bf4aff457f561c0e9ff7288bdacc39780a37a7',
-  getOpsxExploreCommandTemplate: '7249617e9a467d5cce272a111ba81df91c769355a5c3f1cac411d1e86f04f7a6',
+  getOpsxExploreCommandTemplate: 'eef1f8b4fd90ade6d70be46f0f8c3e6722f221fed175a6f9cf626287ef504a94',
   getOpsxNewCommandTemplate: '57c600cce318d16b9b4308a18d0d983ea3c0673034e606a7cceec07b4c705e87',
   getOpsxContinueCommandTemplate: 'f63964fab7720ede097aa48808baff196c391b962930ca960459205c724800e5',
   getOpsxApplyCommandTemplate: 'daeb507206707169de73c828e199648dde5732cbc17791ef2a027adffd028574',
@@ -65,7 +65,7 @@ const EXPECTED_FUNCTION_HASHES: Record<string, string> = {
 };
 
 const EXPECTED_GENERATED_SKILL_CONTENT_HASHES: Record<string, string> = {
-  'openspec-explore': '72f601a1a2c2ec3ad939a6215fb06042aea7d59b5f227d29225350dbef418dc4',
+  'openspec-explore': 'c8de6033b2c78009647647c65a504e4ada1a3bdcee31aed38a4bf7d629513f6e',
   'openspec-new-change': 'd5b8909bea70a33b7a312b38ce204a91f40b6bb2bff12c4c06b3e11641b6a689',
   'openspec-continue-change': 'bdb8bbb6a768a741b05256effbc284d65ac6a45360b59c24b94198792d3d0ebf',
   'openspec-apply-change': '09c0e1cdf5ccc82416d0969d6bd715cc70616bdbc3531358a5c36057f78be55a',


### PR DESCRIPTION
Fixes #696.

**Status:** LGTM — guidance-only change to the explore skill and command templates. No CLI behavior, schema, parser, or architecture changes. Full suite green (2,032 passed; the only failures are the 17 known environment-only `zsh-installer` ones addressed by #1400).

## What was wrong

Explore was the only workflow that never saw the project's own context.

Every artifact-creating workflow (`propose`, `continue`, `ff`, …) gets the `context` and `rules` from the OpenSpec config injected for free, because they all call `openspec instructions <artifact-id> --change "<name>" --json`, which reads the project config internally.

Explore has no artifact and often no change name, so it never travels that path. At session start it ran only:

```bash
openspec list --json
```

That returns active changes and nothing else. So explore — the step where you do your thinking, before anything is written down — was blind to the project's declared tech stack, conventions, and constraints. It would happily reason toward a suggestion the project's own config rules out.

## How it was fixed

After the existing `openspec list --json` call, both the skill and the command surface now read the project's context:

> Then read the project's own context from the resolved root - `<root.path>/openspec/config.yaml` (or `config.yml`). Use the `root.path` returned above, and skip this if neither file exists:
> - `context`: project background - tech stack, conventions, constraints
> - `rules`: keyed by artifact id - the entries for an artifact apply only when you write that artifact
>
> Ground your thinking in these. They are constraints for you to follow, not content to reproduce: do NOT copy them into the conversation or into any artifact you create.

Four deliberate details:

- **Resolved through `root.path`, not a hardcoded path.** `openspec list --json` already reports the resolved root, so this works for stores and workspace planning homes. `<root.path>/openspec/config.*` is exactly what [`instructions.ts`](https://github.com/Fission-AI/OpenSpec/blob/main/src/commands/workflow/instructions.ts) does via `readProjectConfig(root.path)` for every other workflow.
- **Both filenames.** `resolveConfigFilePath` probes `config.yaml` then `config.yml`, and `init` returns `'exists'` for either — so a `.yml` project stays `.yml` forever. Naming only `.yaml` would have silently skipped context for those projects.
- **Rules stay scoped.** `rules` is `Record<artifactId, string[]>`; explore holds no artifact at startup, so the guidance is explicit that entries apply when writing that artifact.
- **Leakage wording matches house style.** Sibling templates and the instructions renderer forbid copying context/rules into the *artifact*, not just the chat. Since explore may create artifacts, the wording covers both.

## Proof it works

New focused test, `test/core/templates/explore.test.ts` — every assertion runs against **both** delivery surfaces (skill and command), since the two bodies must stay in contract:

```
✓ test/core/templates/explore.test.ts (5 tests)
  ✓ loads project context from the OpenSpec config at startup (#696)
  ✓ resolves the config through the reported root rather than assuming a repo-local path (#696)
  ✓ accepts config.yml as well as config.yaml (#696)
  ✓ scopes rules to the artifact they are keyed to (#696)
  ✓ treats project context as constraints that must not leak into output (#696)
```

Reverting the template change fails all five. Regenerated `skills/openspec-explore/SKILL.md` via `pnpm generate:skills` (verified byte-identical, generator is idempotent) and refreshed the three golden hashes in `skill-templates-parity.test.ts`, per the repo's template-change convention.

## Notes / nits

- Guidance-only: no runtime code path is touched. Worst case for any user is an extra file read that is explicitly skippable.
- The generated skill grows by ~390 bytes (11.4 KB → 11.8 KB, about 100 tokens).
- The paragraph appears twice in `explore.ts` because that file carries the skill body and the command body separately — matching how every other workflow template in this directory is structured.
- **Possible follow-up, deliberately out of scope:** `openspec context --json` already loads the parsed project config and discards it ([`context.ts`](https://github.com/Fission-AI/OpenSpec/blob/main/src/commands/context.ts) → `gatherRelationshipData`), but currently emits only `root`/`members`/`status`. Emitting `context` and `rules` there would let this template say `openspec context --json` like every other template uses a CLI call, instead of naming a config path. That is a public JSON-output contract change and a maintainer call, so it is not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Explore sessions now load project context and rules from `openspec/config.yaml` (or `config.yml`) at startup.
  * This context/rules grounding is applied consistently across the Explore skill and the `/opsx:explore` command.

* **Bug Fixes**
  * Template rendering now resolves config via the discovered project root path, avoiding repo-layout assumptions.

* **Documentation**
  * Updated Explore guidance to clarify how context and rules should be used (as constraints only).

* **Tests**
  * Added/updated coverage to confirm template contract parity, `config.yml` support, and correct root-path resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->