### PR TITLE
fix(init): only advertise slash commands the profile installs

### DIFF
--- a/.changeset/profile-aware-onboarding-commands.md
+++ b/.changeset/profile-aware-onboarding-commands.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+Only advertise onboarding commands that will actually exist. The `openspec init` welcome screen and the `openspec update` "Getting started" summary listed `/opsx:new` and `/opsx:continue`, which the default `core` profile never generates, so users were told to run commands that did not exist. Both surfaces now list the commands for the installed workflows. The `init` and `update` completion hints also name the skill (`/openspec-propose`) instead of a command for tools that receive no command files — Codex, and any tool under skills-only delivery.

--- a/src/core/init.ts
+++ b/src/core/init.ts
@@ -174,16 +174,18 @@ export class InitCommand {
       migrateIfNeeded(projectPath, detectedTools);
     }
 
+    // Validate profile override early so invalid values fail before tool setup.
+    // The resolved value is consumed later when generation reads effective config.
+    // This runs ahead of the welcome screen so an invalid --profile does not make
+    // the user press Enter before seeing the error.
+    this.resolveProfileOverride();
+
     // Show animated welcome screen (interactive mode only)
     const canPrompt = this.canPromptInteractively();
     if (canPrompt) {
       const { showWelcomeScreen } = await import('../ui/welcome-screen.js');
-      await showWelcomeScreen();
+      await showWelcomeScreen(this.getActiveWorkflows());
     }
-
-    // Validate profile override early so invalid values fail before tool setup.
-    // The resolved value is consumed later when generation reads effective config.
-    this.resolveProfileOverride();
 
     // Get tool states before processing
     const toolStates = getToolStates(projectPath);
@@ -246,6 +248,16 @@ export class InitCommand {
     }
 
     throw new Error(`Invalid profile "${this.profileOverride}". Available profiles: core, custom`);
+  }
+
+  /**
+   * Resolves the workflows the effective profile installs, so onboarding output
+   * only mentions commands that will actually exist.
+   */
+  private getActiveWorkflows(): string[] {
+    const globalCfg = getGlobalConfig();
+    const activeProfile: Profile = this.resolveProfileOverride() ?? globalCfg.profile ?? 'core';
+    return [...getProfileWorkflows(activeProfile, globalCfg.workflows)];
   }
 
   // ═══════════════════════════════════════════════════════════
@@ -865,12 +877,10 @@ export class InitCommand {
     }
 
     // Getting started (task 7.6: show propose if in profile)
-    const globalCfg = getGlobalConfig();
-    const activeProfile: Profile = (this.profileOverride as Profile) ?? globalCfg.profile ?? 'core';
-    const activeWorkflows = [...getProfileWorkflows(activeProfile, globalCfg.workflows)];
+    const activeWorkflows = this.getActiveWorkflows();
     // When no tool got /opsx:* commands, point at the skill instead of a
     // command that does not exist.
-    const activeDelivery: Delivery = globalCfg.delivery ?? 'both';
+    const activeDelivery: Delivery = getGlobalConfig().delivery ?? 'both';
     const commandsGenerated = successfulTools.some((tool) => shouldGenerateCommandsForTool(tool.value, activeDelivery));
     const skillsGenerated = successfulTools.some((tool) => shouldGenerateSkillsForTool(tool.value, activeDelivery));
     // Each hint line must be a usable instruction for the tool it serves.

--- a/src/core/onboarding-commands.ts
+++ b/src/core/onboarding-commands.ts
@@ -1,0 +1,50 @@
+/**
+ * Onboarding command hints.
+ *
+ * The commands shown to a user after setup must be limited to the workflows
+ * their profile actually installs, otherwise we advertise slash commands that
+ * were correctly never generated.
+ *
+ * This module decides WHICH hints to show. How each one is spelled for a given
+ * tool — command, skill, or a tool-specific skill prefix — is decided by
+ * src/utils/command-references.ts at the call site.
+ */
+
+import type { WorkflowId } from './profiles.js';
+
+export type OnboardingCommand = {
+  workflow: WorkflowId;
+  command: string;
+  description: string;
+};
+
+/**
+ * Longest description the welcome screen can render. It shows these beside a
+ * 24-column art column and only animates at MIN_WIDTH (60) columns or wider; a
+ * longer line wraps, and the animation's cursor-up count assumes unwrapped
+ * lines. See src/ui/welcome-screen.ts.
+ */
+export const DESCRIPTION_BUDGET = 17;
+
+/**
+ * Ordered onboarding hints. Each entry is shown only when its workflow is
+ * installed, so the list follows the change lifecycle: start, then build,
+ * then implement.
+ */
+const ONBOARDING_COMMANDS: readonly OnboardingCommand[] = [
+  { workflow: 'propose', command: '/opsx:propose', description: 'Start a change' },
+  { workflow: 'new', command: '/opsx:new', description: 'Scaffold a change' },
+  { workflow: 'continue', command: '/opsx:continue', description: 'Next artifact' },
+  { workflow: 'apply', command: '/opsx:apply', description: 'Implement tasks' },
+];
+
+/**
+ * Returns the onboarding hints for the installed workflows, in lifecycle order.
+ * Returns an empty array when none of the onboarding workflows are installed.
+ */
+export function getOnboardingCommands(
+  workflows: readonly string[]
+): OnboardingCommand[] {
+  const installed = new Set(workflows);
+  return ONBOARDING_COMMANDS.filter((entry) => installed.has(entry.workflow));
+}

--- a/src/core/update.ts
+++ b/src/core/update.ts
@@ -41,6 +41,7 @@ import {
 import { isInteractive } from '../utils/interactive.js';
 import { getGlobalConfig, type Delivery, type Profile } from './global-config.js';
 import { getProfileWorkflows, ALL_WORKFLOWS, CORE_WORKFLOWS } from './profiles.js';
+import { getOnboardingCommands } from './onboarding-commands.js';
 import { getAvailableTools } from './available-tools.js';
 import {
   WORKFLOW_TO_SKILL_DIR,
@@ -345,18 +346,27 @@ export class UpdateCommand {
         );
         return forms.size === 1 ? [...forms][0] : neutralForm;
       };
-      const entries: Array<[string, string]> = [
-        [referenceFor('/opsx:new'), 'Start a new change'],
-        [referenceFor('/opsx:continue'), 'Create the next artifact'],
-        [referenceFor('/opsx:apply'), 'Implement tasks'],
+      // Only hint at workflows these tools actually received. A legacy upgrade
+      // can install a narrower set than the profile (inferred Codex prompts).
+      const installedWorkflows = [
+        ...new Set(
+          newlyConfiguredTools.flatMap(
+            (toolId) => legacyWorkflowOverrides[toolId] ?? desiredWorkflows
+          )
+        ),
       ];
-      const width = Math.max(...entries.map(([reference]) => reference.length));
+      const entries: Array<[string, string]> = getOnboardingCommands(installedWorkflows).map(
+        ({ command, description }) => [referenceFor(command), description]
+      );
       console.log();
-      console.log(chalk.bold('Getting started:'));
-      for (const [reference, description] of entries) {
-        console.log(`  ${reference.padEnd(width)}  ${description}`);
+      if (entries.length > 0) {
+        const width = Math.max(...entries.map(([reference]) => reference.length));
+        console.log(chalk.bold('Getting started:'));
+        for (const [reference, description] of entries) {
+          console.log(`  ${reference.padEnd(width)}  ${description}`);
+        }
+        console.log();
       }
-      console.log();
       console.log(`Learn more: ${chalk.cyan('https://github.com/Fission-AI/OpenSpec')}`);
     }
 

--- a/src/ui/welcome-screen.ts
+++ b/src/ui/welcome-screen.ts
@@ -5,6 +5,7 @@
 
 import chalk from 'chalk';
 import { WELCOME_ANIMATION } from './ascii-patterns.js';
+import { getOnboardingCommands } from '../core/onboarding-commands.js';
 
 // Minimum terminal width for side-by-side layout
 const MIN_WIDTH = 60;
@@ -15,7 +16,19 @@ const ART_COLUMN_WIDTH = 24;
 /**
  * Welcome text content (right column)
  */
-function getWelcomeText(): string[] {
+function getWelcomeText(workflows: readonly string[]): string[] {
+  const onboardingCommands = getOnboardingCommands(workflows);
+  const quickStart: string[] = [];
+
+  if (onboardingCommands.length > 0) {
+    const commandWidth = Math.max(...onboardingCommands.map((c) => c.command.length));
+    quickStart.push(chalk.white('Quick start after setup:'));
+    for (const { command, description } of onboardingCommands) {
+      quickStart.push(`  ${chalk.yellow(command.padEnd(commandWidth + 1))} ${chalk.dim(description)}`);
+    }
+    quickStart.push('');
+  }
+
   return [
     chalk.white.bold('Welcome to OpenSpec'),
     chalk.dim('A lightweight spec-driven framework'),
@@ -24,11 +37,7 @@ function getWelcomeText(): string[] {
     chalk.dim('  • Agent Skills for AI tools'),
     chalk.dim('  • /opsx:* slash commands'),
     '',
-    chalk.white('Quick start after setup:'),
-    `  ${chalk.yellow('/opsx:new')}      ${chalk.dim('Create a change')}`,
-    `  ${chalk.yellow('/opsx:continue')} ${chalk.dim('Next artifact')}`,
-    `  ${chalk.yellow('/opsx:apply')}    ${chalk.dim('Implement tasks')}`,
-    '',
+    ...quickStart,
     chalk.cyan('Press Enter to select tools...'),
   ];
 }
@@ -107,8 +116,8 @@ async function waitForEnter(): Promise<void> {
  * Shows the animated welcome screen.
  * Returns when user presses Enter.
  */
-export async function showWelcomeScreen(): Promise<void> {
-  const textLines = getWelcomeText();
+export async function showWelcomeScreen(workflows: readonly string[]): Promise<void> {
+  const textLines = getWelcomeText(workflows);
 
   if (!canAnimate()) {
     // Fallback: show static welcome

--- a/test/core/init.test.ts
+++ b/test/core/init.test.ts
@@ -902,6 +902,9 @@ describe('InitCommand - profile and detection features', () => {
     await initCommand.execute(testDir);
 
     expect(showWelcomeScreenMock).toHaveBeenCalled();
+    // The welcome screen must be handed the profile's workflows, otherwise it
+    // advertises commands this profile never installs.
+    expect(showWelcomeScreenMock).toHaveBeenCalledWith(['explore', 'new']);
     expect(confirmMock).not.toHaveBeenCalled();
 
     const exploreSkill = path.join(testDir, '.claude', 'skills', 'openspec-explore', 'SKILL.md');

--- a/test/core/onboarding-commands.test.ts
+++ b/test/core/onboarding-commands.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DESCRIPTION_BUDGET,
+  getOnboardingCommands,
+} from '../../src/core/onboarding-commands.js';
+import { ALL_WORKFLOWS, CORE_WORKFLOWS } from '../../src/core/profiles.js';
+
+describe('getOnboardingCommands', () => {
+  it('omits commands the profile does not install', () => {
+    const commands = getOnboardingCommands(CORE_WORKFLOWS).map((c) => c.command);
+
+    expect(commands).toEqual(['/opsx:propose', '/opsx:apply']);
+    expect(commands).not.toContain('/opsx:new');
+    expect(commands).not.toContain('/opsx:continue');
+  });
+
+  it('includes expanded commands when a custom profile installs them', () => {
+    const commands = getOnboardingCommands(['new', 'continue', 'apply']).map((c) => c.command);
+
+    expect(commands).toEqual(['/opsx:new', '/opsx:continue', '/opsx:apply']);
+  });
+
+  it('returns lifecycle order regardless of the order workflows are given', () => {
+    const commands = getOnboardingCommands(['apply', 'continue', 'propose']).map((c) => c.command);
+
+    expect(commands).toEqual(['/opsx:propose', '/opsx:continue', '/opsx:apply']);
+  });
+
+  it('returns nothing when no onboarding workflow is installed', () => {
+    expect(getOnboardingCommands(['archive', 'sync'])).toEqual([]);
+    expect(getOnboardingCommands([])).toEqual([]);
+  });
+
+  it('keeps descriptions within the welcome screen width budget', () => {
+    // A longer description wraps the welcome screen at 60 columns, which desyncs
+    // its animation. See the width test in test/ui/welcome-screen.test.ts.
+    for (const { command, description } of getOnboardingCommands(ALL_WORKFLOWS)) {
+      expect(description.length, `${command} description is too long`).toBeLessThanOrEqual(
+        DESCRIPTION_BUDGET
+      );
+    }
+  });
+});

--- a/test/core/update.test.ts
+++ b/test/core/update.test.ts
@@ -1130,10 +1130,13 @@ ${OPENSPEC_MARKERS.end}
 
       // Legacy managed Codex prompt with codex not yet configured: the
       // upgrade newly configures codex, whose onboarding menu must not
-      // advertise /opsx:* commands (codex has no slash surface)
+      // advertise /opsx:* commands (codex has no slash surface).
+      // The prompt is opsx-new.md so the inferred workflow ('new') is one the
+      // onboarding menu actually lists — the menu is now filtered to the
+      // workflows the upgrade installed.
       const promptDir = path.join(process.env.CODEX_HOME!, 'prompts');
       await fs.mkdir(promptDir, { recursive: true });
-      await fs.writeFile(path.join(promptDir, 'opsx-explore.md'), 'legacy explore prompt');
+      await fs.writeFile(path.join(promptDir, 'opsx-new.md'), 'legacy new prompt');
 
       const consoleSpy = vi.spyOn(console, 'log');
       const forceUpdateCommand = new UpdateCommand({ force: true });
@@ -1143,12 +1146,15 @@ ${OPENSPEC_MARKERS.end}
       consoleSpy.mockRestore();
 
       expect(logCalls.some((entry) => entry.includes('Getting started'))).toBe(true);
-      const menuLines = logCalls.filter((entry) => entry.includes('Start a new change'));
+      const menuLines = logCalls.filter((entry) => entry.includes('Scaffold a change'));
       expect(menuLines).toHaveLength(1);
       expect(menuLines[0]).toContain('the openspec-new-change skill');
       expect(logCalls.some((entry) => entry.includes('/opsx:new'))).toBe(false);
       expect(logCalls.some((entry) => entry.includes('/opsx:continue'))).toBe(false);
       expect(logCalls.some((entry) => entry.includes('/opsx:apply'))).toBe(false);
+      // Only the inferred workflow is advertised, not the rest of the profile
+      expect(logCalls.some((entry) => entry.includes('Next artifact'))).toBe(false);
+      expect(logCalls.some((entry) => entry.includes('Implement tasks'))).toBe(false);
     });
 
     it('should preserve legacy Codex prompts when a configured Codex tool lacks the replacement workflow', async () => {
@@ -1433,13 +1439,19 @@ More user content after markers.
         expect.stringContaining('Claude Code')
       );
 
-      // Should show getting started message for newly configured tools
+      // Should show getting started message for newly configured tools,
+      // limited to the commands the core profile installs (not new/continue)
       expect(consoleSpy).toHaveBeenCalledWith(
         expect.stringContaining('Getting started')
       );
       expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining('/opsx:new')
+        expect.stringContaining('/opsx:propose')
       );
+      const gettingStartedCalls = consoleSpy.mock.calls
+        .map((call) => call.map((arg) => String(arg)).join(' '))
+        .join('\n');
+      expect(gettingStartedCalls).not.toContain('/opsx:new');
+      expect(gettingStartedCalls).not.toContain('/opsx:continue');
 
       // Skills should be created
       const skillFile = path.join(testDir, '.claude', 'skills', 'openspec-explore', 'SKILL.md');
@@ -1574,6 +1586,35 @@ More user content after markers.
       expect(consoleSpy).toHaveBeenCalledWith(
         expect.stringContaining('Getting started')
       );
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should list the expanded commands a custom profile installs', async () => {
+      setMockConfig({
+        featureFlags: {},
+        profile: 'custom',
+        delivery: 'both',
+        workflows: ['new', 'continue', 'apply'],
+      });
+
+      const legacyCommandDir = path.join(testDir, '.claude', 'commands', 'openspec');
+      await fs.mkdir(legacyCommandDir, { recursive: true });
+      await fs.writeFile(
+        path.join(legacyCommandDir, 'proposal.md'),
+        'old command content'
+      );
+
+      const consoleSpy = vi.spyOn(console, 'log');
+
+      await new UpdateCommand({ force: true }).execute(testDir);
+
+      const output = consoleSpy.mock.calls
+        .map((call) => call.map((arg) => String(arg)).join(' '))
+        .join('\n');
+      expect(output).toContain('/opsx:new');
+      expect(output).toContain('/opsx:continue');
+      expect(output).not.toContain('/opsx:propose');
 
       consoleSpy.mockRestore();
     });

--- a/test/ui/welcome-screen.test.ts
+++ b/test/ui/welcome-screen.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ALL_WORKFLOWS, CORE_WORKFLOWS } from '../../src/core/profiles.js';
 
 const { useKeypressMock } = vi.hoisted(() => ({
   useKeypressMock: vi.fn(),
@@ -25,13 +26,22 @@ describe('welcome screen', () => {
   const originalStdinIsTTY = process.stdin.isTTY;
   const originalStdoutIsTTY = process.stdout.isTTY;
   const originalColumns = process.stdout.columns;
+  let writeSpy: ReturnType<typeof vi.spyOn<typeof process.stdout, 'write'>>;
+
+  const writtenOutput = () =>
+    writeSpy.mock.calls.map((call) => String(call[0])).join('');
+
+  // The animated path paints on a timer, so assert against the static fallback.
+  const renderStatically = () => {
+    Object.defineProperty(process.stdout, 'isTTY', { value: false, configurable: true });
+  };
 
   beforeEach(() => {
     delete process.env.NO_COLOR;
     Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
     Object.defineProperty(process.stdout, 'isTTY', { value: true, configurable: true });
     Object.defineProperty(process.stdout, 'columns', { value: 100, configurable: true });
-    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
     useKeypressMock.mockClear();
   });
 
@@ -50,8 +60,63 @@ describe('welcome screen', () => {
   it('uses an Inquirer prompt to wait for Enter', async () => {
     const { showWelcomeScreen } = await import('../../src/ui/welcome-screen.js');
 
-    await showWelcomeScreen();
+    await showWelcomeScreen(CORE_WORKFLOWS);
 
     expect(useKeypressMock).toHaveBeenCalledOnce();
+  });
+
+  it('only advertises commands the profile installs', async () => {
+    const { showWelcomeScreen } = await import('../../src/ui/welcome-screen.js');
+    renderStatically();
+
+    await showWelcomeScreen(CORE_WORKFLOWS);
+
+    const output = writtenOutput();
+
+    expect(output).toContain('/opsx:propose');
+    expect(output).toContain('/opsx:apply');
+    expect(output).not.toContain('/opsx:new');
+    expect(output).not.toContain('/opsx:continue');
+  });
+
+  it('advertises expanded commands when a custom profile installs them', async () => {
+    const { showWelcomeScreen } = await import('../../src/ui/welcome-screen.js');
+    renderStatically();
+
+    await showWelcomeScreen(['new', 'continue', 'apply']);
+
+    const output = writtenOutput();
+
+    expect(output).toContain('/opsx:new');
+    expect(output).toContain('/opsx:continue');
+    expect(output).not.toContain('/opsx:propose');
+  });
+
+  it('omits the quick start block when no onboarding workflow is installed', async () => {
+    const { showWelcomeScreen } = await import('../../src/ui/welcome-screen.js');
+    renderStatically();
+
+    await showWelcomeScreen(['archive']);
+
+    const output = writtenOutput();
+
+    expect(output).toContain('Welcome to OpenSpec');
+    expect(output).not.toContain('Quick start after setup:');
+  });
+
+  it('keeps every rendered line inside the animation width budget', async () => {
+    const { showWelcomeScreen } = await import('../../src/ui/welcome-screen.js');
+    renderStatically();
+
+    // The animated path moves the cursor up a fixed count of logical lines, so a
+    // line that wraps at the narrowest animating terminal (MIN_WIDTH = 60) makes
+    // each frame redraw lower than the last. Worst case is every command shown.
+    await showWelcomeScreen(ALL_WORKFLOWS);
+
+    const rendered = writtenOutput().replace(/\x1b\[[0-9;]*[A-Za-z]/g, '');
+
+    for (const line of rendered.split('\n')) {
+      expect(line.length).toBeLessThanOrEqual(59);
+    }
   });
 });


### PR DESCRIPTION
**Status:** LGTM — ready for review.

Fixes #1409

> **Stacked on #1404** (approved, mergeable). Base is `fix/adapterless-skill-references`; merge that first, then this retargets to `main`. The two are complementary: **#1404 decides how a hint is spelled** for each tool, **this PR decides which hints appear.**

## What was wrong

Two onboarding surfaces told users to run `/opsx:new` and `/opsx:continue`. Neither is in the default `core` profile (`propose/explore/apply/update/sync/archive`), so OpenSpec never generates them. Users followed the instructions, the command wasn't there, and it looked like the install had failed.

`openspec update` before this change — not one of the three listed commands matches what was installed:

```
Getting started:
  /opsx:new       Start a new change
  /opsx:continue  Create the next artifact
  /opsx:apply     Implement tasks
```
```
$ ls .claude/commands/opsx/
apply.md  archive.md  explore.md  propose.md  sync.md  update.md
```

The same three appear on the `init` welcome screen. Note #1404 rewrites this same block to fix the *reference form* but keeps the three hardcoded workflows, so the bug survives it.

## How it was fixed

`getOnboardingCommands()` holds the hints in lifecycle order and returns only those whose workflow is installed. Both surfaces print its result, then hand each one to #1404's `referenceFor`/`printStartHints` for spelling. After, on `core`:

```
Getting started:
  /opsx:propose  Start a change
  /opsx:apply    Implement tasks
```

A custom profile still sees its own:

```
Getting started:
  /opsx:new       Scaffold a change
  /opsx:continue  Next artifact
  /opsx:apply     Implement tasks
```

Two subtleties:

- **`update` filters by what was installed, not by the profile.** A legacy upgrade infers Codex's workflows from its prompt filenames, so that tool can receive a narrower set. The menu lists the union of what the newly configured tools actually got.
- **The welcome screen is width-constrained.** It renders beside a 24-column art column and only animates at 60 columns or wider, and the animation moves the cursor up a fixed count of *logical* lines — a wrapped line desyncs it and the frame walks down the screen. Descriptions are capped at `DESCRIPTION_BUDGET` so the widest rendered line stays at 59, the budget the screen has always kept.

Also: `--profile` is now validated before the welcome screen instead of being cast, so an invalid value fails before the user presses Enter rather than after. (`getProfileWorkflows` never throws on an unknown profile — anything that isn't literally `'custom'` returns `CORE_WORKFLOWS` — so the old cast silently rendered a plausible core screen.)

## Proof it works

Real output from the built CLI, three tool surfaces:

| Setup | Hint printed | On disk |
|---|---|---|
| `--tools claude` (delivery `both`) | `/opsx:propose "your idea"` | `.claude/commands/opsx/propose.md` |
| `--tools kimi` (no adapter) | `/skill:openspec-propose "your idea"` | skills only, commands skipped |
| `--tools claude`, delivery `skills` | `/openspec-propose "your idea"` | no commands directory at all |

- `test/core/onboarding-commands.test.ts` — core yields `propose`/`apply`; a custom profile yields `new`/`continue`; order is stable; empty when nothing applies; descriptions stay within the width budget.
- `test/ui/welcome-screen.test.ts` — the rendered screen contains the installed commands and not the others, drops the quick-start block entirely when none apply, and no rendered line exceeds 59 columns.
- `test/core/update.test.ts` — the legacy-upgrade test asserted `/opsx:new`, i.e. it pinned the bug; it now asserts `/opsx:propose` and the absence of `new`/`continue`. Added a custom-profile case. #1404's Codex menu test now uses an `opsx-new.md` fixture so it still proves the skill-reference form under filtering, and additionally asserts the rest of the profile is *not* advertised.
- `test/core/init.test.ts` — pins that `showWelcomeScreen` receives the profile's workflows, so the wiring can't silently regress.
- Each new assertion was mutation-checked: reverting the matching source change makes it fail.
- Full suite **2,056 passing**; the 17 `zsh-installer` failures are the known local Oh My Zsh issue (#1400), unaffected in CI. `tsc` clean, lint clean, `madge --circular dist/` clean.

## Notes / nits

- **Overlaps #962.** That draft touches the same files as part of a larger onboarding rework. Draft and conflicting with `main` since May 28. Happy to close this if #962 is rebased and landed instead.
- **The welcome screen still says `/opsx:*`.** It renders before tool selection, so only `delivery` is knowable there, and skill names do not fit the layout: `/openspec-continue-change` puts the line at 70 columns against the 59 budget. Redesigning that is #962's territory. The `init` and `update` completion hints, which do know their tools, go through #1404.
- `showWelcomeScreen()` now takes the active workflows. It is not re-exported from the package entry point, so this is not a public API change.
- Scope limit: the same bug class exists in the apply template (#963); PR #1096 already claims it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Onboarding and “Getting started” guidance now reflects the workflows installed in the active profile.
  - Welcome screens dynamically list available commands and provide tool-appropriate instructions.
  - Added clearer restart guidance for command-based and skills-based setups.

- **Bug Fixes**
  - Removed misleading commands that were not available for certain profiles or tools.
  - Updated legacy upgrade messaging to show only applicable workflows.

- **Tests**
  - Added coverage for profile-specific onboarding commands and welcome-screen output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->