### PR TITLE
test(cli): invoke the CLI without a shell

### DIFF
--- a/test/commands/change.interactive-show.test.ts
+++ b/test/commands/change.interactive-show.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { promises as fs } from 'fs';
 import path from 'path';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 
 describe('change show (interactive behavior)', () => {
   const projectRoot = process.cwd();
@@ -29,7 +29,7 @@ describe('change show (interactive behavior)', () => {
       process.env.OPEN_SPEC_INTERACTIVE = '0';
       let err: any;
       try {
-        execSync(`node ${bin} change show`, { encoding: 'utf-8' });
+        execFileSync('node', [bin, 'change', 'show'], { encoding: 'utf-8' });
       } catch (e) { err = e; }
       expect(err).toBeDefined();
       expect(err.status).not.toBe(0);

--- a/test/commands/change.interactive-validate.test.ts
+++ b/test/commands/change.interactive-validate.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { promises as fs } from 'fs';
 import path from 'path';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 
 // Note: We cannot truly simulate TTY prompts in this test runner easily.
 // Instead, we verify non-interactive fallback behavior and basic invocation.
@@ -32,7 +32,7 @@ describe('change validate (interactive behavior)', () => {
       process.env.OPEN_SPEC_INTERACTIVE = '0';
       let err: any;
       try {
-        execSync(`node ${bin} change validate`, { encoding: 'utf-8' });
+        execFileSync('node', [bin, 'change', 'validate'], { encoding: 'utf-8' });
       } catch (e) { err = e; }
       expect(err).toBeDefined();
       expect(err.status).not.toBe(0);

--- a/test/commands/show.test.ts
+++ b/test/commands/show.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { promises as fs } from 'fs';
 import path from 'path';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 
 describe('top-level show command', () => {
   const projectRoot = process.cwd();
@@ -36,7 +36,7 @@ describe('top-level show command', () => {
       process.env.OPEN_SPEC_INTERACTIVE = '0';
       let err: any;
       try {
-        execSync(`node ${openspecBin} show`, { encoding: 'utf-8' });
+        execFileSync('node', [openspecBin, 'show'], { encoding: 'utf-8' });
       } catch (e) { err = e; }
       expect(err).toBeDefined();
       expect(err.status).not.toBe(0);
@@ -55,7 +55,7 @@ describe('top-level show command', () => {
     const originalCwd = process.cwd();
     try {
       process.chdir(testDir);
-      const output = execSync(`node ${openspecBin} show demo --json`, { encoding: 'utf-8' });
+      const output = execFileSync('node', [openspecBin, 'show', 'demo', '--json'], { encoding: 'utf-8' });
       const json = JSON.parse(output);
       expect(json.id).toBe('demo');
       expect(Array.isArray(json.deltas)).toBe(true);
@@ -68,7 +68,7 @@ describe('top-level show command', () => {
     const originalCwd = process.cwd();
     try {
       process.chdir(testDir);
-      const output = execSync(`node ${openspecBin} show auth --json --requirements`, { encoding: 'utf-8' });
+      const output = execFileSync('node', [openspecBin, 'show', 'auth', '--json', '--requirements'], { encoding: 'utf-8' });
       const json = JSON.parse(output);
       expect(json.id).toBe('auth');
       expect(Array.isArray(json.requirements)).toBe(true);
@@ -89,7 +89,7 @@ describe('top-level show command', () => {
       process.chdir(testDir);
       let err: any;
       try {
-        execSync(`node ${openspecBin} show foo`, { encoding: 'utf-8' });
+        execFileSync('node', [openspecBin, 'show', 'foo'], { encoding: 'utf-8' });
       } catch (e) { err = e; }
       expect(err).toBeDefined();
       expect(err.status).not.toBe(0);
@@ -107,7 +107,7 @@ describe('top-level show command', () => {
       process.chdir(testDir);
       let err: any;
       try {
-        execSync(`node ${openspecBin} show unknown-item`, { encoding: 'utf-8' });
+        execFileSync('node', [openspecBin, 'show', 'unknown-item'], { encoding: 'utf-8' });
       } catch (e) { err = e; }
       expect(err).toBeDefined();
       expect(err.status).not.toBe(0);

--- a/test/commands/spec.interactive-show.test.ts
+++ b/test/commands/spec.interactive-show.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { promises as fs } from 'fs';
 import path from 'path';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 
 describe('spec show (interactive behavior)', () => {
   const projectRoot = process.cwd();
@@ -29,7 +29,7 @@ describe('spec show (interactive behavior)', () => {
       process.env.OPEN_SPEC_INTERACTIVE = '0';
       let err: any;
       try {
-        execSync(`node ${bin} spec show`, { encoding: 'utf-8' });
+        execFileSync('node', [bin, 'spec', 'show'], { encoding: 'utf-8' });
       } catch (e) { err = e; }
       expect(err).toBeDefined();
       expect(err.status).not.toBe(0);

--- a/test/commands/spec.interactive-validate.test.ts
+++ b/test/commands/spec.interactive-validate.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { promises as fs } from 'fs';
 import path from 'path';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 
 describe('spec validate (interactive behavior)', () => {
   const projectRoot = process.cwd();
@@ -29,7 +29,7 @@ describe('spec validate (interactive behavior)', () => {
       process.env.OPEN_SPEC_INTERACTIVE = '0';
       let err: any;
       try {
-        execSync(`node ${bin} spec validate`, { encoding: 'utf-8' });
+        execFileSync('node', [bin, 'spec', 'validate'], { encoding: 'utf-8' });
       } catch (e) { err = e; }
       expect(err).toBeDefined();
       expect(err.status).not.toBe(0);

--- a/test/commands/spec.test.ts
+++ b/test/commands/spec.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { promises as fs } from 'fs';
 import path from 'path';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 
 describe('spec command', () => {
   const projectRoot = process.cwd();
@@ -59,7 +59,7 @@ The system SHALL process credit card payments securely`;
       const originalCwd = process.cwd();
       try {
         process.chdir(testDir);
-        const output = execSync(`node ${openspecBin} spec show auth`, {
+        const output = execFileSync('node', [openspecBin, 'spec', 'show', 'auth'], {
           encoding: 'utf-8'
         });
         
@@ -75,7 +75,7 @@ The system SHALL process credit card payments securely`;
       const originalCwd = process.cwd();
       try {
         process.chdir(testDir);
-        const output = execSync(`node ${openspecBin} spec show auth --json`, {
+        const output = execFileSync('node', [openspecBin, 'spec', 'show', 'auth', '--json'], {
           encoding: 'utf-8'
         });
         
@@ -94,7 +94,7 @@ The system SHALL process credit card payments securely`;
       const originalCwd = process.cwd();
       try {
         process.chdir(testDir);
-        const output = execSync(`node ${openspecBin} spec show auth --json --requirements`, {
+        const output = execFileSync('node', [openspecBin, 'spec', 'show', 'auth', '--json', '--requirements'], {
           encoding: 'utf-8'
         });
         
@@ -111,7 +111,7 @@ The system SHALL process credit card payments securely`;
       const originalCwd = process.cwd();
       try {
         process.chdir(testDir);
-        const output = execSync(`node ${openspecBin} spec show auth --json --no-scenarios`, {
+        const output = execFileSync('node', [openspecBin, 'spec', 'show', 'auth', '--json', '--no-scenarios'], {
           encoding: 'utf-8'
         });
         
@@ -127,7 +127,7 @@ The system SHALL process credit card payments securely`;
       const originalCwd = process.cwd();
       try {
         process.chdir(testDir);
-        const output = execSync(`node ${openspecBin} spec show auth --json -r 1`, {
+        const output = execFileSync('node', [openspecBin, 'spec', 'show', 'auth', '--json', '-r', '1'], {
           encoding: 'utf-8'
         });
         
@@ -143,7 +143,7 @@ The system SHALL process credit card payments securely`;
       const originalCwd = process.cwd();
       try {
         process.chdir(testDir);
-        const output = execSync(`node ${openspecBin} spec show auth --json --no-scenarios`, {
+        const output = execFileSync('node', [openspecBin, 'spec', 'show', 'auth', '--json', '--no-scenarios'], {
           encoding: 'utf-8'
         });
         
@@ -161,7 +161,7 @@ The system SHALL process credit card payments securely`;
       const originalCwd = process.cwd();
       try {
         process.chdir(testDir);
-        const output = execSync(`node ${openspecBin} spec list`, {
+        const output = execFileSync('node', [openspecBin, 'spec', 'list'], {
           encoding: 'utf-8'
         });
         
@@ -178,7 +178,7 @@ The system SHALL process credit card payments securely`;
       const originalCwd = process.cwd();
       try {
         process.chdir(testDir);
-        const output = execSync(`node ${openspecBin} spec list --json`, {
+        const output = execFileSync('node', [openspecBin, 'spec', 'list', '--json'], {
           encoding: 'utf-8'
         });
         
@@ -198,7 +198,7 @@ The system SHALL process credit card payments securely`;
       const originalCwd = process.cwd();
       try {
         process.chdir(testDir);
-        const output = execSync(`node ${openspecBin} spec validate auth`, {
+        const output = execFileSync('node', [openspecBin, 'spec', 'validate', 'auth'], {
           encoding: 'utf-8'
         });
         
@@ -212,7 +212,7 @@ The system SHALL process credit card payments securely`;
       const originalCwd = process.cwd();
       try {
         process.chdir(testDir);
-        const output = execSync(`node ${openspecBin} spec validate auth --json`, {
+        const output = execFileSync('node', [openspecBin, 'spec', 'validate', 'auth', '--json'], {
           encoding: 'utf-8'
         });
         
@@ -231,7 +231,7 @@ The system SHALL process credit card payments securely`;
       const originalCwd = process.cwd();
       try {
         process.chdir(testDir);
-        const output = execSync(`node ${openspecBin} spec validate auth --strict --json`, {
+        const output = execFileSync('node', [openspecBin, 'spec', 'validate', 'auth', '--strict', '--json'], {
           encoding: 'utf-8'
         });
         
@@ -259,7 +259,7 @@ This section has no actual requirements`;
         // This should exit with non-zero code
         let exitCode = 0;
         try {
-          execSync(`node ${openspecBin} spec validate invalid`, {
+          execFileSync('node', [openspecBin, 'spec', 'validate', 'invalid'], {
             encoding: 'utf-8'
           });
         } catch (error: any) {
@@ -281,7 +281,7 @@ This section has no actual requirements`;
         
         let error: any;
         try {
-          execSync(`node ${openspecBin} spec show nonexistent`, {
+          execFileSync('node', [openspecBin, 'spec', 'show', 'nonexistent'], {
             encoding: 'utf-8'
           });
         } catch (e) {
@@ -301,7 +301,7 @@ This section has no actual requirements`;
       const originalCwd = process.cwd();
       try {
         process.chdir(testDir);
-        const output = execSync(`node ${openspecBin} spec list`, { encoding: 'utf-8' });
+        const output = execFileSync('node', [openspecBin, 'spec', 'list'], { encoding: 'utf-8' });
         expect(output.trim()).toBe('No items found');
       } finally {
         process.chdir(originalCwd);
@@ -312,7 +312,7 @@ This section has no actual requirements`;
       const originalCwd = process.cwd();
       try {
         process.chdir(testDir);
-        const output = execSync(`node ${openspecBin} --no-color spec list --long`, { encoding: 'utf-8' });
+        const output = execFileSync('node', [openspecBin, '--no-color', 'spec', 'list', '--long'], { encoding: 'utf-8' });
         // Basic ANSI escape pattern
         const hasAnsi = /\u001b\[[0-9;]*m/.test(output);
         expect(hasAnsi).toBe(false);

--- a/test/commands/validate.enriched-output.test.ts
+++ b/test/commands/validate.enriched-output.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { promises as fs } from 'fs';
 import path from 'path';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 
 describe('validate command enriched human output', () => {
   const projectRoot = process.cwd();
@@ -31,7 +31,7 @@ describe('validate command enriched human output', () => {
       let code = 0;
       let stderr = '';
       try {
-        execSync(`node ${bin} change validate ${changeId}`, { encoding: 'utf-8', stdio: 'pipe' });
+        execFileSync('node', [bin, 'change', 'validate', changeId], { encoding: 'utf-8', stdio: 'pipe' });
       } catch (e: any) {
         code = e?.status ?? 1;
         stderr = e?.stderr?.toString?.() ?? '';


### PR DESCRIPTION
**Status:** Test-only. Clears the last 25 code scanning alerts.

## What was wrong

Twenty-five test call sites built a command string and handed it to `execSync`, which runs it through a shell:

```js
execSync(`node ${openspecBin} spec show auth --json`, { encoding: 'utf-8' })
```

The interpolated value is a constant path in every case, so nothing was exploitable. But it is the pattern CodeQL reports as `js/shell-command-injection-from-environment`, and it accounts for **every remaining alert on the repository**.

## How it was fixed

Each call passes an argument array to `execFileSync`, which never involves a shell:

```js
execFileSync('node', [openspecBin, 'spec', 'show', 'auth', '--json'], { encoding: 'utf-8' })
```

| File | Calls |
| --- | --- |
| `test/commands/spec.test.ts` | 15 |
| `test/commands/show.test.ts` | 5 |
| `test/commands/validate.enriched-output.test.ts` | 1 |
| `test/commands/spec.interactive-show.test.ts` | 1 |
| `test/commands/spec.interactive-validate.test.ts` | 1 |
| `test/commands/change.interactive-show.test.ts` | 1 |
| `test/commands/change.interactive-validate.test.ts` | 1 |

## Why this is safe

- **Nothing ships.** `test/` is not in `package.json` `files`. Packing the tarball gives 362 files, zero from `test/`.
- **No shell features to lose.** Every command was `node ${bin}` followed by plain literal arguments or one simple variable — no pipes, redirects, chaining, or globs.
- **Error handling is unchanged.** Both APIs reject with the same `spawnSync` error carrying `status` and `stderr`, which these tests assert on. The error-path tests pass, which is direct evidence the subprocess still runs and still fails as expected.
- A path containing spaces is now passed as one argument instead of being word-split — more correct, and no test depends on the old behavior.

## Proof

| Check | Result |
| --- | --- |
| Full suite | 2196 pass, 111 files — identical count, nothing skipped or lost |
| The 7 converted files | 25 tests pass, real subprocess timings (~330-400ms each) |
| Build / lint | clean (one pre-existing warning, untouched) |
| `execSync` remaining in these files | none |

No changeset: test-only, nothing to release.

## Note

Unlike the guard change in #1425, this one is a categorical fix rather than a bet on the analyzer's dataflow. `js/shell-command-injection-from-environment` targets shell-invoking APIs; `execFileSync` without `shell: true` is not one, so the rule should no longer apply at all. Still only confirmable once CodeQL re-analyzes `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved CLI test execution reliability by using direct process invocation instead of shell command strings.
  * Preserved coverage for successful output, validation failures, missing arguments, JSON responses, and error messages across show, list, and validate commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->