### PR TITLE
fix(website): show openspec init in the homepage getting-started box

### DIFF
--- a/website/app/(home)/page.tsx
+++ b/website/app/(home)/page.tsx
@@ -618,9 +618,15 @@ function FinalCta() {
         Works with 30+ AI assistants — Claude Code, Cursor, Codex, Windsurf,
         Gemini CLI, and more.
       </p>
-      <div className="mt-8 inline-flex items-center gap-2 rounded-lg border border-fd-border bg-fd-card px-4 py-3 font-mono text-sm">
-        <span className="text-fd-muted-foreground">$</span>
-        npm install -g @fission-ai/openspec@latest
+      <div className="mt-8 inline-flex flex-col gap-1 rounded-lg border border-fd-border bg-fd-card px-4 py-3 text-left font-mono text-sm">
+        <div className="flex items-center gap-2">
+          <span className="text-fd-muted-foreground">$</span>
+          npm install -g @fission-ai/openspec@latest
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-fd-muted-foreground">$</span>
+          cd your-project &amp;&amp; openspec init
+        </div>
       </div>
       <div className="mt-8">
         <Link


### PR DESCRIPTION
**Status:** Ready. Surgical, website-copy only — no CLI behavior, tests, or generated assets touched.

**What was wrong:** The homepage's final call-to-action ("Ship your first change in five minutes") shows a single command box containing only `npm install -g @fission-ai/openspec@latest`. As #1282 reports, that command installs the CLI but "does nothing by itself" — a new user who copies it gets no scaffolding and nothing to run. The README already documents the real flow (install → `cd your-project` → `openspec init`); the landing page didn't.

**How it was fixed:** Added the second step to the box so it reads:

```
$ npm install -g @fission-ai/openspec@latest
$ cd your-project && openspec init
```

The box becomes a stacked two-line block (`flex-col`, left-aligned) and keeps the exact same card styling. No other content changed.

**Proof:** `npx tsc --noEmit` in `website/` passes clean. Change is confined to the `FinalCta` component in `website/app/(home)/page.tsx`; built output under `website/out/` is gitignored and untouched.

**Notes:** Matches the canonical README wording verbatim. No design/architecture change, no golden-hash or template impact.

Closes #1282

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved the installation snippet layout in the final call-to-action section.
  * Commands are now displayed in separate, vertically stacked rows with left alignment for clearer spacing and improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->