### PR TITLE
chore: route reviews to maintainer team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default code ownership
-* @TabishB
+* @Fission-AI/openspec-maintainers

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,6 +7,7 @@ People who maintain and guide OpenSpec.
 | Name | GitHub | Role |
 |------|--------|------|
 | Tabish Bidiwale | [@TabishB](https://github.com/TabishB) | Lead maintainer |
+| Clay Good | [@clay-good](https://github.com/clay-good) | Maintainer |
 
 ## Advisors
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,6 +9,12 @@ People who maintain and guide OpenSpec.
 | Tabish Bidiwale | [@TabishB](https://github.com/TabishB) | Lead maintainer |
 | Clay Good | [@clay-good](https://github.com/clay-good) | Maintainer |
 
+## Automation Maintainers
+
+| Name | GitHub | Role |
+|------|--------|------|
+| Alfred | [@alfred-openspec](https://github.com/alfred-openspec) | Automation maintainer |
+
 ## Advisors
 
 Advisors help shape technical direction and provide guidance to the project.


### PR DESCRIPTION
## What changed

- route repository-wide code ownership to `@Fission-AI/openspec-maintainers`
- add Clay Good to the documented core maintainers

## Why

Review requests currently route only to Tabish. The new visible maintainer team has Maintain access to OpenSpec and is configured to auto-assign one reviewer using load balancing.

## Impact

Once merged, new ready-for-review pull requests will route to an available maintainer instead of always requesting Tabish. The existing one-approval policy remains unchanged.

## Validation

- `git diff --check`
- verified the team is visible
- verified the team has Maintain repository access
- verified auto-assignment is enabled for one load-balanced reviewer


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the project’s core maintainer listing to include Clay Good.
* **Chores**
  * Updated repository code ownership defaults to reflect the current maintainers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->