### PR TITLE
fix(schema): validate artifacts before forced init

### DIFF
--- a/.changeset/schema-init-validates-before-force.md
+++ b/.changeset/schema-init-validates-before-force.md
@@ -1,0 +1,7 @@
+---
+"@fission-ai/openspec": patch
+---
+
+### Bug Fixes
+
+- Preserve an existing project-local schema when `openspec schema init --force` rejects an unknown artifact ID. Forced replacement now begins only after artifact validation succeeds.

--- a/openspec/changes/fix-schema-init-force-validation-order/.openspec.yaml
+++ b/openspec/changes/fix-schema-init-force-validation-order/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-26

--- a/openspec/changes/fix-schema-init-force-validation-order/design.md
+++ b/openspec/changes/fix-schema-init-force-validation-order/design.md
@@ -1,0 +1,53 @@
+## Context
+
+The `schema init` action currently checks whether the destination exists and, when `--force` is present, immediately removes that directory. Only afterward does it collect the remaining inputs and validate `--artifacts`. An unknown artifact therefore produces the expected error only after the existing schema has already been deleted.
+
+The command is implemented as one Commander action in `src/commands/schema.ts`. Its current tests largely exercise supporting schema functions or manually create expected files instead of invoking the registered command, so they do not observe mutation ordering.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Finish collecting and validating schema-init inputs before any forced replacement mutates the destination.
+- Preserve the complete existing schema when an artifact ID is invalid.
+- Keep error output, exit status, and successful `--force` replacement behavior compatible.
+- Cover the behavior through the real registered `schema init` command on cross-platform temporary paths.
+
+**Non-Goals:**
+
+- Change the set of artifact IDs accepted by `schema init` or how the comma-separated list is parsed.
+- Make replacement transactional for filesystem failures that occur after validation succeeds.
+- Change overwrite behavior in other schema subcommands.
+
+## Decisions
+
+### Separate preparation from destination mutation
+
+The action will retain the early destination-exists check so an invocation without `--force` still fails without prompting or doing extra work. When overwrite is allowed, it will defer `fs.rmSync()` until after the command has:
+
+1. Determined interactive or non-interactive mode.
+2. Collected the description and artifact selection.
+3. Rejected an empty selection or unknown artifact ID.
+4. Constructed the artifact definitions and in-memory schema object.
+
+Only then will the command remove the existing directory and write the replacement.
+
+This directly fixes the deterministic validation failure without introducing temporary-directory swaps or rollback machinery. Staging and atomically swapping the entire schema was considered, but it would broaden this targeted fix to cover unrelated filesystem failures and platform-specific rename behavior.
+
+### Preserve the existing failure contract
+
+Invalid artifacts will continue to produce the same text or JSON error, set a non-zero exit code, and report the valid artifact IDs. The only observable difference is that an existing destination remains unchanged.
+
+Keeping the output contract stable limits the change for scripts and agents that already consume the JSON response.
+
+### Add command-level regression tests
+
+Tests will register `schema` on a fresh Commander program and call `parseAsync()` with real command arguments inside a temporary project directory. The primary regression test will place a sentinel file in an existing schema, invoke `schema init --force` with an unknown artifact, and verify that both the directory and sentinel content survive.
+
+A successful overwrite test will use valid artifact IDs and verify that the old sentinel is removed while the expected generated files exist. Paths will be constructed with Node.js `path` helpers so the same tests run on Windows, macOS, and Linux.
+
+## Risks / Trade-offs
+
+- **Risk: Moving mutation later could accidentally weaken successful overwrite behavior.** Mitigation: Keep a positive command-level test that proves a valid forced initialization still replaces the destination.
+- **Risk: Commander tests can leak `process.exitCode` or the working directory into neighboring tests.** Mitigation: Save and restore process state in test setup and teardown.
+- **Trade-off: A write failure after validation can still leave a partial replacement.** Mitigation: Treat full transactional replacement as a separate hardening effort; this change guarantees safety for input and selection failures only.

--- a/openspec/changes/fix-schema-init-force-validation-order/proposal.md
+++ b/openspec/changes/fix-schema-init-force-validation-order/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+`openspec schema init --force` removes an existing project-local schema before validating the requested artifact list. A command that ultimately fails for an unknown artifact can therefore destroy the schema it was supposed to replace, turning a recoverable input error into data loss.
+
+## What Changes
+
+- Complete schema-init input collection and artifact validation before replacing an existing schema.
+- Preserve the existing schema and its contents when validation fails, including when `--force` is present.
+- Keep successful `--force` replacement behavior unchanged once all inputs are valid.
+- Add command-level regression coverage for both failed preservation and successful replacement.
+- Keep the change narrowly scoped to `schema init` artifact validation and forced replacement; no other CLI behavior changes.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `schema-init-command`: Require failed schema-init validation to leave an existing schema unchanged before any forced replacement begins.
+
+## Impact
+
+- **CLI behavior**: Failed `schema init --force` validation no longer deletes an existing project-local schema.
+- **Code**: The `schema init` action in `src/commands/schema.ts` will separate non-destructive preparation from the destructive replacement step.
+- **Tests**: `test/commands/schema.test.ts` will exercise the registered command instead of simulating schema creation for the affected cases.
+- **Dependencies and APIs**: No new dependencies or public API changes.

--- a/openspec/changes/fix-schema-init-force-validation-order/specs/schema-init-command/spec.md
+++ b/openspec/changes/fix-schema-init-force-validation-order/specs/schema-init-command/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Schema init validates artifacts before forced replacement
+The CLI SHALL validate all requested artifact IDs before replacing an existing project-local schema. If artifact validation fails, the CLI SHALL leave the existing schema directory and all of its contents unchanged on every supported platform.
+
+#### Scenario: Unknown artifact preserves existing schema
+- **GIVEN** `openspec/schemas/tdd-driven/` already exists with user-authored files
+- **WHEN** the user runs `schema init tdd-driven` with `--force` and an artifact list containing the unknown ID `task`
+- **THEN** the command exits with a non-zero status and reports the unknown artifact
+- **AND** the existing `tdd-driven` schema directory and its contents remain unchanged
+
+#### Scenario: Unknown artifact preserves a schema at a Windows project path
+- **GIVEN** an existing project-local schema is resolved from a Windows filesystem path
+- **WHEN** forced schema initialization fails artifact validation
+- **THEN** the resolved schema directory and its contents remain unchanged
+
+#### Scenario: Valid artifacts allow forced replacement
+- **GIVEN** a project-local schema already exists
+- **WHEN** the user runs `schema init` with `--force` and only valid artifact IDs
+- **THEN** the command replaces the existing schema with the newly generated schema
+- **AND** reports successful creation

--- a/openspec/changes/fix-schema-init-force-validation-order/tasks.md
+++ b/openspec/changes/fix-schema-init-force-validation-order/tasks.md
@@ -1,0 +1,17 @@
+## 1. Command-Level Regression Coverage
+
+- [x] 1.1 Add a test helper that registers the schema command on a fresh Commander program and restores `cwd`, `process.exitCode`, environment variables, and console spies after each test.
+- [x] 1.2 Add a regression test that creates an existing schema with a sentinel file, runs forced initialization with an unknown artifact ID, and verifies the non-zero JSON error plus byte-for-byte preservation of the existing schema.
+- [x] 1.3 Add a positive regression test that runs forced initialization with valid artifact IDs and verifies the old sentinel is removed and the expected schema and templates are generated.
+
+## 2. Validation-First Forced Replacement
+
+- [x] 2.1 Reorganize the `schema init` action so it collects inputs, validates artifact IDs, and constructs the in-memory schema before deleting an existing destination.
+- [x] 2.2 Keep the existing unknown-artifact output and exit status unchanged while ensuring every pre-mutation return path leaves the destination untouched.
+- [x] 2.3 Confirm a valid `--force` invocation still replaces the existing schema and reports the same successful result.
+
+## 3. Cross-Platform Verification and Release Metadata
+
+- [x] 3.1 Use Node.js path helpers and temporary directories in the regression tests, and confirm the affected test runs in the existing Windows CI environment.
+- [x] 3.2 Run `pnpm exec vitest run test/commands/schema.test.ts`, `pnpm run lint`, and `pnpm run build`.
+- [x] 3.3 Add a patch changeset describing that failed forced schema initialization now preserves the existing schema.

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -704,8 +704,9 @@ export function registerSchemaCommand(program: Command): void {
 
         const schemaDir = path.join(getProjectSchemasDir(projectRoot), name);
 
-        // Check if exists
-        if (fs.existsSync(schemaDir)) {
+        // Check overwrite permission without mutating the destination
+        const schemaExists = fs.existsSync(schemaDir);
+        if (schemaExists) {
           if (!options?.force) {
             if (options?.json) {
               console.log(JSON.stringify({
@@ -720,9 +721,6 @@ export function registerSchemaCommand(program: Command): void {
             process.exitCode = 1;
             return;
           }
-
-          if (spinner) spinner.start(`Removing existing schema '${name}'...`);
-          fs.rmSync(schemaDir, { recursive: true });
         }
 
         // Determine artifacts and description
@@ -801,10 +799,6 @@ export function registerSchemaCommand(program: Command): void {
           }
         }
 
-        // Create schema directory
-        if (spinner) spinner.start(`Creating schema '${name}'...`);
-        fs.mkdirSync(schemaDir, { recursive: true });
-
         // Build artifacts array with proper dependencies
         const selectedArtifacts = selectedArtifactIds.map((id) => {
           const template = DEFAULT_ARTIFACTS.find((a) => a.id === id)!;
@@ -846,6 +840,16 @@ export function registerSchemaCommand(program: Command): void {
             tracks: 'tasks.md',
           };
         }
+
+        // Replace only after all inputs have been collected and validated
+        if (schemaExists) {
+          if (spinner) spinner.start(`Removing existing schema '${name}'...`);
+          fs.rmSync(schemaDir, { recursive: true });
+        }
+
+        // Create schema directory
+        if (spinner) spinner.start(`Creating schema '${name}'...`);
+        fs.mkdirSync(schemaDir, { recursive: true });
 
         fs.writeFileSync(
           path.join(schemaDir, 'schema.yaml'),

--- a/test/commands/schema.test.ts
+++ b/test/commands/schema.test.ts
@@ -1,12 +1,21 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Command } from 'commander';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
+
+async function runSchemaCommand(args: string[]): Promise<void> {
+  const { registerSchemaCommand } = await import('../../src/commands/schema.js');
+  const program = new Command();
+  registerSchemaCommand(program);
+  await program.parseAsync(['node', 'openspec', 'schema', ...args]);
+}
 
 describe('schema command', () => {
   let tempDir: string;
   let originalCwd: string;
   let originalEnv: NodeJS.ProcessEnv;
+  let originalExitCode: typeof process.exitCode;
   let consoleLogSpy: ReturnType<typeof vi.spyOn>;
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 
@@ -20,6 +29,8 @@ describe('schema command', () => {
     // Save original cwd and env
     originalCwd = process.cwd();
     originalEnv = { ...process.env };
+    originalExitCode = process.exitCode;
+    process.exitCode = undefined;
 
     // Change to temp directory
     process.chdir(tempDir);
@@ -37,6 +48,7 @@ describe('schema command', () => {
     // Restore cwd and env
     process.chdir(originalCwd);
     process.env = originalEnv;
+    process.exitCode = originalExitCode;
 
     // Clean up temp directory
     fs.rmSync(tempDir, { recursive: true, force: true });
@@ -241,6 +253,69 @@ artifacts:
   });
 
   describe('schema init', () => {
+    it('should preserve an existing schema when forced init rejects an artifact', async () => {
+      const schemaDir = path.join(tempDir, 'openspec', 'schemas', 'tdd-driven');
+      const schemaPath = path.join(schemaDir, 'schema.yaml');
+      const sentinelPath = path.join(schemaDir, 'keep.bin');
+      const existingSchema = 'name: tdd-driven\nversion: 1\n';
+      const sentinel = Buffer.from([0x00, 0x01, 0x7f, 0xff]);
+
+      fs.mkdirSync(schemaDir, { recursive: true });
+      fs.writeFileSync(schemaPath, existingSchema);
+      fs.writeFileSync(sentinelPath, sentinel);
+
+      await runSchemaCommand([
+        'init',
+        'tdd-driven',
+        '--force',
+        '--artifacts',
+        'proposal,specs,design,task',
+        '--json',
+      ]);
+
+      expect(process.exitCode).toBe(1);
+      const output = consoleLogSpy.mock.calls.at(-1)?.[0];
+      expect(typeof output).toBe('string');
+      expect(JSON.parse(output as string)).toEqual({
+        created: false,
+        error: "Unknown artifact 'task'",
+        valid: ['proposal', 'specs', 'design', 'tasks'],
+      });
+      expect(fs.readFileSync(schemaPath, 'utf-8')).toBe(existingSchema);
+      expect(fs.readFileSync(sentinelPath)).toEqual(sentinel);
+    });
+
+    it('should replace an existing schema after forced init validates its artifacts', async () => {
+      const schemaDir = path.join(tempDir, 'openspec', 'schemas', 'tdd-driven');
+      const sentinelPath = path.join(schemaDir, 'keep.txt');
+
+      fs.mkdirSync(schemaDir, { recursive: true });
+      fs.writeFileSync(sentinelPath, 'remove me');
+
+      await runSchemaCommand([
+        'init',
+        'tdd-driven',
+        '--force',
+        '--artifacts',
+        'proposal,specs,design,tasks',
+        '--json',
+      ]);
+
+      const output = consoleLogSpy.mock.calls.at(-1)?.[0];
+      expect(typeof output).toBe('string');
+      expect(JSON.parse(output as string)).toMatchObject({
+        created: true,
+        schema: 'tdd-driven',
+        artifacts: ['proposal', 'specs', 'design', 'tasks'],
+      });
+      expect(fs.existsSync(sentinelPath)).toBe(false);
+      expect(fs.existsSync(path.join(schemaDir, 'schema.yaml'))).toBe(true);
+      expect(fs.existsSync(path.join(schemaDir, 'templates', 'proposal.md'))).toBe(true);
+      expect(fs.existsSync(path.join(schemaDir, 'templates', 'specs', 'spec.md'))).toBe(true);
+      expect(fs.existsSync(path.join(schemaDir, 'templates', 'design.md'))).toBe(true);
+      expect(fs.existsSync(path.join(schemaDir, 'templates', 'tasks.md'))).toBe(true);
+    });
+
     it('should create schema directory with schema.yaml', async () => {
       const schemaDir = path.join(tempDir, 'openspec', 'schemas', 'new-schema');
       fs.mkdirSync(schemaDir, { recursive: true });

--- a/test/commands/schema.test.ts
+++ b/test/commands/schema.test.ts
@@ -301,6 +301,7 @@ artifacts:
         '--json',
       ]);
 
+      expect(process.exitCode).toBeUndefined();
       const output = consoleLogSpy.mock.calls.at(-1)?.[0];
       expect(typeof output).toBe('string');
       expect(JSON.parse(output as string)).toMatchObject({


### PR DESCRIPTION
## Summary

- validate schema-init artifact IDs before forced replacement
- preserve an existing schema when artifact validation fails
- add command-level regression coverage and a patch changeset

## Problem

`openspec schema init --force` removed the destination schema before validating `--artifacts`.

When an unknown artifact such as `task` was supplied, the command returned an error but had already deleted the existing schema.

## Root cause

The destination directory was removed before the artifact list was parsed and validated.

## Fix

Defer removal of the existing schema until:

- command input has been collected
- artifact IDs have been validated
- artifact definitions have been created
- the new schema has been constructed in memory

The existing error output, exit code, and successful force-overwrite behavior remain unchanged.

## Tests

- `pnpm exec vitest run test/commands/schema.test.ts` 
- `pnpm run lint`
- `pnpm run build`
- `openspec validate fix-schema-init-force-validation-order --strict`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `openspec schema init --force` now validates requested artifact IDs before replacing an existing project schema.
  * If an unknown artifact is provided, the existing `schema.yaml` and other existing files are preserved and the command exits with the expected error.
  * With valid artifacts, forced initialization still replaces the schema and generates the expected outputs.
* **Tests**
  * Added command-level regression tests covering validation-failure preservation and successful forced replacement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->