### PR TITLE
chore(security): override brace-expansion to fix the failing audit

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,7 +51,7 @@
               inherit (finalAttrs) pname version src;
               pnpm = pkgs.pnpm_9;
               fetcherVersion = 3;
-              hash = "sha256-gDQ8jDwWfK8feX8PXB7acWvMITWsq/+a+eQ8N+I/iRg=";
+              hash = "";
             };
 
             nativeBuildInputs = with pkgs; [

--- a/flake.nix
+++ b/flake.nix
@@ -51,7 +51,7 @@
               inherit (finalAttrs) pname version src;
               pnpm = pkgs.pnpm_9;
               fetcherVersion = 3;
-              hash = "";
+              hash = "sha256-OUK3rXD0xjw2PPGQSzEeRnzN06SSKFRIkT0XHSIgDBU=";
             };
 
             nativeBuildInputs = with pkgs; [

--- a/package.json
+++ b/package.json
@@ -83,5 +83,10 @@
     "posthog-node": "^5.46.0",
     "yaml": "^2.8.3",
     "zod": "^4.4.3"
+  },
+  "pnpm": {
+    "overrides": {
+      "brace-expansion@<=5.0.7": ">=5.0.8"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  brace-expansion@<=5.0.7: '>=5.0.8'
+
 importers:
 
   .:
@@ -796,9 +799,9 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2339,7 +2342,7 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -2706,7 +2709,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   mri@1.2.0: {}
 

--- a/website/package.json
+++ b/website/package.json
@@ -35,7 +35,8 @@
   "pnpm": {
     "overrides": {
       "postcss": "^8.5.22",
-      "sharp": "^0.35.3"
+      "sharp": "^0.35.3",
+      "brace-expansion@<=5.0.7": ">=5.0.8"
     }
   }
 }

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   postcss: ^8.5.22
   sharp: ^0.35.3
+  brace-expansion@<=5.0.7: '>=5.0.8'
 
 importers:
 
@@ -1121,8 +1122,9 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
 
   baseline-browser-mapping@2.11.1:
     resolution: {integrity: sha512-HYXq73DDpCtNzOmrFsm9eSwCvWCql0RzqjpDzXN9EadiLJ4DNat0nsZ/Bzmy+Ud12mb4/zKDY0cQ805ZzN+i0A==}
@@ -1133,8 +1135,9 @@ packages:
     resolution: {integrity: sha512-j//dBVuyacJbvW+tvZ9HuH03fZ46QcaKvvhZickZqtB271DxJ7SNRSNxrV/dZX0085m7hISRZWbzWlJvx/rHSg==}
     engines: {node: '>=14.16'}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   bytes@3.0.0:
     resolution: {integrity: sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==}
@@ -1227,9 +1230,6 @@ packages:
 
   compute-scroll-into-view@3.1.1:
     resolution: {integrity: sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   content-disposition@0.5.2:
     resolution: {integrity: sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==}
@@ -3197,7 +3197,7 @@ snapshots:
 
   bail@2.0.2: {}
 
-  balanced-match@1.0.2: {}
+  balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.11.1: {}
 
@@ -3212,10 +3212,9 @@ snapshots:
       widest-line: 4.0.1
       wrap-ansi: 8.1.0
 
-  brace-expansion@1.1.16:
+  brace-expansion@5.0.8:
     dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
+      balanced-match: 4.0.4
 
   bytes@3.0.0: {}
 
@@ -3295,8 +3294,6 @@ snapshots:
       - supports-color
 
   compute-scroll-into-view@3.1.1: {}
-
-  concat-map@0.0.1: {}
 
   content-disposition@0.5.2: {}
 
@@ -4219,7 +4216,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 5.0.8
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
**Status:** ready to merge — audits clean, website builds, all 2,279 tests pass.

**What was wrong:** The Security workflow has failed on every run on `main` since 2026-07-27. A new advisory ([GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg), high severity) flags `brace-expansion <= 5.0.7`, and both lockfiles resolve a vulnerable version: `5.0.7` at the root and `1.1.16` in `website/` (via `minimatch@3`, which pins `^1.1.7` — the only patched release is `5.0.8`, so a plain update can't reach it).

**How it was fixed:** Ran `pnpm audit --fix` in both packages. It adds a scoped override, `"brace-expansion@<=5.0.7": ">=5.0.8"`, to each `package.json` (next to the existing postcss/sharp overrides in `website/`). The lockfile diffs touch only brace-expansion and its own subtree. No change to the audit workflow — it caught a real advisory.

**Proof:**
- Before: `pnpm audit --audit-level high --dir website` exits 1 (same failure as the [Security run on main](https://github.com/Fission-AI/OpenSpec/actions/runs/30303788204)).
- After: both `pnpm audit --audit-level high` and `pnpm audit --audit-level high --dir website` print `No known vulnerabilities found`.
- `pnpm --dir website build` succeeds; root `pnpm build` + `vitest run` pass (112 files, 2,279 tests).

**Notes:** The forced 1.x → 5.x jump in `website/` only affects `serve-handler` (the `serve out` preview script; not part of the Next build). brace-expansion 5.x changed its export shape, so brace patterns like `{a,b}` in serve-handler globs would break — we use `serve` with no config, so no such patterns exist. The override can be dropped once `minimatch`/`serve` move off the 1.x line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated install dependency resolution to ensure a compatible `brace-expansion` version is selected.
  * Applied the same `brace-expansion` version resolution safeguard to the website package configuration.
* **Chores**
  * Updated the Nix flake’s pinned dependency fetch integrity hash used during builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->