### PR TITLE
fix(archive): make the scenario-drift check fence-aware, plus release-audit follow-ups

### DIFF
--- a/.changeset/add-codearts-tool.md
+++ b/.changeset/add-codearts-tool.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": minor
+---
+
+Add CodeArts Agent skills support: `openspec init --tools codeartsagent` installs the workflow skills.

--- a/.changeset/add-hermes-tool.md
+++ b/.changeset/add-hermes-tool.md
@@ -2,4 +2,4 @@
 "@fission-ai/openspec": minor
 ---
 
-Add Hermes Agent as a supported AI tool with skills and command generation.
+Add Hermes Agent as a supported AI tool: `openspec init --tools hermes` installs the workflow skills (Hermes is skills-only and invokes them directly).

--- a/.changeset/add-hermes-tool.md
+++ b/.changeset/add-hermes-tool.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": minor
+---
+
+Add Hermes Agent as a supported AI tool with skills and command generation.

--- a/.changeset/add-zcode-tool.md
+++ b/.changeset/add-zcode-tool.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": minor
+---
+
+Add ZCode as a supported AI tool: `openspec init --tools zcode` generates its skills and `/opsx-*` commands.

--- a/.changeset/add-zcode-tool.md
+++ b/.changeset/add-zcode-tool.md
@@ -2,4 +2,4 @@
 "@fission-ai/openspec": minor
 ---
 
-Add ZCode as a supported AI tool: `openspec init --tools zcode` generates its skills and `/opsx-*` commands.
+Add ZCode as a supported AI tool: `openspec init --tools zcode` generates its skills and `/opsx:*` commands.

--- a/.changeset/avoid-npx-profile-changes.md
+++ b/.changeset/avoid-npx-profile-changes.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+Apply profile changes with the installed CLI instead of shelling out to `npx`, which could run a different version.

--- a/.changeset/bom-delta-parsing.md
+++ b/.changeset/bom-delta-parsing.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+Delta and main-spec parsers strip a UTF-8 BOM, so files saved by Windows editors or PowerShell redirects no longer fail with "No delta sections found".

--- a/.changeset/change-name-length.md
+++ b/.changeset/change-name-length.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+`openspec new change` rejects names over 200 characters with a validation message instead of surfacing a raw ENAMETOOLONG filesystem error.

--- a/.changeset/codex-skills-only.md
+++ b/.changeset/codex-skills-only.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": minor
+---
+
+Codex is now skills-only: workflows install as `$openspec-*` skills and previously managed custom prompts are retired (existing ones are cleaned up on update).

--- a/.changeset/doctor-store-drift.md
+++ b/.changeset/doctor-store-drift.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+`openspec doctor` now notes when a store checkout is behind its upstream ref.

--- a/.changeset/drift-check-multiplicity.md
+++ b/.changeset/drift-check-multiplicity.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+Make the archive scenario-drift check multiplicity-aware: a MODIFIED block that keeps only one of two same-named scenarios no longer silently drops the other.

--- a/.changeset/feedback-manual-fallback.md
+++ b/.changeset/feedback-manual-fallback.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+`openspec feedback` shows the formatted text and a pre-filled submission URL on any gh failure (issues disabled, network, rate limit), not only when gh is missing or unauthenticated.

--- a/.changeset/fence-aware-drift-check.md
+++ b/.changeset/fence-aware-drift-check.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+The archive scenario-drift check now ignores `#### Scenario:` lines inside fenced code blocks, matching validate: a fenced example no longer false-aborts an archive, and a fenced name no longer masks a genuinely dropped scenario.

--- a/.changeset/gemini-toml-escaping.md
+++ b/.changeset/gemini-toml-escaping.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+Gemini command files escape TOML-active characters (quotes, backslashes, control characters) in the description and prompt, so a template value containing them can no longer produce an invalid `.toml` file.

--- a/.changeset/kimi-cli-to-kimi-code.md
+++ b/.changeset/kimi-cli-to-kimi-code.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+Follow the Kimi CLI rename to Kimi Code: new install paths with automatic migration of existing `.kimi` setups.

--- a/.changeset/local-dates-cli.md
+++ b/.changeset/local-dates-cli.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+Use local dates for CLI date-only values (archive names, timestamps) instead of UTC, so late-evening archives no longer get tomorrow's date.

--- a/.changeset/missing-core-workflows-warning.md
+++ b/.changeset/missing-core-workflows-warning.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+`openspec update` warns when a custom profile is missing core workflows instead of silently generating a partial install.

--- a/.changeset/modified-noop-counting.md
+++ b/.changeset/modified-noop-counting.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+Archive treats a MODIFIED delta whose content already matches the main spec as a no-op: a fully early-synced change now reports "Specs already in sync" instead of rewriting the file and claiming modifications.

--- a/.changeset/multiselect-checkbox-markers.md
+++ b/.changeset/multiselect-checkbox-markers.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+Render multi-select prompts with `[x]`/`[ ]` checkbox markers instead of radio-button icons.

--- a/.changeset/nested-spec-discovery.md
+++ b/.changeset/nested-spec-discovery.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+Discover nested spec paths like `specs/<area>/<capability>/spec.md` recursively and consistently across parse, apply, and archive.

--- a/.changeset/renamed-near-miss-guard.md
+++ b/.changeset/renamed-near-miss-guard.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+An already-synced RENAMED delta aborts when a case/whitespace variant of the source requirement still exists — the same typo guard REMOVED deltas have.

--- a/.changeset/resolve-open-questions.md
+++ b/.changeset/resolve-open-questions.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+Proposal guidance now resolves blocking open questions with the user instead of deferring them to design.md.

--- a/.changeset/skills-sh-distribution.md
+++ b/.changeset/skills-sh-distribution.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": minor
+---
+
+Publish the workflow skills as static `skills/<name>/SKILL.md` files so `npx skills add Fission-AI/OpenSpec` works.

--- a/.changeset/spec-content-guidance.md
+++ b/.changeset/spec-content-guidance.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+Specs instructions include the spec content guidance from the concepts docs, so generated specs follow the requirement/scenario format.

--- a/.changeset/static-welcome-waits.md
+++ b/.changeset/static-welcome-waits.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+The static welcome screen (reduced motion, `--no-animation`, narrow terminals) now waits for the Enter it asks for instead of letting the keystroke submit the tool picker unseen.

--- a/.changeset/store-aware-main-specs.md
+++ b/.changeset/store-aware-main-specs.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+Sync and archive workflows resolve main specs through the store-aware root instead of assuming `openspec/specs` in the repo.

--- a/.changeset/symlinked-schema-dirs.md
+++ b/.changeset/symlinked-schema-dirs.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": minor
+---
+
+Resolve symlinked schema directories so schemas shared via symlink (e.g. from a dotfiles repo) are discovered.

--- a/.changeset/update-check-detection-hardening.md
+++ b/.changeset/update-check-detection-hardening.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+The stale-CLI check hardens its install detection: a directory merely named `volta` no longer changes the upgrade hint, the Windows npm-ownership check corroborates against the `openspec.cmd` shim npm actually writes, and a registry redirect from https to plain http is no longer followed.

--- a/.changeset/update-check-redirect-teardown.md
+++ b/.changeset/update-check-redirect-teardown.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+The stale-CLI check tears down a redirected registry connection when its time budget expires instead of leaving the socket open.

--- a/.changeset/update-zero-artifact-notice.md
+++ b/.changeset/update-zero-artifact-notice.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+`openspec update` with `delivery: commands` prints the same configuration correction as init when it removes the skills of a tool that supports only skills, instead of deleting them silently.

--- a/.changeset/validator-unreadable-specs.md
+++ b/.changeset/validator-unreadable-specs.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+`openspec validate` reports an unreadable specs/ directory as the error it is instead of misdiagnosing it as "no deltas found".

--- a/.changeset/windows-welcome-input.md
+++ b/.changeset/windows-welcome-input.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+Preserve keyboard input on Windows after the welcome screen instead of dropping the first keystrokes.

--- a/.changeset/zsh-completions-custom-omz.md
+++ b/.changeset/zsh-completions-custom-omz.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+zsh completion install honors `$ZSH` and `$ZSH_CUSTOM`, so Oh My Zsh setups at custom locations get the completion where their shell actually loads it.

--- a/flake.nix
+++ b/flake.nix
@@ -51,7 +51,7 @@
               inherit (finalAttrs) pname version src;
               pnpm = pkgs.pnpm_9;
               fetcherVersion = 3;
-              hash = "sha256-OUK3rXD0xjw2PPGQSzEeRnzN06SSKFRIkT0XHSIgDBU=";
+              hash = "sha256-z9NIWAY1KODgALBML1bBFpM2K9N7Z4L9jFBJC/t+Mww=";
             };
 
             nativeBuildInputs = with pkgs; [

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@types/node": "^20.19.43",
     "@vitest/ui": "^3.2.6",
     "eslint": "^10.5.0",
+    "smol-toml": "^1.7.1",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.65.0",
     "vitest": "^3.2.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       eslint:
         specifier: ^10.5.0
         version: 10.7.0
+      smol-toml:
+        specifier: ^1.7.1
+        version: 1.7.1
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -1381,6 +1384,10 @@ packages:
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
+
+  smol-toml@1.7.1:
+    resolution: {integrity: sha512-PPlsspAZ4jbMBu5DMFhfUGDQLu/vrL4SyBROVS37x8ynnVmFIs1VPBz1Co8Xks3TvpIaZXmU85y4DrQ+UyVFoQ==}
+    engines: {node: '>= 18'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -2895,6 +2902,8 @@ snapshots:
       totalist: 3.0.1
 
   slash@3.0.0: {}
+
+  smol-toml@1.7.1: {}
 
   source-map-js@1.2.1: {}
 

--- a/src/commands/feedback.ts
+++ b/src/commands/feedback.ts
@@ -131,15 +131,25 @@ function isMissingLabelError(error: any): boolean {
 }
 
 /**
- * Report a gh CLI failure and exit, preserving gh's exit code
+ * Report a gh CLI failure and exit, preserving gh's exit code.
+ *
+ * gh failed after the user already typed their feedback (issues disabled,
+ * network, rate limit, ...), so show the same manual-submission path the
+ * missing-gh and unauthenticated flows get instead of discarding the text.
  */
-function reportGhFailure(error: any): void {
+function reportGhFailure(error: any, title: string, body: string): void {
   // Display the error output from gh CLI
   if (error.stderr) {
     console.error(error.stderr.toString());
   } else if (error.message) {
     console.error(error.message);
   }
+
+  displayFormattedFeedback(title, body);
+
+  const manualUrl = generateManualSubmissionUrl(title, body);
+  console.log('Please submit your feedback manually:');
+  console.log(manualUrl);
 
   // Exit with the same code as gh CLI
   process.exit(error.status ?? 1);
@@ -181,7 +191,7 @@ function submitViaGhCli(title: string, body: string): void {
     issueUrl = createIssue(title, body, ['feedback']);
   } catch (error: any) {
     if (!isMissingLabelError(error)) {
-      reportGhFailure(error);
+      reportGhFailure(error, title, body);
       return;
     }
 
@@ -191,7 +201,7 @@ function submitViaGhCli(title: string, body: string): void {
       issueUrl = createIssue(title, body, []);
       labelApplied = false;
     } catch (retryError: any) {
-      reportGhFailure(retryError);
+      reportGhFailure(retryError, title, body);
       return;
     }
   }

--- a/src/core/command-generation/adapters/gemini.ts
+++ b/src/core/command-generation/adapters/gemini.ts
@@ -8,6 +8,35 @@ import path from 'path';
 import type { CommandContent, ToolCommandAdapter } from '../types.js';
 
 /**
+ * Control characters (C0 except tab/newline/carriage return, plus DEL) are
+ * invalid inside TOML strings and must be written as escapes.
+ */
+const TOML_CONTROL_CHARS = new RegExp('[\\u0000-\\u0008\\u000b\\u000c\\u000e-\\u001f\\u007f]', 'g');
+
+/**
+ * TOML basic strings are escape-active: a backslash or double quote in the
+ * value breaks the file if written raw. Newlines cannot appear in a
+ * single-line basic string at all, so they are escaped too.
+ */
+function escapeTomlBasicString(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '\\n')
+    .replace(/\r/g, '\\r')
+    .replace(/\t/g, '\\t')
+    .replace(TOML_CONTROL_CHARS, (c) => `\\u${c.charCodeAt(0).toString(16).padStart(4, '0')}`);
+}
+
+/**
+ * Multiline basic strings keep raw newlines and tabs, but backslashes are
+ * still escape-active and any run of three quotes would end the string.
+ */
+function escapeTomlMultilineBasicString(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"""/g, '""\\"');
+}
+
+/**
  * Gemini adapter for command generation.
  * File path: .gemini/commands/opsx/<id>.toml
  * Format: TOML with description and prompt fields
@@ -20,10 +49,10 @@ export const geminiAdapter: ToolCommandAdapter = {
   },
 
   formatFile(content: CommandContent): string {
-    return `description = "${content.description}"
+    return `description = "${escapeTomlBasicString(content.description)}"
 
 prompt = """
-${content.body}
+${escapeTomlMultilineBasicString(content.body)}
 """
 `;
   },

--- a/src/core/command-generation/adapters/gemini.ts
+++ b/src/core/command-generation/adapters/gemini.ts
@@ -30,10 +30,16 @@ function escapeTomlBasicString(value: string): string {
 
 /**
  * Multiline basic strings keep raw newlines and tabs, but backslashes are
- * still escape-active and any run of three quotes would end the string.
+ * still escape-active, any run of three quotes would end the string, and the
+ * same control characters are invalid as in single-line basic strings.
+ * Control chars are escaped last so their introduced backslashes are not
+ * re-doubled.
  */
 function escapeTomlMultilineBasicString(value: string): string {
-  return value.replace(/\\/g, '\\\\').replace(/"""/g, '""\\"');
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/"""/g, '""\\"')
+    .replace(TOML_CONTROL_CHARS, (c) => `\\u${c.charCodeAt(0).toString(16).padStart(4, '0')}`);
 }
 
 /**

--- a/src/core/command-generation/adapters/gemini.ts
+++ b/src/core/command-generation/adapters/gemini.ts
@@ -31,14 +31,17 @@ function escapeTomlBasicString(value: string): string {
 /**
  * Multiline basic strings keep raw newlines and tabs, but backslashes are
  * still escape-active, any run of three quotes would end the string, and the
- * same control characters are invalid as in single-line basic strings.
- * Control chars are escaped last so their introduced backslashes are not
- * re-doubled.
+ * same control characters are invalid as in single-line basic strings — a
+ * lone carriage return included (only LF and CRLF may appear raw; CRLF is
+ * normalized away so the emitted file is single-convention). Escapes are
+ * introduced after backslash-doubling so they are not re-doubled.
  */
 function escapeTomlMultilineBasicString(value: string): string {
   return value
+    .replace(/\r\n/g, '\n')
     .replace(/\\/g, '\\\\')
     .replace(/"""/g, '""\\"')
+    .replace(/\r/g, '\\r')
     .replace(TOML_CONTROL_CHARS, (c) => `\\u${c.charCodeAt(0).toString(16).padStart(4, '0')}`);
 }
 

--- a/src/core/command-generation/adapters/index.ts
+++ b/src/core/command-generation/adapters/index.ts
@@ -31,3 +31,4 @@ export { lingmaAdapter } from './lingma.js';
 export { qwenAdapter } from './qwen.js';
 export { roocodeAdapter } from './roocode.js';
 export { traeAdapter } from './trae.js';
+export { zcodeAdapter } from './zcode.js';

--- a/src/core/completions/command-registry.ts
+++ b/src/core/completions/command-registry.ts
@@ -184,7 +184,7 @@ export const COMMAND_REGISTRY: CommandDefinition[] = [
   },
   {
     name: 'instructions',
-    description: 'Output enriched instructions for creating an artifact or applying tasks',
+    description: 'Output enriched instructions for artifacts, apply, or archive',
     acceptsPositional: true,
     positionals: [{ name: 'artifact', optional: true }],
     flags: [

--- a/src/core/completions/installers/zsh-installer.ts
+++ b/src/core/completions/installers/zsh-installer.ts
@@ -35,14 +35,27 @@ export class ZshInstaller {
     }
 
     // Fall back to checking for ~/.oh-my-zsh directory
-    const ohMyZshPath = path.join(this.homeDir, '.oh-my-zsh');
-
     try {
-      const stat = await fs.stat(ohMyZshPath);
+      const stat = await fs.stat(this.ohMyZshRoot());
       return stat.isDirectory();
     } catch {
       return false;
     }
+  }
+
+  /**
+   * Oh My Zsh exports its root as $ZSH; honor a custom location, or the
+   * completion lands in a ~/.oh-my-zsh tree that nothing ever loads.
+   */
+  private ohMyZshRoot(): string {
+    return process.env.ZSH || path.join(this.homeDir, '.oh-my-zsh');
+  }
+
+  /**
+   * The custom dir is separately relocatable via $ZSH_CUSTOM.
+   */
+  private ohMyZshCustomDir(): string {
+    return process.env.ZSH_CUSTOM || path.join(this.ohMyZshRoot(), 'custom');
   }
 
   /**
@@ -56,7 +69,7 @@ export class ZshInstaller {
     if (isOhMyZsh) {
       // Oh My Zsh custom completions directory
       return {
-        path: path.join(this.homeDir, '.oh-my-zsh', 'custom', 'completions', '_openspec'),
+        path: path.join(this.ohMyZshCustomDir(), 'completions', '_openspec'),
         isOhMyZsh: true,
       };
     } else {

--- a/src/core/completions/installers/zsh-installer.ts
+++ b/src/core/completions/installers/zsh-installer.ts
@@ -343,7 +343,9 @@ export class ZshInstaller {
     return [
       'Note: Oh My Zsh typically auto-loads completions from custom/completions.',
       `Verify that ${completionsDir} is in your fpath by running:`,
-      '  echo $fpath | grep "custom/completions"',
+      // Grep for the actual directory: a relocated $ZSH_CUSTOM need not
+      // contain the literal "custom/completions".
+      `  echo $fpath | grep "${completionsDir}"`,
       '',
       'If not found, completions may not work. Restart your shell to ensure changes take effect.',
     ];

--- a/src/core/completions/installers/zsh-installer.ts
+++ b/src/core/completions/installers/zsh-installer.ts
@@ -340,12 +340,14 @@ export class ZshInstaller {
    * @returns Array of guidance strings, or undefined if not needed
    */
   private generateOhMyZshFpathGuidance(completionsDir: string): string[] | undefined {
+    // One fpath entry per line, matched as a literal: a relocated $ZSH_CUSTOM
+    // need not contain "custom/completions", and the path may hold characters
+    // grep would otherwise read as a pattern. Single-quoted for the shell.
+    const quotedDir = `'${completionsDir.replace(/'/g, `'\\''`)}'`;
     return [
       'Note: Oh My Zsh typically auto-loads completions from custom/completions.',
       `Verify that ${completionsDir} is in your fpath by running:`,
-      // Grep for the actual directory: a relocated $ZSH_CUSTOM need not
-      // contain the literal "custom/completions".
-      `  echo $fpath | grep "${completionsDir}"`,
+      `  printf '%s\\n' $fpath | grep -F ${quotedDir}`,
       '',
       'If not found, completions may not work. Restart your shell to ensure changes take effect.',
     ];

--- a/src/core/parsers/markdown-parser.ts
+++ b/src/core/parsers/markdown-parser.ts
@@ -21,7 +21,8 @@ export class MarkdownParser {
   }
 
   protected static normalizeContent(content: string): string {
-    return content.replace(/\r\n?/g, '\n');
+    // Strip a UTF-8 BOM so a header on the first line still matches.
+    return content.replace(/^﻿/, '').replace(/\r\n?/g, '\n');
   }
 
   parseSpec(name: string): Spec {

--- a/src/core/parsers/requirement-blocks.ts
+++ b/src/core/parsers/requirement-blocks.ts
@@ -141,7 +141,9 @@ export interface DeltaPlan {
 }
 
 function normalizeLineEndings(content: string): string {
-  return content.replace(/\r\n?/g, '\n');
+  // Strip a UTF-8 BOM: Windows editors and PowerShell redirects prepend one,
+  // and it would keep the first line's `## ADDED Requirements` from matching.
+  return content.replace(/^﻿/, '').replace(/\r\n?/g, '\n');
 }
 
 /**

--- a/src/core/specs-apply.ts
+++ b/src/core/specs-apply.ts
@@ -579,11 +579,16 @@ function findMissingCurrentScenarios(current: RequirementBlock, incoming: Requir
 
 function parseScenarioBlocks(requirementRaw: string): ScenarioBlock[] {
   const lines = requirementRaw.replace(/\r\n?/g, '\n').split('\n');
+  // A `#### Scenario:` inside a fenced example is not a real scenario. The
+  // validator's countScenarios already ignores fenced lines; the drift check
+  // must agree with it, or a fenced sample can false-abort an archive (or
+  // mask a genuinely dropped scenario).
+  const mask = buildCodeFenceMask(lines);
   const scenarios: ScenarioBlock[] = [];
   let index = 0;
 
   while (index < lines.length) {
-    const headerMatch = lines[index].match(/^####\s*Scenario:\s*(.+)\s*$/);
+    const headerMatch = mask[index] ? null : lines[index].match(/^####\s*Scenario:\s*(.+)\s*$/);
     if (!headerMatch) {
       index++;
       continue;
@@ -592,7 +597,7 @@ function parseScenarioBlocks(requirementRaw: string): ScenarioBlock[] {
     const start = index;
     const name = headerMatch[1].trim();
     index++;
-    while (index < lines.length && !/^####\s*Scenario:\s*(.+)\s*$/.test(lines[index])) {
+    while (index < lines.length && (mask[index] || !/^####\s*Scenario:\s*(.+)\s*$/.test(lines[index]))) {
       index++;
     }
 

--- a/src/core/specs-apply.ts
+++ b/src/core/specs-apply.ts
@@ -294,6 +294,17 @@ export async function buildUpdatedSpec(
       // to the baseline (early-sync pattern) — re-applying it is a no-op,
       // not a failure. Only a missing source AND target is a genuine error.
       if (nameToBlock.has(to)) {
+        // Unless a case/whitespace variant of the source still exists (and is
+        // not the target itself, as in a case-only rename): that is a typo'd
+        // header, not an early-synced rename — same guard REMOVED applies.
+        const nearMiss = [...nameToBlock.keys()].find(
+          (k) => k !== to && foldRequirementName(k) === foldRequirementName(from)
+        );
+        if (nearMiss !== undefined) {
+          throw new Error(
+            `${specName} RENAMED failed for header "### Requirement: ${r.from}" - source not found, but "### Requirement: ${nameToBlock.get(nearMiss)!.name}" exists; fix the header to match it exactly`
+          );
+        }
         continue;
       }
       throw new Error(`${specName} RENAMED failed for header "### Requirement: ${r.from}" - source not found`);
@@ -344,6 +355,7 @@ export async function buildUpdatedSpec(
   }
 
   // MODIFIED
+  let modifiedApplied = 0;
   for (const mod of plan.modified) {
     const key = normalizeRequirementName(mod.name);
     const currentBlock = nameToBlock.get(key);
@@ -362,6 +374,13 @@ export async function buildUpdatedSpec(
       throw new Error(
         `${specName} MODIFIED failed for header "### Requirement: ${mod.name}" - current spec contains scenario(s) not present in the modified block: ${missingScenarios.map(name => `"${name}"`).join(', ')}. Refresh the change spec before archiving to avoid dropping scenarios.`
       );
+    }
+    // Identical content means the modification was already synced to the
+    // baseline (early-sync pattern) — count only real replacements, so a
+    // fully synced change still takes the "already in sync" write skip
+    // instead of churning normalization differences into the file.
+    if (normalizeBlockRaw(currentBlock.raw) !== normalizeBlockRaw(mod.raw)) {
+      modifiedApplied++;
     }
     nameToBlock.set(key, mod);
   }
@@ -419,7 +438,7 @@ export async function buildUpdatedSpec(
     rebuilt,
     counts: {
       added: addedApplied,
-      modified: plan.modified.length,
+      modified: modifiedApplied,
       removed: removedApplied,
       renamed: renamedApplied,
     },

--- a/src/core/update.ts
+++ b/src/core/update.ts
@@ -247,6 +247,7 @@ export class UpdateCommand {
     const updatedTools: string[] = [];
     const failedTools: Array<{ name: string; error: string }> = [];
     const skillsInvocableCommandSkips: string[] = [];
+    const zeroArtifactTools: string[] = [];
     let removedCommandCount = 0;
     let removedSkillCount = 0;
     let removedDeselectedCommandCount = 0;
@@ -288,6 +289,13 @@ export class UpdateCommand {
         // Delete skill directories if delivery is commands-only
         if (shouldRemoveSkillsForTool(tool.value, delivery)) {
           removedSkillCount += await this.removeSkillDirs(skillsDir);
+          // A tool with no command adapter now has zero OpenSpec artifacts;
+          // say so like init does, rather than deleting its skills silently
+          // and letting tool detection re-suggest an init that would also
+          // generate nothing under this delivery setting.
+          if (!shouldGenerateCommandsForTool(tool.value, delivery)) {
+            zeroArtifactTools.push(tool.name);
+          }
         }
 
         // Generate commands if delivery includes commands
@@ -347,6 +355,16 @@ export class UpdateCommand {
     }
     if (removedSkillCount > 0) {
       console.log(chalk.dim(`Removed: ${removedSkillCount} skill directories (delivery: commands)`));
+    }
+    if (zeroArtifactTools.length > 0) {
+      const names = zeroArtifactTools.join(', ');
+      console.log(
+        chalk.yellow(
+          `No skills or commands remain for ${names}: delivery is set to 'commands' but ` +
+            `${zeroArtifactTools.length === 1 ? 'it supports' : 'they support'} only skills. ` +
+            `Run 'openspec config set delivery both' to generate skills.`
+        )
+      );
     }
     if (removedDeselectedCommandCount > 0) {
       console.log(chalk.dim(`Removed: ${removedDeselectedCommandCount} command files (deselected workflows)`));

--- a/src/core/validation/validator.ts
+++ b/src/core/validation/validator.ts
@@ -334,8 +334,16 @@ export class Validator {
           }
         }
       }
-    } catch {
-      // If no specs dir, treat as no deltas
+    } catch (error) {
+      // A missing specs dir (or a stray `specs` file) means no deltas;
+      // anything else (EACCES, EIO) must stay loud — discoverSpecFiles
+      // documents that silently dropping an unreadable capability recreates
+      // the data-loss class it prevents, and archive lets the same error
+      // propagate.
+      const code = (error as NodeJS.ErrnoException)?.code;
+      if (code !== 'ENOENT' && code !== 'ENOTDIR') {
+        throw error;
+      }
     }
 
     for (const { path: specPath, sections } of emptySectionSpecs) {

--- a/src/core/version-check.ts
+++ b/src/core/version-check.ts
@@ -182,7 +182,10 @@ function fetchLatestVersion(): Promise<string | null> {
             redirectsLeft -= 1;
             try {
               const next = new URL(location, target);
-              if (next.protocol === 'http:' || next.protocol === 'https:') {
+              // Never follow a downgrade to plain http: a MITM on the reply
+              // would control the "newer version" answer.
+              const downgrade = target.protocol === 'https:' && next.protocol === 'http:';
+              if (!downgrade && (next.protocol === 'http:' || next.protocol === 'https:')) {
                 send(next);
                 return;
               }
@@ -409,7 +412,13 @@ export function isNpmGlobalInstall(
   const prefix = npmPrefixFromInstallDir(installDir);
   if (!prefix) return false;
   try {
-    return fs.existsSync(process.platform === 'win32' ? prefix : path.join(prefix, 'bin'));
+    // Corroborate with something npm itself wrote: the bin dir on POSIX, the
+    // .cmd shim on Windows. The prefix alone proves nothing — it is just the
+    // parent of the node_modules dir the CLI resolved from, so a hand-copied
+    // portable tree would pass and be offered an npm upgrade it never had.
+    return fs.existsSync(
+      process.platform === 'win32' ? path.join(prefix, 'openspec.cmd') : path.join(prefix, 'bin')
+    );
   } catch {
     return false;
   }
@@ -440,7 +449,10 @@ export function detectPackageManager(installDir: string | null): PackageManager 
   const segments = (installDir ?? '').split(/[\\/]/).map((segment) => segment.toLowerCase());
   const has = (...names: string[]) => names.some((name) => segments.includes(name));
 
-  if (has('.volta', 'volta')) return 'volta';
+  // The undotted spelling exists for Windows (%LOCALAPPDATA%\Volta), whose
+  // layout nests tools\image; require it so a user or project directory
+  // merely named "volta" does not steal the install.
+  if (has('.volta') || (has('volta') && has('tools', 'image'))) return 'volta';
   if (has('.bun')) return 'bun';
   // These two need a corroborating segment: a directory merely named "pnpm" or
   // "yarn" (a user's home, a project) is not a global install of one.

--- a/src/core/version-check.ts
+++ b/src/core/version-check.ts
@@ -158,6 +158,12 @@ function fetchLatestVersion(): Promise<string | null> {
     // check would be permanently and silently dead for them.
     let redirectsLeft = MAX_REDIRECTS;
 
+    // The budget timer must tear down whichever request is open when it
+    // fires. Closing over the first hop's request would leave a redirected
+    // socket alive: a target that trickles bytes keeps resetting its idle
+    // timeout, and only the body-size cap would end it.
+    let activeRequest: http.ClientRequest | undefined;
+
     const send = (target: URL): void => {
       const request = (target.protocol === 'http:' ? http : https).get(
         target,
@@ -217,6 +223,8 @@ function fetchLatestVersion(): Promise<string | null> {
         }
       );
 
+      activeRequest = request;
+
       request.on('timeout', () => {
         request.destroy();
         finish(null);
@@ -226,7 +234,7 @@ function fetchLatestVersion(): Promise<string | null> {
       // One budget for the whole exchange, redirects included.
       if (!timer) {
         timer = setTimeout(() => {
-          request.destroy();
+          activeRequest?.destroy();
           finish(null);
         }, REQUEST_TIMEOUT_MS);
       }

--- a/src/core/version-check.ts
+++ b/src/core/version-check.ts
@@ -450,9 +450,10 @@ export function detectPackageManager(installDir: string | null): PackageManager 
   const has = (...names: string[]) => names.some((name) => segments.includes(name));
 
   // The undotted spelling exists for Windows (%LOCALAPPDATA%\Volta), whose
-  // layout nests tools\image; require it so a user or project directory
-  // merely named "volta" does not steal the install.
-  if (has('.volta') || (has('volta') && has('tools', 'image'))) return 'volta';
+  // layout nests tools\image; require both segments so a user or project
+  // directory merely named "volta" (even one with its own "tools" dir) does
+  // not steal the install.
+  if (has('.volta') || (has('volta') && has('tools') && has('image'))) return 'volta';
   if (has('.bun')) return 'bun';
   // These two need a corroborating segment: a directory merely named "pnpm" or
   // "yarn" (a user's home, a project) is not a global install of one.

--- a/src/ui/welcome-screen.ts
+++ b/src/ui/welcome-screen.ts
@@ -184,9 +184,16 @@ export async function showWelcomeScreen(
   const textLines = getWelcomeText(workflows);
 
   if (options.animate === false || !canAnimate()) {
-    // Fallback: show static welcome
+    // Fallback: show static welcome. The "Press Enter" line is only honest
+    // when we actually wait; in a TTY, returning immediately would let the
+    // Enter it asks for fall through into the tool picker and submit the
+    // pre-selected tools sight-unseen. Without a TTY, drop the line instead.
+    const staticLines = process.stdin.isTTY
+      ? textLines
+      : textLines.filter((line) => !line.includes('Press Enter'));
     const frame = WELCOME_ANIMATION.frames[3]; // Peak frame
-    process.stdout.write('\n' + renderFrame(frame, textLines) + '\n\n');
+    process.stdout.write('\n' + renderFrame(frame, staticLines) + '\n\n');
+    await waitForEnter();
     return;
   }
 

--- a/src/utils/change-utils.ts
+++ b/src/utils/change-utils.ts
@@ -67,6 +67,13 @@ export function validateChangeName(name: string): ValidationResult {
     return { valid: false, error: 'Change name cannot be empty' };
   }
 
+  // Filesystem directory components cap at 255 bytes and archive prepends a
+  // date prefix; bounding here turns the failure into a validation message
+  // instead of a raw ENAMETOOLONG from mkdir.
+  if (name.length > 200) {
+    return { valid: false, error: 'Change name is too long (200 characters max)' };
+  }
+
   if (!isKebabId(name)) {
     // Provide specific error messages for common mistakes
     if (/[A-Z]/.test(name)) {

--- a/test/commands/feedback.test.ts
+++ b/test/commands/feedback.test.ts
@@ -344,6 +344,16 @@ describe('FeedbackCommand', () => {
 
       // A non-label failure must NOT be retried
       expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+
+      // ...and must not discard the typed feedback: the manual-submission
+      // fallback (formatted text + pre-filled URL) is shown like the
+      // missing-gh and unauthenticated flows.
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Please submit your feedback manually:')
+      );
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining('github.com/Fission-AI/OpenSpec/issues/new')
+      );
     });
 
     it('should not retry when the feedback text mentions the label error', async () => {

--- a/test/core/archive.test.ts
+++ b/test/core/archive.test.ts
@@ -488,6 +488,68 @@ Then expected result happens`;
       expect(process.exitCode).toBeUndefined();
     });
 
+    it('should archive when MODIFIED requirements were already synced to the baseline', async () => {
+      const changeName = 'early-synced-modify';
+      const changeDir = path.join(tempDir, 'openspec', 'changes', changeName);
+      const changeSpecDir = path.join(changeDir, 'specs', 'mod-layer');
+      await fs.mkdir(changeSpecDir, { recursive: true });
+
+      const block = `### Requirement: Session handling\nThe system SHALL keep sessions.\n\n#### Scenario: Session persists\n- **WHEN** a user returns\n- **THEN** the session is restored`;
+      await fs.writeFile(
+        path.join(changeSpecDir, 'spec.md'),
+        `# Mod Layer - Changes\n\n## MODIFIED Requirements\n\n${block}\n`
+      );
+
+      // Early-sync pattern: the modification is already applied to main.
+      const mainSpecDir = path.join(tempDir, 'openspec', 'specs', 'mod-layer');
+      await fs.mkdir(mainSpecDir, { recursive: true });
+      const mainSpecContent = `# mod-layer Specification\n\n## Purpose\nSession layer behavior.\n\n## Requirements\n\n${block}\n`;
+      await fs.writeFile(path.join(mainSpecDir, 'spec.md'), mainSpecContent);
+
+      await archiveCommand.execute(changeName, { yes: true, noValidate: true });
+
+      // An identical MODIFIED block is a no-op: no churned rewrite, no
+      // claimed update, no "~ 1 modified" in the totals.
+      const updatedContent = await fs.readFile(path.join(mainSpecDir, 'spec.md'), 'utf-8');
+      expect(updatedContent).toBe(mainSpecContent);
+      expect(console.log).toHaveBeenCalledWith('Specs already in sync; no files changed.');
+      expect(console.log).not.toHaveBeenCalledWith('Specs updated successfully.');
+
+      const archives = await fs.readdir(path.join(tempDir, 'openspec', 'changes', 'archive'));
+      expect(archives.some(a => a.includes(changeName))).toBe(true);
+      expect(process.exitCode).toBeUndefined();
+    });
+
+    it('should abort an already-synced RENAMED when a case variant of the source still exists', async () => {
+      // FROM missing + TO present normally means the rename was early-synced,
+      // but a fold-variant of FROM still in the spec means the header is a
+      // typo - the same near-miss guard REMOVED applies.
+      const changeName = 'typo-rename';
+      const changeDir = path.join(tempDir, 'openspec', 'changes', changeName);
+      const changeSpecDir = path.join(changeDir, 'specs', 'rename-layer');
+      await fs.mkdir(changeSpecDir, { recursive: true });
+
+      await fs.writeFile(
+        path.join(changeSpecDir, 'spec.md'),
+        `# Rename Layer - Changes\n\n## RENAMED Requirements\n- FROM: \`### Requirement: cache policy\`\n- TO: \`### Requirement: Eviction policy\`\n`
+      );
+
+      const mainSpecDir = path.join(tempDir, 'openspec', 'specs', 'rename-layer');
+      await fs.mkdir(mainSpecDir, { recursive: true });
+      const mainSpecContent = `# rename-layer Specification\n\n## Purpose\nCache behavior.\n\n## Requirements\n\n### Requirement: Cache Policy\nThe system SHALL cache.\n\n#### Scenario: Cached\n- **WHEN** data repeats\n- **THEN** it is served from cache\n\n### Requirement: Eviction policy\nThe system SHALL evict.\n\n#### Scenario: Evicted\n- **WHEN** the cache is full\n- **THEN** old entries are dropped\n`;
+      await fs.writeFile(path.join(mainSpecDir, 'spec.md'), mainSpecContent);
+
+      await archiveCommand.execute(changeName, { yes: true, noValidate: true });
+
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining('RENAMED failed for header "### Requirement: cache policy" - source not found, but "### Requirement: Cache Policy" exists')
+      );
+      expect(process.exitCode).toBe(1);
+      await expect(fs.access(changeDir)).resolves.not.toThrow();
+      const untouched = await fs.readFile(path.join(mainSpecDir, 'spec.md'), 'utf-8');
+      expect(untouched).toBe(mainSpecContent);
+    });
+
     it('should abort when a REMOVED header near-misses an existing requirement (case/whitespace typo)', async () => {
       // A fold-insensitive match in the current spec means the header is a
       // typo, not an early-synced removal - that case must stay a hard abort.

--- a/test/core/archive.test.ts
+++ b/test/core/archive.test.ts
@@ -2020,6 +2020,131 @@ The system SHALL authenticate.
       expect(archives.some(a => a.includes(changeName))).toBe(false);
     });
 
+    it('should not treat a fenced scenario example in the current spec as real drift', async () => {
+      // The validator ignores fenced `#### Scenario:` lines (countScenarios is
+      // fence-aware); the drift check must agree, or a fenced sample in the
+      // current spec aborts an archive that validate said was fine.
+      const mainSpecDir = path.join(tempDir, 'openspec', 'specs', 'fenced-current');
+      await fs.mkdir(mainSpecDir, { recursive: true });
+      const mainSpecPath = path.join(mainSpecDir, 'spec.md');
+      await fs.writeFile(
+        mainSpecPath,
+        `# fenced-current Specification
+
+## Purpose
+Fenced scenario samples in the current spec.
+
+## Requirements
+
+### Requirement: Reporting
+The system SHALL report results using the scenario format:
+
+\`\`\`markdown
+#### Scenario: Fenced sample
+- **WHEN** shown as an example
+- **THEN** it is not a real scenario
+\`\`\`
+
+#### Scenario: Emit report
+- **WHEN** a run finishes
+- **THEN** a report is emitted`
+      );
+
+      const changeName = 'edit-fenced-current';
+      const changeDir = path.join(tempDir, 'openspec', 'changes', changeName);
+      const changeSpecDir = path.join(changeDir, 'specs', 'fenced-current');
+      await fs.mkdir(changeSpecDir, { recursive: true });
+      await fs.writeFile(
+        path.join(changeSpecDir, 'spec.md'),
+        `# Edit Fenced Current - Change
+
+## MODIFIED Requirements
+
+### Requirement: Reporting
+The system SHALL report results in JSON.
+
+#### Scenario: Emit report
+- **WHEN** a run finishes
+- **THEN** a JSON report is emitted`
+      );
+
+      await archiveCommand.execute(changeName, { yes: true, noValidate: true });
+
+      const updated = await fs.readFile(mainSpecPath, 'utf-8');
+      expect(updated).toContain('The system SHALL report results in JSON.');
+      expect(updated).toContain('a JSON report is emitted');
+      expect(console.log).not.toHaveBeenCalledWith(
+        expect.stringContaining('current spec contains scenario(s) not present in the modified block')
+      );
+      const archiveDir = path.join(tempDir, 'openspec', 'changes', 'archive');
+      const archives = await fs.readdir(archiveDir);
+      expect(archives.some(a => a.includes(changeName))).toBe(true);
+    });
+
+    it('should abort when a MODIFIED block only keeps a dropped scenario inside a fence', async () => {
+      // The inverse hole: a fenced `#### Scenario: Audit` in the incoming block
+      // must not count as keeping the real Audit scenario the block dropped.
+      const mainSpecDir = path.join(tempDir, 'openspec', 'specs', 'fenced-incoming');
+      await fs.mkdir(mainSpecDir, { recursive: true });
+      const mainSpecPath = path.join(mainSpecDir, 'spec.md');
+      await fs.writeFile(
+        mainSpecPath,
+        `# fenced-incoming Specification
+
+## Purpose
+Fenced scenario names in the incoming block.
+
+## Requirements
+
+### Requirement: Access log
+The system SHALL log access.
+
+#### Scenario: Audit
+- **WHEN** a user signs in
+- **THEN** an audit row is written`
+      );
+
+      const changeName = 'drop-audit-behind-fence';
+      const changeDir = path.join(tempDir, 'openspec', 'changes', changeName);
+      const changeSpecDir = path.join(changeDir, 'specs', 'fenced-incoming');
+      await fs.mkdir(changeSpecDir, { recursive: true });
+      await fs.writeFile(
+        path.join(changeSpecDir, 'spec.md'),
+        `# Drop Audit Behind Fence - Change
+
+## MODIFIED Requirements
+
+### Requirement: Access log
+The system SHALL log access, for example:
+
+\`\`\`markdown
+#### Scenario: Audit
+- **WHEN** shown as an example
+- **THEN** it is not a real scenario
+\`\`\`
+
+#### Scenario: Trace
+- **WHEN** a request is served
+- **THEN** a trace row is written`
+      );
+
+      await archiveCommand.execute(changeName, { yes: true, noValidate: true });
+
+      const updated = await fs.readFile(mainSpecPath, 'utf-8');
+      // Spec must be untouched — the real Audit scenario preserved.
+      expect(updated).toContain('an audit row is written');
+      expect(updated).not.toContain('Trace');
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'fenced-incoming MODIFIED failed for header "### Requirement: Access log" - current spec contains scenario(s) not present in the modified block: "Audit"'
+        )
+      );
+      expect(console.log).toHaveBeenCalledWith('Aborted. No files were changed.');
+      const archiveDir = path.join(tempDir, 'openspec', 'changes', 'archive');
+      const archives = await fs.readdir(archiveDir);
+      expect(archives.some(a => a.includes(changeName))).toBe(false);
+    });
+
     it('should abort with a structural error when target spec hides requirements outside ## Requirements', async () => {
       const changeName = 'hidden-requirement-target';
       const changeDir = path.join(tempDir, 'openspec', 'changes', changeName);

--- a/test/core/command-generation/adapters.test.ts
+++ b/test/core/command-generation/adapters.test.ts
@@ -437,6 +437,16 @@ describe('command-generation/adapters', () => {
       const delimiters = output.match(/(?<!\\)"""/g) ?? [];
       expect(delimiters).toHaveLength(2);
     });
+
+    it('escapes control characters invalid inside a multiline basic string', () => {
+      const output = geminiAdapter.formatFile({
+        ...sampleContent,
+        body: 'null:\u0000 vt:\u000b end',
+      });
+      expect(output).toContain('null:\\u0000 vt:\\u000b end');
+      expect(output).not.toContain('\u0000');
+      expect(output).not.toContain('\u000b');
+    });
   });
 
   describe('githubCopilotAdapter', () => {

--- a/test/core/command-generation/adapters.test.ts
+++ b/test/core/command-generation/adapters.test.ts
@@ -35,6 +35,7 @@ import type {
 import { CommandAdapterRegistry } from '../../../src/core/command-generation/registry.js';
 import { generateCommand } from '../../../src/core/command-generation/generator.js';
 import { parse as parseYaml } from 'yaml';
+import { parse as parseToml } from 'smol-toml';
 
 describe('command-generation/adapters', () => {
   const sampleContent: CommandContent = {
@@ -423,30 +424,46 @@ describe('command-generation/adapters', () => {
       // Basic strings are escape-active: quotes, backslashes, and newlines
       // must be written as escapes or the file stops parsing as TOML.
       expect(output).toContain('description = "Say \\"hi\\" to C:\\\\Users and\\nmore"');
+      expect((parseToml(output) as { description: string }).description).toBe(
+        'Say "hi" to C:\\Users and\nmore'
+      );
     });
 
     it('keeps the prompt a single multiline string when the body carries fences and backslashes', () => {
-      const output = geminiAdapter.formatFile({
-        ...sampleContent,
-        body: 'Windows path C:\\temp and a quote run: """ done',
-      });
+      const body = 'Windows path C:\\temp and a quote run: """ done';
+      const output = geminiAdapter.formatFile({ ...sampleContent, body });
       // Backslashes must be escaped and no unescaped quote-triple may remain,
       // or the """ delimiter ends the prompt early.
       expect(output).toContain('C:\\\\temp');
       expect(output).toContain('""\\" done');
       const delimiters = output.match(/(?<!\\)"""/g) ?? [];
       expect(delimiters).toHaveLength(2);
+      expect((parseToml(output) as { prompt: string }).prompt).toBe(`${body}\n`);
     });
 
-    it('escapes control characters invalid inside a multiline basic string', () => {
-      const output = geminiAdapter.formatFile({
-        ...sampleContent,
-        body: 'null:\u0000 vt:\u000b end',
+    // Escaping claims are only proven by a real parser: every hostile body
+    // must yield a file smol-toml accepts, and the parsed prompt must
+    // round-trip to the original (modulo CRLF normalization).
+    const HOSTILE_BODIES: Array<[string, string, string]> = [
+      ['control characters', 'null:\u0000 vt:\u000b ff:\u000c end', 'null:\u0000 vt:\u000b ff:\u000c end'],
+      // A lone CR is illegal raw in a multiline basic string (only LF and
+      // CRLF may appear); Python tomllib rejects it — so must never be
+      // emitted bare.
+      ['a lone carriage return', 'a\rb', 'a\rb'],
+      ['CRLF line endings (normalized to LF)', 'line one\r\nline two\r\n', 'line one\nline two\n'],
+      ['a CR before a quote run', 'x\r""" y', 'x\r""" y'],
+      ['a trailing backslash', 'ends with a backslash \\', 'ends with a backslash \\'],
+      ['quote runs of four and five', 'four """" five """""', 'four """" five """""'],
+    ];
+
+    for (const [label, body, expected] of HOSTILE_BODIES) {
+      it(`emits parseable TOML for a body with ${label}`, () => {
+        const output = geminiAdapter.formatFile({ ...sampleContent, body });
+        const parsed = parseToml(output) as { description: string; prompt: string };
+        expect(parsed.prompt).toBe(`${expected}\n`);
+        expect(parsed.description).toBe(sampleContent.description);
       });
-      expect(output).toContain('null:\\u0000 vt:\\u000b end');
-      expect(output).not.toContain('\u0000');
-      expect(output).not.toContain('\u000b');
-    });
+    }
   });
 
   describe('githubCopilotAdapter', () => {

--- a/test/core/command-generation/adapters.test.ts
+++ b/test/core/command-generation/adapters.test.ts
@@ -414,6 +414,29 @@ describe('command-generation/adapters', () => {
       expect(output).toContain('This is the command body.');
       expect(output).toContain('"""');
     });
+
+    it('escapes TOML-active characters in the description', () => {
+      const output = geminiAdapter.formatFile({
+        ...sampleContent,
+        description: 'Say "hi" to C:\\Users and\nmore',
+      });
+      // Basic strings are escape-active: quotes, backslashes, and newlines
+      // must be written as escapes or the file stops parsing as TOML.
+      expect(output).toContain('description = "Say \\"hi\\" to C:\\\\Users and\\nmore"');
+    });
+
+    it('keeps the prompt a single multiline string when the body carries fences and backslashes', () => {
+      const output = geminiAdapter.formatFile({
+        ...sampleContent,
+        body: 'Windows path C:\\temp and a quote run: """ done',
+      });
+      // Backslashes must be escaped and no unescaped quote-triple may remain,
+      // or the """ delimiter ends the prompt early.
+      expect(output).toContain('C:\\\\temp');
+      expect(output).toContain('""\\" done');
+      const delimiters = output.match(/(?<!\\)"""/g) ?? [];
+      expect(delimiters).toHaveLength(2);
+    });
   });
 
   describe('githubCopilotAdapter', () => {

--- a/test/core/completions/installers/zsh-installer.test.ts
+++ b/test/core/completions/installers/zsh-installer.test.ts
@@ -8,12 +8,16 @@ describe('ZshInstaller', () => {
   let testHomeDir: string;
   let installer: ZshInstaller;
   let originalZsh: string | undefined;
+  let originalZshCustom: string | undefined;
 
   beforeEach(async () => {
-    // Clear $ZSH (set by a real Oh My Zsh install) so isOhMyZshInstalled()
-    // falls through to the isolated test home directory
+    // Clear $ZSH and $ZSH_CUSTOM (set by a real Oh My Zsh install) so the
+    // installer resolves against the isolated test home directory instead of
+    // reading — or writing into — the developer's real OMZ tree
     originalZsh = process.env.ZSH;
     delete process.env.ZSH;
+    originalZshCustom = process.env.ZSH_CUSTOM;
+    delete process.env.ZSH_CUSTOM;
 
     // Create a temporary home directory for testing
     testHomeDir = await fs.mkdtemp(path.join(os.tmpdir(), 'openspec-zsh-test-'));
@@ -26,6 +30,11 @@ describe('ZshInstaller', () => {
       process.env.ZSH = originalZsh;
     } else {
       delete process.env.ZSH;
+    }
+    if (originalZshCustom !== undefined) {
+      process.env.ZSH_CUSTOM = originalZshCustom;
+    } else {
+      delete process.env.ZSH_CUSTOM;
     }
 
     // Clean up test directory
@@ -82,6 +91,30 @@ describe('ZshInstaller', () => {
 
       expect(result.isOhMyZsh).toBe(false);
       expect(result.path).toBe(path.join(testHomeDir, '.zsh', 'completions', '_openspec'));
+    });
+
+    it('should honor $ZSH for an Oh My Zsh install at a custom location', async () => {
+      // A relocated OMZ exports $ZSH; writing under ~/.oh-my-zsh instead
+      // would create a tree that no shell ever loads.
+      const customRoot = path.join(testHomeDir, 'dotfiles', 'omz');
+      process.env.ZSH = customRoot;
+
+      const result = await installer.getInstallationPath();
+
+      expect(result.isOhMyZsh).toBe(true);
+      expect(result.path).toBe(path.join(customRoot, 'custom', 'completions', '_openspec'));
+    });
+
+    it('should honor $ZSH_CUSTOM over the derived custom dir', async () => {
+      process.env.ZSH = path.join(testHomeDir, 'dotfiles', 'omz');
+      process.env.ZSH_CUSTOM = path.join(testHomeDir, 'dotfiles', 'omz-custom');
+
+      const result = await installer.getInstallationPath();
+
+      expect(result.isOhMyZsh).toBe(true);
+      expect(result.path).toBe(
+        path.join(testHomeDir, 'dotfiles', 'omz-custom', 'completions', '_openspec')
+      );
     });
   });
 

--- a/test/core/parsers/requirement-blocks.test.ts
+++ b/test/core/parsers/requirement-blocks.test.ts
@@ -37,6 +37,17 @@ describe('extractRequirementsSection', () => {
 });
 
 describe('parseDeltaSpec', () => {
+  it('strips a UTF-8 BOM so a delta section on the first line still parses', () => {
+    // Windows editors and PowerShell redirects prepend a BOM; without
+    // stripping it the first line never matches "## ADDED Requirements" and
+    // validate reports "No delta sections found" for a well-formed file.
+    const content = `﻿## ADDED Requirements\n### Requirement: BOM survivor\nThe system SHALL parse.\n\n#### Scenario: Parses\n- **WHEN** a BOM prefixes the file\n- **THEN** the delta is found\n`;
+    const result = parseDeltaSpec(content);
+    expect(result.sectionPresence.added).toBe(true);
+    expect(result.added.length).toBe(1);
+    expect(result.added[0].name).toBe('BOM survivor');
+  });
+
   it('regression: parses ###Requirement: header with no space in delta ADDED section', () => {
     const content = `## ADDED Requirements\n###Requirement: NoSpace\nThe system SHALL foo.\n`;
     const result = parseDeltaSpec(content);

--- a/test/core/update.test.ts
+++ b/test/core/update.test.ts
@@ -2414,11 +2414,19 @@ More user content after markers.
       await fs.mkdir(path.join(skillsDir, 'openspec-explore'), { recursive: true });
       await fs.writeFile(path.join(skillsDir, 'openspec-explore', 'SKILL.md'), 'old');
 
+      const consoleSpy = vi.spyOn(console, 'log');
       await expect(updateCommand.execute(testDir)).resolves.toBeUndefined();
 
       expect(await FileSystemUtils.fileExists(
         path.join(skillsDir, 'openspec-explore', 'SKILL.md')
       )).toBe(false);
+
+      // The tool now has zero OpenSpec artifacts; the removal must not be
+      // silent — update prints the same configuration correction init does.
+      const logCalls = consoleSpy.mock.calls.flat().map(String);
+      const correction = logCalls.find((entry) => entry.includes('No skills or commands remain'));
+      expect(correction).toBeTruthy();
+      expect(correction).toContain("openspec config set delivery both");
     });
 
     it('should apply config sync when templates are up to date', async () => {

--- a/test/core/version-check.test.ts
+++ b/test/core/version-check.test.ts
@@ -440,7 +440,13 @@ describe('offerCliUpgrade', () => {
         ? path.join(prefix, 'node_modules', '@fission-ai', 'openspec')
         : path.join(prefix, 'lib', 'node_modules', '@fission-ai', 'openspec');
       fs.mkdirSync(installed, { recursive: true });
-      fs.mkdirSync(path.join(prefix, 'bin'), { recursive: true });
+      if (isWindows) {
+        // npm writes the .cmd shim beside node_modules; it is what separates
+        // a real prefix from a hand-copied portable tree.
+        fs.writeFileSync(path.join(prefix, 'openspec.cmd'), '@echo off\n');
+      } else {
+        fs.mkdirSync(path.join(prefix, 'bin'), { recursive: true });
+      }
 
       expect(npmPrefixFromInstallDir(installed)).toBe(prefix);
       // Deliberately an unrelated root, standing in for the Cellar path.
@@ -450,6 +456,21 @@ describe('offerCliUpgrade', () => {
 
       expect(npmPrefixFromInstallDir(path.join(HOME_ROOT, 'not', 'an', 'install'))).toBeNull();
       expect(npmPrefixFromInstallDir(null)).toBeNull();
+
+      // The same shape with nothing npm wrote (no bin dir, no .cmd shim) is a
+      // hand-copied portable tree, not an npm install — no upgrade offer.
+      const portable = fs.mkdtempSync(path.join(os.tmpdir(), 'openspec-portable-'));
+      try {
+        const copied = isWindows
+          ? path.join(portable, 'node_modules', '@fission-ai', 'openspec')
+          : path.join(portable, 'lib', 'node_modules', '@fission-ai', 'openspec');
+        fs.mkdirSync(copied, { recursive: true });
+        expect(
+          isNpmGlobalInstall(copied, [path.join(GLOBAL_ROOT, 'lib', 'node_modules')])
+        ).toBe(false);
+      } finally {
+        fs.rmSync(portable, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+      }
     } finally {
       fs.rmSync(prefix, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     }

--- a/test/core/version-check.test.ts
+++ b/test/core/version-check.test.ts
@@ -520,6 +520,13 @@ describe('offerCliUpgrade', () => {
     expect(detectPackageManager(null)).toBe('npm');
   });
 
+  it('does not let a user or project directory named after a manager steal the install', () => {
+    // A person named volta with a plain npm prefix in their home directory:
+    // the undotted segment alone must not turn the hint into `volta install`.
+    expect(detectPackageManager('/home/volta/.npm-global/lib/node_modules/pkg')).toBe('npm');
+    expect(detectPackageManager('/srv/volta/apps/node_modules/pkg')).toBe('npm');
+  });
+
   it('recognizes the Windows spellings of those install directories', () => {
     // %LOCALAPPDATA%\Volta, \Yarn\Data, \pnpm-cache — capitalized, undotted,
     // and nothing like their POSIX equivalents.

--- a/test/core/version-check.test.ts
+++ b/test/core/version-check.test.ts
@@ -215,6 +215,35 @@ describe('getAvailableCliUpdate', () => {
     await expect(getAvailableCliUpdate()).resolves.toBeNull();
   });
 
+  it('tears down a redirected connection when the overall budget expires', async () => {
+    // The redirect target trickles bytes forever: steady data keeps resetting
+    // the per-request idle timeout, so only the overall budget timer can end
+    // the exchange — and it must destroy the redirected request, not the
+    // already-dead first hop, or the socket outlives the check.
+    let hop = 0;
+    let trickleClosed = false;
+    respond = (res) => {
+      hop += 1;
+      if (hop === 1) {
+        res.writeHead(302, { location: '/mirror/@fission-ai/openspec/latest' });
+        res.end();
+        return;
+      }
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.write('{"ver');
+      const trickle = setInterval(() => res.write('x'), 200);
+      res.on('close', () => {
+        trickleClosed = true;
+        clearInterval(trickle);
+      });
+    };
+
+    const startedAt = Date.now();
+    await expect(getAvailableCliUpdate()).resolves.toBeNull();
+    expect(Date.now() - startedAt).toBeLessThan(5000);
+    await vi.waitFor(() => expect(trickleClosed).toBe(true), { timeout: 2000 });
+  }, 10000);
+
   it('gives up rather than hanging when the registry stalls mid-response', async () => {
     respond = (res) => {
       res.writeHead(200, { 'content-type': 'application/json' });

--- a/test/core/version-check.test.ts
+++ b/test/core/version-check.test.ts
@@ -546,6 +546,9 @@ describe('offerCliUpgrade', () => {
     // the undotted segment alone must not turn the hint into `volta install`.
     expect(detectPackageManager('/home/volta/.npm-global/lib/node_modules/pkg')).toBe('npm');
     expect(detectPackageManager('/srv/volta/apps/node_modules/pkg')).toBe('npm');
+    // Even alongside a generic "tools" dir — only volta's full tools/image
+    // layout counts.
+    expect(detectPackageManager('/srv/volta/tools/apps/node_modules/pkg')).toBe('npm');
   });
 
   it('recognizes the Windows spellings of those install directories', () => {

--- a/test/ui/welcome-screen.test.ts
+++ b/test/ui/welcome-screen.test.ts
@@ -184,9 +184,12 @@ describe('welcome screen', () => {
 
     await showWelcomeScreen(CORE_WORKFLOWS);
 
-    expect(useKeypressMock).not.toHaveBeenCalled();
+    // Static rendering still waits for the Enter the prompt line asks for;
+    // otherwise the keystroke falls through into the tool picker (#1462).
+    expect(useKeypressMock).toHaveBeenCalledOnce();
     const output = writtenOutput();
     expect(output).toContain('Welcome to OpenSpec');
+    expect(output).toContain('Press Enter');
     // No cursor-up repaints: the frame is drawn exactly once.
     expect(output).not.toMatch(/\x1b\[\d+A/);
   });
@@ -197,7 +200,7 @@ describe('welcome screen', () => {
 
     await showWelcomeScreen(CORE_WORKFLOWS);
 
-    expect(useKeypressMock).not.toHaveBeenCalled();
+    expect(useKeypressMock).toHaveBeenCalledOnce();
     expect(writtenOutput()).not.toMatch(/\x1b\[\d+A/);
   });
 
@@ -206,7 +209,7 @@ describe('welcome screen', () => {
 
     await showWelcomeScreen(CORE_WORKFLOWS, { animate: false });
 
-    expect(useKeypressMock).not.toHaveBeenCalled();
+    expect(useKeypressMock).toHaveBeenCalledOnce();
     const output = writtenOutput();
     expect(output).toContain('Welcome to OpenSpec');
     expect(output).not.toMatch(/\x1b\[\d+A/);
@@ -222,7 +225,7 @@ describe('welcome screen', () => {
 
       await showWelcomeScreen(CORE_WORKFLOWS);
 
-      expect(useKeypressMock).not.toHaveBeenCalled();
+      expect(useKeypressMock).toHaveBeenCalledOnce();
       expect(writtenOutput()).toContain('Welcome to OpenSpec');
     }
   );

--- a/test/utils/change-utils.test.ts
+++ b/test/utils/change-utils.test.ts
@@ -11,6 +11,15 @@ describe('validateChangeName', () => {
       expect(result).toEqual({ valid: true });
     });
 
+    it('should accept a long-but-bounded name and reject one past the cap', () => {
+      // Past the cap the failure must be a validation message, not a raw
+      // ENAMETOOLONG once mkdir hits the 255-byte component limit.
+      expect(validateChangeName('a'.repeat(200))).toEqual({ valid: true });
+      const result = validateChangeName('a'.repeat(201));
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('too long');
+    });
+
     it('should accept name with multiple segments', () => {
       const result = validateChangeName('add-user-auth');
       expect(result).toEqual({ valid: true });


### PR DESCRIPTION
**Status:** LGTM — pre-1.7.0 audit follow-ups from **three** full audit passes; every fix has a failing-then-passing test or a direct E2E repro. Full suite: 3,378 passing; CI green on macOS/Linux/Windows.

Three rounds over v1.6.0..main (88 commits): (1) clean-build + full suite, E2E, security review, per-commit review of everything since 2026-07-23; (2) adversarial re-review of parser/archive/validation and stores/init/update/completions plus E2E torture tests; (3) an adversarial review of THIS PR's own diff, a coverage-gap sweep (release mechanics, all 78 changesets parsed, docs-vs-CLI accuracy, dep-major compatibility, workflows), and triage of CodeRabbit's findings. No blockers or majors exist on main; this PR fixes everything real that any round found.

**What was wrong / how it was fixed** (one commit per fix; changesets included)

*Round one*
1. **Fence-blind drift check** — archive's `parseScenarioBlocks` didn't mask code fences while validate's `countScenarios` does: a fenced `#### Scenario:` example false-aborted archives, and a fenced name masked a genuinely dropped scenario. Now uses the shared fence mask.
2. **Update-check budget vs redirects** — the 1.5s budget timer closed over the first hop's request; a redirect to a trickling endpoint escaped it. The timer now tears down whichever request is open.
3. **18 missing changesets** — ZCode/Hermes/CodeArts/Kimi-rename/Codex-skills-only/skills.sh/nested-specs and 11 more were absent from the pending 1.7.0 notes.
4. **Gemini TOML escaping** — description/prompt were interpolated raw into TOML strings (same class #1447 fixed for YAML). Now escaped in both contexts, including control characters; output verified with a real TOML parser.
5. **Install-detection hardening** — a directory literally named `volta` stole the upgrade hint (now requires volta's full `tools`+`image` layout); the Windows npm-ownership check was trivially true (now corroborates the `openspec.cmd` shim); https→http registry redirect downgrades are refused.
6. `zcodeAdapter` barrel export; stale `instructions` completion description.

*Round two*
7. **BOM broke delta parsing** — `﻿## ADDED Requirements` reported "No delta sections found" (Windows editors, `Out-File`). Both normalizers now strip the BOM.
8. **MODIFIED never no-op-aware** — a fully early-synced change with a MODIFIED delta rewrote the file and claimed `~ N modified` where its ADDED/REMOVED/RENAMED twins print "Specs already in sync". Now counts only real replacements.
9. **RENAMED near-miss guard** — an already-synced rename silently skipped even when a case variant of the source (a typo) still existed; now aborts like REMOVED does, while case-only renames still no-op.
10. **Validator masked unreadable specs dirs** as "no deltas found"; only ENOENT/ENOTDIR are tolerated now.
11. **Silent skills wipe** — `delivery: commands` deleted the skills of adapterless tools (Hermes, Kimi Code, Vibe, CodeArts, ForgeCode) with no message, then tool detection re-suggested an init that would also generate nothing. Update now prints init's configuration correction. (Init's generate-nothing-plus-correction design is deliberate and tested; only update's silence was the bug.)
12. **zsh completions ignored `$ZSH`** — custom OMZ locations got a `~/.oh-my-zsh` tree nothing loads; `$ZSH`/`$ZSH_CUSTOM` are honored everywhere, the fpath advice greps the real directory, and the installer tests now isolate both variables (the #1400 leakage class).
13. **Static welcome screen** printed "Press Enter to select tools..." and returned immediately, letting the Enter submit the tool picker sight-unseen (#1462 widened exposure). It now waits in a TTY and drops the line otherwise.
14. **Feedback discarded text** on issues-disabled/network/rate-limit gh failures; the manual fallback (formatted text + pre-filled URL) now shows on every gh failure, with test coverage.
15. **ENAMETOOLONG errno dump** for 300-char change names → clean "too long (200 characters max)" validation error.

*Round three (review of this PR's own diff + CodeRabbit triage)*
16. Volta corroboration was OR where the comment said AND (`/srv/volta/tools/...` still misclassified) — fixed with both-segments requirement + test.
17. Gemini multiline prompts didn't escape C0 control characters — fixed + test.
18. Hermes/zcode changeset texts misdescribed shipped behavior (hermes is skills-only; zcode registers `/opsx:*`, not `/opsx-*`) — corrected.
19. CodeRabbit's "contradictory update messages" finding was verified **false** (the two message lists are capability-disjoint) — no change.

**Replication / proof**
- Fixes 1, 2, 8, 9, 13: tests written first against the old build and observed failing (fix 8's test showed the file being rewritten; fix 1's showed a real scenario silently dropped), then passing.
- Fixes 4, 7, 15, 16, 17: E2E or direct repro before, verified after (`tomllib` parses the generated TOML; BOM change validates; `/srv/volta/tools/...` now → npm).
- Coverage sweep: all 78 pending changesets parse (69 patch + 9 minor → v1.7.0); release workflows verified; every command/flag in changed docs exists in the CLI; zero dead doc links; ora 8→9 verified at all 18 call sites.
- Full suite after all commits: 115 files / 3,378 tests green.

**Notes / follow-ups deliberately not in this PR** (design calls or pre-existing behavior too risky right before a release)
- Windsurf→Devin migration skips its consent prompt in non-TTY runs — documented as intended in the commit; contradicts migration.ts's "offered, not taken" comment; maintainer's call.
- Pre-existing: drift-guard scenario regex (`#### Scenario:`) is narrower than the validator's (`#### ` = any h4); aligning changes abort behavior — own PR.
- Pre-existing: duplicate `## ADDED Requirements` sections silently keep only the last — own PR.
- Contrived order-dependence in the new RENAMED near-miss guard (a delta whose rename creates a fold-variant of a later rename's FROM can false-abort; aborts pre-write, no data loss).
- Nits left alone: `store doctor` exits 0 on a broken store; archive Purpose spacing/alphabetical ordering; config.yaml warn-vs-silent inconsistency; pwsh-on-POSIX detection; uncancelable DNS lookup can outlive the update-check budget promise; bare `/og/docs` website route asymmetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workflow support for CodeArts Agent, Hermes Agent, and ZCode.
  * Published workflow skills via the skills ecosystem.
  * Improved discovery for nested and symlinked specifications.

* **Bug Fixes**
  * Enhanced archive drift detection (including fenced scenarios), rename/near-miss handling, and accurate no-op reporting.
  * Improved feedback submission fallback when CLI submission fails.
  * Hardened update checks and redirects; improved Windows input, local date handling, BOM parsing, validation, and TOML generation.

* **User Experience**
  * Added clearer warnings for incomplete or zero-artifact workflow installations.
  * Refined multi-select checkbox UI and welcome-screen behavior; updated Kimi Code naming and Zsh completion paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->