### PR TITLE
fix(security): patch fast-uri, postcss, and brace-expansion advisories

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -5,9 +5,11 @@ on:
     branches: [main]
   workflow_dispatch: # manually cut a beta prerelease from main
 
+# Floor for both jobs. The prepare job widens this to pull-requests: write for
+# the Version Packages PR; the beta job only tags/releases + publishes via OIDC
+# and needs no PR access, so it inherits this narrower default.
 permissions:
   contents: write
-  pull-requests: write
   id-token: write # Required for npm OIDC trusted publishing
 
 concurrency:
@@ -18,6 +20,10 @@ jobs:
   prepare:
     if: github.repository == 'Fission-AI/OpenSpec' && github.event_name == 'push'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write # changesets opens/updates the Version Packages PR
+      id-token: write # Required for npm OIDC trusted publishing
     steps:
       # Generate GitHub App token first - used for checkout and changesets
       # This allows git operations to trigger CI workflows on the version PR

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -88,3 +88,32 @@ jobs:
         if: ${{ !cancelled() }}
         continue-on-error: ${{ github.event_name == 'pull_request' }}
         run: pnpm audit --audit-level high --dir website
+
+  # The website keeps its own lockfile and is never installed or built elsewhere
+  # in CI, so a website/package.json change — e.g. a security override — that is
+  # not reflected in website/pnpm-lock.yaml goes unnoticed: the override you think
+  # patches an advisory may not be in the committed graph at all, and `pnpm audit`
+  # would happily audit the stale (possibly still-vulnerable) tree. A frozen-lockfile
+  # install fails fast on that drift. Root drift is already caught by the
+  # `--frozen-lockfile` installs in ci.yml; this closes the same gap for the website.
+  # `--ignore-scripts` skips sharp's native build (irrelevant to lockfile validation
+  # and the usual source of install flake).
+  website-lockfile:
+    name: Website Lockfile Drift
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '20.19.0'
+
+      - name: Verify website lockfile matches package.json
+        run: pnpm install --frozen-lockfile --ignore-scripts --dir website

--- a/flake.nix
+++ b/flake.nix
@@ -51,7 +51,7 @@
               inherit (finalAttrs) pname version src;
               pnpm = pkgs.pnpm_9;
               fetcherVersion = 3;
-              hash = "sha256-6huf6aAPGkK8Oz6YqbRXObTmFbwRv+6GH5qtNlhlfFw=";
+              hash = "sha256-w3nzoSXu6eONUDcuzgbGhA0a5ix5zU1QhNIFwwJPnXs=";
             };
 
             nativeBuildInputs = with pkgs; [

--- a/package.json
+++ b/package.json
@@ -86,8 +86,8 @@
   },
   "pnpm": {
     "overrides": {
-      "brace-expansion@<=5.0.8": ">=5.0.9",
-      "postcss@<8.5.23": ">=8.5.23"
+      "brace-expansion@<=5.0.8": ">=5.0.9 <6",
+      "postcss@<8.5.23": ">=8.5.23 <9"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
   },
   "pnpm": {
     "overrides": {
-      "brace-expansion@<=5.0.7": ">=5.0.8"
+      "brace-expansion@<=5.0.8": ">=5.0.9",
+      "postcss@<8.5.23": ">=8.5.23"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  brace-expansion@<=5.0.7: '>=5.0.8'
+  brace-expansion@<=5.0.8: '>=5.0.9'
+  postcss@<8.5.23: '>=8.5.23'
 
 importers:
 
@@ -1282,8 +1283,8 @@ packages:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
 
-  postcss@8.5.22:
-    resolution: {integrity: sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==}
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -2782,7 +2783,7 @@ snapshots:
 
   pify@4.0.1: {}
 
-  postcss@8.5.22:
+  postcss@8.5.25:
     dependencies:
       nanoid: 3.3.16
       picocolors: 1.1.1
@@ -3000,7 +3001,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.22
+      postcss: 8.5.25
       rollup: 4.62.2
       tinyglobby: 0.2.15
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,8 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  brace-expansion@<=5.0.8: '>=5.0.9'
-  postcss@<8.5.23: '>=8.5.23'
+  brace-expansion@<=5.0.8: '>=5.0.9 <6'
+  postcss@<8.5.23: '>=8.5.23 <9'
 
 importers:
 

--- a/src/core/archive.ts
+++ b/src/core/archive.ts
@@ -574,6 +574,9 @@ async function releaseArchiveClaim(
   await claim.handle.close().catch(() => undefined);
   if (owned === undefined) return;
   try {
+    // Read between two lstats by design: the identity + content match below
+    // proves we still own this claim before unlinking it. This is a concurrent-
+    // change detector, not an fd-less race to "fix" (CodeQL js/file-system-race).
     const current = await fs.lstat(claimPath, { bigint: true });
     const contents = await fs.readFile(claimPath, 'utf8');
     const currentAfterRead = await fs.lstat(claimPath, { bigint: true });
@@ -706,6 +709,9 @@ async function fingerprintPath(filePath: string): Promise<string> {
 async function fingerprintMovablePath(filePath: string): Promise<string> {
   try {
     const entry = await fs.lstat(filePath, { bigint: true });
+    // Deliberate stat -> read -> re-stat: a concurrent change is DETECTED by the
+    // statIdentity comparison below and throws. Do not collapse to fd I/O, which
+    // would pin one inode and blind the detector (CodeQL js/file-system-race).
     const hash = createHash('sha256')
       .update(await fs.readFile(filePath))
       .digest('hex');
@@ -741,6 +747,9 @@ async function fingerprintMovablePath(filePath: string): Promise<string> {
 async function fingerprintPortableContent(filePath: string): Promise<string> {
   try {
     const entry = await fs.lstat(filePath);
+    // Point-in-time content hash by design (no re-stat): callers compare it
+    // against a prior fingerprint of the same bytes, so any concurrent change
+    // surfaces as a hash mismatch (CodeQL js/file-system-race is a false positive here).
     const hash = createHash('sha256')
       .update(await fs.readFile(filePath))
       .digest('hex');
@@ -818,6 +827,9 @@ async function captureSpecSnapshots(mutations: SpecMutation[]): Promise<SpecSnap
           let contentExisted = false;
           if (outcome === 'write') {
             try {
+              // Best-effort rollback snapshot; a concurrent edit is caught later
+              // by restoreSpecSnapshots refusing to overwrite non-matching content,
+              // not here (CodeQL js/file-system-race).
               content = await fs.readFile(update.target);
               contentExisted = true;
             } catch (error) {
@@ -839,6 +851,9 @@ async function captureSpecSnapshots(mutations: SpecMutation[]): Promise<SpecSnap
           existed: true,
           outcome,
           ...(outcome === 'write' ? { expectedContent: Buffer.from(rebuilt) } : {}),
+          // Snapshot read for rollback; restoreSpecSnapshots re-checks this
+          // content before restoring, so a mid-run change aborts instead of
+          // clobbering (CodeQL js/file-system-race).
           ...(stat.isFile() ? { content: await fs.readFile(update.target) } : {}),
           ...(stat.isFile() ? { mode: stat.mode } : {}),
         };
@@ -882,6 +897,9 @@ async function restoreSpecSnapshots(snapshots: SpecSnapshot[]): Promise<void> {
             snapshot.symlink !== undefined &&
             current.isSymbolicLink() &&
             (await fs.readlink(snapshot.target)) === snapshot.symlink;
+          // Re-read to confirm the target still holds the snapshot content; a
+          // mismatch means a concurrent edit, and rollback throws below rather
+          // than overwrite it (CodeQL js/file-system-race is intentional here).
           const unchangedFile =
             snapshot.symlink === undefined &&
             snapshot.content !== undefined &&
@@ -919,6 +937,9 @@ async function restoreSpecSnapshots(snapshots: SpecSnapshot[]): Promise<void> {
             `Archive rollback would overwrite a concurrent change at ${snapshot.target}.`
           );
         }
+        // Re-read at rollback: only restore when current content matches what
+        // archive wrote or snapshotted; otherwise abort to preserve a concurrent
+        // change (CodeQL js/file-system-race is intentional here).
         const currentContent = await fs.readFile(snapshot.target);
         const originalContent =
           snapshot.symlink !== undefined && !snapshot.contentExisted

--- a/website/package.json
+++ b/website/package.json
@@ -37,7 +37,8 @@
     "overrides": {
       "postcss": "^8.5.22",
       "sharp": "^0.35.3",
-      "brace-expansion@<=5.0.7": ">=5.0.8"
+      "brace-expansion@<=5.0.8": ">=5.0.9",
+      "fast-uri@<3.1.5": "^3.1.5"
     }
   }
 }

--- a/website/package.json
+++ b/website/package.json
@@ -37,7 +37,7 @@
     "overrides": {
       "postcss": "^8.5.22",
       "sharp": "^0.35.3",
-      "brace-expansion@<=5.0.8": ">=5.0.9",
+      "brace-expansion@<=5.0.8": ">=5.0.9 <6",
       "fast-uri@<3.1.5": "^3.1.5"
     }
   }

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -7,7 +7,8 @@ settings:
 overrides:
   postcss: ^8.5.22
   sharp: ^0.35.3
-  brace-expansion@<=5.0.7: '>=5.0.8'
+  brace-expansion@<=5.0.8: '>=5.0.9'
+  fast-uri@<3.1.5: ^3.1.5
 
 importers:
 
@@ -1143,8 +1144,8 @@ packages:
     resolution: {integrity: sha512-j//dBVuyacJbvW+tvZ9HuH03fZ46QcaKvvhZickZqtB271DxJ7SNRSNxrV/dZX0085m7hISRZWbzWlJvx/rHSg==}
     engines: {node: '>=14.16'}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   bytes@3.0.0:
@@ -1361,8 +1362,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -3190,7 +3191,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -3240,7 +3241,7 @@ snapshots:
       widest-line: 4.0.1
       wrap-ansi: 8.1.0
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -3472,7 +3473,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
@@ -4253,7 +4254,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   postcss: ^8.5.22
   sharp: ^0.35.3
-  brace-expansion@<=5.0.8: '>=5.0.9'
+  brace-expansion@<=5.0.8: '>=5.0.9 <6'
   fast-uri@<3.1.5: ^3.1.5
 
 importers:


### PR DESCRIPTION
## Status

Ready. Fixes every open Dependabot alert (plus one high-severity advisory Dependabot had not filed) at the root. The 10 open CodeQL alerts are triaged with a documented disposition below — they are not exploitable in OpenSpec's threat model, and none has a code fix that doesn't degrade the tests or defeat the archive engine's deliberate concurrency guard.

## Dependency alerts — fixed

| Advisory | Package | Sev | Where | Chain | Fix |
|---|---|---|---|---|---|
| [GHSA-7p8r-x3mc-p8w7](https://github.com/advisories/GHSA-7p8r-x3mc-p8w7) (#95) | fast-uri 3.1.4 → **3.1.5** | High | website | `ajv@8.18.0` | override `fast-uri@<3.1.5` → `^3.1.5` |
| [GHSA-fxqj-rqcc-2cmp](https://github.com/advisories/GHSA-fxqj-rqcc-2cmp) (#93) | postcss 8.5.22 → **8.5.25** | Moderate | root | `vite` (test tooling) | override `postcss@<8.5.23` → `>=8.5.23` |
| [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) | brace-expansion 5.0.8 → **5.0.9** | High | website | `minimatch@3` | override `brace-expansion@<=5.0.8` → `>=5.0.9` |

**What was wrong:** three vulnerable transitive dev-dependencies. `fast-uri` and `postcss` are the two open Dependabot alerts. The `brace-expansion` one is not in the Dependabot list, but the repo's own website audit already fails on it on `main` (2 high before this change) — the previous override capped at `>=5.0.8`, and 5.0.8 is itself vulnerable under this newer advisory.

**How it was fixed:** version-ranged `pnpm.overrides`, matching the pattern already in the repo. Each range lapses automatically once the upstream tree moves past it. `fast-uri` is bounded to `^3.1.5` (stays on the 3.x line `ajv` expects) rather than the unbounded `>=3.1.5`, which resolved to a 4.x major.

**Proof:**
- `pnpm audit --prod --audit-level high` (root) → clean
- `pnpm audit --audit-level high` (root, all deps) → clean
- `pnpm audit --audit-level high --dir website` → clean (and clean at any severity)
- Full test suite: **3662 passing** (122 files)
- `website` production build (static export) → clean
- Lockfile diffs are surgical — only the three target packages changed, no incidental bumps.

## Code-scanning alerts — triaged, documented risk-acceptance

All 10 open alerts are `js/file-system-race` (CWE-367, TOCTOU). None is exploitable here and none has a non-degrading code fix:

- **CWE-367 requires a privilege boundary** — a privileged process an attacker races in a shared writable directory. `openspec archive` is an unprivileged CLI operating on the user's *own* files with the user's *own* permissions. No boundary is crossed.
- **7 alerts in `src/core/archive.ts`** sit inside the rollback / concurrent-change-detection engine (`fingerprintPath`, `releaseArchiveClaim`, `restoreSpecSnapshots`, …). That code *intentionally* does stat → read → **re-stat by name** and then throws `"Path changed while archive was reading …"` / `"rollback would overwrite a concurrent change"`. The flagged pattern is a deliberate race **detector**. Rewriting it to a pinned file descriptor would blind exactly the detection it exists to perform — strictly worse.
- **3 alerts in test files** are assertions inside the tests' own `mkdtemp` temp dirs (asserting inode preservation / file mode / content). There is no attacker and no untrusted path; a file-descriptor rewrite would only make the assertions less readable.

CodeQL runs via GitHub **default setup** (no workflow file in-repo), so a committed `paths-ignore` to descope test code isn't available. Disposition: dismiss the 10 as *won't fix — not exploitable in this threat model; concurrent-change already guarded* (7 archive) and *used in tests* (3 test), with this write-up as the justification.

## Notes

- The `brace-expansion` bump also forces `minimatch@3`'s copy to 5.0.9 (the previous override already forced it to 5.0.8, i.e. the 5.x line). Verified harmless: `minimatch@3` reaches the website only via `serve-handler` (dev preview, no brace-pattern globs), and the production build passes.
- Scope note: the `brace-expansion` fix is beyond the literal Dependabot list but is a real high-severity advisory the CI audit catches; leaving it would keep `main`'s Security workflow red.

---

## Hardening pass (commit `harden(security): …`)

A parallel review of four surfaces (dependency, CI, archive engine, adjacent code) produced these low-risk additions. Resolved dependency versions are unchanged.

| Item | Why |
|---|---|
| **Bound the 3 overrides** to current major (`brace-expansion ">=5.0.9 <6"`, `postcss ">=8.5.23 <9"`) | a bare `>=X` pin would take a future major on the next lockfile regen without review; the website already used the caret-bounded idiom |
| **Per-job permissions in `release-prepare.yml`** | dropped `pull-requests: write` from the top-level block; only the `prepare` job (opens the Version Packages PR) keeps it. The `beta` job only tags/releases + publishes via OIDC — least privilege |
| **New `Website Lockfile Drift` CI job** | the website keeps its own lockfile and is never installed in CI, so a website override that stops resolving would go unnoticed and `pnpm audit` would scan a stale graph. `pnpm install --frozen-lockfile --ignore-scripts --dir website` fails fast on drift (root drift is already caught in `ci.yml`) |
| **7 intent comments** at the `js/file-system-race` sites in `src/core/archive.ts` | records that the stat→read→re-stat pattern is a deliberate concurrent-change *detector*, so no future refactor (human or scanner-driven) collapses it to fd I/O and blinds the guard |

The review also **confirmed as already-solid** (nothing added): Dependabot covers all three surfaces, npm provenance is live, the `files` allowlist ships no source/secrets, `postinstall` is inert, every Action is SHA-pinned, no script-injection, and the injection/traversal/prototype-pollution surface is guarded. An independent trace of the archive rollback path found **no** constructible data-loss or symlink-escape exploit.

**Nix:** the root lockfile change staled `flake.nix`'s `pnpmDeps` hash; repinned to the value CI computed. All checks green.
