### PR TITLE
refactor(templates): share one apply instruction body across skill and command

### DIFF
--- a/src/core/templates/skill-templates.ts
+++ b/src/core/templates/skill-templates.ts
@@ -9,7 +9,7 @@ export type { SkillTemplate, CommandTemplate } from './types.js';
 export { getExploreSkillTemplate, getOpsxExploreCommandTemplate } from './workflows/explore.js';
 export { getNewChangeSkillTemplate, getOpsxNewCommandTemplate } from './workflows/new-change.js';
 export { getContinueChangeSkillTemplate, getOpsxContinueCommandTemplate } from './workflows/continue-change.js';
-export { getApplyChangeSkillTemplate, getOpsxApplyCommandTemplate } from './workflows/apply-change.js';
+export { getApplyInstructions, getApplyChangeSkillTemplate, getOpsxApplyCommandTemplate } from './workflows/apply-change.js';
 export { getUpdateChangeSkillTemplate, getOpsxUpdateCommandTemplate } from './workflows/update-change.js';
 export { getFfChangeSkillTemplate, getOpsxFfCommandTemplate } from './workflows/ff-change.js';
 export { getSyncSpecsSkillTemplate, getOpsxSyncCommandTemplate } from './workflows/sync-specs.js';

--- a/src/core/templates/workflows/apply-change.ts
+++ b/src/core/templates/workflows/apply-change.ts
@@ -8,13 +8,15 @@ import type { SkillTemplate, CommandTemplate } from '../types.js';
 import { STORE_SELECTION_GUIDANCE } from './store-selection.js';
 
 /**
- * The apply workflow instructions are shared by the skill and command
- * surfaces and authored once here, so the two outputs cannot silently drift.
- * Each surface renders this body with its own `contextFiles` note — the only
- * intentional wording difference between them — and can add further per-surface
- * parameters here as the surfaces evolve.
+ * The apply workflow instructions, authored once and rendered by both the
+ * skill and command surfaces. The surfaces are intentionally distinct, but
+ * they differ only in how they are invoked — the generation transformers
+ * rewrite the canonical `/opsx:<id>` tokens per surface downstream (see
+ * command-references.ts). The instruction text itself is shared, so the two
+ * cannot silently drift. Should a surface ever need genuinely different
+ * wording, add a parameter here and pass it from that surface's template.
  */
-function getApplyInstructions(contextFilesNote: string): string {
+export function getApplyInstructions(): string {
   return `Implement tasks from an OpenSpec change.
 
 ${STORE_SELECTION_GUIDANCE}
@@ -48,7 +50,7 @@ ${STORE_SELECTION_GUIDANCE}
    \`\`\`
 
    This returns:
-   - \`contextFiles\`: artifact ID -> array of concrete file paths (${contextFilesNote})
+   - \`contextFiles\`: artifact ID -> array of concrete file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
    - Progress (total, complete, remaining)
    - Task list with status
    - Dynamic instruction based on current state
@@ -190,18 +192,11 @@ This skill supports the "actions on a change" model:
 - **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly`;
 }
 
-/** Skill surface spells out example artifact sets in the contextFiles note. */
-const APPLY_SKILL_CONTEXT_FILES_NOTE =
-  'varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs';
-
-/** Command surface keeps the contextFiles note terse. */
-const APPLY_COMMAND_CONTEXT_FILES_NOTE = 'varies by schema';
-
 export function getApplyChangeSkillTemplate(): SkillTemplate {
   return {
     name: 'openspec-apply-change',
     description: 'Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.',
-    instructions: getApplyInstructions(APPLY_SKILL_CONTEXT_FILES_NOTE),
+    instructions: getApplyInstructions(),
     license: 'MIT',
     compatibility: 'Requires openspec CLI.',
     metadata: { author: 'openspec', version: '1.0' },
@@ -214,6 +209,6 @@ export function getOpsxApplyCommandTemplate(): CommandTemplate {
     description: 'Implement tasks from an OpenSpec change (Experimental)',
     category: 'Workflow',
     tags: ['workflow', 'artifacts', 'experimental'],
-    content: getApplyInstructions(APPLY_COMMAND_CONTEXT_FILES_NOTE),
+    content: getApplyInstructions(),
   };
 }

--- a/src/core/templates/workflows/apply-change.ts
+++ b/src/core/templates/workflows/apply-change.ts
@@ -7,11 +7,15 @@
 import type { SkillTemplate, CommandTemplate } from '../types.js';
 import { STORE_SELECTION_GUIDANCE } from './store-selection.js';
 
-export function getApplyChangeSkillTemplate(): SkillTemplate {
-  return {
-    name: 'openspec-apply-change',
-    description: 'Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.',
-    instructions: `Implement tasks from an OpenSpec change.
+/**
+ * The apply workflow instructions are shared by the skill and command
+ * surfaces and authored once here, so the two outputs cannot silently drift.
+ * Each surface renders this body with its own `contextFiles` note — the only
+ * intentional wording difference between them — and can add further per-surface
+ * parameters here as the surfaces evolve.
+ */
+function getApplyInstructions(contextFilesNote: string): string {
+  return `Implement tasks from an OpenSpec change.
 
 ${STORE_SELECTION_GUIDANCE}
 
@@ -44,7 +48,7 @@ ${STORE_SELECTION_GUIDANCE}
    \`\`\`
 
    This returns:
-   - \`contextFiles\`: artifact ID -> array of concrete file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - \`contextFiles\`: artifact ID -> array of concrete file paths (${contextFilesNote})
    - Progress (total, complete, remaining)
    - Task list with status
    - Dynamic instruction based on current state
@@ -183,7 +187,21 @@ What would you like to do?
 This skill supports the "actions on a change" model:
 
 - **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
-- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly`,
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly`;
+}
+
+/** Skill surface spells out example artifact sets in the contextFiles note. */
+const APPLY_SKILL_CONTEXT_FILES_NOTE =
+  'varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs';
+
+/** Command surface keeps the contextFiles note terse. */
+const APPLY_COMMAND_CONTEXT_FILES_NOTE = 'varies by schema';
+
+export function getApplyChangeSkillTemplate(): SkillTemplate {
+  return {
+    name: 'openspec-apply-change',
+    description: 'Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.',
+    instructions: getApplyInstructions(APPLY_SKILL_CONTEXT_FILES_NOTE),
     license: 'MIT',
     compatibility: 'Requires openspec CLI.',
     metadata: { author: 'openspec', version: '1.0' },
@@ -196,178 +214,6 @@ export function getOpsxApplyCommandTemplate(): CommandTemplate {
     description: 'Implement tasks from an OpenSpec change (Experimental)',
     category: 'Workflow',
     tags: ['workflow', 'artifacts', 'experimental'],
-    content: `Implement tasks from an OpenSpec change.
-
-${STORE_SELECTION_GUIDANCE}
-
-**Input**: Optionally specify a change name (e.g., \`/opsx:apply add-auth\`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
-
-**Steps**
-
-1. **Select the change**
-
-   If a name is provided, use it. Otherwise:
-   - Infer from conversation context if the user mentioned a change
-   - Auto-select if only one active change exists
-   - If ambiguous, run \`openspec list --json\` to get available changes and ask the user to select one
-
-   Always announce: "Using change: <name>" and how to override (e.g., \`/opsx:apply <other>\`).
-
-2. **Check status to understand the schema**
-   \`\`\`bash
-   openspec status --change "<name>" --json
-   \`\`\`
-   Parse the JSON to understand:
-   - \`schemaName\`: The workflow being used (e.g., "spec-driven")
-   - \`planningHome\`, \`changeRoot\`, and \`actionContext\`: planning scope and edit constraints
-   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
-
-3. **Get apply instructions**
-
-   \`\`\`bash
-   openspec instructions apply --change "<name>" --json
-   \`\`\`
-
-   This returns:
-   - \`contextFiles\`: artifact ID -> array of concrete file paths (varies by schema)
-   - Progress (total, complete, remaining)
-   - Task list with status
-   - Dynamic instruction based on current state
-   - Optional \`context\`: current required project instruction input from the selected root
-   - Optional \`operationGuidance\`: current advisory guidance for apply
-
-   **Handle states:**
-   - If \`state: "blocked"\` (missing artifacts): show message, suggest using \`/opsx:continue\` (if it is not installed, run \`openspec status --change "<name>" --json\` to see the next artifact and \`openspec instructions <artifact-id> --change "<name>" --json\` for how to create it)
-   - If \`state: "all_done"\`: congratulate, suggest archive
-   - Otherwise: proceed to implementation
-
-   Treat \`context\` as a required prompt-level input. Read and consider it, and
-   apply relevant project facts, conventions, and constraints while implementing.
-   Treat \`operationGuidance\` as optional additive advice. Read and consider every
-   entry, and follow entries that are applicable and compatible with the built-in
-   workflow.
-
-   Keep both fields separate from CLI-returned state, missing artifacts, tasks,
-   progress, \`contextFiles\`, and the built-in \`instruction\`. They are not
-   evidence of task completion, do not replace the built-in instruction, and do
-   not permit bypassing a blocked state. If context conflicts with the built-in
-   instruction, an explicit user choice, or a CLI-controlled value, report the
-   conflict and preserve the controlling value. If guidance is inapplicable or
-   conflicts with those controlling inputs, do not follow it and explain why.
-   These are prompt-level behavior contracts, not enforceable checks.
-
-4. **Read context files**
-
-   Read every file path listed under \`contextFiles\` from the apply instructions output.
-   The files depend on the schema being used:
-   - **spec-driven**: proposal, specs, design, tasks
-   - Other schemas: follow the contextFiles from CLI output
-
-   Do not copy \`context\` or \`operationGuidance\` verbatim into implementation
-   files or planning artifacts unless the user separately asks for that content.
-
-5. **Show current progress**
-
-   Display:
-   - Schema being used
-   - Progress: "N/M tasks complete"
-   - Remaining tasks overview
-   - Dynamic instruction from CLI
-
-6. **Implement tasks (loop until done or blocked)**
-
-   For each pending task:
-   - Show which task is being worked on
-   - Make the code changes required
-   - Keep changes minimal and focused
-   - Mark task complete in the tasks file: \`- [ ]\` → \`- [x]\`
-   - Continue to next task
-
-   **Pause if:**
-   - Task is unclear → ask for clarification
-   - Implementation reveals a design issue → suggest updating artifacts
-   - Error or blocker encountered → report and wait for guidance
-   - User interrupts
-
-7. **On completion or pause, show status**
-
-   Display:
-   - Tasks completed this session
-   - Overall progress: "N/M tasks complete"
-   - If all done: suggest archive
-   - If paused: explain why and wait for guidance
-
-**Output During Implementation**
-
-\`\`\`
-## Implementing: <change-name> (schema: <schema-name>)
-
-Working on task 3/7: <task description>
-[...implementation happening...]
-✓ Task complete
-
-Working on task 4/7: <task description>
-[...implementation happening...]
-✓ Task complete
-\`\`\`
-
-**Output On Completion**
-
-\`\`\`
-## Implementation Complete
-
-**Change:** <change-name>
-**Schema:** <schema-name>
-**Progress:** 7/7 tasks complete ✓
-
-### Completed This Session
-- [x] Task 1
-- [x] Task 2
-...
-
-All tasks complete! You can archive this change with \`/opsx:archive\`.
-\`\`\`
-
-**Output On Pause (Issue Encountered)**
-
-\`\`\`
-## Implementation Paused
-
-**Change:** <change-name>
-**Schema:** <schema-name>
-**Progress:** 4/7 tasks complete
-
-### Issue Encountered
-<description of the issue>
-
-**Options:**
-1. <option 1>
-2. <option 2>
-3. Other approach
-
-What would you like to do?
-\`\`\`
-
-**Guardrails**
-- Keep going through tasks until done or blocked
-- Always read context files before starting (from the apply instructions output)
-- If task is ambiguous, pause and ask before implementing
-- If implementation reveals issues, pause and suggest artifact updates
-- Keep code changes minimal and scoped to each task
-- Update task checkbox immediately after completing each task
-- Pause on errors, blockers, or unclear requirements - don't guess
-- Use contextFiles from CLI output, don't assume specific file names
-- Do not use context or operation guidance as proof that a task is complete
-- Apply relevant project context; report conflicts with controlling workflow inputs
-- Consider every guidance entry; explain any inapplicable or conflicting advice
-- Do not copy runtime context or operation guidance into implementation files or planning artifacts
-- Preserve CLI-controlled blocked/ready/all-done behavior and completion criteria
-
-**Fluid Workflow Integration**
-
-This skill supports the "actions on a change" model:
-
-- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
-- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly`
+    content: getApplyInstructions(APPLY_COMMAND_CONTEXT_FILES_NOTE),
   };
 }

--- a/test/core/templates/skill-templates-parity.test.ts
+++ b/test/core/templates/skill-templates-parity.test.ts
@@ -950,3 +950,28 @@ describe('skill templates split parity', () => {
     }
   });
 });
+
+describe('apply skill/command shared instruction core', () => {
+  // The apply skill and command render one shared instruction body. The only
+  // intentional wording difference is how fully the `contextFiles` note spells
+  // out possible artifact sets. This pins that contract: it fails if the body
+  // drifts between surfaces (accidental divergence) and equally fails if the
+  // note is flattened to a single form (erasing the intentional difference).
+  const SKILL_NOTE =
+    'varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs';
+  const COMMAND_NOTE = 'varies by schema';
+
+  it('differs only in the contextFiles note', () => {
+    const skill = getApplyChangeSkillTemplate().instructions;
+    const command = getOpsxApplyCommandTemplate().content;
+    expect(skill.replace(SKILL_NOTE, COMMAND_NOTE)).toBe(command);
+  });
+
+  it('keeps the intentional per-surface contextFiles difference', () => {
+    const skill = getApplyChangeSkillTemplate().instructions;
+    const command = getOpsxApplyCommandTemplate().content;
+    expect(skill).toContain(SKILL_NOTE);
+    expect(command).toContain(`(${COMMAND_NOTE})`);
+    expect(command).not.toContain(SKILL_NOTE);
+  });
+});

--- a/test/core/templates/skill-templates-parity.test.ts
+++ b/test/core/templates/skill-templates-parity.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   type SkillTemplate,
+  getApplyInstructions,
   getApplyChangeSkillTemplate,
   getArchiveChangeSkillTemplate,
   getBulkArchiveChangeSkillTemplate,
@@ -47,7 +48,7 @@ const EXPECTED_FUNCTION_HASHES: Record<string, string> = {
   getOpsxExploreCommandTemplate: 'e2d470148708a9070675edddd1e783f1c71c96625d08cff4fe7a9994e0d292c0',
   getOpsxNewCommandTemplate: '08e784e52ac2c146975a874257c589d88e93efbd83dc4d79253c8525f5c3064f',
   getOpsxContinueCommandTemplate: 'ae964cd00f6ca332fd7f9428a577ade75be279f50431d5f60ece8172e8d1a4b1',
-  getOpsxApplyCommandTemplate: 'd879b0430f756b9dbc5a1a1348a34409b2fcd453eeae7add4bf9f421616c2ad1',
+  getOpsxApplyCommandTemplate: 'd27ad905657dd3797571eccee2b6416495fa9b39759d36b43a9871a301757979',
   getOpsxFfCommandTemplate: '012610f85576a7055dfec2aaabba6bfc245454ce91fb6214587ae9316dc2b864',
   getArchiveChangeSkillTemplate: '5ef19163f73997fdda1c69dc8bca710c16c50b052b481821d916f4084bb42a64',
   getBulkArchiveChangeSkillTemplate: '03cc44a0ce9bdb3ba2668a9d43946596308901600aa29a728c4a71fc76e86de3',
@@ -952,26 +953,15 @@ describe('skill templates split parity', () => {
 });
 
 describe('apply skill/command shared instruction core', () => {
-  // The apply skill and command render one shared instruction body. The only
-  // intentional wording difference is how fully the `contextFiles` note spells
-  // out possible artifact sets. This pins that contract: it fails if the body
-  // drifts between surfaces (accidental divergence) and equally fails if the
-  // note is flattened to a single form (erasing the intentional difference).
-  const SKILL_NOTE =
-    'varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs';
-  const COMMAND_NOTE = 'varies by schema';
-
-  it('differs only in the contextFiles note', () => {
-    const skill = getApplyChangeSkillTemplate().instructions;
-    const command = getOpsxApplyCommandTemplate().content;
-    expect(skill.replace(SKILL_NOTE, COMMAND_NOTE)).toBe(command);
-  });
-
-  it('keeps the intentional per-surface contextFiles difference', () => {
-    const skill = getApplyChangeSkillTemplate().instructions;
-    const command = getOpsxApplyCommandTemplate().content;
-    expect(skill).toContain(SKILL_NOTE);
-    expect(command).toContain(`(${COMMAND_NOTE})`);
-    expect(command).not.toContain(SKILL_NOTE);
+  // The apply skill and command are intentionally distinct surfaces, but they
+  // differ only in how they are invoked — the generation transformers rewrite
+  // the canonical `/opsx:<id>` tokens per surface downstream (asserted in
+  // test/utils/command-references.test.ts). The instruction text itself is
+  // shared, so this pins the contract: both surfaces render the one canonical
+  // core and cannot silently drift apart at the template level.
+  it('renders both apply surfaces from the shared instruction core', () => {
+    const core = getApplyInstructions();
+    expect(getApplyChangeSkillTemplate().instructions).toBe(core);
+    expect(getOpsxApplyCommandTemplate().content).toBe(core);
   });
 });


### PR DESCRIPTION
**Status:** Ready. Internal refactor plus one small drift fix — no change to the generated skill; the generated command gains a more informative note.

**What was wrong**
The apply skill and command templates each held a full ~150-line copy of the same instruction body. They differed in exactly one line — the `contextFiles` note (skill spelled out example artifact sets; command said only "varies by schema"). Two near-identical copies drift over time, and that one line was itself long-standing accidental drift between the copies.

**What it does**
- **Shared core.** The body is authored once in `getApplyInstructions()` and rendered by both surfaces.
- **Drift resolved.** The surfaces are meant to differ only in *how they are invoked* — the generation transformers already handle that downstream, rewriting the canonical `/opsx:<id>` tokens per surface (`/openspec-*` for skills, `/opsx:*` for commands, etc.). The `contextFiles` wording was never an intentional surface difference, so both now use the more informative note.
- **Contract test.** A new test asserts both surfaces render the shared core, so they can't silently drift at the template level; the per-surface invocation rendering stays covered by the existing tests in `test/utils/command-references.test.ts`.

**Proof it's safe**
- Generated **skill** output (`skills/openspec-apply-change/SKILL.md`) is **byte-identical** to before.
- Only change to generated output: the apply **command**'s `contextFiles` line now reads `(varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)` instead of `(varies by schema)`. One parity hash regenerated to match.
- Full template + generation + init/update/migration suites green (645 tests); typecheck and lint clean.

**Scope**
`apply-change.ts` (the shared core), a one-line re-export in `skill-templates.ts`, and the contract test. No other workflow file touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Standardized instructions across the apply skill and apply command for a more consistent experience.
  * Unified guidance for context files across both workflow surfaces.

* **Tests**
  * Added coverage to verify that both apply experiences use the same core instructions.
  * Updated validation to preserve consistent template content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->