### PR TITLE
chore(release): add catch-up changeset for Rovo, Codex dir, status

### DIFF
--- a/.changeset/catch-up-rovo-codex-status.md
+++ b/.changeset/catch-up-rovo-codex-status.md
@@ -1,0 +1,12 @@
+---
+"@fission-ai/openspec": minor
+---
+
+### New Features
+
+- **Atlassian Rovo Dev CLI** — `openspec init --tools rovodev` installs the OpenSpec workflow skills for Atlassian's Rovo Dev CLI. It is skills-only (no slash commands), written to `.rovodev`.
+
+### Bug Fixes
+
+- **Codex skills now live in the shared `.agents` directory** — `openspec init` and `openspec update` install Codex skills under `.agents/skills/` (the canonical location assistants read) and migrate an existing `.codex` skills directory in place. Files you customized are preserved, not overwritten.
+- **`openspec status` separates planning from implementation** — status now reports `isPlanningComplete` (every planning artifact is written) distinctly from overall progress, and its messages no longer imply a change is finished before it has been implemented. `isComplete` is kept as a compatibility alias, so existing scripts keep working.

--- a/.changeset/catch-up-rovo-codex-status.md
+++ b/.changeset/catch-up-rovo-codex-status.md
@@ -9,4 +9,4 @@
 ### Bug Fixes
 
 - **Codex skills now live in the shared `.agents` directory** — `openspec init` and `openspec update` install Codex skills under `.agents/skills/` (the canonical location assistants read) and migrate an existing `.codex` skills directory in place. Files you customized are preserved, not overwritten.
-- **`openspec status` separates planning from implementation** — status now reports `isPlanningComplete` (every planning artifact is written) distinctly from overall progress, and its messages no longer imply a change is finished before it has been implemented. `isComplete` is kept as a compatibility alias, so existing scripts keep working.
+- **`openspec status` separates planning from implementation** — status now reports `isPlanningComplete` (every non-skipped planning artifact exists; skipped artifacts count as satisfied without being written) distinctly from overall progress, and its messages no longer imply a change is finished before it has been implemented. `isComplete` is kept as a compatibility alias, so existing scripts keep working.


### PR DESCRIPTION
## Status
Catch-up changeset only — no code changes. Adds one `.changeset/*.md` so three user-facing PRs that merged without release tracking land in the v1.8.0 CHANGELOG.

## What was missing
These merged since v1.7.0 with no changeset, so the auto-generated Version Packages PR (#1488) omits them from `CHANGELOG.md`:

| PR | Change | Why it's user-facing |
|----|--------|----------------------|
| #1516 | Atlassian Rovo Dev CLI | New first-class `--tools rovodev` target |
| #1511 | Codex skills → shared `.agents` dir | `update` migrates existing codex users' files |
| #1505 | `openspec status` planning vs. done | New `isPlanningComplete` field + changed output |

## What this does
Adds `.changeset/catch-up-rovo-codex-status.md` (minor bump). The release stays **1.8.0** — it was already minor. Once this merges, the Changesets action refreshes #1488 to include these entries; then #1488 is the publish trigger.

## Verification
`changeset status` → `@fission-ai/openspec` bumped at minor. No source files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Atlassian Rovo Dev CLI.
  * Migrated Codex skills to the `.agents/skills/` location while preserving customized files.
  * Improved `openspec status` reporting for planned and completed work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->