### PR TITLE
feat(validate): add --archived to lint task completion of archived changes

### DIFF
--- a/.changeset/validate-archived-tasks.md
+++ b/.changeset/validate-archived-tasks.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": minor
+---
+
+Add `openspec validate --archived`: an opt-in check that every change under `changes/archive/` has all of its `tasks.md` checkboxes ticked, exiting non-zero if any are unchecked. This surfaces changes that were archived with unfinished work — which the normal validate flow never catches, because it only looks at active changes — and is meant for a pre-commit or CI hook (#205). It is a standalone scope: it does not alter any existing `validate` invocation and does not re-validate already-applied spec deltas.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -553,11 +553,14 @@ A change with zero spec deltas fails validation unless its `.openspec.yaml` decl
 | `--all` | Validate all changes and specs |
 | `--changes` | Validate all changes |
 | `--specs` | Validate all specs |
+| `--archived` | Check that archived changes have all tasks completed (for pre-commit linting) |
 | `--type <type>` | Specify type when name is ambiguous: `change` or `spec` |
 | `--strict` | Enable strict validation mode |
 | `--json` | Output as JSON |
 | `--concurrency <n>` | Max parallel validations (default: 6, or `OPENSPEC_CONCURRENCY` env) |
 | `--no-interactive` | Disable prompts |
+
+`--archived` is its own scope: it does not validate spec deltas (already applied at archive time), it verifies that every change under `changes/archive/` has all of its `tasks.md` checkboxes ticked, exiting non-zero if any are unchecked. This catches changes that were archived with unfinished work — handy in a pre-commit hook.
 
 **Examples:**
 
@@ -576,6 +579,9 @@ openspec validate --all --json
 
 # Strict validation with increased parallelism
 openspec validate --all --strict --concurrency 12
+
+# Fail if any archived change still has unchecked tasks
+openspec validate --archived
 ```
 
 **Output (text):**

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -553,7 +553,7 @@ A change with zero spec deltas fails validation unless its `.openspec.yaml` decl
 | `--all` | Validate all changes and specs |
 | `--changes` | Validate all changes |
 | `--specs` | Validate all specs |
-| `--archived` | Check that archived changes have all tasks completed (for pre-commit linting) |
+| `--archived` | Validate that archived changes have all tasks completed (for pre-commit linting) |
 | `--type <type>` | Specify type when name is ambiguous: `change` or `spec` |
 | `--strict` | Enable strict validation mode |
 | `--json` | Output as JSON |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -92,6 +92,7 @@ Validation checks your specs and changes for structural problems. Read the messa
 openspec validate <name>           # validate one item
 openspec validate --all            # validate everything
 openspec validate --all --strict   # stricter checks, good for CI
+openspec validate --archived       # fail if archived changes have unchecked tasks
 ```
 
 Common causes are a missing required section (like a spec with no scenarios) or a malformed delta header. Fix the file and re-run. The [CLI reference](cli.md#openspec-validate) documents the output format.

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -439,6 +439,7 @@ program
   .option('--all', 'Validate all changes and specs')
   .option('--changes', 'Validate all changes')
   .option('--specs', 'Validate all specs')
+  .option('--archived', 'Validate that archived changes have all tasks completed (for pre-commit linting)')
   .option('--type <type>', 'Specify item type when ambiguous: change|spec')
   .option('--strict', 'Enable strict validation mode')
   .option('--json', 'Output validation results as JSON')
@@ -446,7 +447,7 @@ program
   .option('--no-interactive', 'Disable interactive prompts')
   .option('--store <id>', STORE_OPTION_DESCRIPTION)
   .addOption(hiddenStorePathOption())
-  .action(async (itemName?: string, options?: { all?: boolean; changes?: boolean; specs?: boolean; type?: string; strict?: boolean; json?: boolean; noInteractive?: boolean; concurrency?: string; store?: string; storePath?: string }) => {
+  .action(async (itemName?: string, options?: { all?: boolean; changes?: boolean; specs?: boolean; archived?: boolean; type?: string; strict?: boolean; json?: boolean; noInteractive?: boolean; concurrency?: string; store?: string; storePath?: string }) => {
     try {
       const validateCommand = new ValidateCommand();
       await validateCommand.execute(itemName, options);

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -14,7 +14,7 @@ import { getSpecIds } from '../utils/item-discovery.js';
 import { getAvailableChanges } from './workflow/shared.js';
 import { nearestMatches } from '../utils/match.js';
 import { promises as fs } from 'fs';
-import { getTaskProgressForChange } from '../utils/task-progress.js';
+import { getTaskProgressDetailForChange } from '../utils/task-progress.js';
 
 type ItemType = 'change' | 'spec';
 
@@ -407,6 +407,11 @@ export class ValidateCommand {
    * Lists archived change ids from the resolved root's archive directory,
    * mirroring `getArchivedChangeIds` but store-aware (uses `root.archiveDir`
    * rather than a cwd-relative path). Directories only, hidden entries skipped.
+   *
+   * Only a missing archive directory (ENOENT) is an empty list; a permission
+   * error, an I/O error, or an `archive` path that is a file (ENOTDIR) is a real
+   * failure and must not read as "no archived changes" — that would let a
+   * pre-commit lint pass without inspecting anything (#205).
    */
   private async listArchivedChangeIds(root: ResolvedOpenSpecRoot): Promise<string[]> {
     try {
@@ -415,8 +420,9 @@ export class ValidateCommand {
         .filter((entry) => entry.isDirectory() && !entry.name.startsWith('.'))
         .map((entry) => entry.name)
         .sort();
-    } catch {
-      return [];
+    } catch (error: any) {
+      if (error?.code === 'ENOENT') return [];
+      throw error;
     }
   }
 
@@ -434,8 +440,10 @@ export class ValidateCommand {
     root: ResolvedOpenSpecRoot,
     opts: { json: boolean; noInteractive?: boolean }
   ): Promise<void> {
-    const spinner = !opts.json && !opts.noInteractive ? ora('Validating archived changes...').start() : undefined;
+    // List first (may throw on a real archive-read failure), then start the
+    // spinner so a thrown error never leaves a spinner spinning.
     const ids = await this.listArchivedChangeIds(root);
+    const spinner = !opts.json && !opts.noInteractive ? ora('Validating archived changes...').start() : undefined;
 
     const results: BulkItemResult[] = [];
     let passed = 0;
@@ -444,7 +452,19 @@ export class ValidateCommand {
       const start = Date.now();
       const issues: BulkItemResult['issues'] = [];
       try {
-        const progress = await getTaskProgressForChange(root.archiveDir, id, root.path);
+        const progress = await getTaskProgressDetailForChange(root.archiveDir, id, root.path);
+        // A tasks file that exists but cannot be read must fail loudly, not be
+        // silently counted as "no tasks" and pass.
+        if (progress.unreadable.length > 0) {
+          const files = progress.unreadable
+            .map((file) => path.relative(root.path, file))
+            .join(', ');
+          issues.push({
+            level: 'ERROR',
+            path: 'tasks',
+            message: `could not read task file${progress.unreadable.length === 1 ? '' : 's'}: ${files}`,
+          });
+        }
         const incomplete = Math.max(progress.total - progress.completed, 0);
         if (incomplete > 0) {
           issues.push({

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -14,7 +14,8 @@ import { getSpecIds } from '../utils/item-discovery.js';
 import { getAvailableChanges } from './workflow/shared.js';
 import { nearestMatches } from '../utils/match.js';
 import { promises as fs } from 'fs';
-import { getTaskProgressDetailForChange } from '../utils/task-progress.js';
+import { getTaskProgressDetailForChange, type SchemaGlobCache } from '../utils/task-progress.js';
+import { FileSystemUtils } from '../utils/file-system.js';
 
 type ItemType = 'change' | 'spec';
 
@@ -445,6 +446,14 @@ export class ValidateCommand {
     const ids = await this.listArchivedChangeIds(root);
     const spinner = !opts.json && !opts.noInteractive ? ora('Validating archived changes...').start() : undefined;
 
+    // The archive is append-only and can hold thousands of changes; a single
+    // run resolves them all under one constant projectRoot (root.path), so
+    // memoize the schema→glob lookup to avoid re-parsing the same schema.yaml
+    // once per change. The loop is intentionally sequential: the per-change work
+    // is dominated by synchronous schema/config resolution, which a promise pool
+    // cannot overlap on Node's single thread — a pool would add complexity for
+    // no real gain here.
+    const schemaGlobCache: SchemaGlobCache = new Map();
     const results: BulkItemResult[] = [];
     let passed = 0;
     let failed = 0;
@@ -452,29 +461,30 @@ export class ValidateCommand {
       const start = Date.now();
       const issues: BulkItemResult['issues'] = [];
       try {
-        const progress = await getTaskProgressDetailForChange(root.archiveDir, id, root.path);
+        // The explicit root.path override is load-bearing: an archived change
+        // lives one directory deeper (changes/archive/<id>), so the default
+        // "../../.." projectRoot derivation would be wrong without it.
+        const progress = await getTaskProgressDetailForChange(root.archiveDir, id, root.path, schemaGlobCache);
         // A tasks file that exists but cannot be read must fail loudly, not be
-        // silently counted as "no tasks" and pass.
-        if (progress.unreadable.length > 0) {
-          const files = progress.unreadable
-            .map((file) => path.relative(root.path, file))
-            .join(', ');
+        // silently counted as "no tasks" and pass. Report one issue per file,
+        // pathed like every other validate issue (POSIX, root-relative).
+        for (const file of progress.unreadable) {
           issues.push({
             level: 'ERROR',
-            path: 'tasks',
-            message: `could not read task file${progress.unreadable.length === 1 ? '' : 's'}: ${files}`,
+            path: FileSystemUtils.toPosixPath(path.relative(root.path, file)),
+            message: 'could not read task file',
           });
         }
         const incomplete = Math.max(progress.total - progress.completed, 0);
         if (incomplete > 0) {
           issues.push({
             level: 'ERROR',
-            path: 'tasks',
+            path: 'tasks.md',
             message: `${incomplete} incomplete task${incomplete === 1 ? '' : 's'} (${progress.completed}/${progress.total} completed)`,
           });
         }
       } catch (error: any) {
-        issues.push({ level: 'ERROR', path: 'tasks', message: error?.message || 'Unknown error' });
+        issues.push({ level: 'ERROR', path: 'tasks.md', message: error?.message || 'Unknown error' });
       }
       const valid = issues.length === 0;
       if (valid) passed++; else failed++;
@@ -501,11 +511,13 @@ export class ValidateCommand {
       return;
     }
 
+    // Use the same `<type>/<id>` prefix bulk validation prints, so the plain
+    // output maps to the JSON `type` ('change') and stays greppable the same way.
     for (const res of results) {
       if (res.valid) {
-        console.log(`✓ archived/${res.id}`);
+        console.log(`✓ change/${res.id}`);
       } else {
-        console.error(`✗ archived/${res.id}`);
+        console.error(`✗ change/${res.id}`);
         for (const issue of res.issues) {
           const prefix = issue.level === 'ERROR' ? '✗' : issue.level === 'WARNING' ? '⚠' : 'ℹ';
           console.error(`  ${prefix} ${issue.message}`);

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -13,6 +13,8 @@ import { isInteractive, resolveNoInteractive } from '../utils/interactive.js';
 import { getSpecIds } from '../utils/item-discovery.js';
 import { getAvailableChanges } from './workflow/shared.js';
 import { nearestMatches } from '../utils/match.js';
+import { promises as fs } from 'fs';
+import { getTaskProgressForChange } from '../utils/task-progress.js';
 
 type ItemType = 'change' | 'spec';
 
@@ -20,6 +22,7 @@ interface ExecuteOptions {
   all?: boolean;
   changes?: boolean;
   specs?: boolean;
+  archived?: boolean;
   type?: string;
   strict?: boolean;
   json?: boolean;
@@ -46,6 +49,18 @@ export class ValidateCommand {
     }
 
     const interactive = isInteractive(options);
+
+    // Archived-task linting is its own scope: it checks task completion of
+    // already-archived changes, not delta specs (whose operations are already
+    // applied). Handled before the other bulk flags so `--archived` is explicit
+    // and never alters an existing invocation's behavior (#205).
+    if (options.archived) {
+      await this.runArchivedTaskValidation(root, {
+        json: !!options.json,
+        noInteractive: resolveNoInteractive(options),
+      });
+      return;
+    }
 
     // Handle bulk flags first
     if (options.all || options.changes || options.specs) {
@@ -385,6 +400,99 @@ export class ValidateCommand {
       }
     }
 
+    process.exitCode = failed > 0 ? 1 : 0;
+  }
+
+  /**
+   * Lists archived change ids from the resolved root's archive directory,
+   * mirroring `getArchivedChangeIds` but store-aware (uses `root.archiveDir`
+   * rather than a cwd-relative path). Directories only, hidden entries skipped.
+   */
+  private async listArchivedChangeIds(root: ResolvedOpenSpecRoot): Promise<string[]> {
+    try {
+      const entries = await fs.readdir(root.archiveDir, { withFileTypes: true });
+      return entries
+        .filter((entry) => entry.isDirectory() && !entry.name.startsWith('.'))
+        .map((entry) => entry.name)
+        .sort();
+    } catch {
+      return [];
+    }
+  }
+
+  /**
+   * Validates that every archived change has all of its tasks completed.
+   *
+   * An archived change is expected to be finished; an archived change with
+   * unchecked tasks is a real integrity problem the normal validate flow never
+   * surfaces, because active-change discovery excludes the archive directory
+   * (#205). Reuses the same task-progress counting `status`, `list`, and
+   * `archive` rely on, so what counts as a task never forks. Changes with no
+   * tasks pass (nothing to complete).
+   */
+  private async runArchivedTaskValidation(
+    root: ResolvedOpenSpecRoot,
+    opts: { json: boolean; noInteractive?: boolean }
+  ): Promise<void> {
+    const spinner = !opts.json && !opts.noInteractive ? ora('Validating archived changes...').start() : undefined;
+    const ids = await this.listArchivedChangeIds(root);
+
+    const results: BulkItemResult[] = [];
+    let passed = 0;
+    let failed = 0;
+    for (const id of ids) {
+      const start = Date.now();
+      const issues: BulkItemResult['issues'] = [];
+      try {
+        const progress = await getTaskProgressForChange(root.archiveDir, id, root.path);
+        const incomplete = Math.max(progress.total - progress.completed, 0);
+        if (incomplete > 0) {
+          issues.push({
+            level: 'ERROR',
+            path: 'tasks',
+            message: `${incomplete} incomplete task${incomplete === 1 ? '' : 's'} (${progress.completed}/${progress.total} completed)`,
+          });
+        }
+      } catch (error: any) {
+        issues.push({ level: 'ERROR', path: 'tasks', message: error?.message || 'Unknown error' });
+      }
+      const valid = issues.length === 0;
+      if (valid) passed++; else failed++;
+      results.push({ id, type: 'change', valid, issues, durationMs: Date.now() - start });
+    }
+
+    spinner?.stop();
+
+    const summary = {
+      totals: { items: results.length, passed, failed },
+      byType: { change: summarizeType(results, 'change') },
+    } as const;
+
+    if (opts.json) {
+      const out = { items: results, summary, version: '1.0', root: toRootOutput(root) };
+      console.log(JSON.stringify(out, null, 2));
+      process.exitCode = failed > 0 ? 1 : 0;
+      return;
+    }
+
+    if (results.length === 0) {
+      console.log('No archived changes found.');
+      process.exitCode = 0;
+      return;
+    }
+
+    for (const res of results) {
+      if (res.valid) {
+        console.log(`✓ archived/${res.id}`);
+      } else {
+        console.error(`✗ archived/${res.id}`);
+        for (const issue of res.issues) {
+          const prefix = issue.level === 'ERROR' ? '✗' : issue.level === 'WARNING' ? '⚠' : 'ℹ';
+          console.error(`  ${prefix} ${issue.message}`);
+        }
+      }
+    }
+    console.log(`Totals: ${summary.totals.passed} passed, ${summary.totals.failed} failed (${summary.totals.items} items)`);
     process.exitCode = failed > 0 ? 1 : 0;
   }
 }

--- a/src/core/completions/command-registry.ts
+++ b/src/core/completions/command-registry.ts
@@ -98,6 +98,10 @@ export const COMMAND_REGISTRY: CommandDefinition[] = [
         name: 'specs',
         description: 'Validate all specs',
       },
+      {
+        name: 'archived',
+        description: 'Validate that archived changes have all tasks completed (for pre-commit linting)',
+      },
       COMMON_FLAGS.type,
       COMMON_FLAGS.strict,
       COMMON_FLAGS.jsonValidation,

--- a/src/utils/task-progress.ts
+++ b/src/utils/task-progress.ts
@@ -80,24 +80,47 @@ function findTrackedTasksArtifact(schema: SchemaYaml): Artifact | undefined {
 }
 
 /**
+ * Run-scoped memo mapping a schema name to its tracked-tasks `generates` glob.
+ * When one command resolves progress for many changes under a constant
+ * `projectRoot` — e.g. `validate --archived` over an append-only archive — this
+ * avoids re-reading and re-parsing (YAML + Zod) the same `schema.yaml` once per
+ * change. Keyed by schema name alone, which is safe *only* because a single run
+ * holds `projectRoot` constant; never reuse one cache across differing roots.
+ */
+export type SchemaGlobCache = Map<string, string | undefined>;
+
+/**
  * Resolves the tracked-tasks artifact's output glob for a change, or undefined
  * when the schema cannot be resolved or no tracked-tasks artifact exists.
  * `resolveSchema` throws on an unresolvable/misnamed schema; we swallow that so
  * the caller falls back to a single top-level `tasks.md` and never crashes.
+ * A `schemaGlobCache`, when supplied, memoizes the schema-name → glob lookup for
+ * the duration of one run.
  */
-function resolveTrackedTasksGlob(changeDir: string, projectRoot: string): string | undefined {
+function resolveTrackedTasksGlob(
+  changeDir: string,
+  projectRoot: string,
+  schemaGlobCache?: SchemaGlobCache
+): string | undefined {
   try {
     const schemaName = resolveSchemaForChange(changeDir, undefined, projectRoot);
+    if (schemaGlobCache?.has(schemaName)) return schemaGlobCache.get(schemaName);
     const schema = resolveSchema(schemaName, projectRoot);
-    return findTrackedTasksArtifact(schema)?.generates;
+    const generates = findTrackedTasksArtifact(schema)?.generates;
+    schemaGlobCache?.set(schemaName, generates);
+    return generates;
   } catch {
     return undefined;
   }
 }
 
 /** Resolves the task files selected by the schema's apply tracking rule. */
-export function resolveTaskFilesForChange(changeDir: string, projectRoot: string): string[] {
-  const generates = resolveTrackedTasksGlob(changeDir, projectRoot);
+export function resolveTaskFilesForChange(
+  changeDir: string,
+  projectRoot: string,
+  schemaGlobCache?: SchemaGlobCache
+): string[] {
+  const generates = resolveTrackedTasksGlob(changeDir, projectRoot, schemaGlobCache);
   return generates ? resolveArtifactOutputs(changeDir, generates) : [];
 }
 
@@ -137,15 +160,19 @@ async function countTaskFile(file: string, unreadable: string[]): Promise<TaskPr
  * `tasks.md` files (#1202). Falls back to a single top-level `tasks.md` (exactly
  * as before) when the schema is unresolvable, no tracked-tasks artifact is found,
  * or the glob matches no file. Also reports task files that exist but could not
- * be read. Never throws.
+ * be read. Per-file read errors are captured (never thrown); the only throw path
+ * is a malformed/unsafe schema whose glob resolution rejects (path traversal or
+ * a linked-directory cycle in `resolveArtifactOutputs`). Pass `schemaGlobCache`
+ * to memoize schema→glob resolution across many changes in one run.
  */
 export async function getTaskProgressDetailForChange(
   changesDir: string,
   changeName: string,
-  projectRoot: string
+  projectRoot: string,
+  schemaGlobCache?: SchemaGlobCache
 ): Promise<TaskProgressDetail> {
   const changeDir = path.join(changesDir, changeName);
-  const files = resolveTaskFilesForChange(changeDir, projectRoot);
+  const files = resolveTaskFilesForChange(changeDir, projectRoot, schemaGlobCache);
   const targets = files.length > 0 ? files : [path.join(changeDir, 'tasks.md')];
   const unreadable: string[] = [];
   let total = 0;
@@ -161,7 +188,9 @@ export async function getTaskProgressDetailForChange(
 /**
  * The task-completion counter `status`, `list`, and `archive` share. Delegates
  * to `getTaskProgressDetailForChange` and drops the `unreadable` detail, so its
- * returned totals are unchanged. Never throws.
+ * returned totals are unchanged. Throws only on the same malformed/unsafe-schema
+ * glob-resolution path as that function (existing behavior; callers guard it as
+ * they did before).
  */
 export async function getTaskProgressForChange(
   changesDir: string,

--- a/src/utils/task-progress.ts
+++ b/src/utils/task-progress.ts
@@ -95,20 +95,38 @@ function resolveTrackedTasksGlob(changeDir: string, projectRoot: string): string
   }
 }
 
-async function countSingleTopLevelTasksFile(changeDir: string): Promise<TaskProgress> {
-  const tasksPath = path.join(changeDir, 'tasks.md');
-  try {
-    const content = await fs.readFile(tasksPath, 'utf-8');
-    return countTasksFromContent(content);
-  } catch {
-    return { total: 0, completed: 0 };
-  }
-}
-
 /** Resolves the task files selected by the schema's apply tracking rule. */
 export function resolveTaskFilesForChange(changeDir: string, projectRoot: string): string[] {
   const generates = resolveTrackedTasksGlob(changeDir, projectRoot);
   return generates ? resolveArtifactOutputs(changeDir, generates) : [];
+}
+
+export interface TaskProgressDetail extends TaskProgress {
+  /**
+   * Task files that exist but could not be read (any error other than ENOENT).
+   * `getTaskProgressForChange` discards this list to preserve its behavior;
+   * callers that must fail loudly on an unreadable tasks file — e.g.
+   * `openspec validate --archived` — read it so an unreadable file is never
+   * silently counted as "no tasks" (#205).
+   */
+  unreadable: string[];
+}
+
+/**
+ * Reads one task file and counts its checkboxes. ENOENT (a glob file that
+ * vanished between resolve and read, or the absent single top-level `tasks.md`)
+ * means zero tasks, exactly as before. Any other error (permissions, I/O,
+ * ENOTDIR) is recorded in `unreadable` so a caller can surface it; the count
+ * still contributes zero, so existing callers see no change.
+ */
+async function countTaskFile(file: string, unreadable: string[]): Promise<TaskProgress> {
+  try {
+    const content = await fs.readFile(file, 'utf-8');
+    return countTasksFromContent(content);
+  } catch (error: any) {
+    if (error?.code !== 'ENOENT') unreadable.push(file);
+    return { total: 0, completed: 0 };
+  }
 }
 
 /**
@@ -118,32 +136,44 @@ export function resolveTaskFilesForChange(changeDir: string, projectRoot: string
  * artifact (`resolveArtifactOutputs`) — so progress is no longer blind to nested
  * `tasks.md` files (#1202). Falls back to a single top-level `tasks.md` (exactly
  * as before) when the schema is unresolvable, no tracked-tasks artifact is found,
- * or the glob matches no file. Never throws.
+ * or the glob matches no file. Also reports task files that exist but could not
+ * be read. Never throws.
+ */
+export async function getTaskProgressDetailForChange(
+  changesDir: string,
+  changeName: string,
+  projectRoot: string
+): Promise<TaskProgressDetail> {
+  const changeDir = path.join(changesDir, changeName);
+  const files = resolveTaskFilesForChange(changeDir, projectRoot);
+  const targets = files.length > 0 ? files : [path.join(changeDir, 'tasks.md')];
+  const unreadable: string[] = [];
+  let total = 0;
+  let completed = 0;
+  for (const file of targets) {
+    const progress = await countTaskFile(file, unreadable);
+    total += progress.total;
+    completed += progress.completed;
+  }
+  return { total, completed, unreadable };
+}
+
+/**
+ * The task-completion counter `status`, `list`, and `archive` share. Delegates
+ * to `getTaskProgressDetailForChange` and drops the `unreadable` detail, so its
+ * returned totals are unchanged. Never throws.
  */
 export async function getTaskProgressForChange(
   changesDir: string,
   changeName: string,
   projectRoot: string
 ): Promise<TaskProgress> {
-  const changeDir = path.join(changesDir, changeName);
-  const files = resolveTaskFilesForChange(changeDir, projectRoot);
-  if (files.length > 0) {
-    let total = 0;
-    let completed = 0;
-    for (const file of files) {
-      try {
-        const content = await fs.readFile(file, 'utf-8');
-        const progress = countTasksFromContent(content);
-        total += progress.total;
-        completed += progress.completed;
-      } catch {
-        // Swallow files that vanish between glob and read, as before.
-      }
-    }
-    return { total, completed };
-  }
-
-  return countSingleTopLevelTasksFile(changeDir);
+  const { total, completed } = await getTaskProgressDetailForChange(
+    changesDir,
+    changeName,
+    projectRoot
+  );
+  return { total, completed };
 }
 
 export function formatTaskStatus(progress: TaskProgress): string {

--- a/test/cli-e2e/validate-archived-tasks.test.ts
+++ b/test/cli-e2e/validate-archived-tasks.test.ts
@@ -1,0 +1,104 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { tmpdir } from 'os';
+import { runCLI } from '../helpers/run-cli.js';
+
+describe('openspec validate --archived checks archived task completion (#205)', () => {
+  let projectDir: string;
+
+  const write = async (relative: string, content: string) => {
+    const file = path.join(projectDir, relative);
+    await fs.mkdir(path.dirname(file), { recursive: true });
+    await fs.writeFile(file, content, 'utf-8');
+  };
+
+  beforeAll(async () => {
+    projectDir = await fs.mkdtemp(path.join(tmpdir(), 'openspec-archived-tasks-e2e-'));
+
+    // Fully completed archived change.
+    await write(
+      'openspec/changes/archive/2026-01-01-done-change/tasks.md',
+      ['# Tasks', '', '- [x] 1.1 do a', '- [x] 1.2 do b', ''].join('\n')
+    );
+
+    // Archived change with an unchecked nested sub-task.
+    await write(
+      'openspec/changes/archive/2026-01-02-incomplete-change/tasks.md',
+      [
+        '# Tasks',
+        '',
+        '- [x] 1.1 do a',
+        '- [ ] 1.2 do b',
+        '  - [ ] 1.2.1 nested unfinished work',
+        '',
+      ].join('\n')
+    );
+
+    // An active change with unchecked tasks must NOT be scanned by --archived.
+    await write(
+      'openspec/changes/active-change/tasks.md',
+      ['# Tasks', '', '- [ ] 1.1 still in progress', ''].join('\n')
+    );
+  });
+
+  afterAll(async () => {
+    await fs.rm(projectDir, { recursive: true, force: true });
+  });
+
+  it('fails when an archived change has unchecked tasks and passes the complete one', async () => {
+    const result = await runCLI(['validate', '--archived', '--json'], {
+      cwd: projectDir,
+    });
+
+    expect(result.exitCode).toBe(1);
+    const report = JSON.parse(result.stdout);
+    const byId = Object.fromEntries(
+      report.items.map((item: { id: string; valid: boolean }) => [item.id, item.valid])
+    );
+
+    // Only archived changes are considered; the active change is absent.
+    expect(byId['active-change']).toBeUndefined();
+    expect(byId['2026-01-01-done-change']).toBe(true);
+    expect(byId['2026-01-02-incomplete-change']).toBe(false);
+
+    const incomplete = report.items.find(
+      (item: { id: string }) => item.id === '2026-01-02-incomplete-change'
+    );
+    // The unchecked nested sub-task counts, so 2 of 3 tasks are open.
+    expect(incomplete.issues[0]).toEqual(
+      expect.objectContaining({
+        level: 'ERROR',
+        path: 'tasks',
+        message: expect.stringContaining('2 incomplete tasks (1/3 completed)'),
+      })
+    );
+  });
+
+  it('exits 0 when every archived change is complete', async () => {
+    await fs.rm(
+      path.join(
+        projectDir,
+        'openspec/changes/archive/2026-01-02-incomplete-change'
+      ),
+      { recursive: true, force: true }
+    );
+
+    const result = await runCLI(['validate', '--archived'], { cwd: projectDir });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('✓ archived/2026-01-01-done-change');
+  });
+
+  it('exits 0 with a friendly message when there is no archive directory', async () => {
+    const emptyDir = await fs.mkdtemp(path.join(tmpdir(), 'openspec-no-archive-e2e-'));
+    await fs.mkdir(path.join(emptyDir, 'openspec', 'changes'), { recursive: true });
+    await fs.mkdir(path.join(emptyDir, 'openspec', 'specs'), { recursive: true });
+
+    const result = await runCLI(['validate', '--archived'], { cwd: emptyDir });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('No archived changes found.');
+    await fs.rm(emptyDir, { recursive: true, force: true });
+  });
+});

--- a/test/cli-e2e/validate-archived-tasks.test.ts
+++ b/test/cli-e2e/validate-archived-tasks.test.ts
@@ -101,4 +101,55 @@ describe('openspec validate --archived checks archived task completion (#205)', 
     expect(result.stdout).toContain('No archived changes found.');
     await fs.rm(emptyDir, { recursive: true, force: true });
   });
+
+  it('fails instead of passing silently when the archive path is not a directory', async () => {
+    const dir = await fs.mkdtemp(path.join(tmpdir(), 'openspec-archive-notdir-e2e-'));
+    await fs.mkdir(path.join(dir, 'openspec', 'changes'), { recursive: true });
+    await fs.mkdir(path.join(dir, 'openspec', 'specs'), { recursive: true });
+    // A real read failure (ENOTDIR) must not read as "no archived changes".
+    await fs.writeFile(
+      path.join(dir, 'openspec', 'changes', 'archive'),
+      'not a directory\n'
+    );
+
+    const result = await runCLI(['validate', '--archived'], { cwd: dir });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).not.toContain('No archived changes found.');
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  it('fails when an archived tasks file exists but cannot be read', async () => {
+    const dir = await fs.mkdtemp(path.join(tmpdir(), 'openspec-archive-unreadable-e2e-'));
+    await fs.mkdir(path.join(dir, 'openspec', 'specs'), { recursive: true });
+    // A tasks.md that is a directory triggers a non-ENOENT read error (EISDIR)
+    // on every platform, standing in for a genuinely unreadable file. It must
+    // be reported, not silently counted as "no tasks".
+    await fs.mkdir(
+      path.join(
+        dir,
+        'openspec/changes/archive/unreadable-change/tasks.md'
+      ),
+      { recursive: true }
+    );
+
+    const result = await runCLI(['validate', '--archived', '--json'], {
+      cwd: dir,
+    });
+
+    expect(result.exitCode).toBe(1);
+    const report = JSON.parse(result.stdout);
+    const item = report.items.find(
+      (i: { id: string }) => i.id === 'unreadable-change'
+    );
+    expect(item.valid).toBe(false);
+    expect(item.issues[0]).toEqual(
+      expect.objectContaining({
+        level: 'ERROR',
+        path: 'tasks',
+        message: expect.stringContaining('could not read'),
+      })
+    );
+    await fs.rm(dir, { recursive: true, force: true });
+  });
 });

--- a/test/cli-e2e/validate-archived-tasks.test.ts
+++ b/test/cli-e2e/validate-archived-tasks.test.ts
@@ -69,7 +69,7 @@ describe('openspec validate --archived checks archived task completion (#205)', 
     expect(incomplete.issues[0]).toEqual(
       expect.objectContaining({
         level: 'ERROR',
-        path: 'tasks',
+        path: 'tasks.md',
         message: expect.stringContaining('2 incomplete tasks (1/3 completed)'),
       })
     );
@@ -87,7 +87,7 @@ describe('openspec validate --archived checks archived task completion (#205)', 
     const result = await runCLI(['validate', '--archived'], { cwd: projectDir });
 
     expect(result.exitCode).toBe(0);
-    expect(result.stdout).toContain('✓ archived/2026-01-01-done-change');
+    expect(result.stdout).toContain('✓ change/2026-01-01-done-change');
   });
 
   it('exits 0 with a friendly message when there is no archive directory', async () => {
@@ -150,8 +150,9 @@ describe('openspec validate --archived checks archived task completion (#205)', 
     expect(item.issues[0]).toEqual(
       expect.objectContaining({
         level: 'ERROR',
-        path: 'tasks',
-        message: expect.stringContaining('could not read'),
+        // Pathed like every other validate issue: POSIX, root-relative.
+        path: 'openspec/changes/archive/unreadable-change/tasks.md',
+        message: 'could not read task file',
       })
     );
     await fs.rm(dir, { recursive: true, force: true });

--- a/test/cli-e2e/validate-archived-tasks.test.ts
+++ b/test/cli-e2e/validate-archived-tasks.test.ts
@@ -128,7 +128,11 @@ describe('openspec validate --archived checks archived task completion (#205)', 
     await fs.mkdir(
       path.join(
         dir,
-        'openspec/changes/archive/unreadable-change/tasks.md'
+        'openspec',
+        'changes',
+        'archive',
+        'unreadable-change',
+        'tasks.md'
       ),
       { recursive: true }
     );

--- a/test/utils/task-progress.test.ts
+++ b/test/utils/task-progress.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { promises as fs } from 'fs';
+import { promises as fs, realpathSync } from 'fs';
 import path from 'path';
 import os from 'os';
 import {
@@ -338,12 +338,18 @@ describe('getTaskProgressDetailForChange (#205 unreadable reporting)', () => {
   it('records a task file that exists but cannot be read (EISDIR)', async () => {
     // A tasks.md that is a directory yields a non-ENOENT read error on every
     // platform, standing in for a genuinely unreadable file.
-    await fs.mkdir(path.join(changesDir, 'bad', 'tasks.md'), { recursive: true });
+    const badTasks = path.join(changesDir, 'bad', 'tasks.md');
+    await fs.mkdir(badTasks, { recursive: true });
 
     const detail = await getTaskProgressDetailForChange(changesDir, 'bad', root);
     expect(detail.total).toBe(0);
     expect(detail.completed).toBe(0);
     expect(detail.unreadable).toHaveLength(1);
+    // The reported path is the file that could not be read (both canonicalized
+    // so a /var vs /private/var symlink difference does not fail the identity).
+    expect(realpathSync.native(detail.unreadable[0])).toBe(
+      realpathSync.native(badTasks)
+    );
   });
 
   it('treats a missing tasks.md as zero tasks, not unreadable', async () => {

--- a/test/utils/task-progress.test.ts
+++ b/test/utils/task-progress.test.ts
@@ -116,6 +116,25 @@ describe('getTaskProgressForChange (#1202 tracked-tasks resolution)', () => {
     expect(progress).toEqual({ total: 2, completed: 1 });
   });
 
+  it('memoizes schema→glob resolution across changes via the shared cache (#205)', async () => {
+    await writeGlobSchema();
+    await writeChange('c1', { 'backend/tasks.md': '- [x] a\n' });
+    await writeChange('c2', { 'backend/tasks.md': '- [ ] b\n' });
+
+    const cache = new Map<string, string | undefined>();
+    const d1 = await getTaskProgressDetailForChange(changesDir, 'c1', projectRoot, cache);
+    // The schema→glob lookup is now cached under the resolved schema name.
+    expect(cache.get('glob-tasks')).toBe('**/tasks.md');
+    expect(cache.size).toBe(1);
+
+    // A second change on the same schema reuses the entry (no new key added),
+    // and results are still correct.
+    const d2 = await getTaskProgressDetailForChange(changesDir, 'c2', projectRoot, cache);
+    expect(cache.size).toBe(1);
+    expect(d1).toEqual({ total: 1, completed: 1, unreadable: [] });
+    expect(d2).toEqual({ total: 1, completed: 0, unreadable: [] });
+  });
+
   it('identifies the tracked artifact by apply.tracks even when it is not named "tasks"', async () => {
     const schemaDir = path.join(projectRoot, 'openspec', 'schemas', 'custom-track');
     await fs.mkdir(schemaDir, { recursive: true });

--- a/test/utils/task-progress.test.ts
+++ b/test/utils/task-progress.test.ts
@@ -5,6 +5,7 @@ import os from 'os';
 import {
   countTasksFromContent,
   getTaskProgressForChange,
+  getTaskProgressDetailForChange,
   parseTaskLines,
 } from '../../src/utils/task-progress.js';
 import { resolveArtifactOutputs } from '../../src/core/artifact-graph/index.js';
@@ -303,5 +304,52 @@ describe('countTasksFromContent', () => {
     ].join('\n');
 
     expect(countTasksFromContent(content)).toEqual({ total: 6, completed: 3 });
+  });
+});
+
+/**
+ * #205 — `getTaskProgressDetailForChange` mirrors `getTaskProgressForChange`
+ * but also reports task files that exist yet cannot be read, so a lint can fail
+ * loudly instead of silently counting an unreadable file as "no tasks".
+ */
+describe('getTaskProgressDetailForChange (#205 unreadable reporting)', () => {
+  let root: string;
+  let changesDir: string;
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'openspec-taskdetail-'));
+    changesDir = path.join(root, 'openspec', 'changes');
+    await fs.mkdir(changesDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('reports no unreadable files for a normal tasks.md and counts as before', async () => {
+    const changeDir = path.join(changesDir, 'ok');
+    await fs.mkdir(changeDir, { recursive: true });
+    await fs.writeFile(path.join(changeDir, 'tasks.md'), '- [x] a\n- [ ] b\n', 'utf-8');
+
+    const detail = await getTaskProgressDetailForChange(changesDir, 'ok', root);
+    expect(detail).toEqual({ total: 2, completed: 1, unreadable: [] });
+  });
+
+  it('records a task file that exists but cannot be read (EISDIR)', async () => {
+    // A tasks.md that is a directory yields a non-ENOENT read error on every
+    // platform, standing in for a genuinely unreadable file.
+    await fs.mkdir(path.join(changesDir, 'bad', 'tasks.md'), { recursive: true });
+
+    const detail = await getTaskProgressDetailForChange(changesDir, 'bad', root);
+    expect(detail.total).toBe(0);
+    expect(detail.completed).toBe(0);
+    expect(detail.unreadable).toHaveLength(1);
+  });
+
+  it('treats a missing tasks.md as zero tasks, not unreadable', async () => {
+    await fs.mkdir(path.join(changesDir, 'empty'), { recursive: true });
+
+    const detail = await getTaskProgressDetailForChange(changesDir, 'empty', root);
+    expect(detail).toEqual({ total: 0, completed: 0, unreadable: [] });
   });
 });


### PR DESCRIPTION
## Status

LGTM — ready for review. New behavior is fully opt-in; no existing `validate` invocation changes.

## What was missing

`openspec validate` only ever looks at **active** changes and specs — active-change discovery explicitly skips `changes/archive/`. So there was no way to check that changes were *finished* when they were archived. A change can be archived with unchecked tasks (e.g. via `archive --yes` past the incomplete-task warning), and nothing surfaces it afterward. [#205](https://github.com/Fission-AI/OpenSpec/issues/205) asks for exactly this: a lint that fails in a pre-commit hook when archived changes still have open tasks.

## What it does

Adds an opt-in `--archived` flag to `openspec validate`:

```bash
# Fail if any archived change still has unchecked tasks
openspec validate --archived
```

- Scans every change directory under `changes/archive/` and checks its `tasks.md` checkboxes.
- Exits **1** if any archived change has incomplete tasks; prints per-change results and a totals line. Supports `--json` with the same shape as `validate --all`.
- Changes with zero tasks pass (nothing to complete).
- A **missing** archive directory (ENOENT) prints a friendly message and exits 0 — but a **real** archive-read failure (permissions, I/O, or an `archive` path that is a file) throws and exits 1 rather than being silently treated as "no archived changes", which would let a pre-commit lint pass without inspecting anything.
- An archived `tasks.md` that **exists but cannot be read** is reported as an ERROR (naming the file) and fails, instead of being silently counted as zero tasks.

It is a **standalone scope**: the `--archived` branch returns before any existing bulk path, so `validate`, `--all`, `--changes`, `--specs`, and `<item>` are byte-for-byte unchanged. It intentionally does **not** re-validate spec deltas of archived changes (their operations were already applied at archive time) — it only checks task completion, which is the concrete ask in #205.

## Why it's safe

- **Opt-in, isolated:** guarded solely by `options.archived`; no default behavior changes.
- **No forked logic:** the archived path uses `getTaskProgressDetailForChange` — the same task counter `status`, `list`, and `archive` use (now wrapped by `getTaskProgressForChange`, which drops the extra "unreadable" detail so those three callers get byte-identical totals). "What counts as a task" never forks; `--archived` only *additionally* surfaces unreadable files.
- **Store-aware:** reads `root.archiveDir`, so it respects a selected `--store` like the rest of the command.
- **Reviewed hard:** five adversarial reviews across two rounds (correctness/safety, design/scope, refactor behavior-preservation, error-handling/edge-cases, docs/linkage) plus CodeRabbit — no blockers survived. CodeRabbit's two "Major" findings (swallowing all archive-read errors; counting unreadable task files as complete) are fixed and covered by new tests.

## Proof it works

`test/cli-e2e/validate-archived-tasks.test.ts` (5 cases):
- archived change with an unchecked nested sub-task → exit 1, active changes are **not** scanned;
- all archived changes complete → exit 0;
- no archive directory → exit 0 with a friendly message;
- `archive` path is a file → exit 1 (not a silent pass);
- archived `tasks.md` unreadable → exit 1 with a "could not read" error.

Plus unit tests in `test/utils/task-progress.test.ts` for the new detail variant (normal / unreadable / missing).

```
$ openspec validate --archived
✗ change/one-left
  ✗ 1 incomplete task (1/2 completed)
Totals: 0 passed, 1 failed (1 items)   # exit 1
```

Full suite green locally (3867 passing; two unrelated failures — `artifact-workflow` "creates skills for Cursor tool" and `config-profile` "confirmed project apply…" — are pre-existing on `main` and pass in CI).

## Notes / scope

- `--archived` is a standalone scope and does not compose with `--all`/`--strict`; a "lint everything including archives" gate is two commands: `openspec validate --all --strict && openspec validate --archived`. Kept standalone deliberately to keep the change surgical and side-effect-free.
- Complementary to (not overlapping) the in-flight #576, which validates active-change tasks.md **structure**; this validates archived task **completion**.
- Output matches bulk `validate`: rows print `change/<id>` (mapping to the JSON `type`), issue `path` values follow the `tasks.md` / root-relative-file convention, and schema resolution is memoized across archived changes so a large archive isn't re-parsed per change.
- Docs updated (`docs/cli.md`, regenerated website reference, and a `docs/troubleshooting.md` one-liner) and a `minor` changeset added.

Closes #205

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the opt-in `openspec validate --archived` command.
  * Checks archived changes for incomplete tasks, including nested subtasks, while excluding active changes.
  * Supports human-readable and JSON results with appropriate exit codes.
  * Reports unreadable task files and validation errors; missing archives are treated as empty.

* **Documentation**
  * Added CLI usage examples and troubleshooting guidance.

* **Tests**
  * Added coverage for complete, incomplete, nested, missing, invalid, and unreadable archived changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
