### PR TITLE
chore(dependabot): ignore unsupported major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,13 @@ updates:
       semver-minor-days: 7
       semver-patch-days: 3
     open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "@types/node"
+        update-types:
+          - version-update:semver-major
+      - dependency-name: "typescript"
+        update-types:
+          - version-update:semver-major
     commit-message:
       prefix: chore
       include: scope
@@ -46,6 +53,13 @@ updates:
       semver-minor-days: 7
       semver-patch-days: 3
     open-pull-requests-limit: 3
+    ignore:
+      - dependency-name: "@types/node"
+        update-types:
+          - version-update:semver-major
+      - dependency-name: "typescript"
+        update-types:
+          - version-update:semver-major
     commit-message:
       prefix: chore
       include: scope


### PR DESCRIPTION
## Status

LGTM.

## What was missing / motivation

Dependabot can propose major updates to Node type definitions and TypeScript that exceed the repository's supported runtime or require a deliberate migration.

## What it does

Ignores SemVer-major version updates for `@types/node` and `typescript` in both npm manifests. Minor, patch, and security updates continue normally.

## Proof it works

- Parsed `.github/dependabot.yml` successfully.
- Verified both npm entries contain the expected ignore rules.
- `git diff --check` passes.

## Notes / nits

Supersedes #1619 and #1621.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update settings to defer major-version updates for TypeScript and Node.js type definitions in both npm projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->