### PR TITLE
fix(archive): preserve blank lines around ## Requirements when syncing specs

### DIFF
--- a/src/core/specs-apply.ts
+++ b/src/core/specs-apply.ts
@@ -545,9 +545,15 @@ export async function buildUpdatedSpec(
     .join('\n\n')
     .trimEnd();
 
-  const rebuilt = [parts.before.trimEnd(), parts.headerLine, reqBody, parts.after]
-    .filter((s, idx) => !(idx === 0 && s === ''))
-    .join('\n')
+  // The blank lines surrounding `## Requirements` belong to no slice: `before`
+  // and `after` carry at most one trailing/leading '\n' by construction, and
+  // the body is trimEnd()ed. Joining the slices with a bare '\n' therefore
+  // glued the heading to the Purpose paragraph and the first requirement, so
+  // every archive rewrote a well-formatted spec into that shape. Separate
+  // non-empty slices with one blank line instead.
+  const rebuilt = [parts.before.trimEnd(), parts.headerLine, reqBody, parts.after.trim()]
+    .filter((s) => s !== '')
+    .join('\n\n')
     .replace(/\n{3,}/g, '\n\n')
     .trimEnd() + '\n';
 

--- a/test/core/specs-apply.serialization.test.ts
+++ b/test/core/specs-apply.serialization.test.ts
@@ -90,4 +90,43 @@ describe('spec serialization', () => {
     expectOneFinalLf(result.rebuilt);
     expect(result.rebuilt).toContain('## Notes\n\nKeep this later section.\n');
   });
+
+  it('keeps the blank lines around ## Requirements when the target has them', async () => {
+    const blankLinedSpec = [
+      '# demo Specification',
+      '',
+      '## Purpose',
+      '',
+      'Demonstrates blank-line preservation.',
+      '',
+      '## Requirements',
+      '',
+      ORIGINAL_REQUIREMENT,
+      '',
+    ].join('\n');
+
+    const result = await build(blankLinedSpec);
+
+    expectOneFinalLf(result.rebuilt);
+    expect(result.rebuilt).toContain(
+      'blank-line preservation.\n\n## Requirements\n\n### Requirement: Existing behavior'
+    );
+  });
+
+  it('separates a ## Requirements heading glued to its neighbors', async () => {
+    const gluedSpec = [
+      '# demo Specification',
+      '',
+      '## Purpose',
+      'Demonstrates deterministic serializer output.',
+      '## Requirements',
+      ORIGINAL_REQUIREMENT,
+    ].join('\n');
+
+    const result = await build(gluedSpec);
+
+    expect(result.rebuilt).toContain(
+      'serializer output.\n\n## Requirements\n\n### Requirement: Existing behavior'
+    );
+  });
 });


### PR DESCRIPTION
   Fixes #1625                                                                      
                                                                                      
     ## Problem                                                                       
                                                                                      
     When `openspec archive` syncs a delta into `openspec/specs/<capability>/spec.md`,
     `buildUpdatedSpec` rebuilds the file by joining its slices (`before`,            
     `## Requirements` header, requirement body, trailing sections) with a bare       
     `'\n'`. The blank lines surrounding the heading belong to no slice, so every     
     archive glues the heading to the Purpose paragraph and the first requirement,    
     producing unrelated whitespace noise in every archive diff.                      
                                                                                      
     ## Fix                                                                           
                                                                                      
     - Join the non-empty slices with `'\n\n'` so the `## Requirements` heading       
       keeps one blank line before and after (`src/core/specs-apply.ts`).             
     - Trim `parts.after` before joining, since it carries a leading `'\n'` by        
       construction.                                                                  
     - Add two serialization tests covering both directions: preserving existing      
       blank lines, and separating an already-glued heading.                          
                                                                                      
     ## Verification                                                                  
                                                                                      
     - `pnpm test` — 3903 passed, 0 failed                                            
     - `pnpm run lint` — clean                                                        
     - Manual end-to-end: archived a change against a well-formatted spec and         
       confirmed the blank lines around `## Requirements` survive.                    
                                                                                      
     Generated with Kimi Code CLI (AI-assisted); tested and verified as above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spacing around the `## Requirements` section when specifications are rebuilt.
  * Preserved existing blank lines and added missing separators between neighboring content.
  * Normalized surrounding whitespace for more consistent formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->