### PR TITLE
chore(changeset): catch-up changesets for 6 untracked v1.9.0 fixes

### DIFF
--- a/.changeset/catchup-archive-requirements-blank-lines.md
+++ b/.changeset/catchup-archive-requirements-blank-lines.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+Preserve the blank lines around a spec's `## Requirements` heading when syncing a delta. `openspec archive` rebuilt `openspec/specs/<capability>/spec.md` by joining its slices with a bare newline, so the blank lines that surround the heading were dropped and the resulting file failed Markdown whitespace checks. The rebuild now keeps that spacing intact. Fixes #1625. Thanks [@jwang513](https://github.com/jwang513)! ([#1637](https://github.com/Fission-AI/OpenSpec/pull/1637))

--- a/.changeset/catchup-cli-reject-missing-roots.md
+++ b/.changeset/catchup-cli-reject-missing-roots.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+`openspec validate --all` and `openspec list --json` no longer silently pass when run outside an OpenSpec project. From a directory with no root they used to resolve the current directory as an implicit root, exit 0, and report empty results — a false pass for CI and agents. Bulk validation (`--all`, `--changes`, `--specs`) and `list` now require an existing root (the `openspec/project.md` fallback for legacy projects is kept), while direct validation and other intentional implicit-root workflows are unchanged. Thanks [@clay-good](https://github.com/clay-good)! ([#1612](https://github.com/Fission-AI/OpenSpec/pull/1612))

--- a/.changeset/catchup-config-picker-update-label.md
+++ b/.changeset/catchup-config-picker-update-label.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+Label the `update` workflow in the `openspec config` workflow picker. The checklist had friendly labels for 11 of the 12 workflows but was missing `update`, so that row — one of the six core workflows every user sees — fell back to its raw id with a placeholder description. The update-change template's stale "expanded-profile" wording is also reworded to "optional". Fixes #1627. Thanks [@clay-good](https://github.com/clay-good)! ([#1632](https://github.com/Fission-AI/OpenSpec/pull/1632))

--- a/.changeset/catchup-schema-fork-yaml-fidelity.md
+++ b/.changeset/catchup-schema-fork-yaml-fidelity.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+`openspec schema fork` now preserves the source schema's YAML formatting. Renaming a forked `schema.yaml` round-tripped through a parse/re-serialize step that dropped comments, could rewrite block-scalar style (a literal `|` folded to `>`), and reordered keys, so the fork no longer matched its source. The rename now edits the document in place via the YAML Document API, leaving comments, scalar style, and key order untouched. Thanks [@clay-good](https://github.com/clay-good)! ([#1607](https://github.com/Fission-AI/OpenSpec/pull/1607))

--- a/.changeset/catchup-schemas-canonical-root.md
+++ b/.changeset/catchup-schemas-canonical-root.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+`openspec schemas` now resolves through the canonical OpenSpec root-selection precedence instead of always reading from the current directory. It accepts `--store <id>`, rejects `--store-path` like the other store-aware commands, and returns the shared machine-readable diagnostics on JSON failures, while preserving the existing human output and bare JSON array on success. Thanks [@Patodo](https://github.com/Patodo)! ([#1616](https://github.com/Fission-AI/OpenSpec/pull/1616))

--- a/.changeset/catchup-validate-task-numbering.md
+++ b/.changeset/catchup-validate-task-numbering.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+`openspec validate` now warns on ambiguous task numbering in `spec-driven` changes: a task ID duplicated at full depth (including across resolved task files), or a task whose leading number disagrees with its enclosing `## N.` group. Numeric-looking text outside numbered groups is ignored, and custom schemas are unchanged until they opt in. The checks run across direct, bulk, and deprecated change validation. Closes #1520. Thanks [@alectimison-maker](https://github.com/alectimison-maker)! ([#1523](https://github.com/Fission-AI/OpenSpec/pull/1523))


### PR DESCRIPTION
## Status
Ready for review. Adds only `.changeset/*.md` files — no code changes.

## What was missing
Six user-facing fixes merged after v1.8.0 without a changeset. As-is, the v1.9.0 Version Packages PR (#1629) would ship them with **no changelog entry**, and three external contributors would go uncredited:

| PR | Fix | Author |
|----|-----|--------|
| #1637 | archive: preserve blank lines around `## Requirements` when syncing specs | @jwang513 |
| #1607 | schema fork: preserve YAML formatting | @clay-good |
| #1632 | config picker: label the `update` workflow; drop "expanded-profile" wording | @clay-good |
| #1616 | schemas: honor canonical root selection | @Patodo |
| #1612 | cli: reject missing roots for list and validate | @clay-good |
| #1523 | validate: warn on ambiguous task numbering | @alectimison-maker |

## What it does
Adds one patch changeset per fix, each with a user-focused description and a manual `Thanks @author` credit + PR link (since the changeset is authored here, not in the original PR).

## Proof it's safe
- All six are **patch** bumps. `changeset status` still resolves `@fission-ai/openspec` to **minor → 1.9.0** — the release target is unchanged; this only fills in the changelog.
- No source, test, or config files touched.

## Next step
Once merged, the Changesets action regenerates the Version Packages PR (#1629) to include all 17 items. Then #1629 can be approved and merged to publish v1.9.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Archiving specs and rebuilding `spec.md` now preserves blank lines around the Requirements heading.
  * Schema forking preserves YAML comments, formatting, and key order.
  * Bulk validation and JSON listing require an existing OpenSpec root.
* **Improvements**
  * Updated config picker labels and terminology for clearer update workflows.
  * Schema listing supports canonical root selection and `--store`, with consistent JSON error diagnostics.
  * Validation warns about ambiguous task numbering in spec-driven changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->