### PR TITLE
docs(workflows): fix sequence diagram rendering

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -94,7 +94,7 @@ sequenceDiagram
     Assistant->>Files: Move the change into the archive
     Assistant-->>Human: Report archive location and sync result
 
-    Note over Human,CLI: CLI alternative: openspec archive change-name --yes skips confirmation prompts; it still validates, then applies any delta specs and archives
+    Note over Human,CLI: CLI alternative: openspec archive change-name --yes skips confirmation prompts. It still validates, then applies any delta specs and archives
 ```
 
 ## Two Modes


### PR DESCRIPTION
**Risk: none.** One character in one documentation file. No source, no tests.

## What was wrong
The workflow sequence diagram didn't render on GitHub. A semicolon in the final note was read by Mermaid as a statement separator, so it tried to parse the rest of the sentence as diagram syntax and gave up.

## What changes
That semicolon becomes a period. Same meaning, valid syntax.

## Proof
On `main` GitHub reports a parse error on line 37 and shows no diagram. On this branch the full diagram renders. An independent Mermaid renderer returns 400 for the old source and 200 for the new one.

Closes #1639
