### PR TITLE
fix(telemetry): print first-run notice to stderr, not stdout

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -154,8 +154,9 @@ program.hook('preAction', async (thisCommand, actionCommand) => {
     process.env.NO_COLOR = '1';
   }
 
-  // Show first-run telemetry notice (if not seen). Suppress it whenever the run
-  // asked for JSON so stdout stays a single valid JSON document (see isJsonRun).
+  // Show first-run telemetry notice (if not seen). It's written to stderr, so it
+  // never pollutes stdout — but --json runs still defer it (see isJsonRun) so the
+  // very first invocation stays free of any incidental output on either stream.
   await maybeShowTelemetryNotice({ silent: isJsonRun(actionCommand) });
 
   // Track command execution (use actionCommand to get the actual subcommand)

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -197,8 +197,9 @@ export async function maybeShowTelemetryNotice(
       return;
     }
 
-    // Display notice
-    console.log(
+    // Display notice on stderr, not stdout: stdout is reserved for command
+    // output (raw passthrough text, JSON, etc.) and must stay parser/pipe-safe.
+    console.error(
       'Note: OpenSpec collects anonymous usage stats. Opt out: OPENSPEC_TELEMETRY=0 or openspec config set telemetry.enabled false'
     );
 

--- a/test/telemetry/index.test.ts
+++ b/test/telemetry/index.test.ts
@@ -9,7 +9,7 @@ import { getTelemetryConfig } from '../../src/telemetry/config.js';
 describe('telemetry/index', () => {
   let tempDir: string;
   let originalEnv: NodeJS.ProcessEnv;
-  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
   let fetchSpy: ReturnType<typeof vi.spyOn<typeof globalThis, 'fetch'>>;
 
   beforeEach(() => {
@@ -28,8 +28,8 @@ describe('telemetry/index', () => {
     // Clear all mocks
     vi.clearAllMocks();
 
-    // Spy on console.log for notice tests
-    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    // Notice is written to stderr so it never pollutes stdout (raw/JSON output)
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     // Telemetry must never reach the real network in tests
     fetchSpy = vi
       .spyOn(globalThis, 'fetch')
@@ -167,7 +167,7 @@ describe('telemetry/index', () => {
 
       await maybeShowTelemetryNotice();
 
-      expect(consoleLogSpy).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
     });
 
     it('should not show notice when telemetry.enabled is false', async () => {
@@ -176,21 +176,21 @@ describe('telemetry/index', () => {
 
       await maybeShowTelemetryNotice();
 
-      expect(consoleLogSpy).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
     });
 
     it('should show notice on the first non-silent run, then never repeat it', async () => {
       enableTelemetry();
 
       await maybeShowTelemetryNotice();
-      expect(consoleLogSpy).toHaveBeenCalledTimes(1);
-      expect(consoleLogSpy).toHaveBeenCalledWith(
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
         expect.stringContaining('OpenSpec collects anonymous usage stats')
       );
 
       // noticeSeen is now persisted: a second run stays quiet.
       await maybeShowTelemetryNotice();
-      expect(consoleLogSpy).toHaveBeenCalledTimes(1);
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
     });
 
     it('should suppress the notice in silent (--json) mode and defer the disclosure', async () => {
@@ -198,15 +198,15 @@ describe('telemetry/index', () => {
 
       // A first-ever run in --json mode must not pollute stdout.
       await maybeShowTelemetryNotice({ silent: true });
-      expect(consoleLogSpy).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
 
       // The disclosure must be deferred, not consumed: noticeSeen stays unset.
       expect((await getTelemetryConfig()).noticeSeen).toBeFalsy();
 
       // Disclosure is only deferred, not skipped: the next non-JSON run shows it.
       await maybeShowTelemetryNotice();
-      expect(consoleLogSpy).toHaveBeenCalledTimes(1);
-      expect(consoleLogSpy).toHaveBeenCalledWith(
+      expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
         expect.stringContaining('OpenSpec collects anonymous usage stats')
       );
     });


### PR DESCRIPTION
## Summary

`maybeShowTelemetryNotice()` printed the first-run notice with `console.log`, so it landed on **stdout**. On any machine with no prior global telemetry config (fresh clone, new container, new dev laptop), the first non-JSON command that prints raw content gets the notice prepended to its output.

Reproduction on `main` today:

```console
$ openspec spec show auth > auth.md
$ head -3 auth.md
Note: OpenSpec collects anonymous usage stats. Opt out: OPENSPEC_TELEMETRY=0 or openspec config set telemetry.enabled false
## Purpose
Demo spec.
```

The redirected file starts with the notice instead of the spec. Anything piping or parsing that output gets corrupted content.

**Why CI never caught this:** telemetry is disabled whenever `CI` is set (`isCiEnvironment`), so the notice never fires in GitHub Actions. Verified both ways against `main`:

| Environment | `test/commands/spec.test.ts` |
|---|---|
| `CI=true` (GitHub Actions) | 15/15 pass |
| no `CI`, clean config (real user machine) | **1 failed** — `spec show > should display spec in text format` |

So `main` currently fails its own test suite for a contributor cloning fresh, while CI stays green.

`--json` mode was already special-cased to defer the notice (#1609, #742) precisely because it broke JSON parsers — but the same stdout-pollution exists for every other stdout-producing command and wasn't covered.

## Fix

Move the notice to `console.error` (stderr). Stdout stays reserved for command output in every mode, rather than special-casing one command shape at a time. Existing `--json` defer behavior (`silent` option, `noticeSeen` persistence) is untouched.

## Test plan

- [x] `pnpm test` — 136/136 files, 3969/3969 tests pass (135/136 before the fix, on a machine with no prior telemetry config)
- [x] `pnpm lint` — clean
- [x] `pnpm build` — clean
- [x] Updated `test/telemetry/index.test.ts` to spy on `console.error` instead of `console.log`, matching the new stream
- [x] Manually verified with an isolated `XDG_CONFIG_HOME`: after the fix, `openspec spec show auth > auth.md` writes only spec content, and the notice still reaches the user on stderr

No changeset added — per `.changeset/README.md`, routine bug fixes follow the normal release cadence unless a maintainer wants dedicated release tracking. Happy to add one on request.
