### PR TITLE
test: opt the test suite out of telemetry

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,6 +25,16 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     globalSetup: './vitest.setup.ts',
+    // Opt the suite out of telemetry. Many tests spawn the real CLI, which runs
+    // the preAction hook like any user invocation: it would persist an
+    // anonymousId into the developer's *real* global config and POST a
+    // command_executed event per spawn. Workers inherit this env, and so do the
+    // CLI child processes they spawn. Telemetry's own tests delete these vars
+    // before asserting, so they are unaffected.
+    env: {
+      OPENSPEC_TELEMETRY: '0',
+      DO_NOT_TRACK: '1',
+    },
     // Tests rely on per-file process isolation (e.g., `process.cwd()` assumptions).
     pool: 'forks',
     maxWorkers: resolveMaxWorkers(),


### PR DESCRIPTION
## Problem

34 test files spawn the real CLI across ~62 call sites. Each spawn runs the `preAction` hook exactly like a user invocation, so running `pnpm test` locally:

1. **writes to the developer's real global config** — `~/.config/openspec/config.json` gains a persisted `anonymousId` and `noticeSeen`
2. **sends a `command_executed` event per spawn** to `edge.openspec.dev`

`anonymousId` is only ever written by `getOrCreateAnonymousId()`, which is called solely from `trackCommand()` *after* the `isTelemetryEnabled()` gate — so its presence is proof that events were sent, not just that a file was touched.

**CI never sees this.** `isCiEnvironment()` disables telemetry whenever `CI` is set, so this only happens on contributor machines. The side effects are that contributors emit analytics they didn't opt into by running the test suite, and the maintainers' usage data gets skewed by hundreds of test-generated events per run.

## Reproduction

Against `main` (`2826b88`), with an isolated `HOME` so the write is visible and doesn't touch the real config:

```console
$ env -u CI -u OPENSPEC_TELEMETRY -u DO_NOT_TRACK \
    HOME=/tmp/probe XDG_CONFIG_HOME=/tmp/probe/.config \
    npx vitest run test/commands/spec.test.ts

$ cat /tmp/probe/.config/openspec/config.json
{
  "telemetry": {
    "noticeSeen": true,
    "anonymousId": "804aba08-2684-4294-9599-f16cd5de791f"
  }
}
```

One test file is enough to trigger it.

## Fix

Set `OPENSPEC_TELEMETRY=0` / `DO_NOT_TRACK=1` through vitest's `test.env`. Workers inherit it, and so do the CLI child processes they spawn — verified below rather than assumed. Telemetry's own tests call `enableTelemetry()`, which deletes these vars before asserting, so they keep their coverage.

## Verification

| | `main` | this branch |
|---|---|---|
| global config written under isolated `HOME` | `anonymousId` persisted | none |
| `pnpm test` | 3969 pass | 3969 pass |

- [x] `pnpm test` — 136/136 files, 3969/3969 tests pass
- [x] `pnpm lint` — clean
- [x] Full suite under an isolated `HOME` writes no `config.json` anywhere
- [x] `test/telemetry/*` still passes (it manages its own env and mocks `fetch`)

## Note on the interaction with #1666

On `main`, that same isolated-`HOME` run also fails `spec show > should display spec in text format` — the stdout-pollution bug in #1666. This PR silences that failure as a side effect, because a disabled-telemetry run never prints the notice at all.

That is a masking effect, not a fix: #1666 is the user-facing bug (real users have telemetry enabled and no `CI` set), and it needs to land on its own. I'd suggest treating these as independent — this one for test hygiene, #1666 for the actual stdout contract. #1666 also adds a unit assertion pinning the notice to stderr, so the behavior stays covered even with telemetry off in the suite.

Happy to rebase this on top of #1666, or hold it until that one lands, whichever you prefer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Disabled telemetry during test execution, including in child processes, for improved privacy and more predictable CLI test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->