### PR TITLE
fix(update): gate the IDE restart hint on requiresIdeRestart

### DIFF
--- a/src/core/update.ts
+++ b/src/core/update.ts
@@ -12,7 +12,7 @@ import * as fs from 'fs';
 import { createRequire } from 'module';
 import { FileSystemUtils } from '../utils/file-system.js';
 import { getSkillReferenceTransformer, getTransformerForTool, transformToSkillReferences } from '../utils/command-references.js';
-import { AI_TOOLS, OPENSPEC_DIR_NAME } from './config.js';
+import { AI_TOOLS, OPENSPEC_DIR_NAME, type AIToolOption } from './config.js';
 import {
   generateCommands,
   CommandAdapterRegistry,
@@ -266,7 +266,7 @@ export class UpdateCommand {
     const deliveryIncludesCommands = delivery !== 'skills';
     // 10. Update tools (all if force, otherwise only those needing update)
     const toolsToUpdate = this.force ? configuredTools : [...toolsToUpdateSet];
-    const updatedTools: string[] = [];
+    const updatedTools: AIToolOption[] = [];
     const failedTools: Array<{ name: string; error: string }> = [];
     const skillsInvocableCommandSkips: string[] = [];
     const zeroArtifactTools: string[] = [];
@@ -360,7 +360,7 @@ export class UpdateCommand {
         }
 
         spinner.succeed(`Updated ${tool.name}`);
-        updatedTools.push(tool.name);
+        updatedTools.push(tool);
         for (const migration of migrateLegacyToolDirs(
           resolvedProjectPath,
           [tool.value],
@@ -387,7 +387,9 @@ export class UpdateCommand {
     // 11. Summary
     console.log();
     if (updatedTools.length > 0) {
-      console.log(chalk.green(`✓ Updated: ${updatedTools.join(', ')} (v${OPENSPEC_VERSION})`));
+      console.log(
+        chalk.green(`✓ Updated: ${updatedTools.map((tool) => tool.name).join(', ')} (v${OPENSPEC_VERSION})`)
+      );
     }
     if (failedTools.length > 0) {
       console.log(chalk.red(`✗ Failed: ${failedTools.map(f => `${f.name} (${f.error})`).join(', ')}`));
@@ -479,12 +481,16 @@ export class UpdateCommand {
 
     // 15. List affected tools
     if (updatedTools.length > 0) {
-      const toolDisplayNames = updatedTools;
+      const toolDisplayNames = updatedTools.map((tool) => tool.name);
       console.log(chalk.dim(`Tools: ${toolDisplayNames.join(', ')}`));
     }
 
-    console.log();
-    console.log(chalk.dim('Restart your IDE for changes to take effect.'));
+    // Only IDE-resident tools reload generated files on restart; a CLI picks
+    // them up on its next invocation, so the hint is noise there (#1067).
+    if (updatedTools.some((tool) => tool.requiresIdeRestart)) {
+      console.log();
+      console.log(chalk.dim('Restart your IDE for changes to take effect.'));
+    }
     if (failedTools.length > 0) {
       throw new Error(`OpenSpec update failed for: ${failedTools.map((tool) => tool.name).join(', ')}`);
     }

--- a/test/core/update.test.ts
+++ b/test/core/update.test.ts
@@ -1800,9 +1800,9 @@ metadata:
       consoleSpy.mockRestore();
     });
 
-    it('should suggest IDE restart after update', async () => {
-      // Set up a configured tool
-      const skillsDir = path.join(testDir, '.claude', 'skills');
+    it('should suggest IDE restart after updating an IDE-resident tool', async () => {
+      // Cursor loads generated files in the editor process (requiresIdeRestart)
+      const skillsDir = path.join(testDir, '.cursor', 'skills');
       await fs.mkdir(path.join(skillsDir, 'openspec-explore'), {
         recursive: true,
       });
@@ -1816,6 +1816,29 @@ metadata:
       await updateCommand.execute(testDir);
 
       expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Restart your IDE')
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should not suggest IDE restart after updating only CLI tools', async () => {
+      // Claude Code reads generated files on its next invocation, so a restart
+      // hint is noise for it (#1067, #1608)
+      const skillsDir = path.join(testDir, '.claude', 'skills');
+      await fs.mkdir(path.join(skillsDir, 'openspec-explore'), {
+        recursive: true,
+      });
+      await fs.writeFile(
+        path.join(skillsDir, 'openspec-explore', 'SKILL.md'),
+        'old'
+      );
+
+      const consoleSpy = vi.spyOn(console, 'log');
+
+      await updateCommand.execute(testDir);
+
+      expect(consoleSpy).not.toHaveBeenCalledWith(
         expect.stringContaining('Restart your IDE')
       );
 


### PR DESCRIPTION
Closes #1608.

#1067 stopped `init` showing the restart hint to CLI tools. `update` still shows it to everyone, so this puts the same gate on that path.

The reason it couldn't just be an `if` is that `updatedTools` was `string[]` of `tool.name`, so by the time the summary printed there was nothing left to check `requiresIdeRestart` on. It now holds the `AIToolOption` entries (same as `successfulTools` in `init.ts`) and the two display sites map to `.name`.

```ts
if (updatedTools.some((tool) => tool.requiresIdeRestart)) {
  console.log();
  console.log(chalk.dim('Restart your IDE for changes to take effect.'));
}
```

The blank line went inside the guard too so a CLI-only update doesn't end on a stray newline — `init.ts` does it that way.

I kept the existing wording rather than borrowing the commands/skills split from `init`. The issue mentions #961 adding a shared `formatIdeRestart` helper; if that lands this is one `if` for it to absorb, and changing the wording now would just conflict with it.

**One existing test changed.** `should suggest IDE restart after update` sets up `.claude` and asserts the hint shows. Claude Code is a CLI, so that assertion is the bug rather than the intent, and it's the only test in the suite that fails against this. Split it into the two halves of the rule — `.cursor` expects the hint, `.claude` expects none.

```
npx vitest run test/core/update.test.ts   →  126 passed (125 before, the split adds one)
npx eslint src/core/update.ts            →  clean
npx vitest run                           →  2 failed | 3968 passed
```

Both failures are in `test/commands/workset.test.ts`, expecting `Could not launch Claude Code` and getting `Error: Input must be provided either through stdin or as a prompt argument when using --print`. The Claude Code CLI is installed on this machine so the not-launchable path never runs. Reverting my two files to their pre-change contents reproduces it, so it isn't from this change.

AI was used for assistance.
