### PR TITLE
feat(schema): add layered global overrides

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,7 +15,7 @@ The OpenSpec CLI (`openspec`) provides terminal commands for project setup, vali
 | **Validation** | `validate` | Check changes and specs for issues |
 | **Lifecycle** | `archive` | Finalize completed changes |
 | **Workflow** | `new change`, `status`, `instructions`, `templates`, `schemas` | Artifact-driven workflow support |
-| **Schemas** | `schema init`, `schema fork`, `schema validate`, `schema which` | Create and manage custom workflows |
+| **Schemas** | `schema init`, `schema fork`, `schema override`, `schema validate`, `schema which` | Create and manage custom workflows |
 | **Config** | `config` | View and modify settings |
 | **Utility** | `feedback`, `completion` | Feedback and shell integration |
 
@@ -887,12 +887,14 @@ openspec templates --json
 
 ```
 Schema: spec-driven
+Source: package + user overlay
 
-Templates:
-  proposal  → ~/.openspec/schemas/spec-driven/templates/proposal.md
-  specs     → ~/.openspec/schemas/spec-driven/templates/specs.md
-  design    → ~/.openspec/schemas/spec-driven/templates/design.md
-  tasks     → ~/.openspec/schemas/spec-driven/templates/tasks.md
+proposal:
+  Path: /usr/local/lib/node_modules/@fission-ai/openspec/schemas/spec-driven/templates/proposal.md
+  Source: package
+tasks:
+  Path: /home/user/.local/share/openspec/schemas/spec-driven/templates/tasks.md
+  Source: user
 ```
 
 ---
@@ -1019,6 +1021,39 @@ openspec schema fork <source> [name] [options]
 openspec schema fork spec-driven my-workflow
 ```
 
+When the source has an active layered user override, the fork materializes the effective schema and effective user/package templates into a self-contained project bundle.
+
+---
+
+### `openspec schema override`
+
+Create a layered user override for a packaged schema. Unlike `schema fork`, this command does not copy `schema.yaml` or its templates; packaged updates remain active for fields and templates you do not override.
+
+```
+openspec schema override <name> [options]
+```
+
+**Arguments:**
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `name` | Yes | Packaged schema to customize |
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--force` | Replace an existing layered override with a new starter file |
+| `--json` | Output `created`, `schema`, `path`, and `basePath` as JSON |
+
+**Example:**
+
+```bash
+openspec schema override spec-driven
+```
+
+This creates `schema.override.yaml` in the user OpenSpec data directory. See [Global Overrides](customization.md#global-overrides) for the patch format, template fallback, and platform-specific paths.
+
 ---
 
 ### `openspec schema validate`
@@ -1082,18 +1117,29 @@ openspec schema which [name] [options]
 openspec schema which spec-driven
 ```
 
-**Output:**
+**Package-only output:**
 
 ```
-spec-driven resolves from: package
-  Source: /usr/local/lib/node_modules/@fission-ai/openspec/schemas/spec-driven
+Schema: spec-driven
+Source: package
+Path: /usr/local/lib/node_modules/@fission-ai/openspec/schemas/spec-driven
+```
+
+**Layered output:**
+
+```
+Schema: spec-driven
+Source: package + user overlay
+Path: /usr/local/lib/node_modules/@fission-ai/openspec/schemas/spec-driven
+Overlay: /home/user/.local/share/openspec/schemas/spec-driven/schema.override.yaml
 ```
 
 **Schema precedence:**
 
-1. Project: `openspec/schemas/<name>/`
-2. User: `~/.local/share/openspec/schemas/<name>/`
-3. Package: Built-in schemas
+1. Complete project schema: `openspec/schemas/<name>/schema.yaml`
+2. Complete user schema: `~/.local/share/openspec/schemas/<name>/schema.yaml`
+3. Packaged schema plus optional user `schema.override.yaml`
+4. Packaged schema unchanged
 
 ---
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1029,7 +1029,7 @@ When the source has an active layered user override, the fork materializes the e
 
 Create a layered user override for a packaged schema. Unlike `schema fork`, this command does not copy `schema.yaml` or its templates; packaged updates remain active for fields and templates you do not override.
 
-```
+```text
 openspec schema override <name> [options]
 ```
 
@@ -1044,7 +1044,7 @@ openspec schema override <name> [options]
 | Option | Description |
 |--------|-------------|
 | `--force` | Replace an existing layered override with a new starter file |
-| `--json` | Output `created`, `schema`, `path`, and `basePath` as JSON |
+| `--json` | Output `created`, `schema`, `path`, and `basePath` as JSON; adds `projectSchemaTakesPrecedence: true` when the current project shadows the new override |
 
 **Example:**
 
@@ -1093,7 +1093,7 @@ openspec schema validate
 
 Show where a schema resolves from (useful for debugging precedence).
 
-```
+```text
 openspec schema which [name] [options]
 ```
 
@@ -1119,7 +1119,7 @@ openspec schema which spec-driven
 
 **Package-only output:**
 
-```
+```text
 Schema: spec-driven
 Source: package
 Path: /usr/local/lib/node_modules/@fission-ai/openspec/schemas/spec-driven
@@ -1127,7 +1127,7 @@ Path: /usr/local/lib/node_modules/@fission-ai/openspec/schemas/spec-driven
 
 **Layered output:**
 
-```
+```text
 Schema: spec-driven
 Source: package + user overlay
 Path: /usr/local/lib/node_modules/@fission-ai/openspec/schemas/spec-driven

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -342,7 +342,130 @@ Path: /path/to/project/openspec/schemas/my-workflow
 
 ---
 
-> **Note:** OpenSpec also supports user-level schemas at `~/.local/share/openspec/schemas/` for sharing across projects, but project-level schemas in `openspec/schemas/` are recommended since they're version-controlled with your code.
+## Global Overrides
+
+OpenSpec has two user-level customization modes. Choose one mode per schema name:
+
+| Mode | File | Update behavior |
+|------|------|-----------------|
+| **Layered override** | `schema.override.yaml` | Keeps packaged fields and templates unless explicitly changed |
+| **Complete replacement** | `schema.yaml` plus `templates/` | Freezes a self-contained copy that fully shadows the package |
+
+User schemas live under the OpenSpec data directory:
+
+- `$XDG_DATA_HOME/openspec/schemas/` when `XDG_DATA_HOME` is set
+- `~/.local/share/openspec/schemas/` on Unix and macOS by default
+- `%LOCALAPPDATA%\openspec\schemas\` on Windows by default
+
+Project schemas in `openspec/schemas/` remain higher priority than either user mode because they represent version-controlled team intent.
+
+### Layered Global Customization
+
+Create a starter override for a packaged schema:
+
+```bash
+openspec schema override spec-driven
+```
+
+This creates only:
+
+```text
+~/.local/share/openspec/schemas/spec-driven/
+└── schema.override.yaml
+```
+
+The packaged `schema.yaml` remains the base. For example, keep OpenSpec's task guidance and append personal rules:
+
+```yaml
+patchVersion: 1
+
+artifacts:
+  tasks:
+    instruction:
+      append: |
+        Additional rules:
+        - Include verification commands in every task group.
+        - Mention the affected package in each task.
+```
+
+Text fields use explicit operations:
+
+```yaml
+artifacts:
+  tasks:
+    instruction:
+      prepend: Read the repository contribution guide first.
+      append: Include focused and full verification commands.
+```
+
+`prepend` and `append` may be combined. Use `replace` by itself only when you intend to discard the packaged instruction:
+
+```yaml
+artifacts:
+  tasks:
+    instruction:
+      replace: Write tasks using my personal workflow.
+```
+
+Plain `description`, `generates`, and `template` values replace the matching packaged value. Dependency lists use explicit operations:
+
+```yaml
+artifacts:
+  tasks:
+    requires:
+      remove: [design]
+      add: [proposal]
+```
+
+Use either `replace`, or `add`/`remove`, for one dependency field. Layered overrides modify existing artifacts only; use a complete schema fork to add, remove, or reorder artifacts.
+
+### Optional Template Overrides
+
+You do not need to copy the packaged templates. Add only the templates you want to replace:
+
+```text
+~/.local/share/openspec/schemas/spec-driven/
+├── schema.override.yaml
+└── templates/
+    └── tasks.md             # user version
+```
+
+For a layered schema, each template resolves independently:
+
+1. User `templates/<file>`
+2. Packaged `templates/<file>`
+
+In this example, `tasks.md` is user-owned while proposal, specs, and design templates continue following package updates. Template files are whole-file replacements; their Markdown contents are not merged.
+
+### Complete Global Replacement
+
+The existing global replacement behavior remains available. Copy a complete schema bundle to the user data directory:
+
+```text
+~/.local/share/openspec/schemas/spec-driven/
+├── schema.yaml
+└── templates/
+    ├── proposal.md
+    ├── spec.md
+    ├── design.md
+    └── tasks.md
+```
+
+This directory is self-contained. It receives no packaged schema or template updates, and missing templates do not fall back to the package. You must manually compare and rebase it when OpenSpec changes the built-in workflow.
+
+Do not put `schema.yaml` and `schema.override.yaml` in the same user schema directory. OpenSpec rejects that conflict instead of guessing which customization you intended.
+
+### Inspect and Validate
+
+```bash
+openspec schema which spec-driven
+openspec schema validate spec-driven
+openspec templates --schema spec-driven
+```
+
+For a layered schema, `which` reports both package and user paths, validation checks the composed schema and every effective template, and `templates` shows whether each concrete template came from the user or package directory.
+
+If you later need structural changes, `openspec schema fork spec-driven my-workflow` materializes the effective packaged-plus-user schema and templates into a self-contained project schema.
 
 ---
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -357,6 +357,10 @@ User schemas live under the OpenSpec data directory:
 - `~/.local/share/openspec/schemas/` on Unix and macOS by default
 - `%LOCALAPPDATA%\openspec\schemas\` on Windows by default
 
+In the directory examples below, `<OpenSpec data directory>` means
+`$XDG_DATA_HOME/openspec`, `~/.local/share/openspec`, or
+`%LOCALAPPDATA%\openspec`, depending on the platform and environment.
+
 Project schemas in `openspec/schemas/` remain higher priority than either user mode because they represent version-controlled team intent.
 
 ### Layered Global Customization
@@ -370,7 +374,7 @@ openspec schema override spec-driven
 This creates only:
 
 ```text
-~/.local/share/openspec/schemas/spec-driven/
+<OpenSpec data directory>/schemas/spec-driven/
 └── schema.override.yaml
 ```
 
@@ -424,7 +428,7 @@ Use either `replace`, or `add`/`remove`, for one dependency field. Layered overr
 You do not need to copy the packaged templates. Add only the templates you want to replace:
 
 ```text
-~/.local/share/openspec/schemas/spec-driven/
+<OpenSpec data directory>/schemas/spec-driven/
 ├── schema.override.yaml
 └── templates/
     └── tasks.md             # user version
@@ -442,7 +446,7 @@ In this example, `tasks.md` is user-owned while proposal, specs, and design temp
 The existing global replacement behavior remains available. Copy a complete schema bundle to the user data directory:
 
 ```text
-~/.local/share/openspec/schemas/spec-driven/
+<OpenSpec data directory>/schemas/spec-driven/
 ├── schema.yaml
 └── templates/
     ├── proposal.md

--- a/docs/opsx.md
+++ b/docs/opsx.md
@@ -583,6 +583,9 @@ openspec schema init my-workflow
 # Or fork an existing schema as a starting point
 openspec schema fork spec-driven my-workflow
 
+# Or add personal guidance while retaining packaged updates
+openspec schema override spec-driven
+
 # Validate your schema structure
 openspec schema validate my-workflow
 
@@ -590,7 +593,7 @@ openspec schema validate my-workflow
 openspec schema which my-workflow
 ```
 
-Schemas are stored in `openspec/schemas/` (project-local, version controlled) or `~/.local/share/openspec/schemas/` (user global).
+Schemas are stored in `openspec/schemas/` (project-local, version controlled) or `~/.local/share/openspec/schemas/` (user global). A user `schema.yaml` is a complete replacement; a user `schema.override.yaml` is layered over the packaged schema and may provide only selected templates. See [Customization](customization.md#global-overrides).
 
 **Schema structure:**
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -166,6 +166,24 @@ openspec schema init <name>         # create a custom one
 
 See [Customization](customization.md#custom-schemas).
 
+### My global schema stopped receiving built-in updates
+
+A user-level `schema.yaml` is a complete replacement. Its schema and templates intentionally shadow the packaged bundle, so OpenSpec cannot automatically apply newer built-in guidance.
+
+If you only need additive personal customization, use a layered override instead:
+
+```bash
+openspec schema override spec-driven
+openspec schema validate spec-driven
+openspec schema which spec-driven
+```
+
+Move your changes into `schema.override.yaml`, keep only templates you intentionally replace, and remove the complete user `schema.yaml` after preserving any custom content you still need. See [Global Overrides](customization.md#global-overrides).
+
+### Complete replacement conflicts with layered override
+
+One user schema directory cannot contain both `schema.yaml` and `schema.override.yaml`. Keep `schema.yaml` for a self-contained frozen workflow, or keep `schema.override.yaml` to inherit packaged updates. `openspec schema which <name>` shows which source is active.
+
 ## Migration from the legacy workflow
 
 ### "Legacy files detected in non-interactive mode"

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -172,13 +172,25 @@ A user-level `schema.yaml` is a complete replacement. Its schema and templates i
 
 If you only need additive personal customization, use a layered override instead:
 
+1. Back up the complete user schema, then move or rename its `schema.yaml` outside
+   the active user schema directory.
+2. Create the layered override:
+
 ```bash
 openspec schema override spec-driven
+```
+
+3. Port supported customizations into `schema.override.yaml`, keep only templates
+   you intentionally replace, and remove the old complete `schema.yaml` after
+   preserving any custom content you still need.
+4. Check the effective result:
+
+```bash
 openspec schema validate spec-driven
 openspec schema which spec-driven
 ```
 
-Move your changes into `schema.override.yaml`, keep only templates you intentionally replace, and remove the complete user `schema.yaml` after preserving any custom content you still need. See [Global Overrides](customization.md#global-overrides).
+See [Global Overrides](customization.md#global-overrides).
 
 ### Complete replacement conflicts with layered override
 

--- a/openspec/changes/add-global-schema-overlays/.openspec.yaml
+++ b/openspec/changes/add-global-schema-overlays/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-17

--- a/openspec/changes/add-global-schema-overlays/design.md
+++ b/openspec/changes/add-global-schema-overlays/design.md
@@ -111,7 +111,7 @@ instruction:
   append: text after the packaged instruction
 ```
 
-`prepend` and `append` may be used together. Non-empty segments are joined with one blank line. `replace` is mutually exclusive with both:
+`prepend` and `append` may be used together. Before joining, leading and trailing blank or whitespace-only lines are removed from each prepend, packaged, and append segment; whitespace-only segments are omitted. The remaining segments are joined with exactly one blank line while their internal whitespace is preserved. `replace` is mutually exclusive with both and retains its supplied text exactly:
 
 ```yaml
 instruction:

--- a/openspec/changes/add-global-schema-overlays/design.md
+++ b/openspec/changes/add-global-schema-overlays/design.md
@@ -1,0 +1,210 @@
+## Context
+
+Schema resolution currently returns one winning directory in this order: project-local, user-level, then package. `resolveSchema()` reads only that directory's `schema.yaml`, and template loading reads only its `templates/` directory. This makes every override a complete bundle and prevents packaged changes from flowing into a user customization.
+
+The requested behavior is narrower than general schema inheritance. A user wants to keep the packaged `spec-driven` schema, append personal guidance to an existing artifact such as `tasks`, and optionally replace individual templates. The design must remain deterministic for ordered artifact and dependency arrays, preserve the existing full-replacement contract, and make the effective result debuggable.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Let users layer small, global customizations over packaged schemas without copying the complete bundle.
+- Preserve packaged schema and template updates unless a field or template is explicitly customized.
+- Give text and array fields explicit, unsurprising merge operations.
+- Keep project-local schemas authoritative over personal global customization.
+- Preserve complete user schema replacements without changing their template behavior.
+- Validate the effective schema and report every source involved in resolution.
+
+**Non-Goals:**
+
+- Project-local overlay files in v1; projects continue to use complete, version-controlled schemas and project `rules`.
+- Arbitrary `extends` chains or inheritance between user-created schemas.
+- Adding, removing, or reordering artifacts through an overlay. Structural workflow forks continue to use a complete schema.
+- Merging Markdown template contents. A user template replaces one packaged template as a whole.
+- Automatically converting or rebasing existing complete user schemas.
+- Treating project `rules` as schema fields; they remain separately injected artifact constraints.
+
+## Decisions
+
+### 1. Add an overlay beside, not instead of, complete user schemas
+
+The layered file is:
+
+```text
+${XDG_DATA_HOME}/openspec/schemas/<name>/schema.override.yaml
+```
+
+The existing platform fallbacks from `getGlobalDataDir()` remain authoritative. An optional `templates/` directory in the same user schema directory contains whole-file template overrides.
+
+The existing file keeps its existing meaning:
+
+```text
+${XDG_DATA_HOME}/openspec/schemas/<name>/schema.yaml
+```
+
+It is a complete user schema replacement with self-contained templates. Reinterpreting that file as a partial document would silently change current users' behavior.
+
+If both `schema.yaml` and `schema.override.yaml` exist in the same user schema directory, resolution fails with a conflict diagnostic when the user layer would otherwise be active. Direct user-overlay creation and validation also reject the conflict. A higher-priority project schema continues to resolve normally, while diagnostics may report the inactive conflicting user sources. The user must choose complete replacement or layered customization before the user layer can become active; silently selecting either user file would make edits appear ineffective.
+
+### 2. Preserve project intent and layer only onto packaged schemas
+
+Resolution for a name is:
+
+```text
+1. project schema.yaml                         complete project bundle
+2. user schema.yaml                            complete user bundle
+3. package schema.yaml + user schema.override.yaml
+4. package schema.yaml                         unchanged fallback
+```
+
+A project schema suppresses the personal overlay because version-controlled team intent remains highest priority. A user overlay without a packaged base is invalid and is not treated as a new schema; custom schemas use the existing complete-bundle format.
+
+Calls without `projectRoot` continue to omit project discovery, then follow steps 2-4.
+
+### 3. Use a dedicated, strict overlay format
+
+The overlay is not parsed as `SchemaYaml`. It has its own versioned, strict shape:
+
+```yaml
+patchVersion: 1
+
+description: My global additions to the packaged workflow
+
+artifacts:
+  tasks:
+    instruction:
+      append: |
+        Additional rules:
+        - Include verification commands in every task group.
+        - Mention the affected package in each task.
+    requires:
+      remove: [design]
+      add: [proposal]
+
+apply:
+  instruction:
+    prepend: |
+      Read the repository contribution guide before implementation.
+```
+
+Supported artifact patches are:
+
+- `description`, `generates`, and `template`: a supplied scalar replaces the base value.
+- `instruction`: explicit text operation.
+- `requires`: explicit collection operation.
+
+Supported apply patches are:
+
+- `tracks`: a supplied string or `null` replaces the base value.
+- `instruction`: explicit text operation.
+- `requires`: explicit collection operation.
+
+The overlay cannot set schema `name` or `version`, change an artifact `id`, or introduce an unknown artifact ID. Unknown keys are rejected so misspellings do not become silent no-ops.
+
+### 4. Define deterministic text and collection operations
+
+Text operations support:
+
+```yaml
+instruction:
+  prepend: text before the packaged instruction
+  append: text after the packaged instruction
+```
+
+`prepend` and `append` may be used together. Non-empty segments are joined with one blank line. `replace` is mutually exclusive with both:
+
+```yaml
+instruction:
+  replace: complete replacement text
+```
+
+Collection operations support either `replace`, or `remove` followed by `add`:
+
+```yaml
+requires:
+  remove: [design]
+  add: [proposal]
+```
+
+Removal preserves the relative order of remaining base values. Additions are appended in declaration order and cannot introduce duplicates. `replace` is mutually exclusive with `add` and `remove`. Duplicate entries, an ID present in both `add` and `remove`, and removal of a value not present in the base are validation errors rather than silent behavior.
+
+After applying the overlay, the existing full-schema parser validates required fields, dependency references, and cycles. Artifact declaration order remains the packaged order.
+
+### 5. Layer templates only for composed schemas
+
+For a package schema with a user overlay, each referenced template resolves independently:
+
+```text
+1. user <schema>/templates/<template>
+2. package <schema>/templates/<template>
+```
+
+The user `templates/` directory is optional. If no user template exists, the package template continues to receive package updates. If a user template exists, it is a whole-file replacement and intentionally stops receiving changes to that specific packaged template.
+
+Project schemas and complete user schemas remain self-contained and do not fall back to package templates. This avoids changing current behavior and prevents an incomplete full fork from appearing valid accidentally.
+
+Every candidate path is checked against its own canonical template root using the existing path-containment protections. An override cannot use a relative path to escape from the allowed roots.
+
+### 6. Centralize source resolution
+
+`getSchemaDir()` is insufficient to represent a composed schema but is widely used. Add a centralized resolver that returns a descriptor such as:
+
+```ts
+interface ResolvedSchemaSources {
+  name: string;
+  mode: 'project' | 'user-replacement' | 'package' | 'package-with-user-overlay';
+  base: { source: 'project' | 'user' | 'package'; dir: string; schemaPath: string };
+  overlay?: { source: 'user'; path: string; templatesDir: string };
+  templateRoots: Array<{ source: 'project' | 'user' | 'package'; dir: string }>;
+}
+```
+
+`resolveSchema()`, template loading, schema listing, `schema which`, and schema validation consume this descriptor. Keep `getSchemaDir()` as a compatibility helper returning the complete base directory, but do not use it for new composition-aware behavior.
+
+This avoids duplicating precedence logic in the CLI and prevents runtime behavior from disagreeing with diagnostics.
+
+### 7. Add a small scaffolding command
+
+`openspec schema override <name>` creates a no-op `schema.override.yaml` for an existing packaged schema in the user data directory. It does not copy `schema.yaml` or templates.
+
+Options:
+
+- `--force`: atomically replace an existing overlay after the same destination-safety checks used by schema creation commands.
+- `--json`: report `created`, `schema`, `path`, and `basePath` without decorative output.
+
+The command fails when the name has no packaged schema, a complete user `schema.yaml` conflicts, or the destination exists without `--force`. It is independent of the current project root because its base is explicitly the packaged schema, not an effective project schema.
+
+### 8. Make composition visible and validation effective
+
+For a composed schema, `schema which` keeps `source: "package"` and the existing package `path` for JSON compatibility, then adds an `overlay` object containing the user path. Human output labels the schema as `package + user overlay`. An overlay is composition, not a shadow, so it is not inserted into the existing `shadows` array.
+
+`schema validate <name>` validates the overlay document, the fully composed `SchemaYaml`, and template existence through the ordered template roots. Errors identify `schema.override.yaml` and the relevant artifact or operation. `schema which --all`, `schemas`, and `templates` use the same source descriptor; template output reports the root that supplied each concrete template.
+
+### 9. Keep project rules separate
+
+An appended global `instruction` becomes part of the effective schema instruction. Existing project `rules.<artifact>` remain a separate field in instruction output and retain their current semantics. For an artifact such as `tasks`, consumers therefore receive:
+
+```text
+effective instruction = packaged instruction + global append
+rules                 = project tasks rules
+```
+
+This change does not create global project rules or relabel schema guidance as rules.
+
+## Risks / Trade-offs
+
+- **Packaged edits can change the context around an appended instruction.** → The user intentionally follows the packaged base; `schema which` exposes composition, and `replace` remains available when exact control is required.
+- **Two user customization modes add concepts.** → Use distinct filenames, reject conflicts, provide a scaffolding command, and document a clear choice: complete ownership versus layered customization.
+- **Strict operations are more verbose than generic YAML merge.** → The verbosity prevents accidental array replacement, duplicate dependencies, and uncertainty over whether text appends or replaces.
+- **A user template can still drift.** → Drift is limited to templates explicitly replaced; all others continue to fall back to the package.
+- **Existing callers may assume one schema directory.** → Introduce one source descriptor, retain `getSchemaDir()` for compatibility, and audit every resolver/template call site before implementation is complete.
+
+## Migration Plan
+
+This is additive. Existing project schemas, complete user schemas, and package-only resolution retain their current behavior. Users may opt into overlays by creating `schema.override.yaml` or running `openspec schema override <name>`. Converting a complete user replacement is manual: keep only the desired field operations and template replacements, remove the complete user `schema.yaml`, then validate and inspect the effective sources.
+
+Rollback is removal of `schema.override.yaml` and any optional user template overrides; the packaged schema immediately becomes effective again.
+
+## Open Questions
+
+None for v1. Project overlays, artifact insertion/removal/reordering, and arbitrary schema inheritance require separate proposals if concrete use cases emerge.

--- a/openspec/changes/add-global-schema-overlays/proposal.md
+++ b/openspec/changes/add-global-schema-overlays/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+OpenSpec's current user-level schema override is a complete, self-contained fork. A user who wants to add personal guidance to `spec-driven` must copy both `schema.yaml` and every referenced template into the user data directory. That copy permanently shadows the packaged schema, so later improvements to built-in instructions, dependencies, and templates no longer reach the user.
+
+The common global customization case is additive: keep the maintained packaged workflow, append or prepend personal guidance to artifacts such as `tasks`, and override only the occasional template. OpenSpec needs a layered user override for that case while retaining full schema replacement for users who intentionally own the complete workflow.
+
+## What Changes
+
+- Add an optional `schema.override.yaml` beside user-level schema bundles at `${XDG_DATA_HOME}/openspec/schemas/<name>/` (with the existing platform fallbacks).
+- Compose a packaged schema with its user overlay when no project-local or complete user schema replaces it.
+- Make text operations explicit: `append`, `prepend`, or `replace`. Make dependency-list operations explicit: `add`, `remove`, or `replace`. Plain scalar fields replace their packaged values.
+- Allow optional user templates to override individual packaged templates while unresolved template paths fall back to the packaged schema directory.
+- Keep project-local schemas highest priority and preserve today's complete user `schema.yaml` replacement behavior.
+- Add `openspec schema override <name>` to scaffold a safe, no-op global overlay without copying the packaged bundle.
+- Update schema resolution, validation, `schema which`, and template reporting so composed schemas and each effective source are visible and diagnosable.
+- Document the difference between complete schema replacement and layered global customization, including how packaged updates flow through each model.
+
+## Capabilities
+
+### New Capabilities
+
+- `schema-override-command`: Scaffold a user-level layered override for a packaged schema with safe conflict and overwrite handling.
+
+### Modified Capabilities
+
+- `schema-resolution`: Resolve packaged schemas together with optional user overlays while preserving project and complete-user replacement precedence.
+- `artifact-graph`: Apply validated field-level overlay operations and resolve optional user templates with packaged fallback.
+- `schema-which-command`: Report the base and overlay sources of a composed schema in human and JSON output.
+- `schema-validate-command`: Validate the effective composed schema, overlay operations, and layered template resolution.
+- `cli-artifact-workflow`: Report the actual source path of each template when a schema uses a global overlay.
+
+## Impact
+
+- `src/core/artifact-graph/types.ts` and `schema.ts`: Define and validate the overlay document and its explicit operations.
+- `src/core/artifact-graph/resolver.ts`: Centralize full-schema and overlay source discovery, composition, listing, and diagnostics.
+- `src/core/artifact-graph/instruction-loader.ts`: Resolve templates from an ordered set of trusted roots.
+- `src/commands/schema.ts`: Add overlay scaffolding and make `which` and `validate` composition-aware.
+- `src/commands/workflow/templates.ts`: Report per-template effective source paths.
+- `docs/customization.md`, `docs/cli.md`, and `docs/opsx.md`: Explain full replacements, layered overrides, paths, precedence, and maintenance behavior.
+- Focused resolver, instruction-loader, schema-command, and workflow-command tests, including Windows and XDG path cases.

--- a/openspec/changes/add-global-schema-overlays/specs/artifact-graph/spec.md
+++ b/openspec/changes/add-global-schema-overlays/specs/artifact-graph/spec.md
@@ -23,6 +23,15 @@ The system SHALL apply a valid user overlay to existing artifacts in a packaged 
 - **THEN** the effective instruction SHALL order the non-empty segments as prepend, packaged, append
 - **AND** it SHALL separate adjacent segments with one blank line
 
+#### Scenario: Text operation boundary normalization
+
+- **GIVEN** prepend, packaged, or append text has leading or trailing blank lines
+- **AND** one supplied segment contains only whitespace
+- **WHEN** the overlay is composed
+- **THEN** blank boundary lines SHALL be removed and the whitespace-only segment omitted
+- **AND** the remaining segments SHALL be separated by exactly one blank line
+- **AND** internal whitespace SHALL remain unchanged
+
 #### Scenario: Replace artifact instruction
 
 - **GIVEN** an overlay specifies `artifacts.tasks.instruction.replace`

--- a/openspec/changes/add-global-schema-overlays/specs/artifact-graph/spec.md
+++ b/openspec/changes/add-global-schema-overlays/specs/artifact-graph/spec.md
@@ -1,0 +1,128 @@
+## ADDED Requirements
+
+### Requirement: Schema overlays use explicit field operations
+
+The system SHALL apply a valid user overlay to existing artifacts in a packaged schema using explicit, deterministic operations before validating the effective schema.
+
+#### Scenario: Append artifact instruction
+
+- **GIVEN** an overlay specifies `artifacts.tasks.instruction.append`
+- **WHEN** the overlay is composed with the packaged schema
+- **THEN** the effective tasks instruction SHALL contain the packaged instruction followed by one blank line and the appended text
+
+#### Scenario: Prepend artifact instruction
+
+- **GIVEN** an overlay specifies `artifacts.tasks.instruction.prepend`
+- **WHEN** the overlay is composed with the packaged schema
+- **THEN** the effective tasks instruction SHALL contain the prepended text followed by one blank line and the packaged instruction
+
+#### Scenario: Prepend and append together
+
+- **GIVEN** an overlay specifies both `prepend` and `append` for an instruction
+- **WHEN** the overlay is composed
+- **THEN** the effective instruction SHALL order the non-empty segments as prepend, packaged, append
+- **AND** it SHALL separate adjacent segments with one blank line
+
+#### Scenario: Replace artifact instruction
+
+- **GIVEN** an overlay specifies `artifacts.tasks.instruction.replace`
+- **WHEN** the overlay is composed
+- **THEN** the effective tasks instruction SHALL equal the replacement text
+- **AND** it SHALL NOT include the packaged instruction
+
+#### Scenario: Replace conflicts with additive text operations
+
+- **WHEN** one instruction patch specifies `replace` together with `prepend` or `append`
+- **THEN** overlay validation SHALL fail with the conflicting operation path
+
+#### Scenario: Scalar artifact field replacement
+
+- **GIVEN** an overlay supplies `description`, `generates`, or `template` for an existing artifact
+- **WHEN** the overlay is composed
+- **THEN** each supplied scalar SHALL replace the corresponding packaged value
+- **AND** omitted fields SHALL retain their packaged values
+
+### Requirement: Overlay dependency operations preserve deterministic order
+
+The system SHALL update `requires` arrays using either replacement or ordered remove/add operations.
+
+#### Scenario: Remove and add dependencies
+
+- **GIVEN** an artifact dependency patch removes an existing ID and adds another existing artifact ID
+- **WHEN** the overlay is composed
+- **THEN** removal SHALL preserve the relative order of remaining dependencies
+- **AND** additions SHALL be appended in overlay declaration order
+
+#### Scenario: Replace dependencies
+
+- **GIVEN** an artifact dependency patch specifies `replace`
+- **WHEN** the overlay is composed
+- **THEN** the effective dependency list SHALL exactly match the replacement list
+
+#### Scenario: Replace conflicts with add or remove
+
+- **WHEN** one dependency patch specifies `replace` together with `add` or `remove`
+- **THEN** overlay validation SHALL fail with the conflicting operation path
+
+#### Scenario: Invalid dependency operation is rejected
+
+- **WHEN** a dependency patch contains duplicates, adds and removes the same ID, or removes an ID absent from the base list
+- **THEN** overlay validation SHALL fail with an actionable diagnostic
+
+### Requirement: Overlay scope is limited to existing artifacts
+
+The system SHALL reject structural artifact changes that are outside the layered override contract.
+
+#### Scenario: Unknown artifact ID is rejected
+
+- **WHEN** an overlay contains an artifact ID absent from the packaged schema
+- **THEN** composition SHALL fail and identify the unknown artifact ID
+
+#### Scenario: Schema identity cannot be overridden
+
+- **WHEN** an overlay attempts to set schema `name`, schema `version`, or an artifact `id`
+- **THEN** overlay validation SHALL reject the unsupported field
+
+#### Scenario: Effective graph is invalid
+
+- **WHEN** otherwise valid overlay operations produce an unknown dependency or cycle
+- **THEN** the existing complete-schema validation SHALL reject the effective schema
+- **AND** the error SHALL identify the overlay as the source of the invalid effective result
+
+### Requirement: Composed schemas use layered template resolution
+
+For a packaged schema with a user overlay, the system SHALL resolve each template from the optional user template directory before falling back to the packaged template directory.
+
+#### Scenario: User template overrides packaged template
+
+- **GIVEN** the effective schema references `tasks.md`
+- **AND** both user and packaged template directories contain `tasks.md`
+- **WHEN** task instructions are loaded
+- **THEN** the user template SHALL be used
+- **AND** its source path SHALL be reported
+
+#### Scenario: Missing user template falls back to package
+
+- **GIVEN** the effective schema references `proposal.md`
+- **AND** no user `proposal.md` template exists
+- **AND** the packaged template exists
+- **WHEN** proposal instructions are loaded
+- **THEN** the packaged template SHALL be used
+
+#### Scenario: Missing template in all roots fails
+
+- **WHEN** an effective schema references a template absent from every allowed template root
+- **THEN** template loading and schema validation SHALL fail with all checked roots identified
+
+#### Scenario: Complete replacement stays self-contained
+
+- **GIVEN** a project or complete user schema references a template missing from its own directory
+- **AND** a same-named packaged template exists
+- **WHEN** the template is loaded or validated
+- **THEN** the operation SHALL fail
+- **AND** it SHALL NOT fall back to the packaged template
+
+#### Scenario: Template path cannot escape either root
+
+- **WHEN** an overlay template path or symlink escapes its candidate user or package template root
+- **THEN** the system SHALL reject the path using the existing containment policy

--- a/openspec/changes/add-global-schema-overlays/specs/cli-artifact-workflow/spec.md
+++ b/openspec/changes/add-global-schema-overlays/specs/cli-artifact-workflow/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Template command reports layered source paths
+
+The templates command SHALL report the concrete source selected for each template in a composed schema.
+
+#### Scenario: Mixed user and package templates
+
+- **GIVEN** a composed schema whose user directory overrides `tasks.md` but not `proposal.md`
+- **WHEN** the user runs `openspec templates --schema <name>`
+- **THEN** the tasks template SHALL be labeled as user-sourced with its user path
+- **AND** the proposal template SHALL be labeled as package-sourced with its package path
+
+#### Scenario: Templates JSON reports concrete paths
+
+- **GIVEN** a composed schema uses templates from both user and package roots
+- **WHEN** the user runs `openspec templates --schema <name> --json`
+- **THEN** each artifact entry SHALL contain the concrete resolved path and its actual `user` or `package` source
+
+#### Scenario: Instruction output uses reported template
+
+- **WHEN** a template path is reported for an artifact in a composed schema
+- **THEN** `openspec instructions` for that artifact SHALL load the same concrete file

--- a/openspec/changes/add-global-schema-overlays/specs/schema-override-command/spec.md
+++ b/openspec/changes/add-global-schema-overlays/specs/schema-override-command/spec.md
@@ -1,0 +1,68 @@
+## Purpose
+
+Provide a safe CLI entry point for creating layered user schema overrides that retain packaged schema and template updates across projects.
+
+## ADDED Requirements
+
+### Requirement: Schema override command scaffolds a global overlay
+
+The CLI SHALL provide `openspec schema override <name>` to create a user-level `schema.override.yaml` for an existing packaged schema without copying the complete schema or templates.
+
+#### Scenario: Create overlay for packaged schema
+
+- **GIVEN** a packaged schema named `spec-driven` exists
+- **AND** no user replacement or overlay exists for that name
+- **WHEN** the user runs `openspec schema override spec-driven`
+- **THEN** the system SHALL create `${XDG_DATA_HOME}/openspec/schemas/spec-driven/schema.override.yaml`
+- **AND** the file SHALL contain a valid no-op `patchVersion: 1` overlay
+- **AND** it SHALL NOT copy the packaged `schema.yaml` or templates
+
+#### Scenario: Command is independent of project schema
+
+- **GIVEN** the current project contains a project-local schema with the same name
+- **WHEN** the user runs `openspec schema override <name>`
+- **THEN** the command SHALL target the packaged schema and user data directory
+- **AND** it SHALL explain that the project schema remains higher priority in that project
+
+#### Scenario: Packaged schema does not exist
+
+- **WHEN** the user runs `openspec schema override custom` and no packaged schema named `custom` exists
+- **THEN** the command SHALL fail with an actionable error
+- **AND** it SHALL NOT create a user directory or file
+
+### Requirement: Schema override command protects existing customization
+
+The command SHALL not overwrite or ambiguously combine user customization without explicit authorization.
+
+#### Scenario: Overlay already exists without force
+
+- **WHEN** the destination `schema.override.yaml` already exists and `--force` is absent
+- **THEN** the command SHALL fail and suggest `--force`
+- **AND** the existing file SHALL remain unchanged
+
+#### Scenario: Force replaces overlay atomically
+
+- **WHEN** the destination overlay exists and the user supplies `--force`
+- **THEN** the command SHALL stage and validate the replacement before swapping it into place
+- **AND** a failure SHALL leave the previous overlay unchanged
+
+#### Scenario: Complete user replacement conflicts
+
+- **WHEN** the user schema directory contains `schema.yaml`
+- **THEN** the command SHALL refuse to create `schema.override.yaml`
+- **AND** it SHALL explain how complete replacement differs from layered customization
+
+### Requirement: Schema override command supports JSON output
+
+The command SHALL provide machine-readable success and error output.
+
+#### Scenario: JSON success
+
+- **WHEN** the user runs `openspec schema override spec-driven --json`
+- **THEN** output SHALL contain `created: true`, `schema`, `path`, and `basePath`
+
+#### Scenario: JSON failure
+
+- **WHEN** overlay creation fails with `--json`
+- **THEN** output SHALL contain `created: false` and an actionable `error`
+- **AND** the command SHALL exit non-zero

--- a/openspec/changes/add-global-schema-overlays/specs/schema-resolution/spec.md
+++ b/openspec/changes/add-global-schema-overlays/specs/schema-resolution/spec.md
@@ -1,0 +1,82 @@
+## ADDED Requirements
+
+### Requirement: Layered user schema override resolution
+
+The system SHALL compose a packaged schema with a user-level `schema.override.yaml` of the same name when no complete project or user schema has higher precedence.
+
+#### Scenario: User overlay augments packaged schema
+
+- **GIVEN** `spec-driven` exists as a packaged schema
+- **AND** `${XDG_DATA_HOME}/openspec/schemas/spec-driven/schema.override.yaml` exists
+- **AND** no complete project or user `spec-driven/schema.yaml` exists
+- **WHEN** the system resolves `spec-driven`
+- **THEN** it SHALL use the packaged schema as the base
+- **AND** it SHALL apply the user overlay to produce the effective schema
+
+#### Scenario: Project schema suppresses user overlay
+
+- **GIVEN** project-local `spec-driven/schema.yaml`, user `spec-driven/schema.override.yaml`, and packaged `spec-driven/schema.yaml` all exist
+- **WHEN** the system resolves `spec-driven` with that project root
+- **THEN** it SHALL use the complete project schema unchanged
+- **AND** it SHALL NOT apply the user overlay
+
+#### Scenario: Complete user schema retains replacement behavior
+
+- **GIVEN** no project-local `spec-driven` schema exists
+- **AND** a complete user `spec-driven/schema.yaml` exists
+- **WHEN** the system resolves `spec-driven`
+- **THEN** it SHALL use the complete user schema unchanged
+- **AND** it SHALL NOT compose it with the packaged schema
+
+#### Scenario: Rootless resolution supports user overlay
+
+- **GIVEN** a packaged schema and matching user overlay exist
+- **WHEN** schema resolution is called without a project root
+- **THEN** it SHALL compose the packaged schema with the user overlay
+- **AND** it SHALL NOT inspect project-local schema directories
+
+#### Scenario: Overlay without packaged base is rejected
+
+- **GIVEN** `${XDG_DATA_HOME}/openspec/schemas/custom/schema.override.yaml` exists
+- **AND** no packaged schema named `custom` exists
+- **WHEN** the system resolves or lists schemas
+- **THEN** it SHALL NOT treat the overlay as a standalone schema
+- **AND** validation or direct resolution SHALL report that the packaged base is missing
+
+### Requirement: User schema customization mode is unambiguous
+
+The system SHALL prevent one user schema directory from acting as both a complete replacement and a layered override.
+
+#### Scenario: Complete replacement conflicts with overlay
+
+- **GIVEN** a user schema directory contains both `schema.yaml` and `schema.override.yaml`
+- **AND** no project-local schema of the same name has higher priority
+- **WHEN** the schema is resolved or validated
+- **THEN** the operation SHALL fail with a diagnostic naming both files
+- **AND** it SHALL instruct the user to choose complete replacement or layered customization
+
+#### Scenario: Project schema remains authoritative over inactive user conflict
+
+- **GIVEN** a project-local schema exists
+- **AND** the same-named user directory contains both `schema.yaml` and `schema.override.yaml`
+- **WHEN** the schema is resolved with that project root
+- **THEN** the complete project schema SHALL remain active
+- **AND** runtime schema loading SHALL NOT fail because of the inactive user-layer conflict
+
+### Requirement: Composed schemas remain discoverable
+
+Schema listing SHALL include a packaged schema when a valid user overlay is present and SHALL derive its effective description and artifacts from the composed schema.
+
+#### Scenario: Listing includes composed package schema once
+
+- **GIVEN** a packaged `spec-driven` schema and matching user overlay exist
+- **WHEN** schemas are listed
+- **THEN** `spec-driven` SHALL appear exactly once
+- **AND** its effective description and artifact IDs SHALL reflect the composed schema
+
+#### Scenario: Invalid overlay does not silently disappear
+
+- **GIVEN** a user overlay for a packaged schema is invalid
+- **WHEN** that schema is explicitly resolved or validated
+- **THEN** the operation SHALL report the overlay error and its path
+- **AND** it SHALL NOT silently fall back to the unmodified packaged schema

--- a/openspec/changes/add-global-schema-overlays/specs/schema-validate-command/spec.md
+++ b/openspec/changes/add-global-schema-overlays/specs/schema-validate-command/spec.md
@@ -1,0 +1,45 @@
+## ADDED Requirements
+
+### Requirement: Schema validate checks layered overrides
+
+`openspec schema validate <name>` SHALL validate the overlay document, effective composed schema, and every effective template source for a layered schema.
+
+#### Scenario: Valid composed schema
+
+- **GIVEN** a packaged schema and valid user overlay produce a valid effective schema
+- **AND** every referenced template resolves from the user or package root
+- **WHEN** the user validates the schema
+- **THEN** validation SHALL succeed
+- **AND** output SHALL identify both the base and overlay paths
+
+#### Scenario: Invalid overlay operation
+
+- **GIVEN** a user overlay contains conflicting or unsupported operations
+- **WHEN** the user validates the schema
+- **THEN** validation SHALL fail
+- **AND** the issue path SHALL identify `schema.override.yaml` and the invalid field
+
+#### Scenario: Invalid effective schema
+
+- **GIVEN** valid overlay syntax produces an invalid dependency graph
+- **WHEN** the user validates the schema
+- **THEN** validation SHALL fail with the complete-schema validation error
+- **AND** output SHALL state that the effective schema became invalid after applying the overlay
+
+#### Scenario: Template fallback is valid
+
+- **GIVEN** a referenced template is absent from the user overlay directory but present in the packaged directory
+- **WHEN** the user validates the composed schema
+- **THEN** template validation SHALL succeed using the packaged template
+
+#### Scenario: User replacement and overlay conflict
+
+- **GIVEN** the user schema directory contains both `schema.yaml` and `schema.override.yaml`
+- **WHEN** the user validates that schema
+- **THEN** validation SHALL fail and explain the two mutually exclusive customization modes
+
+#### Scenario: JSON validation reports composed paths
+
+- **WHEN** a composed schema is validated with `--json`
+- **THEN** output SHALL retain `valid`, `name`, `path`, and `issues`
+- **AND** it SHALL add base and overlay path metadata

--- a/openspec/changes/add-global-schema-overlays/specs/schema-validate-command/spec.md
+++ b/openspec/changes/add-global-schema-overlays/specs/schema-validate-command/spec.md
@@ -35,6 +35,7 @@
 #### Scenario: User replacement and overlay conflict
 
 - **GIVEN** the user schema directory contains both `schema.yaml` and `schema.override.yaml`
+- **AND** no higher-priority project schema of the same name exists
 - **WHEN** the user validates that schema
 - **THEN** validation SHALL fail and explain the two mutually exclusive customization modes
 

--- a/openspec/changes/add-global-schema-overlays/specs/schema-which-command/spec.md
+++ b/openspec/changes/add-global-schema-overlays/specs/schema-which-command/spec.md
@@ -1,0 +1,39 @@
+## ADDED Requirements
+
+### Requirement: Schema which reports layered resolution
+
+`openspec schema which` SHALL distinguish a composed package schema from both a package-only schema and a complete user replacement.
+
+#### Scenario: Human output shows package and user overlay
+
+- **GIVEN** a packaged schema has an active user overlay
+- **WHEN** the user runs `openspec schema which <name>`
+- **THEN** output SHALL identify the effective mode as package plus user overlay
+- **AND** it SHALL display both the packaged schema path and user overlay path
+
+#### Scenario: JSON output adds overlay metadata compatibly
+
+- **GIVEN** a packaged schema has an active user overlay
+- **WHEN** the user runs `openspec schema which <name> --json`
+- **THEN** `source` SHALL remain `package`
+- **AND** `path` SHALL remain the packaged schema directory
+- **AND** output SHALL add an `overlay` object with `source: user` and the overlay path
+
+#### Scenario: Overlay is not reported as a shadow
+
+- **GIVEN** a packaged schema has an active user overlay
+- **WHEN** resolution details are produced
+- **THEN** the overlay SHALL be reported as composition metadata
+- **AND** it SHALL NOT be placed in the existing `shadows` array
+
+#### Scenario: Project source reports inactive overlay
+
+- **GIVEN** a project schema has highest priority and a user overlay of the same name exists
+- **WHEN** the user runs `openspec schema which <name>`
+- **THEN** output SHALL identify the project schema as active
+- **AND** it SHALL identify the user overlay and package schema as inactive lower-priority sources
+
+#### Scenario: List mode includes composed resolution
+
+- **WHEN** the user runs `openspec schema which --all` or `--all --json`
+- **THEN** each composed schema SHALL expose the same base and overlay information as single-schema mode

--- a/openspec/changes/add-global-schema-overlays/tasks.md
+++ b/openspec/changes/add-global-schema-overlays/tasks.md
@@ -1,0 +1,44 @@
+## 1. Overlay model and merge behavior
+
+- [x] 1.1 Add strict Zod/types for `schema.override.yaml`, text operations, and collection operations, including `patchVersion: 1` and unknown-key rejection.
+- [x] 1.2 Implement pure merge helpers for scalar replacement, instruction `prepend`/`append`/`replace`, and dependency `add`/`remove`/`replace` with deterministic ordering and conflict validation.
+- [x] 1.3 Compose the overlay with the packaged schema and run the existing complete-schema parser over the effective result so dependency references, cycles, and required fields remain authoritative.
+- [x] 1.4 Add unit tests for every operation, combined prepend/append behavior, blank-line joining, invalid operations, unknown artifact IDs, duplicates, missing removals, and invalid final graphs.
+
+## 2. Source resolution and compatibility
+
+- [x] 2.1 Introduce one `ResolvedSchemaSources` API that represents project bundles, complete user bundles, package schemas, and package schemas with user overlays.
+- [x] 2.2 Implement precedence `project replacement → user replacement → package + user overlay → package`, including rootless resolution without project lookup.
+- [x] 2.3 Reject a user directory containing both `schema.yaml` and `schema.override.yaml`, and reject an overlay without a packaged base.
+- [x] 2.4 Keep `getSchemaDir()` backward-compatible while migrating composition-aware runtime and listing call sites to the centralized descriptor.
+- [x] 2.5 Add resolver/listing tests for all precedence combinations, XDG overrides, Unix/macOS fallbacks, Windows paths, symlink/path-containment cases, conflicts, and package-update passthrough.
+
+## 3. Layered template resolution
+
+- [x] 3.1 Resolve templates for composed schemas from the optional user template root first and the packaged root second.
+- [x] 3.2 Preserve self-contained template behavior for project schemas and complete user replacements with no package fallback.
+- [x] 3.3 Return the concrete template path and source so instruction loading and `openspec templates` report the same effective file.
+- [x] 3.4 Apply canonical containment checks independently to every candidate root and add tests for missing templates, user shadowing, packaged fallback, nested paths, symlinks, and escape attempts.
+
+## 4. Schema management commands and diagnostics
+
+- [x] 4.1 Add `openspec schema override <name>` with `--force` and `--json`, creating an atomic no-op overlay only for a packaged schema.
+- [x] 4.2 Refuse overlay creation when a complete user replacement conflicts or an existing overlay lacks `--force`; preserve the existing destination if staging or validation fails.
+- [x] 4.3 Update `schema which`, `schema which --all`, and JSON output to report package base plus user overlay without changing the existing `source` and `path` meanings.
+- [x] 4.4 Update `schema validate <name>` to validate the overlay, effective schema, and layered templates with file-specific diagnostics.
+- [x] 4.5 Update `openspec schemas` and `openspec templates` to consume the centralized source descriptor and report effective schema/template sources.
+- [x] 4.6 Add command tests for success, JSON contracts, conflicts, `--force` safety, root independence, effective validation, and composed source reporting.
+
+## 5. Documentation
+
+- [x] 5.1 Expand `docs/customization.md` with a dedicated Global Overrides section comparing complete replacement and layered customization, including exact cross-platform paths and precedence.
+- [x] 5.2 Document the overlay format and explicit field operations with a `tasks.instruction.append` example and optional template override example.
+- [x] 5.3 Update `docs/cli.md`, `docs/opsx.md`, troubleshooting, and command help for overlay creation, validation, inspection, conflicts, and rollback.
+- [x] 5.4 Explain update behavior clearly: packaged schema and non-overridden templates continue to evolve; replaced fields/templates remain user-owned.
+
+## 6. Verification
+
+- [x] 6.1 Run focused artifact-graph resolver, instruction-loader, schema command, workflow templates, project-config, and task-progress tests.
+- [x] 6.2 Run lint, type-check/build, and the full test suite.
+- [x] 6.3 Run `openspec validate add-global-schema-overlays --strict` and confirm every modified capability has a complete, valid delta spec.
+- [x] 6.4 Manually verify a packaged `spec-driven` update changes the effective schema while a global `tasks.instruction.append` and one user template override remain applied.

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -514,7 +514,19 @@ function installSchemaOverrideFile(
     parseSchemaOverride(fs.readFileSync(stagingPath, 'utf-8'));
 
     if (!destinationExists) {
-      fs.renameSync(stagingPath, destinationPath);
+      try {
+        // A same-directory hard link commits the staged inode atomically and
+        // fails instead of replacing a destination created after our check.
+        fs.linkSync(stagingPath, destinationPath);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+          throw new Error(
+            `Schema override already exists at ${destinationPath}. Use --force to replace it.`
+          );
+        }
+        throw error;
+      }
+      fs.rmSync(stagingPath, { force: true });
       return;
     }
 

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -272,6 +272,7 @@ function validateSchema(
   return { valid: issues.length === 0, issues };
 }
 
+/** Validates a composed schema and every template selected by its effective artifacts. */
 function validateEffectiveSchema(
   name: string,
   projectRoot: string,

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -11,8 +11,19 @@ import {
   getPackageSchemasDir,
   isSchemaDir,
   listSchemas,
+  resolveSchema,
+  resolveSchemaSources,
+  resolveSchemaTemplate,
+  SCHEMA_FILE_NAME,
+  SCHEMA_OVERRIDE_FILE_NAME,
+  SchemaLoadError,
+  type ResolvedSchemaSources,
 } from '../core/artifact-graph/resolver.js';
-import { parseSchema, SchemaValidationError } from '../core/artifact-graph/schema.js';
+import {
+  parseSchema,
+  parseSchemaOverride,
+  SchemaValidationError,
+} from '../core/artifact-graph/schema.js';
 import type { SchemaYaml, Artifact } from '../core/artifact-graph/types.js';
 import { FileSystemUtils } from '../utils/file-system.js';
 
@@ -38,6 +49,8 @@ interface SchemaResolution {
   source: SchemaSource;
   path: string;
   shadows: Array<{ source: SchemaSource; path: string }>;
+  overlay?: { source: 'user'; path: string };
+  inactiveOverlays?: Array<{ source: 'user'; path: string }>;
 }
 
 /**
@@ -95,24 +108,37 @@ function getSchemaResolution(
   name: string,
   projectRoot: string
 ): SchemaResolution | null {
+  const sources = resolveSchemaSources(name, projectRoot);
+  if (!sources) return null;
+
   const locations = checkAllLocations(name, projectRoot);
   const existingLocations = locations.filter((loc) => loc.exists);
-
-  if (existingLocations.length === 0) {
-    return null;
-  }
-
-  const active = existingLocations[0];
-  const shadows = existingLocations.slice(1).map((loc) => ({
+  const activeIndex = existingLocations.findIndex(
+    (location) => location.source === sources.base.source && location.path === sources.base.dir
+  );
+  const shadows = existingLocations.slice(activeIndex + 1).map((loc) => ({
     source: loc.source,
     path: loc.path,
   }));
 
+  const userOverlayPath = path.join(
+    getUserSchemasDir(),
+    name,
+    SCHEMA_OVERRIDE_FILE_NAME
+  );
+  const hasUserOverlay = fs.existsSync(userOverlayPath);
+
   return {
     name,
-    source: active.source,
-    path: active.path,
+    source: sources.base.source,
+    path: sources.base.dir,
     shadows,
+    ...(sources.overlay
+      ? { overlay: { source: 'user' as const, path: sources.overlay.path } }
+      : {}),
+    ...(!sources.overlay && hasUserOverlay
+      ? { inactiveOverlays: [{ source: 'user' as const, path: userOverlayPath }] }
+      : {}),
   };
 }
 
@@ -233,6 +259,69 @@ function validateSchema(
   }
 
   return { valid: issues.length === 0, issues };
+}
+
+function validateEffectiveSchema(
+  name: string,
+  projectRoot: string,
+  verbose: boolean = false
+): {
+  valid: boolean;
+  path?: string;
+  basePath?: string;
+  overlayPath?: string;
+  issues: ValidationIssue[];
+} {
+  const issues: ValidationIssue[] = [];
+
+  try {
+    if (verbose) console.log('  Resolving schema sources...');
+    const sources = resolveSchemaSources(name, projectRoot);
+    if (!sources) {
+      return {
+        valid: false,
+        issues: [{ level: 'error', path: name, message: `Schema '${name}' not found` }],
+      };
+    }
+
+    if (verbose && sources.overlay) console.log('  Applying schema.override.yaml...');
+    const schema = resolveSchema(name, projectRoot);
+
+    if (verbose) console.log('  Checking effective template files...');
+    for (const artifact of schema.artifacts) {
+      try {
+        resolveSchemaTemplate(name, artifact.template, projectRoot);
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
+        issues.push({
+          level: 'error',
+          path: `artifacts.${artifact.id}.template`,
+          message: detail.includes('outside the allowed directory')
+            ? `Template file '${artifact.template}' points outside the schema templates directory`
+            : detail,
+        });
+      }
+    }
+
+    return {
+      valid: issues.length === 0,
+      path: sources.base.dir,
+      basePath: sources.base.schemaPath,
+      ...(sources.overlay ? { overlayPath: sources.overlay.path } : {}),
+      issues,
+    };
+  } catch (error) {
+    const issuePath = error instanceof SchemaLoadError ? error.schemaPath : name;
+    return {
+      valid: false,
+      path: error instanceof SchemaLoadError ? path.dirname(error.schemaPath) : undefined,
+      issues: [{
+        level: 'error',
+        path: issuePath,
+        message: error instanceof Error ? error.message : String(error),
+      }],
+    };
+  }
 }
 
 /**
@@ -371,6 +460,75 @@ function fingerprintDir(dir: string): string {
   return hash.digest('hex');
 }
 
+const EMPTY_SCHEMA_OVERRIDE = `# Layered user customization for the packaged schema.
+# Example:
+# artifacts:
+#   tasks:
+#     instruction:
+#       append: |
+#         Add your global task guidance here.
+patchVersion: 1
+`;
+
+function fingerprintFile(filePath: string): string {
+  return createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+
+function installSchemaOverrideFile(
+  destinationPath: string,
+  content: string,
+  force: boolean
+): void {
+  const destinationDir = path.dirname(destinationPath);
+  fs.mkdirSync(destinationDir, { recursive: true });
+
+  const destinationExists = fs.existsSync(destinationPath);
+  const authorizedFingerprint = destinationExists
+    ? fingerprintFile(destinationPath)
+    : null;
+  const stagingPath = path.join(
+    destinationDir,
+    `.override-staging-${process.pid}-${Date.now()}.yaml`
+  );
+
+  try {
+    fs.writeFileSync(stagingPath, content, { flag: 'wx' });
+    parseSchemaOverride(fs.readFileSync(stagingPath, 'utf-8'));
+
+    if (!destinationExists) {
+      fs.renameSync(stagingPath, destinationPath);
+      return;
+    }
+
+    if (!force) {
+      throw new Error(`Schema override already exists at ${destinationPath}`);
+    }
+
+    const currentFingerprint = fs.existsSync(destinationPath)
+      ? fingerprintFile(destinationPath)
+      : null;
+    if (currentFingerprint !== authorizedFingerprint) {
+      throw new Error(
+        `Schema override at ${destinationPath} changed while the replacement was being prepared; nothing was overwritten.`
+      );
+    }
+
+    const backupPath = `${destinationPath}.override-backup-${process.pid}-${Date.now()}`;
+    fs.renameSync(destinationPath, backupPath);
+    try {
+      fs.renameSync(stagingPath, destinationPath);
+      fs.rmSync(backupPath, { force: true });
+    } catch (error) {
+      if (!fs.existsSync(destinationPath) && fs.existsSync(backupPath)) {
+        fs.renameSync(backupPath, destinationPath);
+      }
+      throw error;
+    }
+  } finally {
+    if (fs.existsSync(stagingPath)) fs.rmSync(stagingPath, { force: true });
+  }
+}
+
 /**
  * Default artifacts with descriptions for schema init.
  */
@@ -454,7 +612,10 @@ export function registerSchemaCommand(program: Command): void {
                 const shadowInfo = schema.shadows.length > 0
                   ? ` (shadows: ${schema.shadows.map((s) => s.source).join(', ')})`
                   : '';
-                console.log(`  ${schema.name}${shadowInfo}`);
+                const overlayInfo = schema.inactiveOverlays?.length
+                  ? ' (inactive user overlay)'
+                  : '';
+                console.log(`  ${schema.name}${shadowInfo}${overlayInfo}`);
               }
             }
 
@@ -464,14 +625,18 @@ export function registerSchemaCommand(program: Command): void {
                 const shadowInfo = schema.shadows.length > 0
                   ? ` (shadows: ${schema.shadows.map((s) => s.source).join(', ')})`
                   : '';
-                console.log(`  ${schema.name}${shadowInfo}`);
+                const overlayInfo = schema.inactiveOverlays?.length
+                  ? ' (inactive user overlay)'
+                  : '';
+                console.log(`  ${schema.name}${shadowInfo}${overlayInfo}`);
               }
             }
 
             if (bySource.package.length > 0) {
               console.log('\nPackage schemas:');
               for (const schema of bySource.package) {
-                console.log(`  ${schema.name}`);
+                const overlayInfo = schema.overlay ? ' (user overlay)' : '';
+                console.log(`  ${schema.name}${overlayInfo}`);
               }
             }
           }
@@ -505,13 +670,26 @@ export function registerSchemaCommand(program: Command): void {
           console.log(JSON.stringify(resolution, null, 2));
         } else {
           console.log(`Schema: ${resolution.name}`);
-          console.log(`Source: ${resolution.source}`);
+          console.log(
+            `Source: ${resolution.overlay ? 'package + user overlay' : resolution.source}`
+          );
           console.log(`Path: ${resolution.path}`);
+
+          if (resolution.overlay) {
+            console.log(`Overlay: ${resolution.overlay.path}`);
+          }
 
           if (resolution.shadows.length > 0) {
             console.log('\nShadows:');
             for (const shadow of resolution.shadows) {
               console.log(`  ${shadow.source}: ${shadow.path}`);
+            }
+          }
+
+          if (resolution.inactiveOverlays?.length) {
+            console.log('\nInactive overlays:');
+            for (const overlay of resolution.inactiveOverlays) {
+              console.log(`  ${overlay.source}: ${overlay.path}`);
             }
           }
         }
@@ -610,10 +788,34 @@ export function registerSchemaCommand(program: Command): void {
           return;
         }
 
-        // Validate specific schema
-        const schemaDir = getSchemaDir(name, projectRoot);
+        // Validate a specific effective schema, including a user overlay.
+        let sources: ResolvedSchemaSources | null;
+        try {
+          sources = resolveSchemaSources(name, projectRoot);
+        } catch {
+          const result = validateEffectiveSchema(
+            name,
+            projectRoot,
+            options?.verbose && !options?.json
+          );
+          if (options?.json) {
+            console.log(JSON.stringify({
+              name,
+              path: result.path,
+              valid: false,
+              issues: result.issues,
+            }, null, 2));
+          } else {
+            console.log(`✗ Schema '${name}' has errors:`);
+            for (const issue of result.issues) {
+              console.log(`  ${issue.level}: ${issue.message}`);
+            }
+          }
+          process.exitCode = 1;
+          return;
+        }
 
-        if (!schemaDir) {
+        if (!sources) {
           const available = listSchemas(projectRoot);
           if (options?.json) {
             console.log(JSON.stringify({
@@ -633,12 +835,18 @@ export function registerSchemaCommand(program: Command): void {
           console.log(`Validating ${name}...`);
         }
 
-        const result = validateSchema(schemaDir, options?.verbose && !options?.json);
+        const result = validateEffectiveSchema(
+          name,
+          projectRoot,
+          options?.verbose && !options?.json
+        );
 
         if (options?.json) {
           console.log(JSON.stringify({
             name,
-            path: schemaDir,
+            path: result.path ?? sources.base.dir,
+            basePath: result.basePath ?? sources.base.schemaPath,
+            ...(result.overlayPath ? { overlayPath: result.overlayPath } : {}),
             valid: result.valid,
             issues: result.issues,
           }, null, 2));
@@ -663,6 +871,86 @@ export function registerSchemaCommand(program: Command): void {
           }, null, 2));
         } else {
           console.error(`Error: ${(error as Error).message}`);
+        }
+        process.exitCode = 1;
+      }
+    });
+
+  // schema override
+  schemaCmd
+    .command('override <name>')
+    .description('Create a layered user override for a packaged schema')
+    .option('--json', 'Output as JSON')
+    .option('--force', 'Overwrite an existing layered override')
+    .action(async (name: string, options?: { json?: boolean; force?: boolean }) => {
+      const spinner = options?.json ? null : ora();
+      try {
+        if (!isValidSchemaName(name)) {
+          throw new Error(
+            `Invalid schema name '${name}'. Schema names must be kebab-case (e.g., spec-driven)`
+          );
+        }
+
+        const packageSchemaDir = path.join(getPackageSchemasDir(), name);
+        const packageSchemaPath = path.join(packageSchemaDir, SCHEMA_FILE_NAME);
+        if (!fs.existsSync(packageSchemaPath)) {
+          throw new Error(
+            `Packaged schema '${name}' not found. Layered overrides can only customize packaged schemas.`
+          );
+        }
+
+        const userSchemaDir = path.join(getUserSchemasDir(), name);
+        const completeUserSchemaPath = path.join(userSchemaDir, SCHEMA_FILE_NAME);
+        const destinationPath = path.join(userSchemaDir, SCHEMA_OVERRIDE_FILE_NAME);
+        if (fs.existsSync(completeUserSchemaPath)) {
+          throw new Error(
+            `Cannot create a layered override while complete user schema '${completeUserSchemaPath}' exists. Remove it first or keep using complete replacement.`
+          );
+        }
+        if (fs.existsSync(destinationPath) && !options?.force) {
+          throw new Error(
+            `Schema override already exists at ${destinationPath}. Use --force to replace it.`
+          );
+        }
+
+        if (spinner) spinner.start(`Creating global overlay for '${name}'...`);
+        installSchemaOverrideFile(destinationPath, EMPTY_SCHEMA_OVERRIDE, options?.force ?? false);
+        if (spinner) spinner.succeed(`Created global overlay for '${name}'`);
+
+        const projectSchemaPath = path.join(
+          getProjectSchemasDir(process.cwd()),
+          name,
+          SCHEMA_FILE_NAME
+        );
+        const projectSchemaTakesPrecedence = fs.existsSync(projectSchemaPath);
+
+        if (options?.json) {
+          console.log(JSON.stringify({
+            created: true,
+            schema: name,
+            path: destinationPath,
+            basePath: packageSchemaPath,
+            ...(projectSchemaTakesPrecedence ? { projectSchemaTakesPrecedence: true } : {}),
+          }, null, 2));
+        } else {
+          console.log(`\nBase: ${packageSchemaPath}`);
+          console.log(`Override: ${destinationPath}`);
+          console.log('Packaged fields and templates remain active unless explicitly overridden.');
+          if (projectSchemaTakesPrecedence) {
+            console.log(
+              `Note: ${projectSchemaPath} remains higher priority in the current project.`
+            );
+          }
+        }
+      } catch (error) {
+        if (spinner) spinner.fail('Override creation failed');
+        if (options?.json) {
+          console.log(JSON.stringify({
+            created: false,
+            error: error instanceof Error ? error.message : String(error),
+          }, null, 2));
+        } else {
+          console.error(`Error: ${error instanceof Error ? error.message : String(error)}`);
         }
         process.exitCode = 1;
       }
@@ -717,6 +1005,7 @@ export function registerSchemaCommand(program: Command): void {
         // Determine source location
         const sourceResolution = getSchemaResolution(source, projectRoot);
         const sourceLocation = sourceResolution?.source || 'package';
+        const sourceSources = resolveSchemaSources(source, projectRoot)!;
 
         // Validate the complete source before a forced fork removes anything.
         const trustedSourceDir = fs.realpathSync(sourceDir);
@@ -727,9 +1016,15 @@ export function registerSchemaCommand(program: Command): void {
         // existing destination. This keeps `fork --force` atomic — an unusable
         // source never destroys a valid destination — matching `schema init`,
         // which likewise validates before it overwrites.
-        parseSchema(
-          fs.readFileSync(path.join(trustedSourceDir, 'schema.yaml'), 'utf-8')
-        );
+        const effectiveSourceSchema = resolveSchema(source, projectRoot);
+        if (sourceSources.overlay) {
+          // A composed fork must become self-contained, so every effective
+          // template needs to resolve before staging. Complete-schema forks
+          // preserve the historical behavior of copying their tree as-is.
+          for (const artifact of effectiveSourceSchema.artifacts) {
+            resolveSchemaTemplate(source, artifact.template, projectRoot);
+          }
+        }
 
         // Check destination
         const schemasDir = getProjectSchemasDir(projectRoot);
@@ -786,14 +1081,29 @@ export function registerSchemaCommand(program: Command): void {
         try {
           copyDirRecursive(trustedSourceDir, stagingDir);
 
-          // Update name in the staged schema.yaml via yaml's Document API
-          // instead of re-serializing the parsed object, so block scalars,
-          // comments, and key order in the source schema.yaml survive the fork.
           const stagedSchemaPath = path.join(stagingDir, 'schema.yaml');
-          const schemaContent = fs.readFileSync(stagedSchemaPath, 'utf-8');
-          const doc = parseDocument(schemaContent);
-          doc.set('name', destinationName);
-          fs.writeFileSync(stagedSchemaPath, doc.toString());
+          if (sourceSources.overlay) {
+            // Materialize the effective composed schema into a self-contained
+            // project fork. User templates replace same-named package files;
+            // untouched package templates remain available in the staged tree.
+            if (fs.existsSync(sourceSources.overlay.templatesDir)) {
+              copyDirRecursive(
+                sourceSources.overlay.templatesDir,
+                path.join(stagingDir, 'templates'),
+                sourceSources.overlay.templatesDir
+              );
+            }
+            fs.writeFileSync(stagedSchemaPath, stringifyYaml({
+              ...effectiveSourceSchema,
+              name: destinationName,
+            }));
+          } else {
+            // Preserve formatting for ordinary complete-schema forks.
+            const schemaContent = fs.readFileSync(stagedSchemaPath, 'utf-8');
+            const doc = parseDocument(schemaContent);
+            doc.set('name', destinationName);
+            fs.writeFileSync(stagedSchemaPath, doc.toString());
+          }
 
           // Authoritative gate: validate the COMPLETED staged schema — the exact
           // bytes we are about to install — not just the source at the pre-check.
@@ -895,6 +1205,7 @@ export function registerSchemaCommand(program: Command): void {
             source,
             sourcePath: sourceDir,
             sourceLocation,
+            ...(sourceSources.overlay ? { overlayPath: sourceSources.overlay.path } : {}),
             destination: destinationName,
             destinationPath: destinationDir,
           }, null, 2));

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import ora from 'ora';
 import { stringify as stringifyYaml, parseDocument } from 'yaml';
 import {
@@ -108,14 +108,20 @@ function getSchemaResolution(
   name: string,
   projectRoot: string
 ): SchemaResolution | null {
-  const sources = resolveSchemaSources(name, projectRoot);
+  const normalizedName = normalizeSchemaLookupName(name);
+  const sources = resolveSchemaSources(normalizedName, projectRoot);
   if (!sources) return null;
 
-  const locations = checkAllLocations(name, projectRoot);
+  const locations = checkAllLocations(normalizedName, projectRoot);
   const existingLocations = locations.filter((loc) => loc.exists);
   const activeIndex = existingLocations.findIndex(
     (location) => location.source === sources.base.source && location.path === sources.base.dir
   );
+  if (activeIndex === -1) {
+    throw new Error(
+      `Schema resolution invariant failed for '${normalizedName}': active source was not found among known locations`
+    );
+  }
   const shadows = existingLocations.slice(activeIndex + 1).map((loc) => ({
     source: loc.source,
     path: loc.path,
@@ -123,13 +129,13 @@ function getSchemaResolution(
 
   const userOverlayPath = path.join(
     getUserSchemasDir(),
-    name,
+    normalizedName,
     SCHEMA_OVERRIDE_FILE_NAME
   );
   const hasUserOverlay = fs.existsSync(userOverlayPath);
 
   return {
-    name,
+    name: normalizedName,
     source: sources.base.source,
     path: sources.base.dir,
     shadows,
@@ -152,9 +158,14 @@ function getAllSchemasWithResolution(
   const results: SchemaResolution[] = [];
 
   for (const name of schemaNames) {
-    const resolution = getSchemaResolution(name, projectRoot);
-    if (resolution) {
-      results.push(resolution);
+    try {
+      const resolution = getSchemaResolution(name, projectRoot);
+      if (resolution) {
+        results.push(resolution);
+      }
+    } catch (error) {
+      if (!(error instanceof SchemaLoadError)) throw error;
+      console.error(`Warning: skipped '${name}': ${error.message}`);
     }
   }
 
@@ -331,6 +342,11 @@ function isValidSchemaName(name: string): boolean {
   return /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/.test(name);
 }
 
+/** Matches resolver compatibility by accepting a trailing YAML extension. */
+function normalizeSchemaLookupName(name: string): string {
+  return name.replace(/\.ya?ml$/u, '');
+}
+
 /**
  * Copy a directory recursively.
  */
@@ -470,10 +486,12 @@ const EMPTY_SCHEMA_OVERRIDE = `# Layered user customization for the packaged sch
 patchVersion: 1
 `;
 
+/** Returns a stable digest used to detect replacement races. */
 function fingerprintFile(filePath: string): string {
   return createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
 }
 
+/** Atomically installs a validated overlay while preserving concurrent user edits. */
 function installSchemaOverrideFile(
   destinationPath: string,
   content: string,
@@ -488,7 +506,7 @@ function installSchemaOverrideFile(
     : null;
   const stagingPath = path.join(
     destinationDir,
-    `.override-staging-${process.pid}-${Date.now()}.yaml`
+    `.override-staging-${process.pid}-${randomUUID()}.yaml`
   );
 
   try {
@@ -625,10 +643,7 @@ export function registerSchemaCommand(program: Command): void {
                 const shadowInfo = schema.shadows.length > 0
                   ? ` (shadows: ${schema.shadows.map((s) => s.source).join(', ')})`
                   : '';
-                const overlayInfo = schema.inactiveOverlays?.length
-                  ? ' (inactive user overlay)'
-                  : '';
-                console.log(`  ${schema.name}${shadowInfo}${overlayInfo}`);
+                console.log(`  ${schema.name}${shadowInfo}`);
               }
             }
 
@@ -789,33 +804,15 @@ export function registerSchemaCommand(program: Command): void {
         }
 
         // Validate a specific effective schema, including a user overlay.
-        let sources: ResolvedSchemaSources | null;
+        let sources: ResolvedSchemaSources | null = null;
+        let sourceResolutionFailed = false;
         try {
           sources = resolveSchemaSources(name, projectRoot);
         } catch {
-          const result = validateEffectiveSchema(
-            name,
-            projectRoot,
-            options?.verbose && !options?.json
-          );
-          if (options?.json) {
-            console.log(JSON.stringify({
-              name,
-              path: result.path,
-              valid: false,
-              issues: result.issues,
-            }, null, 2));
-          } else {
-            console.log(`✗ Schema '${name}' has errors:`);
-            for (const issue of result.issues) {
-              console.log(`  ${issue.level}: ${issue.message}`);
-            }
-          }
-          process.exitCode = 1;
-          return;
+          sourceResolutionFailed = true;
         }
 
-        if (!sources) {
+        if (!sources && !sourceResolutionFailed) {
           const available = listSchemas(projectRoot);
           if (options?.json) {
             console.log(JSON.stringify({
@@ -842,10 +839,12 @@ export function registerSchemaCommand(program: Command): void {
         );
 
         if (options?.json) {
+          const effectivePath = result.path ?? sources?.base.dir;
+          const effectiveBasePath = result.basePath ?? sources?.base.schemaPath;
           console.log(JSON.stringify({
             name,
-            path: result.path ?? sources.base.dir,
-            basePath: result.basePath ?? sources.base.schemaPath,
+            ...(effectivePath ? { path: effectivePath } : {}),
+            ...(effectiveBasePath ? { basePath: effectiveBasePath } : {}),
             ...(result.overlayPath ? { overlayPath: result.overlayPath } : {}),
             valid: result.valid,
             issues: result.issues,
@@ -885,6 +884,7 @@ export function registerSchemaCommand(program: Command): void {
     .action(async (name: string, options?: { json?: boolean; force?: boolean }) => {
       const spinner = options?.json ? null : ora();
       try {
+        const projectRoot = process.cwd();
         if (!isValidSchemaName(name)) {
           throw new Error(
             `Invalid schema name '${name}'. Schema names must be kebab-case (e.g., spec-driven)`
@@ -918,7 +918,7 @@ export function registerSchemaCommand(program: Command): void {
         if (spinner) spinner.succeed(`Created global overlay for '${name}'`);
 
         const projectSchemaPath = path.join(
-          getProjectSchemasDir(process.cwd()),
+          getProjectSchemasDir(projectRoot),
           name,
           SCHEMA_FILE_NAME
         );

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -73,7 +73,7 @@ function checkAllLocations(
 
   // Project location
   const projectDir = path.join(getProjectSchemasDir(projectRoot), name);
-  const projectSchemaPath = path.join(projectDir, 'schema.yaml');
+  const projectSchemaPath = path.join(projectDir, SCHEMA_FILE_NAME);
   locations.push({
     source: 'project',
     path: projectDir,
@@ -82,7 +82,7 @@ function checkAllLocations(
 
   // User location
   const userDir = path.join(getUserSchemasDir(), name);
-  const userSchemaPath = path.join(userDir, 'schema.yaml');
+  const userSchemaPath = path.join(userDir, SCHEMA_FILE_NAME);
   locations.push({
     source: 'user',
     path: userDir,
@@ -91,7 +91,7 @@ function checkAllLocations(
 
   // Package location
   const packageDir = path.join(getPackageSchemasDir(), name);
-  const packageSchemaPath = path.join(packageDir, 'schema.yaml');
+  const packageSchemaPath = path.join(packageDir, SCHEMA_FILE_NAME);
   locations.push({
     source: 'package',
     path: packageDir,
@@ -180,7 +180,7 @@ function validateSchema(
   verbose: boolean = false
 ): { valid: boolean; issues: ValidationIssue[] } {
   const issues: ValidationIssue[] = [];
-  const schemaPath = path.join(schemaDir, 'schema.yaml');
+  const schemaPath = path.join(schemaDir, SCHEMA_FILE_NAME);
 
   // Check schema.yaml exists
   if (verbose) {
@@ -512,7 +512,8 @@ function installSchemaOverrideFile(
 
   try {
     fs.writeFileSync(stagingPath, content, { flag: 'wx' });
-    parseSchemaOverride(fs.readFileSync(stagingPath, 'utf-8'));
+    const stagedContent = fs.readFileSync(stagingPath, 'utf-8');
+    parseSchemaOverride(stagedContent);
 
     if (!destinationExists) {
       try {
@@ -520,12 +521,24 @@ function installSchemaOverrideFile(
         // fails instead of replacing a destination created after our check.
         fs.linkSync(stagingPath, destinationPath);
       } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === 'EEXIST') {
+        const errorCode = (error as NodeJS.ErrnoException).code;
+        if (errorCode === 'EEXIST') {
           throw new Error(
             `Schema override already exists at ${destinationPath}. Use --force to replace it.`
           );
         }
-        throw error;
+        if (!['EPERM', 'ENOSYS', 'EXDEV'].includes(errorCode ?? '')) throw error;
+
+        try {
+          fs.writeFileSync(destinationPath, stagedContent, { flag: 'wx' });
+        } catch (fallbackError) {
+          if ((fallbackError as NodeJS.ErrnoException).code === 'EEXIST') {
+            throw new Error(
+              `Schema override already exists at ${destinationPath}. Use --force to replace it.`
+            );
+          }
+          throw fallbackError;
+        }
       }
       fs.rmSync(stagingPath, { force: true });
       return;
@@ -817,10 +830,11 @@ export function registerSchemaCommand(program: Command): void {
         }
 
         // Validate a specific effective schema, including a user overlay.
+        const normalizedName = normalizeSchemaLookupName(name);
         let sources: ResolvedSchemaSources | null = null;
         let sourceResolutionFailed = false;
         try {
-          sources = resolveSchemaSources(name, projectRoot);
+          sources = resolveSchemaSources(normalizedName, projectRoot);
         } catch {
           sourceResolutionFailed = true;
         }
@@ -830,11 +844,11 @@ export function registerSchemaCommand(program: Command): void {
           if (options?.json) {
             console.log(JSON.stringify({
               valid: false,
-              error: `Schema '${name}' not found`,
+              error: `Schema '${normalizedName}' not found`,
               available,
             }, null, 2));
           } else {
-            console.error(`Error: Schema '${name}' not found`);
+            console.error(`Error: Schema '${normalizedName}' not found`);
             console.error(`Available schemas: ${available.join(', ')}`);
           }
           process.exitCode = 1;
@@ -842,11 +856,11 @@ export function registerSchemaCommand(program: Command): void {
         }
 
         if (options?.verbose && !options?.json) {
-          console.log(`Validating ${name}...`);
+          console.log(`Validating ${normalizedName}...`);
         }
 
         const result = validateEffectiveSchema(
-          name,
+          normalizedName,
           projectRoot,
           options?.verbose && !options?.json
         );
@@ -855,7 +869,7 @@ export function registerSchemaCommand(program: Command): void {
           const effectivePath = result.path ?? sources?.base.dir;
           const effectiveBasePath = result.basePath ?? sources?.base.schemaPath;
           console.log(JSON.stringify({
-            name,
+            name: normalizedName,
             ...(effectivePath ? { path: effectivePath } : {}),
             ...(effectiveBasePath ? { basePath: effectiveBasePath } : {}),
             ...(result.overlayPath ? { overlayPath: result.overlayPath } : {}),
@@ -864,9 +878,9 @@ export function registerSchemaCommand(program: Command): void {
           }, null, 2));
         } else {
           if (result.valid) {
-            console.log(`✓ Schema '${name}' is valid`);
+            console.log(`✓ Schema '${normalizedName}' is valid`);
           } else {
-            console.log(`✗ Schema '${name}' has errors:`);
+            console.log(`✗ Schema '${normalizedName}' has errors:`);
             for (const issue of result.issues) {
               console.log(`  ${issue.level}: ${issue.message}`);
             }

--- a/src/commands/workflow/schemas.ts
+++ b/src/commands/workflow/schemas.ts
@@ -47,6 +47,8 @@ export async function schemasCommand(options: SchemasOptions): Promise<void> {
       sourceLabel = chalk.cyan(' (project)');
     } else if (schema.source === 'user') {
       sourceLabel = chalk.dim(' (user override)');
+    } else if (schema.overlay) {
+      sourceLabel = chalk.dim(' (package + user overlay)');
     }
     console.log(`  ${chalk.bold(schema.name)}${sourceLabel}`);
     console.log(`    ${schema.description}`);

--- a/src/commands/workflow/templates.ts
+++ b/src/commands/workflow/templates.ts
@@ -5,13 +5,12 @@
  */
 
 import ora from 'ora';
-import path from 'path';
 import {
   resolveSchema,
-  getSchemaDir,
+  resolveSchemaSources,
+  resolveSchemaTemplate,
   ArtifactGraph,
 } from '../../core/artifact-graph/index.js';
-import { FileSystemUtils } from '../../utils/file-system.js';
 import { validateSchemaExists, DEFAULT_SCHEMA } from './shared.js';
 
 // -----------------------------------------------------------------------------
@@ -41,45 +40,24 @@ export async function templatesCommand(options: TemplatesOptions): Promise<void>
     const schemaName = validateSchemaExists(options.schema ?? DEFAULT_SCHEMA, projectRoot);
     const schema = resolveSchema(schemaName, projectRoot);
     const graph = ArtifactGraph.fromSchema(schema);
-    const schemaDir = getSchemaDir(schemaName, projectRoot)!;
-
-    // Determine the source (project, user, or package)
-    const {
-      getUserSchemasDir,
-      getProjectSchemasDir,
-    } = await import('../../core/artifact-graph/resolver.js');
-    const projectSchemasDir = getProjectSchemasDir(projectRoot);
-    const userSchemasDir = getUserSchemasDir();
-
-    // Determine source by checking if schemaDir is inside each base directory
-    // Using path.relative is more robust than startsWith for path comparisons
-    const isInsideDir = (child: string, parent: string): boolean => {
-      const relative = path.relative(parent, child);
-      return !relative.startsWith('..') && !path.isAbsolute(relative);
-    };
-
-    let source: 'project' | 'user' | 'package';
-    if (isInsideDir(schemaDir, projectSchemasDir)) {
-      source = 'project';
-    } else if (isInsideDir(schemaDir, userSchemasDir)) {
-      source = 'user';
-    } else {
-      source = 'package';
-    }
-
-    const templatesDir = path.join(schemaDir, 'templates');
+    const sources = resolveSchemaSources(schemaName, projectRoot)!;
+    const source = sources.base.source;
     const templates: TemplateInfo[] = graph.getAllArtifacts().map((artifact) => {
-      const templatePath = path.join(templatesDir, artifact.template);
       try {
-        FileSystemUtils.assertPathWithin(templatesDir, templatePath);
+        const resolution = resolveSchemaTemplate(
+          schemaName,
+          artifact.template,
+          projectRoot
+        );
         return {
           artifactId: artifact.id,
-          templatePath: FileSystemUtils.canonicalizeExistingPath(templatePath),
-          source,
+          templatePath: resolution.path,
+          source: resolution.source,
         };
-      } catch {
+      } catch (error) {
+        const detail = error instanceof Error ? error.message : String(error);
         throw new Error(
-          `Template '${artifact.template}' for artifact '${artifact.id}' points outside the schema templates directory`
+          `Template '${artifact.template}' for artifact '${artifact.id}' could not be resolved: ${detail}`
         );
       }
     });
@@ -96,12 +74,13 @@ export async function templatesCommand(options: TemplatesOptions): Promise<void>
     }
 
     console.log(`Schema: ${schemaName}`);
-    console.log(`Source: ${source}`);
+    console.log(`Source: ${sources.overlay ? 'package + user overlay' : source}`);
     console.log();
 
     for (const t of templates) {
       console.log(`${t.artifactId}:`);
-      console.log(`  ${t.templatePath}`);
+      console.log(`  Path: ${t.templatePath}`);
+      console.log(`  Source: ${t.source}`);
     }
   } catch (error) {
     spinner?.stop();

--- a/src/core/artifact-graph/index.ts
+++ b/src/core/artifact-graph/index.ts
@@ -1,15 +1,27 @@
 // Types
 export {
   ArtifactSchema,
+  SchemaOverrideYamlSchema,
   SchemaYamlSchema,
   type Artifact,
+  type SchemaOverrideYaml,
   type SchemaYaml,
+  type StringCollectionOverride,
+  type TextOverrideOperation,
   type CompletedSet,
   type BlockedArtifacts,
 } from './types.js';
 
 // Schema loading and validation
-export { loadSchema, parseSchema, SchemaValidationError } from './schema.js';
+export {
+  applySchemaOverride,
+  loadSchema,
+  parseSchema,
+  parseSchemaOverride,
+  validateSchemaValue,
+  SchemaOverrideValidationError,
+  SchemaValidationError,
+} from './schema.js';
 
 // Graph operations
 export { ArtifactGraph } from './graph.js';
@@ -31,7 +43,19 @@ export {
   getSchemaDir,
   getPackageSchemasDir,
   getUserSchemasDir,
+  getProjectSchemasDir,
+  resolveSchemaSources,
+  resolveSchemaTemplate,
+  SCHEMA_FILE_NAME,
+  SCHEMA_OVERRIDE_FILE_NAME,
   SchemaLoadError,
+  type ResolvedSchemaSources,
+  type ResolvedTemplate,
+  type SchemaOverlayLocation,
+  type SchemaResolutionMode,
+  type SchemaSource,
+  type SchemaSourceLocation,
+  type SchemaTemplateRoot,
   type SchemaInfo,
 } from './resolver.js';
 

--- a/src/core/artifact-graph/instruction-loader.ts
+++ b/src/core/artifact-graph/instruction-loader.ts
@@ -1,6 +1,10 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { getSchemaDir, resolveSchema, listSchemasWithInfo } from './resolver.js';
+import {
+  resolveSchema,
+  resolveSchemaTemplate,
+  listSchemasWithInfo,
+} from './resolver.js';
 import { ArtifactGraph } from './graph.js';
 import { detectCompleted } from './state.js';
 import { resolveArtifactOutputPath, resolveArtifactOutputs } from './outputs.js';
@@ -205,30 +209,13 @@ export function loadTemplate(
   templatePath: string,
   projectRoot?: string
 ): string {
-  const schemaDir = getSchemaDir(schemaName, projectRoot);
-  if (!schemaDir) {
-    throw new TemplateLoadError(
-      `Schema '${schemaName}' not found`,
-      templatePath
-    );
-  }
-
-  const templatesDir = path.join(schemaDir, 'templates');
-  const templatePathOnDisk = path.join(templatesDir, templatePath);
-
+  let templatePathOnDisk: string;
   try {
-    FileSystemUtils.assertPathWithin(templatesDir, templatePathOnDisk);
+    templatePathOnDisk = resolveSchemaTemplate(schemaName, templatePath, projectRoot).path;
   } catch (error) {
     throw new TemplateLoadError(
       error instanceof Error ? error.message : String(error),
-      templatePathOnDisk
-    );
-  }
-
-  if (!fs.existsSync(templatePathOnDisk)) {
-    throw new TemplateLoadError(
-      `Template not found: ${templatePathOnDisk}`,
-      templatePathOnDisk
+      templatePath
     );
   }
 

--- a/src/core/artifact-graph/resolver.ts
+++ b/src/core/artifact-graph/resolver.ts
@@ -239,6 +239,7 @@ export function resolveSchemaSources(
   }
 
   const overlayDir = path.dirname(userOverlayPath);
+  const overlayTemplatesDir = path.join(overlayDir, 'templates');
   return {
     name: normalizedName,
     mode: 'package-with-user-overlay',
@@ -246,10 +247,10 @@ export function resolveSchemaSources(
     overlay: {
       source: 'user',
       path: userOverlayPath,
-      templatesDir: path.join(overlayDir, 'templates'),
+      templatesDir: overlayTemplatesDir,
     },
     templateRoots: [
-      { source: 'user', dir: path.join(overlayDir, 'templates') },
+      { source: 'user', dir: overlayTemplatesDir },
       { source: 'package', dir: path.join(base.dir, 'templates') },
     ],
   };

--- a/src/core/artifact-graph/resolver.ts
+++ b/src/core/artifact-graph/resolver.ts
@@ -3,12 +3,56 @@ import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { getGlobalDataDir } from '../global-config.js';
 import { FileSystemUtils } from '../../utils/file-system.js';
-import { parseSchema, SchemaValidationError } from './schema.js';
+import {
+  applySchemaOverride,
+  parseSchema,
+  parseSchemaOverride,
+  SchemaOverrideValidationError,
+  SchemaValidationError,
+} from './schema.js';
 import type { SchemaYaml } from './types.js';
 
-/**
- * Error thrown when loading a schema fails.
- */
+export const SCHEMA_FILE_NAME = 'schema.yaml';
+export const SCHEMA_OVERRIDE_FILE_NAME = 'schema.override.yaml';
+
+export type SchemaSource = 'project' | 'user' | 'package';
+export type SchemaResolutionMode =
+  | 'project'
+  | 'user-replacement'
+  | 'package'
+  | 'package-with-user-overlay';
+
+export interface SchemaSourceLocation {
+  source: SchemaSource;
+  dir: string;
+  schemaPath: string;
+}
+
+export interface SchemaOverlayLocation {
+  source: 'user';
+  path: string;
+  templatesDir: string;
+}
+
+export interface SchemaTemplateRoot {
+  source: SchemaSource;
+  dir: string;
+}
+
+export interface ResolvedSchemaSources {
+  name: string;
+  mode: SchemaResolutionMode;
+  base: SchemaSourceLocation;
+  overlay?: SchemaOverlayLocation;
+  templateRoots: SchemaTemplateRoot[];
+}
+
+export interface ResolvedTemplate {
+  path: string;
+  source: SchemaSource;
+}
+
+/** Error thrown when loading a schema or schema overlay fails. */
 export class SchemaLoadError extends Error {
   constructor(
     message: string,
@@ -20,115 +64,51 @@ export class SchemaLoadError extends Error {
   }
 }
 
-/**
- * Gets the package's built-in schemas directory path.
- * Uses import.meta.url to resolve relative to the current module.
- */
+/** Gets the package's built-in schemas directory path. */
 export function getPackageSchemasDir(): string {
   const currentFile = fileURLToPath(import.meta.url);
-  // Navigate from dist/core/artifact-graph/ to package root's schemas/
   return path.join(path.dirname(currentFile), '..', '..', '..', 'schemas');
 }
 
-/**
- * Gets the user's schema override directory path.
- */
+/** Gets the user's schema data directory path. */
 export function getUserSchemasDir(): string {
   return path.join(getGlobalDataDir(), 'schemas');
 }
 
-/**
- * Gets the project-local schemas directory path.
- * @param projectRoot - The project root directory
- * @returns The path to the project's schemas directory
- */
+/** Gets the project-local schemas directory path. */
 export function getProjectSchemasDir(projectRoot: string): string {
   return path.join(projectRoot, 'openspec', 'schemas');
 }
 
-/**
- * Determines whether a directory entry represents a schema directory candidate.
- *
- * Returns true for real directories and for symlinks whose target is a
- * directory. `fs.Dirent.isDirectory()` reports the raw entry type, so a symlink
- * (even one pointing at a directory) has `isDirectory() === false`; we
- * dereference such entries via `fs.statSync` to admit symlinked schema dirs
- * while still rejecting symlinks-to-files and broken/dangling symlinks.
- *
- * @param parentDir - The directory containing the entry
- * @param entry - The directory entry from `fs.readdirSync(..., { withFileTypes: true })`
- */
-/**
- * Directories `schema fork` creates transiently while swapping a fork into
- * place: a staging copy (`.fork-staging-<rand>`, created via mkdtemp) and a
- * backup of the previous destination (`<name>.fork-backup-<pid>-<ts>`). Either
- * can briefly coexist with real schemas in the schemas dir, so discovery must
- * never surface them. Real schema names are kebab-case (no dots), so excluding
- * these dot-bearing temp names can never hide a legitimate schema.
- */
-function isOwnedForkTempDir(name: string): boolean {
-  return name.startsWith('.fork-staging-') || name.includes('.fork-backup-');
+/** Directories temporarily owned by the schema fork/override commands. */
+function isOwnedSchemaTempDir(name: string): boolean {
+  return (
+    name.startsWith('.fork-staging-') ||
+    name.includes('.fork-backup-') ||
+    name.startsWith('.override-staging-') ||
+    name.includes('.override-backup-')
+  );
 }
 
 export function isSchemaDir(parentDir: string, entry: fs.Dirent): boolean {
-  if (isOwnedForkTempDir(entry.name)) {
-    return false;
-  }
-  if (entry.isDirectory()) {
-    return true;
-  }
+  if (isOwnedSchemaTempDir(entry.name)) return false;
+  if (entry.isDirectory()) return true;
   if (entry.isSymbolicLink()) {
     try {
-      // statSync follows the link; isDirectory() reflects the target type.
       return fs.statSync(path.join(parentDir, entry.name)).isDirectory();
     } catch {
-      // Broken symlink (dangling target) — statSync throws; treat as non-dir.
       return false;
     }
   }
   return false;
 }
 
-/**
- * Returns a schema directory only when its schema file stays within that
- * directory's canonical trust boundary. The directory itself may be a symlink;
- * external user schema links are an intentionally supported workflow.
- */
-function getSchemaCandidateDir(schemasDir: string, name: string): string | null {
-  const schemaDir = path.join(schemasDir, name);
-  const schemaPath = path.join(schemaDir, 'schema.yaml');
-  if (!fs.existsSync(schemaPath)) {
-    return null;
-  }
-
-  try {
-    FileSystemUtils.assertPathWithin(schemaDir, schemaPath);
-    return schemaDir;
-  } catch {
-    return null;
-  }
+function normalizeSchemaName(name: string): string {
+  return name.replace(/\.ya?ml$/u, '');
 }
 
-/**
- * Resolves a schema name to its directory path.
- *
- * Resolution order (when projectRoot is provided):
- * 1. Project-local: <projectRoot>/openspec/schemas/<name>/schema.yaml
- * 2. User override: ${XDG_DATA_HOME}/openspec/schemas/<name>/schema.yaml
- * 3. Package built-in: <package>/schemas/<name>/schema.yaml
- *
- * When projectRoot is not provided, only user override and package built-in are checked
- * (backward compatible behavior).
- *
- * @param name - Schema name (e.g., "spec-driven")
- * @param projectRoot - Optional project root directory for project-local schema resolution
- * @returns The path to the schema directory, or null if not found
- */
-export function getSchemaDir(
-  name: string,
-  projectRoot?: string
-): string | null {
-  if (
+function isValidLookupName(name: string): boolean {
+  return !(
     name.length === 0 ||
     name === '.' ||
     name === '..' ||
@@ -136,69 +116,152 @@ export function getSchemaDir(
     /^[A-Za-z]:/u.test(name) ||
     path.posix.isAbsolute(name) ||
     path.win32.isAbsolute(name)
-  ) {
-    return null;
-  }
-
-  // 1. Check project-local directory (if projectRoot provided)
-  if (projectRoot) {
-    const projectDir = getSchemaCandidateDir(getProjectSchemasDir(projectRoot), name);
-    if (projectDir) {
-      return projectDir;
-    }
-  }
-
-  // 2. Check user override directory
-  const userDir = getSchemaCandidateDir(getUserSchemasDir(), name);
-  if (userDir) {
-    return userDir;
-  }
-
-  // 3. Check package built-in directory
-  const packageDir = getSchemaCandidateDir(getPackageSchemasDir(), name);
-  if (packageDir) {
-    return packageDir;
-  }
-
-  return null;
+  );
 }
 
 /**
- * Resolves a schema name to a SchemaYaml object.
- *
- * Resolution order (when projectRoot is provided):
- * 1. Project-local: <projectRoot>/openspec/schemas/<name>/schema.yaml
- * 2. User override: ${XDG_DATA_HOME}/openspec/schemas/<name>/schema.yaml
- * 3. Package built-in: <package>/schemas/<name>/schema.yaml
- *
- * When projectRoot is not provided, only user override and package built-in are checked
- * (backward compatible behavior).
- *
- * @param name - Schema name (e.g., "spec-driven")
- * @param projectRoot - Optional project root directory for project-local schema resolution
- * @returns The resolved schema object
- * @throws Error if schema is not found in any location
+ * Returns a schema-owned file only when it remains inside the canonical schema
+ * directory. The schema directory itself may be a symlink.
  */
-export function resolveSchema(name: string, projectRoot?: string): SchemaYaml {
-  // Normalize name (remove .yaml extension if provided)
-  const normalizedName = name.replace(/\.ya?ml$/, '');
+function getSchemaCandidateFile(
+  schemasDir: string,
+  name: string,
+  fileName: string
+): string | null {
+  const schemaDir = path.join(schemasDir, name);
+  const filePath = path.join(schemaDir, fileName);
+  if (!fs.existsSync(filePath)) return null;
 
-  const schemaDir = getSchemaDir(normalizedName, projectRoot);
-  if (!schemaDir) {
-    const availableSchemas = listSchemas(projectRoot);
-    throw new Error(
-      `Schema '${normalizedName}' not found. Available schemas: ${availableSchemas.join(', ')}`
+  try {
+    FileSystemUtils.assertPathWithin(schemaDir, filePath);
+    return filePath;
+  } catch {
+    return null;
+  }
+}
+
+function locationFor(
+  source: SchemaSource,
+  schemaPath: string
+): SchemaSourceLocation {
+  return { source, dir: path.dirname(schemaPath), schemaPath };
+}
+
+/**
+ * Resolves every source participating in an effective schema.
+ *
+ * Precedence:
+ * 1. complete project schema
+ * 2. complete user schema
+ * 3. package schema plus optional user overlay
+ */
+export function resolveSchemaSources(
+  name: string,
+  projectRoot?: string
+): ResolvedSchemaSources | null {
+  const normalizedName = normalizeSchemaName(name);
+  if (!isValidLookupName(normalizedName)) return null;
+
+  if (projectRoot) {
+    const projectSchemaPath = getSchemaCandidateFile(
+      getProjectSchemasDir(projectRoot),
+      normalizedName,
+      SCHEMA_FILE_NAME
+    );
+    if (projectSchemaPath) {
+      const base = locationFor('project', projectSchemaPath);
+      return {
+        name: normalizedName,
+        mode: 'project',
+        base,
+        templateRoots: [{ source: 'project', dir: path.join(base.dir, 'templates') }],
+      };
+    }
+  }
+
+  const userSchemasDir = getUserSchemasDir();
+  const userSchemaPath = getSchemaCandidateFile(
+    userSchemasDir,
+    normalizedName,
+    SCHEMA_FILE_NAME
+  );
+  const userOverlayPath = getSchemaCandidateFile(
+    userSchemasDir,
+    normalizedName,
+    SCHEMA_OVERRIDE_FILE_NAME
+  );
+
+  if (userSchemaPath && userOverlayPath) {
+    throw new SchemaLoadError(
+      `Schema '${normalizedName}' has both a complete user replacement (${userSchemaPath}) and a layered override (${userOverlayPath}). Remove one and choose either complete replacement or layered customization.`,
+      userOverlayPath
     );
   }
 
-  const schemaPath = path.join(schemaDir, 'schema.yaml');
+  if (userSchemaPath) {
+    const base = locationFor('user', userSchemaPath);
+    return {
+      name: normalizedName,
+      mode: 'user-replacement',
+      base,
+      templateRoots: [{ source: 'user', dir: path.join(base.dir, 'templates') }],
+    };
+  }
 
-  // Load and parse the schema
+  const packageSchemaPath = getSchemaCandidateFile(
+    getPackageSchemasDir(),
+    normalizedName,
+    SCHEMA_FILE_NAME
+  );
+
+  if (!packageSchemaPath) {
+    if (userOverlayPath) {
+      throw new SchemaLoadError(
+        `Schema override '${userOverlayPath}' has no packaged schema '${normalizedName}' to extend. Layered overrides can only customize packaged schemas.`,
+        userOverlayPath
+      );
+    }
+    return null;
+  }
+
+  const base = locationFor('package', packageSchemaPath);
+  if (!userOverlayPath) {
+    return {
+      name: normalizedName,
+      mode: 'package',
+      base,
+      templateRoots: [{ source: 'package', dir: path.join(base.dir, 'templates') }],
+    };
+  }
+
+  const overlayDir = path.dirname(userOverlayPath);
+  return {
+    name: normalizedName,
+    mode: 'package-with-user-overlay',
+    base,
+    overlay: {
+      source: 'user',
+      path: userOverlayPath,
+      templatesDir: path.join(overlayDir, 'templates'),
+    },
+    templateRoots: [
+      { source: 'user', dir: path.join(overlayDir, 'templates') },
+      { source: 'package', dir: path.join(base.dir, 'templates') },
+    ],
+  };
+}
+
+/** Compatibility helper returning the complete base schema directory. */
+export function getSchemaDir(name: string, projectRoot?: string): string | null {
+  return resolveSchemaSources(name, projectRoot)?.base.dir ?? null;
+}
+
+function readSchemaFile(schemaPath: string): SchemaYaml {
   let content: string;
   try {
     content = fs.readFileSync(schemaPath, 'utf-8');
-  } catch (err) {
-    const ioError = err instanceof Error ? err : new Error(String(err));
+  } catch (error) {
+    const ioError = error instanceof Error ? error : new Error(String(error));
     throw new SchemaLoadError(
       `Failed to read schema at '${schemaPath}': ${ioError.message}`,
       schemaPath,
@@ -208,168 +271,132 @@ export function resolveSchema(name: string, projectRoot?: string): SchemaYaml {
 
   try {
     return parseSchema(content);
-  } catch (err) {
-    if (err instanceof SchemaValidationError) {
-      throw new SchemaLoadError(
-        `Invalid schema at '${schemaPath}': ${err.message}`,
-        schemaPath,
-        err
-      );
-    }
-    const parseError = err instanceof Error ? err : new Error(String(err));
+  } catch (error) {
+    const parseError = error instanceof Error ? error : new Error(String(error));
+    const prefix = error instanceof SchemaValidationError ? 'Invalid schema' : 'Failed to parse schema';
     throw new SchemaLoadError(
-      `Failed to parse schema at '${schemaPath}': ${parseError.message}`,
+      `${prefix} at '${schemaPath}': ${parseError.message}`,
       schemaPath,
       parseError
     );
   }
 }
 
-/**
- * Lists all available schema names.
- * Combines project-local, user override, and package built-in schemas.
- *
- * @param projectRoot - Optional project root directory for project-local schema resolution
- */
+/** Resolves and loads the effective schema, including a user overlay when active. */
+export function resolveSchema(name: string, projectRoot?: string): SchemaYaml {
+  const normalizedName = normalizeSchemaName(name);
+  const sources = resolveSchemaSources(normalizedName, projectRoot);
+  if (!sources) {
+    const availableSchemas = listSchemas(projectRoot);
+    throw new Error(
+      `Schema '${normalizedName}' not found. Available schemas: ${availableSchemas.join(', ')}`
+    );
+  }
+
+  const base = readSchemaFile(sources.base.schemaPath);
+  if (!sources.overlay) return base;
+
+  let overrideContent: string;
+  try {
+    overrideContent = fs.readFileSync(sources.overlay.path, 'utf-8');
+  } catch (error) {
+    const ioError = error instanceof Error ? error : new Error(String(error));
+    throw new SchemaLoadError(
+      `Failed to read schema override at '${sources.overlay.path}': ${ioError.message}`,
+      sources.overlay.path,
+      ioError
+    );
+  }
+
+  try {
+    return applySchemaOverride(base, parseSchemaOverride(overrideContent));
+  } catch (error) {
+    const overrideError = error instanceof Error ? error : new Error(String(error));
+    const prefix = error instanceof SchemaOverrideValidationError
+      ? 'Invalid schema override'
+      : 'Failed to apply schema override';
+    throw new SchemaLoadError(
+      `${prefix} at '${sources.overlay.path}': ${overrideError.message}`,
+      sources.overlay.path,
+      overrideError
+    );
+  }
+}
+
+function addSchemaDirectoryNames(schemas: Set<string>, schemasDir: string): void {
+  if (!fs.existsSync(schemasDir)) return;
+  for (const entry of fs.readdirSync(schemasDir, { withFileTypes: true })) {
+    if (!isSchemaDir(schemasDir, entry)) continue;
+    const schemaPath = path.join(schemasDir, entry.name, SCHEMA_FILE_NAME);
+    if (fs.existsSync(schemaPath)) schemas.add(entry.name);
+  }
+}
+
+/** Lists complete schema names. Overlay-only names are supplied by package discovery. */
 export function listSchemas(projectRoot?: string): string[] {
   const schemas = new Set<string>();
-
-  // Add package built-in schemas
-  const packageDir = getPackageSchemasDir();
-  if (fs.existsSync(packageDir)) {
-    for (const entry of fs.readdirSync(packageDir, { withFileTypes: true })) {
-      if (isSchemaDir(packageDir, entry)) {
-        const schemaPath = path.join(packageDir, entry.name, 'schema.yaml');
-        if (fs.existsSync(schemaPath)) {
-          schemas.add(entry.name);
-        }
-      }
-    }
-  }
-
-  // Add user override schemas (may override package schemas)
-  const userDir = getUserSchemasDir();
-  if (fs.existsSync(userDir)) {
-    for (const entry of fs.readdirSync(userDir, { withFileTypes: true })) {
-      if (isSchemaDir(userDir, entry)) {
-        const schemaPath = path.join(userDir, entry.name, 'schema.yaml');
-        if (fs.existsSync(schemaPath)) {
-          schemas.add(entry.name);
-        }
-      }
-    }
-  }
-
-  // Add project-local schemas (if projectRoot provided)
-  if (projectRoot) {
-    const projectDir = getProjectSchemasDir(projectRoot);
-    if (fs.existsSync(projectDir)) {
-      for (const entry of fs.readdirSync(projectDir, { withFileTypes: true })) {
-        if (isSchemaDir(projectDir, entry)) {
-          const schemaPath = path.join(projectDir, entry.name, 'schema.yaml');
-          if (fs.existsSync(schemaPath)) {
-            schemas.add(entry.name);
-          }
-        }
-      }
-    }
-  }
-
+  addSchemaDirectoryNames(schemas, getPackageSchemasDir());
+  addSchemaDirectoryNames(schemas, getUserSchemasDir());
+  if (projectRoot) addSchemaDirectoryNames(schemas, getProjectSchemasDir(projectRoot));
   return Array.from(schemas).sort();
 }
 
-/**
- * Schema info with metadata (name, description, artifacts).
- */
 export interface SchemaInfo {
   name: string;
   description: string;
   artifacts: string[];
-  source: 'project' | 'user' | 'package';
+  source: SchemaSource;
+  overlay?: { source: 'user'; path: string };
 }
 
-/**
- * Lists all available schemas with their descriptions and artifact lists.
- * Useful for agent skills to present schema selection to users.
- *
- * @param projectRoot - Optional project root directory for project-local schema resolution
- */
+/** Lists available schemas using their effective composed metadata. */
 export function listSchemasWithInfo(projectRoot?: string): SchemaInfo[] {
   const schemas: SchemaInfo[] = [];
-  const seenNames = new Set<string>();
-
-  // Add project-local schemas first (highest priority, if projectRoot provided)
-  if (projectRoot) {
-    const projectDir = getProjectSchemasDir(projectRoot);
-    if (fs.existsSync(projectDir)) {
-      for (const entry of fs.readdirSync(projectDir, { withFileTypes: true })) {
-        if (isSchemaDir(projectDir, entry)) {
-          const schemaPath = path.join(projectDir, entry.name, 'schema.yaml');
-          if (fs.existsSync(schemaPath)) {
-            try {
-              const schema = parseSchema(fs.readFileSync(schemaPath, 'utf-8'));
-              schemas.push({
-                name: entry.name,
-                description: schema.description || '',
-                artifacts: schema.artifacts.map((a) => a.id),
-                source: 'project',
-              });
-              seenNames.add(entry.name);
-            } catch {
-              // Skip invalid schemas
-            }
-          }
-        }
-      }
+  for (const name of listSchemas(projectRoot)) {
+    try {
+      const sources = resolveSchemaSources(name, projectRoot);
+      if (!sources) continue;
+      const schema = resolveSchema(name, projectRoot);
+      schemas.push({
+        name,
+        description: schema.description ?? '',
+        artifacts: schema.artifacts.map((artifact) => artifact.id),
+        source: sources.base.source,
+        ...(sources.overlay
+          ? { overlay: { source: 'user' as const, path: sources.overlay.path } }
+          : {}),
+      });
+    } catch {
+      // Preserve existing discovery behavior: invalid schemas are omitted.
+      // Explicit resolution and validation surface the detailed error.
     }
   }
-
-  // Add user override schemas (if not overridden by project)
-  const userDir = getUserSchemasDir();
-  if (fs.existsSync(userDir)) {
-    for (const entry of fs.readdirSync(userDir, { withFileTypes: true })) {
-      if (isSchemaDir(userDir, entry) && !seenNames.has(entry.name)) {
-        const schemaPath = path.join(userDir, entry.name, 'schema.yaml');
-        if (fs.existsSync(schemaPath)) {
-          try {
-            const schema = parseSchema(fs.readFileSync(schemaPath, 'utf-8'));
-            schemas.push({
-              name: entry.name,
-              description: schema.description || '',
-              artifacts: schema.artifacts.map((a) => a.id),
-              source: 'user',
-            });
-            seenNames.add(entry.name);
-          } catch {
-            // Skip invalid schemas
-          }
-        }
-      }
-    }
-  }
-
-  // Add package built-in schemas (if not overridden by project or user)
-  const packageDir = getPackageSchemasDir();
-  if (fs.existsSync(packageDir)) {
-    for (const entry of fs.readdirSync(packageDir, { withFileTypes: true })) {
-      if (isSchemaDir(packageDir, entry) && !seenNames.has(entry.name)) {
-        const schemaPath = path.join(packageDir, entry.name, 'schema.yaml');
-        if (fs.existsSync(schemaPath)) {
-          try {
-            const schema = parseSchema(fs.readFileSync(schemaPath, 'utf-8'));
-            schemas.push({
-              name: entry.name,
-              description: schema.description || '',
-              artifacts: schema.artifacts.map((a) => a.id),
-              source: 'package',
-            });
-          } catch {
-            // Skip invalid schemas
-          }
-        }
-      }
-    }
-  }
-
   return schemas.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/** Resolves one concrete template from the effective schema's trusted roots. */
+export function resolveSchemaTemplate(
+  schemaName: string,
+  templatePath: string,
+  projectRoot?: string
+): ResolvedTemplate {
+  const sources = resolveSchemaSources(schemaName, projectRoot);
+  if (!sources) {
+    throw new Error(`Schema '${normalizeSchemaName(schemaName)}' not found`);
+  }
+
+  const checked: string[] = [];
+  for (const root of sources.templateRoots) {
+    const candidate = path.join(root.dir, templatePath);
+    checked.push(candidate);
+    FileSystemUtils.assertPathWithin(root.dir, candidate);
+    if (!fs.existsSync(candidate)) continue;
+    if (!fs.statSync(candidate).isFile()) continue;
+    return {
+      path: FileSystemUtils.canonicalizeExistingPath(candidate),
+      source: root.source,
+    };
+  }
+
+  throw new Error(`Template not found. Checked: ${checked.join(', ')}`);
 }

--- a/src/core/artifact-graph/resolver.ts
+++ b/src/core/artifact-graph/resolver.ts
@@ -90,6 +90,7 @@ function isOwnedSchemaTempDir(name: string): boolean {
   );
 }
 
+/** Reports whether a directory entry is a usable schema directory rather than command-owned state. */
 export function isSchemaDir(parentDir: string, entry: fs.Dirent): boolean {
   if (isOwnedSchemaTempDir(entry.name)) return false;
   if (entry.isDirectory()) return true;
@@ -103,10 +104,12 @@ export function isSchemaDir(parentDir: string, entry: fs.Dirent): boolean {
   return false;
 }
 
+/** Removes an optional YAML extension accepted by schema lookup APIs. */
 function normalizeSchemaName(name: string): string {
   return name.replace(/\.ya?ml$/u, '');
 }
 
+/** Rejects empty and path-like values before joining a schema name to trusted roots. */
 function isValidLookupName(name: string): boolean {
   return !(
     name.length === 0 ||
@@ -140,6 +143,7 @@ function getSchemaCandidateFile(
   }
 }
 
+/** Describes a located schema file and its containing source directory. */
 function locationFor(
   source: SchemaSource,
   schemaPath: string
@@ -256,6 +260,7 @@ export function getSchemaDir(name: string, projectRoot?: string): string | null 
   return resolveSchemaSources(name, projectRoot)?.base.dir ?? null;
 }
 
+/** Reads and validates one complete schema while preserving file-specific error context. */
 function readSchemaFile(schemaPath: string): SchemaYaml {
   let content: string;
   try {
@@ -323,6 +328,7 @@ export function resolveSchema(name: string, projectRoot?: string): SchemaYaml {
   }
 }
 
+/** Adds complete schema directory names from one precedence root to a shared set. */
 function addSchemaDirectoryNames(schemas: Set<string>, schemasDir: string): void {
   if (!fs.existsSync(schemasDir)) return;
   for (const entry of fs.readdirSync(schemasDir, { withFileTypes: true })) {

--- a/src/core/artifact-graph/schema.ts
+++ b/src/core/artifact-graph/schema.ts
@@ -56,7 +56,7 @@ export function validateSchemaValue(value: unknown): SchemaYaml {
   validateNoDuplicateIds(schema.artifacts);
 
   // Check that all requires references are valid
-  validateRequiresReferences(schema.artifacts);
+  validateRequiresReferences(schema.artifacts, schema.apply?.requires);
 
   // Check for cycles
   validateNoCycles(schema.artifacts);
@@ -225,7 +225,10 @@ function validateNoDuplicateIds(artifacts: Artifact[]): void {
 /**
  * Validates that all `requires` references point to valid artifact IDs.
  */
-function validateRequiresReferences(artifacts: Artifact[]): void {
+function validateRequiresReferences(
+  artifacts: Artifact[],
+  applyRequires: string[] = []
+): void {
   const validIds = new Set(artifacts.map(a => a.id));
 
   for (const artifact of artifacts) {
@@ -235,6 +238,14 @@ function validateRequiresReferences(artifacts: Artifact[]): void {
           `Invalid dependency reference in artifact '${artifact.id}': '${req}' does not exist`
         );
       }
+    }
+  }
+
+  for (const req of applyRequires) {
+    if (!validIds.has(req)) {
+      throw new SchemaValidationError(
+        `Invalid dependency reference in apply: '${req}' does not exist`
+      );
     }
   }
 }

--- a/src/core/artifact-graph/schema.ts
+++ b/src/core/artifact-graph/schema.ts
@@ -77,6 +77,19 @@ export function parseSchemaOverride(yamlContent: string): SchemaOverrideYaml {
   return result.data;
 }
 
+/** Removes blank boundary lines while preserving the content and indentation inside a segment. */
+function normalizeTextSegment(segment: string | undefined): string | undefined {
+  if (segment === undefined) return undefined;
+
+  const lines = segment.split(/\r?\n/u);
+  while (lines.length > 0 && lines[0].trim().length === 0) lines.shift();
+  while (lines.length > 0 && lines[lines.length - 1].trim().length === 0) lines.pop();
+
+  const normalized = lines.join('\n');
+  return normalized.trim().length > 0 ? normalized : undefined;
+}
+
+/** Applies one explicit instruction-text operation to an optional base value. */
 function applyTextOverride(
   base: string | undefined,
   operation: TextOverrideOperation
@@ -85,12 +98,13 @@ function applyTextOverride(
     return operation.replace;
   }
 
-  const segments = [operation.prepend, base, operation.append].filter(
-    (segment): segment is string => segment !== undefined && segment.length > 0
-  );
+  const segments = [operation.prepend, base, operation.append]
+    .map(normalizeTextSegment)
+    .filter((segment): segment is string => segment !== undefined);
   return segments.length > 0 ? segments.join('\n\n') : undefined;
 }
 
+/** Applies a deterministic replace or remove-then-add operation to a string collection. */
 function applyCollectionOverride(
   base: string[],
   operation: StringCollectionOverride,

--- a/src/core/artifact-graph/schema.ts
+++ b/src/core/artifact-graph/schema.ts
@@ -1,11 +1,26 @@
 import * as fs from 'node:fs';
 import { parse as parseYaml } from 'yaml';
-import { SchemaYamlSchema, type SchemaYaml, type Artifact } from './types.js';
+import {
+  SchemaOverrideYamlSchema,
+  SchemaYamlSchema,
+  type Artifact,
+  type SchemaOverrideYaml,
+  type SchemaYaml,
+  type StringCollectionOverride,
+  type TextOverrideOperation,
+} from './types.js';
 
 export class SchemaValidationError extends Error {
   constructor(message: string) {
     super(message);
     this.name = 'SchemaValidationError';
+  }
+}
+
+export class SchemaOverrideValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SchemaOverrideValidationError';
   }
 }
 
@@ -23,8 +38,13 @@ export function loadSchema(filePath: string): SchemaYaml {
 export function parseSchema(yamlContent: string): SchemaYaml {
   const parsed = parseYaml(yamlContent);
 
-  // Validate with Zod
-  const result = SchemaYamlSchema.safeParse(parsed);
+  return validateSchemaValue(parsed);
+}
+
+/** Validates an already-parsed schema value and its dependency graph. */
+export function validateSchemaValue(value: unknown): SchemaYaml {
+  const result = SchemaYamlSchema.safeParse(value);
+
   if (!result.success) {
     const errors = result.error.issues.map(e => `${e.path.join('.')}: ${e.message}`).join(', ');
     throw new SchemaValidationError(`Invalid schema: ${errors}`);
@@ -42,6 +62,137 @@ export function parseSchema(yamlContent: string): SchemaYaml {
   validateNoCycles(schema.artifacts);
 
   return schema;
+}
+
+/** Parses and validates a layered user schema override. */
+export function parseSchemaOverride(yamlContent: string): SchemaOverrideYaml {
+  const parsed = parseYaml(yamlContent);
+  const result = SchemaOverrideYamlSchema.safeParse(parsed);
+  if (!result.success) {
+    const errors = result.error.issues
+      .map((issue) => `${issue.path.join('.')}: ${issue.message}`)
+      .join(', ');
+    throw new SchemaOverrideValidationError(`Invalid schema override: ${errors}`);
+  }
+  return result.data;
+}
+
+function applyTextOverride(
+  base: string | undefined,
+  operation: TextOverrideOperation
+): string | undefined {
+  if (operation.replace !== undefined) {
+    return operation.replace;
+  }
+
+  const segments = [operation.prepend, base, operation.append].filter(
+    (segment): segment is string => segment !== undefined && segment.length > 0
+  );
+  return segments.length > 0 ? segments.join('\n\n') : undefined;
+}
+
+function applyCollectionOverride(
+  base: string[],
+  operation: StringCollectionOverride,
+  fieldPath: string
+): string[] {
+  if (operation.replace) {
+    return [...operation.replace];
+  }
+
+  const result = [...base];
+  for (const value of operation.remove ?? []) {
+    const index = result.indexOf(value);
+    if (index === -1) {
+      throw new SchemaOverrideValidationError(
+        `${fieldPath}.remove cannot remove '${value}' because it is not present in the base value`
+      );
+    }
+    result.splice(index, 1);
+  }
+  for (const value of operation.add ?? []) {
+    if (result.includes(value)) {
+      throw new SchemaOverrideValidationError(
+        `${fieldPath}.add cannot add duplicate value '${value}'`
+      );
+    }
+    result.push(value);
+  }
+  return result;
+}
+
+/** Applies a validated user override and validates the complete effective schema. */
+export function applySchemaOverride(
+  base: SchemaYaml,
+  override: SchemaOverrideYaml
+): SchemaYaml {
+  const artifacts = base.artifacts.map((artifact) => ({
+    ...artifact,
+    requires: [...artifact.requires],
+  }));
+  const artifactsById = new Map(artifacts.map((artifact) => [artifact.id, artifact]));
+
+  for (const [artifactId, patch] of Object.entries(override.artifacts ?? {})) {
+    const artifact = artifactsById.get(artifactId);
+    if (!artifact) {
+      throw new SchemaOverrideValidationError(
+        `artifacts.${artifactId}: unknown artifact ID in packaged schema '${base.name}'`
+      );
+    }
+
+    if (patch.generates !== undefined) artifact.generates = patch.generates;
+    if (patch.description !== undefined) artifact.description = patch.description;
+    if (patch.template !== undefined) artifact.template = patch.template;
+    if (patch.instruction !== undefined) {
+      artifact.instruction = applyTextOverride(artifact.instruction, patch.instruction);
+    }
+    if (patch.requires !== undefined) {
+      artifact.requires = applyCollectionOverride(
+        artifact.requires,
+        patch.requires,
+        `artifacts.${artifactId}.requires`
+      );
+    }
+  }
+
+  let apply = base.apply
+    ? { ...base.apply, requires: [...base.apply.requires] }
+    : undefined;
+  if (override.apply) {
+    apply ??= { requires: [] };
+    if (override.apply.requires !== undefined) {
+      apply.requires = applyCollectionOverride(
+        apply.requires,
+        override.apply.requires,
+        'apply.requires'
+      );
+    }
+    if (override.apply.tracks !== undefined) {
+      apply.tracks = override.apply.tracks;
+    }
+    if (override.apply.instruction !== undefined) {
+      apply.instruction = applyTextOverride(
+        apply.instruction,
+        override.apply.instruction
+      );
+    }
+  }
+
+  const effective = {
+    ...base,
+    description: override.description ?? base.description,
+    artifacts,
+    ...(apply ? { apply } : {}),
+  };
+
+  try {
+    return validateSchemaValue(effective);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new SchemaOverrideValidationError(
+      `Effective schema is invalid after applying override: ${detail}`
+    );
+  }
 }
 
 /**

--- a/src/core/artifact-graph/types.ts
+++ b/src/core/artifact-graph/types.ts
@@ -51,10 +51,114 @@ export const SchemaYamlSchema = z.object({
   apply: ApplyPhaseSchema.optional(),
 });
 
+const TextOverrideOperationSchema = z
+  .object({
+    prepend: z.string().optional(),
+    append: z.string().optional(),
+    replace: z.string().optional(),
+  })
+  .strict()
+  .superRefine((operation, ctx) => {
+    const hasPrepend = operation.prepend !== undefined;
+    const hasAppend = operation.append !== undefined;
+    const hasReplace = operation.replace !== undefined;
+
+    if (!hasPrepend && !hasAppend && !hasReplace) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Text override requires prepend, append, or replace',
+      });
+    }
+    if (hasReplace && (hasPrepend || hasAppend)) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'replace cannot be combined with prepend or append',
+      });
+    }
+  });
+
+const StringCollectionOverrideSchema = z
+  .object({
+    add: z.array(z.string().min(1)).optional(),
+    remove: z.array(z.string().min(1)).optional(),
+    replace: z.array(z.string().min(1)).optional(),
+  })
+  .strict()
+  .superRefine((operation, ctx) => {
+    const hasAdd = operation.add !== undefined;
+    const hasRemove = operation.remove !== undefined;
+    const hasReplace = operation.replace !== undefined;
+
+    if (!hasAdd && !hasRemove && !hasReplace) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'Collection override requires add, remove, or replace',
+      });
+    }
+    if (hasReplace && (hasAdd || hasRemove)) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'replace cannot be combined with add or remove',
+      });
+    }
+
+    for (const [field, values] of Object.entries(operation)) {
+      if (values && new Set(values).size !== values.length) {
+        ctx.addIssue({
+          code: 'custom',
+          path: [field],
+          message: `${field} contains duplicate entries`,
+        });
+      }
+    }
+
+    if (operation.add && operation.remove) {
+      const removed = new Set(operation.remove);
+      const overlap = operation.add.filter((value) => removed.has(value));
+      if (overlap.length > 0) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `Values cannot be both added and removed: ${overlap.join(', ')}`,
+        });
+      }
+    }
+  });
+
+const ArtifactOverrideSchema = z
+  .object({
+    generates: relativePathSchema('generates field').optional(),
+    description: z.string().optional(),
+    template: relativePathSchema('template field').optional(),
+    instruction: TextOverrideOperationSchema.optional(),
+    requires: StringCollectionOverrideSchema.optional(),
+  })
+  .strict();
+
+const ApplyPhaseOverrideSchema = z
+  .object({
+    requires: StringCollectionOverrideSchema.optional(),
+    tracks: relativePathSchema('apply.tracks').nullable().optional(),
+    instruction: TextOverrideOperationSchema.optional(),
+  })
+  .strict();
+
+/** A user-level patch layered over a package schema. */
+export const SchemaOverrideYamlSchema = z
+  .object({
+    patchVersion: z.literal(1),
+    description: z.string().optional(),
+    artifacts: z.record(z.string().min(1), ArtifactOverrideSchema).optional(),
+    apply: ApplyPhaseOverrideSchema.optional(),
+  })
+  .strict();
+
 // Derived TypeScript types
 export type Artifact = z.infer<typeof ArtifactSchema>;
 export type ApplyPhase = z.infer<typeof ApplyPhaseSchema>;
 export type SchemaYaml = z.infer<typeof SchemaYamlSchema>;
+export type TextOverrideOperation = z.infer<typeof TextOverrideOperationSchema>;
+export type StringCollectionOverride = z.infer<typeof StringCollectionOverrideSchema>;
+export type SchemaOverrideYaml = z.infer<typeof SchemaOverrideYamlSchema>;
 
 // Runtime state types (not Zod - internal only)
 

--- a/src/core/completions/command-registry.ts
+++ b/src/core/completions/command-registry.ts
@@ -729,6 +729,20 @@ export const COMMAND_REGISTRY: CommandDefinition[] = [
         ],
       },
       {
+        name: 'override',
+        description: 'Create a layered user override for a packaged schema',
+        acceptsPositional: true,
+        positionalType: 'schema-name',
+        positionals: [{ name: 'name', type: 'schema-name' }],
+        flags: [
+          COMMON_FLAGS.json,
+          {
+            name: 'force',
+            description: 'Overwrite an existing layered override',
+          },
+        ],
+      },
+      {
         name: 'fork',
         description: 'Copy an existing schema to project for customization',
         acceptsPositional: true,

--- a/src/core/validation/validator.ts
+++ b/src/core/validation/validator.ts
@@ -33,7 +33,7 @@ import {
 } from '../../utils/change-metadata.js';
 import { resolveTaskFilesForChange } from '../../utils/task-progress.js';
 import { findTaskNumberingIssues } from './task-numbering.js';
-import { resolveSchemaSources } from '../artifact-graph/index.js';
+import { getPackageSchemasDir, getSchemaDir } from '../artifact-graph/index.js';
 
 export class Validator {
   private strictMode: boolean;
@@ -474,10 +474,13 @@ export class Validator {
         /\.ya?ml$/,
         ''
       );
-      const schemaSources = resolveSchemaSources(schemaName, projectRoot);
+      const schemaDir = getSchemaDir(schemaName, projectRoot);
+      const builtInSchemaDir = path.join(getPackageSchemasDir(), 'spec-driven');
       if (
         schemaName !== 'spec-driven' ||
-        schemaSources?.mode !== 'package'
+        schemaDir === null ||
+        FileSystemUtils.canonicalizeExistingPath(schemaDir) !==
+          FileSystemUtils.canonicalizeExistingPath(builtInSchemaDir)
       ) {
         return [];
       }

--- a/src/core/validation/validator.ts
+++ b/src/core/validation/validator.ts
@@ -33,7 +33,7 @@ import {
 } from '../../utils/change-metadata.js';
 import { resolveTaskFilesForChange } from '../../utils/task-progress.js';
 import { findTaskNumberingIssues } from './task-numbering.js';
-import { getPackageSchemasDir, getSchemaDir } from '../artifact-graph/index.js';
+import { resolveSchemaSources } from '../artifact-graph/index.js';
 
 export class Validator {
   private strictMode: boolean;
@@ -474,13 +474,10 @@ export class Validator {
         /\.ya?ml$/,
         ''
       );
-      const schemaDir = getSchemaDir(schemaName, projectRoot);
-      const builtInSchemaDir = path.join(getPackageSchemasDir(), 'spec-driven');
+      const schemaSources = resolveSchemaSources(schemaName, projectRoot);
       if (
         schemaName !== 'spec-driven' ||
-        schemaDir === null ||
-        FileSystemUtils.canonicalizeExistingPath(schemaDir) !==
-          FileSystemUtils.canonicalizeExistingPath(builtInSchemaDir)
+        schemaSources?.mode !== 'package'
       ) {
         return [];
       }

--- a/test/cli-e2e/validate-task-numbering.test.ts
+++ b/test/cli-e2e/validate-task-numbering.test.ts
@@ -198,6 +198,33 @@ describe('openspec validate checks task numbering (#1520)', () => {
     expect(taskIssues).toEqual([]);
   });
 
+  it('retains built-in numbering warnings with an instruction-only user overlay', async () => {
+    const xdgDataHome = path.join(projectDir, 'overlay-user-data');
+    await write(
+      'overlay-user-data/openspec/schemas/spec-driven/schema.override.yaml',
+      [
+        'patchVersion: 1',
+        'artifacts:',
+        '  tasks:',
+        '    instruction:',
+        '      append: Personal task guidance',
+        '',
+      ].join('\n')
+    );
+
+    const result = await runCLI(
+      ['validate', '--type', 'change', 'bad-numbering', '--strict', '--json'],
+      { cwd: projectDir, env: { XDG_DATA_HOME: xdgDataHome } }
+    );
+
+    expect(result.exitCode).toBe(1);
+    const report = JSON.parse(result.stdout);
+    const taskIssues = report.items[0].issues.filter(
+      (issue: { path: string }) => issue.path === 'tasks.md'
+    );
+    expect(taskIssues).toHaveLength(3);
+  });
+
   it('applies the same warnings to the deprecated change validate command', async () => {
     const result = await runCLI(
       ['change', 'validate', 'bad-numbering', '--strict'],

--- a/test/cli-e2e/validate-task-numbering.test.ts
+++ b/test/cli-e2e/validate-task-numbering.test.ts
@@ -212,6 +212,24 @@ describe('openspec validate checks task numbering (#1520)', () => {
       ].join('\n')
     );
 
+    const whichResult = await runCLI(
+      ['schema', 'which', 'spec-driven', '--json'],
+      { cwd: projectDir, env: { XDG_DATA_HOME: xdgDataHome } }
+    );
+
+    expect(whichResult.exitCode).toBe(0);
+    expect(JSON.parse(whichResult.stdout)).toMatchObject({
+      overlay: {
+        path: path.join(
+          xdgDataHome,
+          'openspec',
+          'schemas',
+          'spec-driven',
+          'schema.override.yaml'
+        ),
+      },
+    });
+
     const result = await runCLI(
       ['validate', '--type', 'change', 'bad-numbering', '--strict', '--json'],
       { cwd: projectDir, env: { XDG_DATA_HOME: xdgDataHome } }

--- a/test/commands/schema-overlay.test.ts
+++ b/test/commands/schema-overlay.test.ts
@@ -110,6 +110,23 @@ describe('schema overlay commands', () => {
     expect(fs.existsSync(path.join(path.dirname(overlayPath()), 'templates'))).toBe(false);
   });
 
+  it('does not overwrite an overlay created during initial installation', async () => {
+    const concurrentContent = 'patchVersion: 1\ndescription: Concurrent creation\n';
+    fsControl.mutateDestinationAfterStaging = {
+      path: overlayPath(),
+      content: concurrentContent,
+    };
+
+    await runSchemaCommand(['override', 'spec-driven', '--json']);
+
+    expect(process.exitCode).toBe(1);
+    expect(lastJsonLog()).toMatchObject({
+      created: false,
+      error: expect.stringContaining('Schema override already exists'),
+    });
+    expect(fs.readFileSync(overlayPath(), 'utf-8')).toBe(concurrentContent);
+  });
+
   it('preserves an existing overlay unless force is supplied', async () => {
     await runSchemaCommand(['override', 'spec-driven', '--json']);
     fs.writeFileSync(overlayPath(), 'patchVersion: 1\ndescription: Keep me\n');

--- a/test/commands/schema-overlay.test.ts
+++ b/test/commands/schema-overlay.test.ts
@@ -4,6 +4,39 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
+const fsControl = vi.hoisted(() => ({
+  mutateDestinationAfterStaging: null as null | { path: string; content: string },
+  replaceStagingContent: null as string | null,
+}));
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    default: actual,
+    writeFileSync: (...args: Parameters<typeof actual.writeFileSync>) => {
+      const result = actual.writeFileSync(...args);
+      if (
+        fsControl.replaceStagingContent !== null &&
+        String(args[0]).includes('.override-staging-')
+      ) {
+        const replacement = fsControl.replaceStagingContent;
+        fsControl.replaceStagingContent = null;
+        actual.writeFileSync(args[0], replacement);
+      }
+      if (
+        fsControl.mutateDestinationAfterStaging &&
+        String(args[0]).includes('.override-staging-')
+      ) {
+        const mutation = fsControl.mutateDestinationAfterStaging;
+        fsControl.mutateDestinationAfterStaging = null;
+        actual.writeFileSync(mutation.path, mutation.content);
+      }
+      return result;
+    },
+  };
+});
+
 async function runSchemaCommand(args: string[]): Promise<void> {
   const { registerSchemaCommand } = await import('../../src/commands/schema.js');
   const program = new Command();
@@ -20,7 +53,9 @@ describe('schema overlay commands', () => {
   let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openspec-schema-overlay-command-'));
+    tempDir = fs.realpathSync.native(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'openspec-schema-overlay-command-'))
+    );
     originalCwd = process.cwd();
     originalEnv = { ...process.env };
     originalExitCode = process.exitCode;
@@ -39,6 +74,8 @@ describe('schema overlay commands', () => {
     fs.rmSync(tempDir, { recursive: true, force: true });
     consoleLogSpy.mockRestore();
     consoleErrorSpy.mockRestore();
+    fsControl.mutateDestinationAfterStaging = null;
+    fsControl.replaceStagingContent = null;
     vi.resetModules();
   });
 
@@ -102,6 +139,44 @@ describe('schema overlay commands', () => {
     ).toEqual([]);
   });
 
+  it('preserves a concurrently modified overlay during force replacement', async () => {
+    await runSchemaCommand(['override', 'spec-driven', '--json']);
+    const concurrentContent = 'patchVersion: 1\ndescription: Concurrent edit\n';
+    fsControl.mutateDestinationAfterStaging = {
+      path: overlayPath(),
+      content: concurrentContent,
+    };
+    consoleLogSpy.mockClear();
+    process.exitCode = undefined;
+
+    await runSchemaCommand(['override', 'spec-driven', '--force', '--json']);
+
+    expect(process.exitCode).toBe(1);
+    expect(lastJsonLog()).toMatchObject({
+      created: false,
+      error: expect.stringContaining('changed while the replacement was being prepared'),
+    });
+    expect(fs.readFileSync(overlayPath(), 'utf-8')).toBe(concurrentContent);
+  });
+
+  it('rejects invalid staged content without installing a partial overlay', async () => {
+    fsControl.replaceStagingContent = 'patchVersion: invalid\n';
+
+    await runSchemaCommand(['override', 'spec-driven', '--json']);
+
+    expect(process.exitCode).toBe(1);
+    expect(lastJsonLog()).toMatchObject({
+      created: false,
+      error: expect.stringContaining('Invalid schema override'),
+    });
+    expect(fs.existsSync(overlayPath())).toBe(false);
+    expect(
+      fs.readdirSync(path.dirname(overlayPath())).filter((entry) =>
+        entry.startsWith('.override-staging-')
+      )
+    ).toEqual([]);
+  });
+
   it('refuses to combine an overlay with a complete user replacement', async () => {
     const userSchemaDir = path.dirname(overlayPath());
     fs.mkdirSync(userSchemaDir, { recursive: true });
@@ -110,9 +185,54 @@ describe('schema overlay commands', () => {
     await runSchemaCommand(['override', 'spec-driven', '--json']);
 
     expect(process.exitCode).toBe(1);
-    expect(lastJsonLog()).toMatchObject({ created: false });
-    expect((lastJsonLog().error as string)).toContain('complete user schema');
+    const output = lastJsonLog();
+    expect(output).toMatchObject({ created: false });
+    expect(output.error as string).toContain('complete user schema');
     expect(fs.existsSync(overlayPath())).toBe(false);
+  });
+
+  it('normalizes a YAML extension before reporting schema resolution', async () => {
+    fs.mkdirSync(path.dirname(overlayPath()), { recursive: true });
+    fs.writeFileSync(overlayPath(), 'patchVersion: 1\n');
+
+    await runSchemaCommand(['which', 'spec-driven.yaml', '--json']);
+
+    expect(lastJsonLog()).toMatchObject({
+      name: 'spec-driven',
+      source: 'package',
+      overlay: { path: overlayPath() },
+    });
+  });
+
+  it('continues listing usable schemas when one user schema conflicts', async () => {
+    const conflictingDir = path.join(
+      tempDir,
+      'xdg-data',
+      'openspec',
+      'schemas',
+      'conflicting'
+    );
+    fs.mkdirSync(conflictingDir, { recursive: true });
+    fs.writeFileSync(path.join(conflictingDir, 'schema.yaml'), `
+name: conflicting
+version: 1
+artifacts:
+  - id: proposal
+    generates: proposal.md
+    description: Proposal
+    template: proposal.md
+`);
+    fs.writeFileSync(path.join(conflictingDir, 'schema.override.yaml'), 'patchVersion: 1\n');
+
+    await runSchemaCommand(['which', '--all', '--json']);
+
+    const value = consoleLogSpy.mock.calls.at(-1)?.[0];
+    const output = JSON.parse(String(value)) as Array<{ name: string }>;
+    expect(output.map((schema) => schema.name)).toContain('spec-driven');
+    expect(output.map((schema) => schema.name)).not.toContain('conflicting');
+    expect(consoleErrorSpy.mock.calls.flat().join('\n')).toContain(
+      "Warning: skipped 'conflicting'"
+    );
   });
 
   it('reports and validates a composed package schema', async () => {
@@ -216,6 +336,40 @@ artifacts:
           message: expect.stringContaining('both a complete user replacement'),
         }),
       ],
+    });
+  });
+
+  it('validates a project schema despite an inactive conflicting user layer', async () => {
+    const userSchemaDir = path.dirname(overlayPath());
+    fs.mkdirSync(userSchemaDir, { recursive: true });
+    fs.writeFileSync(overlayPath(), 'patchVersion: 1\n');
+    fs.writeFileSync(path.join(userSchemaDir, 'schema.yaml'), 'name: conflicting-user\n');
+
+    const projectSchemaDir = path.join(
+      tempDir,
+      'openspec',
+      'schemas',
+      'spec-driven'
+    );
+    fs.mkdirSync(path.join(projectSchemaDir, 'templates'), { recursive: true });
+    fs.writeFileSync(path.join(projectSchemaDir, 'schema.yaml'), `
+name: spec-driven
+version: 1
+artifacts:
+  - id: proposal
+    generates: proposal.md
+    description: Proposal
+    template: proposal.md
+`);
+    fs.writeFileSync(path.join(projectSchemaDir, 'templates', 'proposal.md'), '# Proposal\n');
+
+    await runSchemaCommand(['validate', 'spec-driven', '--json']);
+
+    expect(process.exitCode).toBeUndefined();
+    expect(lastJsonLog()).toMatchObject({
+      name: 'spec-driven',
+      valid: true,
+      issues: [],
     });
   });
 

--- a/test/commands/schema-overlay.test.ts
+++ b/test/commands/schema-overlay.test.ts
@@ -159,17 +159,20 @@ describe('schema overlay commands', () => {
     expect(fs.readFileSync(overlayPath(), 'utf-8')).toBe(concurrentContent);
   });
 
-  it('rejects invalid staged content without installing a partial overlay', async () => {
+  it('rejects invalid staged content without replacing the existing overlay', async () => {
+    const existingContent = 'patchVersion: 1\ndescription: Keep me\n';
+    fs.mkdirSync(path.dirname(overlayPath()), { recursive: true });
+    fs.writeFileSync(overlayPath(), existingContent);
     fsControl.replaceStagingContent = 'patchVersion: invalid\n';
 
-    await runSchemaCommand(['override', 'spec-driven', '--json']);
+    await runSchemaCommand(['override', 'spec-driven', '--force', '--json']);
 
     expect(process.exitCode).toBe(1);
     expect(lastJsonLog()).toMatchObject({
       created: false,
       error: expect.stringContaining('Invalid schema override'),
     });
-    expect(fs.existsSync(overlayPath())).toBe(false);
+    expect(fs.readFileSync(overlayPath(), 'utf-8')).toBe(existingContent);
     expect(
       fs.readdirSync(path.dirname(overlayPath())).filter((entry) =>
         entry.startsWith('.override-staging-')

--- a/test/commands/schema-overlay.test.ts
+++ b/test/commands/schema-overlay.test.ts
@@ -156,7 +156,7 @@ artifacts:
 
     expect(lastJsonLog()).toMatchObject({
       tasks: {
-        path: path.join(userTemplatesDir, 'tasks.md'),
+        path: fs.realpathSync.native(path.join(userTemplatesDir, 'tasks.md')),
         source: 'user',
       },
       proposal: {

--- a/test/commands/schema-overlay.test.ts
+++ b/test/commands/schema-overlay.test.ts
@@ -1,0 +1,247 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Command } from 'commander';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+async function runSchemaCommand(args: string[]): Promise<void> {
+  const { registerSchemaCommand } = await import('../../src/commands/schema.js');
+  const program = new Command();
+  registerSchemaCommand(program);
+  await program.parseAsync(['node', 'openspec', 'schema', ...args]);
+}
+
+describe('schema overlay commands', () => {
+  let tempDir: string;
+  let originalCwd: string;
+  let originalEnv: NodeJS.ProcessEnv;
+  let originalExitCode: typeof process.exitCode;
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openspec-schema-overlay-command-'));
+    originalCwd = process.cwd();
+    originalEnv = { ...process.env };
+    originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+    process.chdir(tempDir);
+    process.env.XDG_DATA_HOME = path.join(tempDir, 'xdg-data');
+    process.env.XDG_CONFIG_HOME = path.join(tempDir, 'xdg-config');
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    process.env = originalEnv;
+    process.exitCode = originalExitCode;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+    vi.resetModules();
+  });
+
+  function overlayPath(): string {
+    return path.join(
+      tempDir,
+      'xdg-data',
+      'openspec',
+      'schemas',
+      'spec-driven',
+      'schema.override.yaml'
+    );
+  }
+
+  function lastJsonLog(): Record<string, unknown> {
+    const value = consoleLogSpy.mock.calls.at(-1)?.[0];
+    expect(typeof value).toBe('string');
+    return JSON.parse(value as string) as Record<string, unknown>;
+  }
+
+  it('creates a no-op overlay without copying schema or templates', async () => {
+    await runSchemaCommand(['override', 'spec-driven', '--json']);
+
+    expect(process.exitCode).toBeUndefined();
+    expect(lastJsonLog()).toMatchObject({
+      created: true,
+      schema: 'spec-driven',
+      path: overlayPath(),
+    });
+    expect(fs.readFileSync(overlayPath(), 'utf-8')).toContain('patchVersion: 1');
+    expect(fs.existsSync(path.join(path.dirname(overlayPath()), 'schema.yaml'))).toBe(false);
+    expect(fs.existsSync(path.join(path.dirname(overlayPath()), 'templates'))).toBe(false);
+  });
+
+  it('preserves an existing overlay unless force is supplied', async () => {
+    await runSchemaCommand(['override', 'spec-driven', '--json']);
+    fs.writeFileSync(overlayPath(), 'patchVersion: 1\ndescription: Keep me\n');
+    consoleLogSpy.mockClear();
+    process.exitCode = undefined;
+
+    await runSchemaCommand(['override', 'spec-driven', '--json']);
+
+    expect(process.exitCode).toBe(1);
+    expect(lastJsonLog()).toMatchObject({ created: false });
+    expect(fs.readFileSync(overlayPath(), 'utf-8')).toContain('Keep me');
+  });
+
+  it('atomically replaces an existing overlay with force', async () => {
+    await runSchemaCommand(['override', 'spec-driven', '--json']);
+    fs.writeFileSync(overlayPath(), 'patchVersion: 1\ndescription: Replace me\n');
+    consoleLogSpy.mockClear();
+    process.exitCode = undefined;
+
+    await runSchemaCommand(['override', 'spec-driven', '--force', '--json']);
+
+    expect(process.exitCode).toBeUndefined();
+    expect(lastJsonLog()).toMatchObject({ created: true });
+    expect(fs.readFileSync(overlayPath(), 'utf-8')).not.toContain('Replace me');
+    expect(
+      fs.readdirSync(path.dirname(overlayPath())).filter((name) => name.includes('override-'))
+    ).toEqual([]);
+  });
+
+  it('refuses to combine an overlay with a complete user replacement', async () => {
+    const userSchemaDir = path.dirname(overlayPath());
+    fs.mkdirSync(userSchemaDir, { recursive: true });
+    fs.writeFileSync(path.join(userSchemaDir, 'schema.yaml'), 'name: spec-driven\n');
+
+    await runSchemaCommand(['override', 'spec-driven', '--json']);
+
+    expect(process.exitCode).toBe(1);
+    expect(lastJsonLog()).toMatchObject({ created: false });
+    expect((lastJsonLog().error as string)).toContain('complete user schema');
+    expect(fs.existsSync(overlayPath())).toBe(false);
+  });
+
+  it('reports and validates a composed package schema', async () => {
+    const userSchemaDir = path.dirname(overlayPath());
+    fs.mkdirSync(userSchemaDir, { recursive: true });
+    fs.writeFileSync(overlayPath(), `
+patchVersion: 1
+artifacts:
+  tasks:
+    instruction:
+      append: Personal rule
+`);
+
+    await runSchemaCommand(['which', 'spec-driven', '--json']);
+    expect(lastJsonLog()).toMatchObject({
+      name: 'spec-driven',
+      source: 'package',
+      overlay: { source: 'user', path: overlayPath() },
+    });
+
+    consoleLogSpy.mockClear();
+    process.exitCode = undefined;
+    await runSchemaCommand(['validate', 'spec-driven', '--json']);
+    expect(lastJsonLog()).toMatchObject({
+      name: 'spec-driven',
+      valid: true,
+      overlayPath: overlayPath(),
+      issues: [],
+    });
+  });
+
+  it('reports the concrete user and package source for each template', async () => {
+    const userSchemaDir = path.dirname(overlayPath());
+    const userTemplatesDir = path.join(userSchemaDir, 'templates');
+    fs.mkdirSync(userTemplatesDir, { recursive: true });
+    fs.writeFileSync(overlayPath(), 'patchVersion: 1\n');
+    fs.writeFileSync(path.join(userTemplatesDir, 'tasks.md'), '# Personal tasks\n');
+
+    const { templatesCommand } = await import('../../src/commands/workflow/templates.js');
+    await templatesCommand({ schema: 'spec-driven', json: true });
+
+    expect(lastJsonLog()).toMatchObject({
+      tasks: {
+        path: path.join(userTemplatesDir, 'tasks.md'),
+        source: 'user',
+      },
+      proposal: {
+        source: 'package',
+      },
+    });
+  });
+
+  it('returns file-specific validation issues for an invalid overlay', async () => {
+    fs.mkdirSync(path.dirname(overlayPath()), { recursive: true });
+    fs.writeFileSync(overlayPath(), `
+patchVersion: 1
+artifacts:
+  tasks:
+    instruction:
+      replace: Replacement
+      append: Conflict
+`);
+
+    await runSchemaCommand(['validate', 'spec-driven', '--json']);
+
+    expect(process.exitCode).toBe(1);
+    const output = lastJsonLog();
+    expect(output.valid).toBe(false);
+    expect(output.issues).toEqual([
+      expect.objectContaining({
+        level: 'error',
+        path: overlayPath(),
+        message: expect.stringContaining('replace cannot be combined'),
+      }),
+    ]);
+  });
+
+  it('reports a complete user schema and overlay conflict during validation', async () => {
+    const userSchemaDir = path.dirname(overlayPath());
+    fs.mkdirSync(userSchemaDir, { recursive: true });
+    fs.writeFileSync(overlayPath(), 'patchVersion: 1\n');
+    fs.writeFileSync(path.join(userSchemaDir, 'schema.yaml'), `
+name: spec-driven
+version: 1
+artifacts:
+  - id: proposal
+    generates: proposal.md
+    description: Proposal
+    template: proposal.md
+`);
+
+    await runSchemaCommand(['validate', 'spec-driven', '--json']);
+
+    expect(process.exitCode).toBe(1);
+    expect(lastJsonLog()).toMatchObject({
+      name: 'spec-driven',
+      valid: false,
+      issues: [
+        expect.objectContaining({
+          path: overlayPath(),
+          message: expect.stringContaining('both a complete user replacement'),
+        }),
+      ],
+    });
+  });
+
+  it('materializes the effective overlay and templates when forking', async () => {
+    const userSchemaDir = path.dirname(overlayPath());
+    const userTemplatesDir = path.join(userSchemaDir, 'templates');
+    fs.mkdirSync(userTemplatesDir, { recursive: true });
+    fs.writeFileSync(overlayPath(), `
+patchVersion: 1
+artifacts:
+  tasks:
+    instruction:
+      append: Personal forked rule
+`);
+    fs.writeFileSync(path.join(userTemplatesDir, 'tasks.md'), '# Personal tasks template\n');
+
+    await runSchemaCommand(['fork', 'spec-driven', 'personal-flow', '--json']);
+
+    expect(process.exitCode).toBeUndefined();
+    const destination = path.join(tempDir, 'openspec', 'schemas', 'personal-flow');
+    const schemaContent = fs.readFileSync(path.join(destination, 'schema.yaml'), 'utf-8');
+    expect(schemaContent).toContain('name: personal-flow');
+    expect(schemaContent).toContain('Personal forked rule');
+    expect(fs.readFileSync(path.join(destination, 'templates', 'tasks.md'), 'utf-8'))
+      .toContain('Personal tasks template');
+    expect(fs.readFileSync(path.join(destination, 'templates', 'proposal.md'), 'utf-8'))
+      .toContain('## Why');
+  });
+});

--- a/test/commands/schema-overlay.test.ts
+++ b/test/commands/schema-overlay.test.ts
@@ -5,6 +5,7 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 
 const fsControl = vi.hoisted(() => ({
+  linkErrorCode: null as string | null,
   mutateDestinationAfterStaging: null as null | { path: string; content: string },
   replaceStagingContent: null as string | null,
 }));
@@ -14,6 +15,15 @@ vi.mock('node:fs', async (importOriginal) => {
   return {
     ...actual,
     default: actual,
+    linkSync: (...args: Parameters<typeof actual.linkSync>) => {
+      if (fsControl.linkErrorCode !== null) {
+        const error = new Error('Mocked hard-link failure') as NodeJS.ErrnoException;
+        error.code = fsControl.linkErrorCode;
+        fsControl.linkErrorCode = null;
+        throw error;
+      }
+      return actual.linkSync(...args);
+    },
     writeFileSync: (...args: Parameters<typeof actual.writeFileSync>) => {
       const result = actual.writeFileSync(...args);
       if (
@@ -74,6 +84,7 @@ describe('schema overlay commands', () => {
     fs.rmSync(tempDir, { recursive: true, force: true });
     consoleLogSpy.mockRestore();
     consoleErrorSpy.mockRestore();
+    fsControl.linkErrorCode = null;
     fsControl.mutateDestinationAfterStaging = null;
     fsControl.replaceStagingContent = null;
     vi.resetModules();
@@ -126,6 +137,19 @@ describe('schema overlay commands', () => {
     });
     expect(fs.readFileSync(overlayPath(), 'utf-8')).toBe(concurrentContent);
   });
+
+  it.each(['EPERM', 'ENOSYS', 'EXDEV'])(
+    'falls back to exclusive creation when hard links fail with %s',
+    async (errorCode) => {
+      fsControl.linkErrorCode = errorCode;
+
+      await runSchemaCommand(['override', 'spec-driven', '--json']);
+
+      expect(process.exitCode).toBeUndefined();
+      expect(lastJsonLog()).toMatchObject({ created: true, path: overlayPath() });
+      expect(fs.readFileSync(overlayPath(), 'utf-8')).toContain('patchVersion: 1');
+    }
+  );
 
   it('preserves an existing overlay unless force is supplied', async () => {
     await runSchemaCommand(['override', 'spec-driven', '--json']);
@@ -211,7 +235,7 @@ describe('schema overlay commands', () => {
     expect(fs.existsSync(overlayPath())).toBe(false);
   });
 
-  it('normalizes a YAML extension before reporting schema resolution', async () => {
+  it('normalizes YAML extensions in schema resolution and validation output', async () => {
     fs.mkdirSync(path.dirname(overlayPath()), { recursive: true });
     fs.writeFileSync(overlayPath(), 'patchVersion: 1\n');
 
@@ -222,6 +246,37 @@ describe('schema overlay commands', () => {
       source: 'package',
       overlay: { path: overlayPath() },
     });
+
+    consoleLogSpy.mockClear();
+    await runSchemaCommand(['validate', 'spec-driven.yml', '--json']);
+
+    expect(lastJsonLog()).toMatchObject({
+      name: 'spec-driven',
+      valid: true,
+      overlayPath: overlayPath(),
+    });
+  });
+
+  it('labels active and inactive overlays in the human schema listing', async () => {
+    fs.mkdirSync(path.dirname(overlayPath()), { recursive: true });
+    fs.writeFileSync(overlayPath(), 'patchVersion: 1\n');
+
+    await runSchemaCommand(['which', '--all']);
+
+    expect(consoleLogSpy.mock.calls.flat().join('\n')).toContain(
+      'spec-driven (user overlay)'
+    );
+
+    const projectSchemaDir = path.join(tempDir, 'openspec', 'schemas', 'spec-driven');
+    fs.mkdirSync(projectSchemaDir, { recursive: true });
+    fs.writeFileSync(path.join(projectSchemaDir, 'schema.yaml'), 'name: spec-driven\n');
+    consoleLogSpy.mockClear();
+
+    await runSchemaCommand(['which', '--all']);
+
+    expect(consoleLogSpy.mock.calls.flat().join('\n')).toContain(
+      'spec-driven (shadows: package) (inactive user overlay)'
+    );
   });
 
   it('continues listing usable schemas when one user schema conflicts', async () => {

--- a/test/core/artifact-graph/schema-overlay.integration.test.ts
+++ b/test/core/artifact-graph/schema-overlay.integration.test.ts
@@ -16,7 +16,9 @@ describe('layered global schema overlays', () => {
   let originalEnv: NodeJS.ProcessEnv;
 
   beforeEach(() => {
-    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openspec-overlay-test-'));
+    tempDir = fs.realpathSync.native(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'openspec-overlay-test-'))
+    );
     originalEnv = { ...process.env };
     process.env.XDG_DATA_HOME = tempDir;
   });
@@ -129,8 +131,26 @@ artifacts:
     const proposal = resolveSchemaTemplate('spec-driven', 'proposal.md');
 
     expect(tasks.source).toBe('user');
+    expect(tasks.path).toBe(
+      fs.realpathSync.native(path.join(templatesDir, 'tasks.md'))
+    );
     expect(fs.readFileSync(tasks.path, 'utf-8')).toContain('Personal tasks');
     expect(proposal.source).toBe('package');
+  });
+
+  it('rejects a user template symlink that escapes the overlay template root', () => {
+    if (process.platform === 'win32') return;
+
+    const userSchemaDir = writeOverlay('patchVersion: 1\n');
+    const templatesDir = path.join(userSchemaDir, 'templates');
+    const outsideTemplate = path.join(tempDir, 'outside-tasks.md');
+    fs.mkdirSync(templatesDir, { recursive: true });
+    fs.writeFileSync(outsideTemplate, '# Outside\n');
+    fs.symlinkSync(outsideTemplate, path.join(templatesDir, 'tasks.md'));
+
+    expect(() => resolveSchemaTemplate('spec-driven', 'tasks.md')).toThrow(
+      /outside the allowed directory/u
+    );
   });
 
   it('does not give complete user replacements package template fallback', () => {

--- a/test/core/artifact-graph/schema-overlay.integration.test.ts
+++ b/test/core/artifact-graph/schema-overlay.integration.test.ts
@@ -138,6 +138,19 @@ artifacts:
     expect(proposal.source).toBe('package');
   });
 
+  it('canonicalizes a confined user template alias', () => {
+    const userSchemaDir = writeOverlay('patchVersion: 1\n');
+    const templatesDir = path.join(userSchemaDir, 'templates');
+    const tasksPath = path.join(templatesDir, 'tasks.md');
+    fs.mkdirSync(templatesDir, { recursive: true });
+    fs.writeFileSync(tasksPath, '# Personal tasks\n');
+
+    const tasks = resolveSchemaTemplate('spec-driven', 'nested/../tasks.md');
+
+    expect(tasks.source).toBe('user');
+    expect(tasks.path).toBe(fs.realpathSync.native(tasksPath));
+  });
+
   it('rejects a user template symlink that escapes the overlay template root', () => {
     if (process.platform === 'win32') return;
 

--- a/test/core/artifact-graph/schema-overlay.integration.test.ts
+++ b/test/core/artifact-graph/schema-overlay.integration.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {
+  getSchemaDir,
+  listSchemasWithInfo,
+  resolveSchema,
+  resolveSchemaSources,
+  resolveSchemaTemplate,
+  SchemaLoadError,
+} from '../../../src/core/artifact-graph/resolver.js';
+
+describe('layered global schema overlays', () => {
+  let tempDir: string;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'openspec-overlay-test-'));
+    originalEnv = { ...process.env };
+    process.env.XDG_DATA_HOME = tempDir;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function writeOverlay(content: string): string {
+    const schemaDir = path.join(tempDir, 'openspec', 'schemas', 'spec-driven');
+    fs.mkdirSync(schemaDir, { recursive: true });
+    fs.writeFileSync(path.join(schemaDir, 'schema.override.yaml'), content);
+    return schemaDir;
+  }
+
+  it('composes a user overlay with the package schema', () => {
+    writeOverlay(`
+patchVersion: 1
+artifacts:
+  tasks:
+    instruction:
+      append: Personal global task rule
+`);
+
+    const sources = resolveSchemaSources('spec-driven');
+    const schema = resolveSchema('spec-driven');
+
+    expect(sources?.mode).toBe('package-with-user-overlay');
+    expect(getSchemaDir('spec-driven')).toBe(sources?.base.dir);
+    expect(schema.artifacts.find((artifact) => artifact.id === 'tasks')?.instruction)
+      .toContain('Personal global task rule');
+    expect(schema.artifacts.find((artifact) => artifact.id === 'proposal')?.instruction)
+      .toContain('Create the proposal document');
+  });
+
+  it('keeps a project schema authoritative over conflicting user customizations', () => {
+    const userSchemaDir = writeOverlay('patchVersion: 1\ndescription: User overlay\n');
+    fs.writeFileSync(path.join(userSchemaDir, 'schema.yaml'), `
+name: spec-driven
+version: 1
+description: Complete user schema
+artifacts:
+  - id: proposal
+    generates: proposal.md
+    description: Proposal
+    template: proposal.md
+`);
+    const projectRoot = path.join(tempDir, 'project');
+    const projectSchemaDir = path.join(projectRoot, 'openspec', 'schemas', 'spec-driven');
+    fs.mkdirSync(projectSchemaDir, { recursive: true });
+    fs.writeFileSync(path.join(projectSchemaDir, 'schema.yaml'), `
+name: spec-driven
+version: 1
+description: Project schema
+artifacts:
+  - id: proposal
+    generates: proposal.md
+    description: Proposal
+    template: proposal.md
+`);
+
+    expect(resolveSchemaSources('spec-driven', projectRoot)?.mode).toBe('project');
+    expect(resolveSchema('spec-driven', projectRoot).description).toBe('Project schema');
+  });
+
+  it('rejects simultaneous complete user replacement and layered override', () => {
+    const userSchemaDir = writeOverlay('patchVersion: 1\n');
+    fs.writeFileSync(path.join(userSchemaDir, 'schema.yaml'), `
+name: spec-driven
+version: 1
+artifacts:
+  - id: proposal
+    generates: proposal.md
+    description: Proposal
+    template: proposal.md
+`);
+
+    expect(() => resolveSchemaSources('spec-driven')).toThrow(SchemaLoadError);
+    expect(() => resolveSchemaSources('spec-driven')).toThrow(/both a complete user replacement/u);
+  });
+
+  it('rejects an overlay with no packaged base', () => {
+    const schemaDir = path.join(tempDir, 'openspec', 'schemas', 'custom');
+    fs.mkdirSync(schemaDir, { recursive: true });
+    fs.writeFileSync(path.join(schemaDir, 'schema.override.yaml'), 'patchVersion: 1\n');
+
+    expect(() => resolveSchemaSources('custom')).toThrow(/no packaged schema/u);
+  });
+
+  it('lists effective composed metadata and overlay source', () => {
+    writeOverlay('patchVersion: 1\ndescription: Personal effective schema\n');
+
+    const info = listSchemasWithInfo().find((schema) => schema.name === 'spec-driven');
+    expect(info).toMatchObject({
+      name: 'spec-driven',
+      description: 'Personal effective schema',
+      source: 'package',
+      overlay: { source: 'user' },
+    });
+  });
+
+  it('uses a user template when present and package fallback otherwise', () => {
+    const userSchemaDir = writeOverlay('patchVersion: 1\n');
+    const templatesDir = path.join(userSchemaDir, 'templates');
+    fs.mkdirSync(templatesDir, { recursive: true });
+    fs.writeFileSync(path.join(templatesDir, 'tasks.md'), '# Personal tasks\n');
+
+    const tasks = resolveSchemaTemplate('spec-driven', 'tasks.md');
+    const proposal = resolveSchemaTemplate('spec-driven', 'proposal.md');
+
+    expect(tasks.source).toBe('user');
+    expect(fs.readFileSync(tasks.path, 'utf-8')).toContain('Personal tasks');
+    expect(proposal.source).toBe('package');
+  });
+
+  it('does not give complete user replacements package template fallback', () => {
+    const userSchemaDir = path.join(tempDir, 'openspec', 'schemas', 'spec-driven');
+    fs.mkdirSync(userSchemaDir, { recursive: true });
+    fs.writeFileSync(path.join(userSchemaDir, 'schema.yaml'), `
+name: spec-driven
+version: 1
+artifacts:
+  - id: proposal
+    generates: proposal.md
+    description: Proposal
+    template: proposal.md
+`);
+
+    expect(resolveSchemaSources('spec-driven')?.mode).toBe('user-replacement');
+    expect(() => resolveSchemaTemplate('spec-driven', 'proposal.md')).toThrow(
+      /Template not found/u
+    );
+  });
+});

--- a/test/core/artifact-graph/schema-override.test.ts
+++ b/test/core/artifact-graph/schema-override.test.ts
@@ -96,7 +96,8 @@ artifacts:
 
   it('normalizes blank boundary lines and omits whitespace-only text segments', () => {
     const base = baseSchema();
-    base.artifacts[2].instruction = '\nPackaged tasks instruction\n\n  ';
+    base.artifacts[2].instruction =
+      '\nPackaged  tasks instruction\n\nKeep  internal spacing\n\n  ';
     const override = parseSchemaOverride(`
 patchVersion: 1
 artifacts:
@@ -107,7 +108,7 @@ artifacts:
 `);
 
     expect(applySchemaOverride(base, override).artifacts[2].instruction).toBe(
-      'Personal preface\n\nPackaged tasks instruction'
+      'Personal preface\n\nPackaged  tasks instruction\n\nKeep  internal spacing'
     );
   });
 

--- a/test/core/artifact-graph/schema-override.test.ts
+++ b/test/core/artifact-graph/schema-override.test.ts
@@ -177,18 +177,36 @@ artifacts:
   });
 
   it('applies additive dependency operations in deterministic order', () => {
+    const base = baseSchema();
+    base.artifacts[2].requires = ['proposal'];
     const override = parseSchemaOverride(`
 patchVersion: 1
 artifacts:
   tasks:
     requires:
       remove: [proposal]
-      add: []
+      add: [design]
 `);
 
-    expect(applySchemaOverride(baseSchema(), override).artifacts[2].requires).toEqual([
+    expect(applySchemaOverride(base, override).artifacts[2].requires).toEqual([
       'design',
     ]);
+  });
+
+  it.each([
+    ['add', 'add: [unknown]'],
+    ['replace', 'replace: [unknown]'],
+  ])('rejects unknown apply prerequisites from %s operations', (_operation, yaml) => {
+    const override = parseSchemaOverride(`
+patchVersion: 1
+apply:
+  requires:
+    ${yaml}
+`);
+
+    expect(() => applySchemaOverride(baseSchema(), override)).toThrow(
+      /Invalid dependency reference in apply: 'unknown' does not exist/u
+    );
   });
 
   it('rejects ambiguous and misspelled operations', () => {

--- a/test/core/artifact-graph/schema-override.test.ts
+++ b/test/core/artifact-graph/schema-override.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applySchemaOverride,
+  parseSchemaOverride,
+  SchemaOverrideValidationError,
+} from '../../../src/core/artifact-graph/schema.js';
+import type { SchemaYaml } from '../../../src/core/artifact-graph/types.js';
+
+function baseSchema(): SchemaYaml {
+  return {
+    name: 'spec-driven',
+    version: 1,
+    description: 'Packaged description',
+    artifacts: [
+      {
+        id: 'proposal',
+        generates: 'proposal.md',
+        description: 'Proposal',
+        template: 'proposal.md',
+        instruction: 'Packaged proposal instruction',
+        requires: [],
+      },
+      {
+        id: 'design',
+        generates: 'design.md',
+        description: 'Design',
+        template: 'design.md',
+        instruction: 'Packaged design instruction',
+        requires: ['proposal'],
+      },
+      {
+        id: 'tasks',
+        generates: 'tasks.md',
+        description: 'Tasks',
+        template: 'tasks.md',
+        instruction: 'Packaged tasks instruction',
+        requires: ['proposal', 'design'],
+      },
+    ],
+    apply: {
+      requires: ['tasks'],
+      tracks: 'tasks.md',
+      instruction: 'Packaged apply instruction',
+    },
+  };
+}
+
+describe('schema override', () => {
+  it('supports a no-op patch', () => {
+    const effective = applySchemaOverride(
+      baseSchema(),
+      parseSchemaOverride('patchVersion: 1\n')
+    );
+
+    expect(effective).toEqual(baseSchema());
+  });
+
+  it('keeps package updates for fields the overlay does not replace', () => {
+    const override = parseSchemaOverride(`
+patchVersion: 1
+artifacts:
+  tasks:
+    instruction:
+      append: Personal rules
+`);
+    const updatedBase = baseSchema();
+    updatedBase.artifacts[0].instruction = 'Updated packaged proposal instruction';
+    updatedBase.artifacts[2].instruction = 'Updated packaged tasks instruction';
+
+    const effective = applySchemaOverride(updatedBase, override);
+
+    expect(effective.artifacts[0].instruction).toBe(
+      'Updated packaged proposal instruction'
+    );
+    expect(effective.artifacts[2].instruction).toBe(
+      'Updated packaged tasks instruction\n\nPersonal rules'
+    );
+  });
+
+  it('prepends and appends instruction text with one blank line', () => {
+    const override = parseSchemaOverride(`
+patchVersion: 1
+artifacts:
+  tasks:
+    instruction:
+      prepend: Personal preface
+      append: Personal rules
+`);
+
+    const effective = applySchemaOverride(baseSchema(), override);
+
+    expect(effective.artifacts[2].instruction).toBe(
+      'Personal preface\n\nPackaged tasks instruction\n\nPersonal rules'
+    );
+  });
+
+  it('replaces instruction text without retaining the packaged value', () => {
+    const override = parseSchemaOverride(`
+patchVersion: 1
+artifacts:
+  tasks:
+    instruction:
+      replace: Personal replacement
+`);
+
+    expect(applySchemaOverride(baseSchema(), override).artifacts[2].instruction).toBe(
+      'Personal replacement'
+    );
+  });
+
+  it('replaces scalar fields and applies ordered dependency removal and addition', () => {
+    const override = parseSchemaOverride(`
+patchVersion: 1
+description: Effective description
+artifacts:
+  tasks:
+    description: Effective tasks
+    template: personal-tasks.md
+    requires:
+      remove: [design]
+      add: [proposal]
+`);
+
+    expect(() => applySchemaOverride(baseSchema(), override)).toThrow(
+      /cannot add duplicate value 'proposal'/u
+    );
+
+    expect(() => parseSchemaOverride(`
+patchVersion: 1
+description: Effective description
+artifacts:
+  tasks:
+    description: Effective tasks
+    template: personal-tasks.md
+    requires:
+      remove: [proposal]
+      add: [proposal]
+`)).toThrow(
+      /both added and removed/u
+    );
+
+    const replaceOverride = parseSchemaOverride(`
+patchVersion: 1
+description: Effective description
+artifacts:
+  tasks:
+    description: Effective tasks
+    template: personal-tasks.md
+    requires:
+      replace: [design]
+`);
+    const effective = applySchemaOverride(baseSchema(), replaceOverride);
+    expect(effective.description).toBe('Effective description');
+    expect(effective.artifacts[2]).toMatchObject({
+      description: 'Effective tasks',
+      template: 'personal-tasks.md',
+      requires: ['design'],
+    });
+  });
+
+  it('applies additive dependency operations in deterministic order', () => {
+    const override = parseSchemaOverride(`
+patchVersion: 1
+artifacts:
+  tasks:
+    requires:
+      remove: [proposal]
+      add: []
+`);
+
+    expect(applySchemaOverride(baseSchema(), override).artifacts[2].requires).toEqual([
+      'design',
+    ]);
+  });
+
+  it('rejects ambiguous and misspelled operations', () => {
+    expect(() => parseSchemaOverride(`
+patchVersion: 1
+artifacts:
+  tasks:
+    instruction:
+      replace: replacement
+      append: addition
+`)).toThrow(/replace cannot be combined/u);
+
+    expect(() => parseSchemaOverride(`
+patchVersion: 1
+artifacts:
+  tasks:
+    instructions:
+      append: typo
+`)).toThrow(/Unrecognized key/u);
+
+    expect(() => parseSchemaOverride(`
+patchVersion: 1
+artifacts:
+  tasks:
+    requires:
+      add: [proposal, proposal]
+`)).toThrow(/duplicate entries/u);
+  });
+
+  it('rejects unknown artifacts and absent removals', () => {
+    const unknown = parseSchemaOverride(`
+patchVersion: 1
+artifacts:
+  review:
+    description: Review
+`);
+    expect(() => applySchemaOverride(baseSchema(), unknown)).toThrow(
+      /unknown artifact ID/u
+    );
+
+    const absentRemoval = parseSchemaOverride(`
+patchVersion: 1
+artifacts:
+  tasks:
+    requires:
+      remove: [missing]
+`);
+    expect(() => applySchemaOverride(baseSchema(), absentRemoval)).toThrow(
+      /not present in the base value/u
+    );
+  });
+
+  it('rejects an effective schema with a cycle', () => {
+    const override = parseSchemaOverride(`
+patchVersion: 1
+artifacts:
+  proposal:
+    requires:
+      add: [tasks]
+`);
+
+    expect(() => applySchemaOverride(baseSchema(), override)).toThrow(
+      SchemaOverrideValidationError
+    );
+    expect(() => applySchemaOverride(baseSchema(), override)).toThrow(/Cyclic dependency/u);
+  });
+
+  it('supports apply instruction and collection operations', () => {
+    const override = parseSchemaOverride(`
+patchVersion: 1
+apply:
+  instruction:
+    append: Personal apply rules
+  requires:
+    replace: [design]
+  tracks: null
+`);
+    const effective = applySchemaOverride(baseSchema(), override);
+
+    expect(effective.apply).toEqual({
+      requires: ['design'],
+      tracks: null,
+      instruction: 'Packaged apply instruction\n\nPersonal apply rules',
+    });
+  });
+});

--- a/test/core/artifact-graph/schema-override.test.ts
+++ b/test/core/artifact-graph/schema-override.test.ts
@@ -94,6 +94,23 @@ artifacts:
     );
   });
 
+  it('normalizes blank boundary lines and omits whitespace-only text segments', () => {
+    const base = baseSchema();
+    base.artifacts[2].instruction = '\nPackaged tasks instruction\n\n  ';
+    const override = parseSchemaOverride(`
+patchVersion: 1
+artifacts:
+  tasks:
+    instruction:
+      prepend: "\\n\\nPersonal preface\\n\\n"
+      append: "  \\n\\t\\n"
+`);
+
+    expect(applySchemaOverride(base, override).artifacts[2].instruction).toBe(
+      'Personal preface\n\nPackaged tasks instruction'
+    );
+  });
+
   it('replaces instruction text without retaining the packaged value', () => {
     const override = parseSchemaOverride(`
 patchVersion: 1


### PR DESCRIPTION
## Motivation

OpenSpec already supports global schema customization, but the current mechanism is a complete replacement: users copy `schema.yaml` and every referenced template into their user data directory. From that point onward, the copied bundle shadows the packaged schema entirely.

That works when someone wants to own a whole workflow, but it is costly for the more common additive case. For example, I want to keep the maintained `spec-driven` workflow and add a few personal rules to the `tasks` instruction. With a complete replacement, I also become responsible for manually tracking every later improvement OpenSpec makes to built-in instructions, dependencies, validation behavior, and templates.

This PR adds a second, explicitly layered customization mode so small personal changes can coexist with upstream schema evolution.

## Proposed solution

A user can now create:

```text
${XDG_DATA_HOME}/openspec/schemas/<name>/schema.override.yaml
```

The packaged `schema.yaml` remains the base. OpenSpec applies the user overlay to that base at resolution time and then validates the complete effective schema using the existing schema validation rules.

For example:

```yaml
patchVersion: 1

artifacts:
  tasks:
    instruction:
      append: |
        Additional rules:
        - Include verification commands in every task group.
        - Mention the affected package in each task.
```

If a later OpenSpec release updates the packaged task instruction, the updated instruction is still used and the personal guidance remains appended. Fields that the overlay explicitly replaces remain user-owned.

The new command:

```bash
openspec schema override spec-driven
```

creates a valid no-op overlay without copying the packaged schema or templates.

## Merge model

The overlay format is deliberately strict and versioned with `patchVersion: 1`. It uses explicit operations instead of generic YAML merge semantics:

- Instruction text supports `prepend`, `append`, or `replace`. `prepend` and `append` may be combined; `replace` is exclusive.
- Dependency arrays support `add`, `remove`, or `replace`. Removal preserves the order of remaining values and additions are appended in declaration order.
- Artifact `description`, `generates`, and `template` values are direct replacements.
- Unknown keys, unknown artifact IDs, duplicate dependencies, invalid removals, operation conflicts, invalid references, and dependency cycles are rejected.

Overlays intentionally cannot add, remove, or reorder artifacts. Those are structural workflow changes and remain a use case for a complete schema fork.

## Template behavior

An overlay may include only the templates the user wants to replace:

```text
schemas/spec-driven/
├── schema.override.yaml
└── templates/
    └── tasks.md
```

For a composed schema, each template resolves independently:

1. User override template
2. Packaged template fallback

In this example, `tasks.md` is user-owned while proposal, specs, and design templates continue to receive packaged updates. Template content is not merged; a user template is a whole-file replacement.

Complete project and user schemas remain self-contained and do not gain package fallback.

## Resolution and compatibility

Schema precedence becomes:

1. Complete project `schema.yaml`
2. Complete user `schema.yaml`
3. Packaged `schema.yaml` plus user `schema.override.yaml`
4. Packaged schema without an overlay

This preserves existing behavior for project schemas, complete global replacements, and package-only users. A project schema remains authoritative because it represents version-controlled team intent.

The two user customization modes are mutually exclusive. If `schema.yaml` and `schema.override.yaml` exist in the same active user schema directory, OpenSpec reports a conflict instead of silently choosing one. An overlay without a packaged base is also rejected.

## Visibility and tooling

The same centralized source descriptor now drives runtime loading and diagnostics, so the CLI cannot report one source while using another. This PR updates:

- `schema which` and `schema which --all` to show package-plus-overlay composition
- `schema validate` to validate the overlay, effective schema, and layered templates
- `schemas` to report effective composed metadata
- `templates` to report the concrete user or package source for every template
- `schema fork` to materialize a composed schema and all effective templates into a self-contained project bundle

All template candidates retain the existing canonical path-containment checks.

## Scope

This PR does not add project-level overlays, arbitrary schema inheritance, Markdown merging, artifact insertion/removal/reordering, or automatic migration of complete user schemas. Existing complete replacements remain available for users who intentionally want full ownership.

## Testing

- `npm run lint`
- `node build.js`
- 262 focused and regression tests passed
- `openspec validate add-global-schema-overlays --strict`
- Full local suite: 3,992 of 3,993 tests passed. The remaining environment-specific workset test launched the installed Claude binary instead of its intentionally broken fixture; it is unrelated to schema resolution.


Closes #1687


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added layered user overrides for packaged schemas, including field, instruction, and dependency customizations.
  * Added `schema override` with JSON output and forced replacement options.
  * Schema validation, listing, templates, instructions, and forking now report and use effective schema sources.
  * Added safeguards for conflicting, invalid, incomplete, or unsafe schema and template configurations.

* **Documentation**
  * Expanded guidance for creating, customizing, validating, troubleshooting, and resolving schema overrides.
  * Corrected schema command synopsis formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->