### PR TITLE
fix(update): close the dead end for partially populated glob artifacts

### DIFF
--- a/.changeset/update-glob-artifact-gap.md
+++ b/.changeset/update-glob-artifact-gap.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+Let `/opsx:update` fill a missing file under an already-satisfied glob artifact. A glob artifact is complete once one file matches it, and `/opsx:continue` only picks up `ready` artifacts, so the previous "point the user to `/opsx:continue`" handoff was unreachable and the missing file could never be created through the documented flow.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -345,7 +345,13 @@ Revise a change's existing planning artifacts and keep them coherent with one an
 - Applies your requested revision, or reviews the artifacts for contradictions if you didn't name one
 - Reconciles the other existing artifacts in any direction (a design edit may ripple back to the proposal)
 - Confirms every edit with you before writing, one artifact at a time
-- Ends by recommending the next step: `/opsx:continue` (artifacts missing), `/opsx:apply` (carry a revised plan into code), or `/opsx:archive` (all done)
+- Ends by recommending the next step: `/opsx:continue` (unstarted artifacts), `/opsx:apply` (carry a revised plan into code), or `/opsx:archive` (all done)
+
+**Missing files:**
+
+- For a glob artifact such as `specs/**/*.md` with at least one existing file, update can propose a missing companion file. It uses the schema's instructions and asks you to confirm the concrete path before creating it.
+- Artifacts with no files yet remain with `/opsx:continue`. Intentionally skipped artifacts stay untouched.
+- New files must stay inside the change directory. If a file appears at the confirmed path before creation, update stops instead of overwriting it.
 
 **Example:**
 
@@ -366,7 +372,7 @@ AI:  Reading add-dark-mode artifacts...
 
 **Tips:**
 
-- It won't create missing artifacts - that's `/opsx:continue`
+- It won't start an artifact with no existing files. Enable `/opsx:continue` for that, or use `openspec status` and `openspec instructions` if that optional workflow isn't installed.
 - If the change was already implemented, follow up with `/opsx:apply` so the code matches the revised plan
 - If your revision changes the *intent* of the change, start fresh with a new change instead (see [When to Update vs. Start Fresh](opsx.md#when-to-update-vs-start-fresh))
 

--- a/docs/opsx.md
+++ b/docs/opsx.md
@@ -213,7 +213,9 @@ Works through tasks, checking them off as you go. If you're juggling multiple ch
 ```
 /opsx:update add-dark-mode - we're storing the theme in a cookie now
 ```
-Revises the change's existing planning artifacts and keeps them coherent - in any direction (a design edit may ripple back to the proposal). Planning artifacts only: it never edits code, and it never creates missing artifacts (that's `/opsx:continue`). Every edit is confirmed with you first. If the change was already implemented, it recommends `/opsx:apply` so the code catches up with the revised plan. If your revision changes the change's *intent*, start fresh instead - see [When to Update vs. Start Fresh](#when-to-update-vs-start-fresh).
+Revises the change's existing planning artifacts and keeps them coherent in any direction (a design edit may ripple back to the proposal). It never edits code. Every edit is confirmed with you first. See [the update reference](commands.md#opsxupdate) for how it handles missing files without starting a new artifact.
+
+If the change was already implemented, it recommends `/opsx:apply` so the code catches up with the revised plan. If your revision changes the change's *intent*, start fresh instead. See [When to Update vs. Start Fresh](#when-to-update-vs-start-fresh).
 
 ### Sync delta specs
 ```text

--- a/openspec/changes/add-update-workflow/design.md
+++ b/openspec/changes/add-update-workflow/design.md
@@ -105,6 +105,12 @@ Review feedback flagged that "update" alone is generic — could it apply to any
 ### 6. Next-step guidance, especially for already-implemented changes
 A change can be revised after it was built — tasks checked off, `/opsx:apply` already run. The update itself behaves identically (planning artifacts only), but stopping silently would strand the user: the code and the revised plan now disagree. So the skill ends by reporting where the change stands (from the status JSON and the tasks checklist) and recommending the next command — `/opsx:continue` if artifacts are missing, `/opsx:apply` to carry a revised plan into code, `/opsx:archive` when everything is done. Guidance only: the skill never implements, mirroring the "All artifacts created! You can now implement this change with `/opsx:apply`" hand-off that `continue-change.ts` already uses.
 
+### 7. Companion-file correction (#1733)
+
+The original glob-file deferral was unreachable: one matching file marks an artifact `done`, while continue selects only `ready` artifacts. Update can therefore propose a missing companion file within an already populated glob. This corrects the unarchived spec's former blanket deferral without changing the graph's completion rule or starting another artifact.
+
+The exception uses existing status and instructions output, requires current dependency context and user confirmation, and preserves the change-only planning scope. Immediately before creation, it rechecks scope and the concrete path and uses an operation that refuses an existing target. Delegated creators must obey the same limits. No new CLI command, metadata, graph state, or automatic artifact writer is introduced.
+
 ## Risks / Trade-offs
 
 - **No deterministic staleness signal.** With no digest/ledger, the skill relies on the agent reading the artifacts to spot incoherence. Trade-off accepted: an agent that rewrites prose must read it anyway, and a content-blind signal earns its cost only for use cases this change excludes (Decision 3).

--- a/openspec/changes/add-update-workflow/specs/opsx-update-skill/spec.md
+++ b/openspec/changes/add-update-workflow/specs/opsx-update-skill/spec.md
@@ -19,7 +19,7 @@ The system SHALL provide a `/opsx:update` workflow skill that revises a change's
 
 #### Scenario: Missing artifacts are deferred to continue
 
-- **WHEN** keeping the change coherent would require an artifact that has not been created yet
+- **WHEN** keeping the change coherent would require an artifact with no existing output files and status `ready` or `blocked`
 - **THEN** the skill revises only the artifacts that currently exist
 - **AND** it notes the not-yet-created artifacts and points the user to `/opsx:continue` to create them
 
@@ -53,7 +53,7 @@ The `/opsx:update` skill SHALL learn which artifacts exist and where they live b
 
 #### Scenario: Resolve artifact paths cross-platform
 
-- **WHEN** the skill reads or writes an artifact on macOS, Linux, or Windows
+- **WHEN** the skill reads or revises an existing artifact file on macOS, Linux, or Windows
 - **THEN** it uses the `existingOutputPaths` provided by the CLI status output
 - **AND** it does not assume forward-slash separators
 
@@ -63,11 +63,30 @@ The `/opsx:update` skill SHALL learn which artifacts exist and where they live b
 - **THEN** the skill edits the concrete files reported in that artifact's `existingOutputPaths`
 - **AND** it does not write to `resolvedOutputPath`, which for a glob artifact remains the glob pattern rather than a real file
 
-#### Scenario: A new file under a glob artifact is deferred to continue
+#### Scenario: A missing companion file under a populated glob artifact
 
-- **WHEN** keeping the change coherent would require a new file under a glob artifact that does not exist yet (for example a spec for a not-yet-captured capability)
-- **THEN** the skill revises only the files already present in `existingOutputPaths`
-- **AND** it points the user to `/opsx:continue`/`/opsx:propose` to create the new file rather than inventing a path from the glob
+- **WHEN** reconciliation identifies a missing companion file for a glob artifact with non-empty `existingOutputPaths`
+- **THEN** the skill MAY propose creating that file using the artifact's instructions, template, project context, rules, and current dependency files
+- **AND** it selects an unused concrete path matching the artifact's `outputPath` inside `changeRoot`, including after resolving linked parent directories
+- **AND** it creates the file only after user confirmation, refreshing status, instructions, and path checks immediately before creation
+- **AND** creation SHALL fail rather than overwrite a file that appeared in the meantime
+- **AND** it SHALL NOT start another artifact, write main specs, or edit implementation code
+
+#### Scenario: Required inputs are no longer available
+
+- **WHEN** a populated glob artifact remains `done` but a required non-skipped dependency is missing
+- **THEN** the skill SHALL stop new companion creation and ask the user to restore the dependency first
+
+#### Scenario: Schema delegates companion creation
+
+- **WHEN** the artifact instruction delegates creation to another skill or command
+- **THEN** the skill SHALL invoke it only if it can honor the confirmed concrete path and the update guardrails
+- **AND** otherwise it SHALL stop rather than invoke broader generation
+
+#### Scenario: Intentionally skipped artifact
+
+- **WHEN** status or instructions mark an artifact as skipped
+- **THEN** the skill SHALL leave it untouched and SHALL NOT treat its empty outputs as missing or send it to continue
 
 ### Requirement: Bidirectional Coherence Review
 
@@ -109,7 +128,7 @@ After applying confirmed revisions (or finding none needed), the `/opsx:update` 
 
 #### Scenario: Next step when artifacts are incomplete
 
-- **WHEN** the update finishes and the change still has not-yet-created artifacts
+- **WHEN** the update finishes and the change still has artifacts with no outputs and status `ready` or `blocked`
 - **THEN** the skill recommends `/opsx:continue` to create them
 
 #### Scenario: Next step when the change is fully done

--- a/skills/openspec-update-change/SKILL.md
+++ b/skills/openspec-update-change/SKILL.md
@@ -74,7 +74,7 @@ Revise a change's existing planning artifacts and keep them coherent. Never edit
      ```
 
 6. **Point to the next step (guidance only - NEVER act on it)**
-   - Artifacts still missing -> suggest `/openspec-continue-change` to create them.
+   - Artifacts with empty `existingOutputPaths` still missing -> suggest `/openspec-continue-change` to create them.
    - Change already implemented (tasks checked off / already applied) -> the code may no longer match the revised plan; suggest `/openspec-apply-change` to carry the delta into code.
    - Everything done and implemented -> suggest `/openspec-archive-change`.
 

--- a/skills/openspec-update-change/SKILL.md
+++ b/skills/openspec-update-change/SKILL.md
@@ -48,7 +48,7 @@ Revise a change's existing planning artifacts and keep them coherent. Never edit
 
    The artifact ids and paths come from the active schema - do NOT assume them, and do NOT branch on hardcoded artifact names. Custom schemas must work unchanged.
 
-   The files to edit are `artifactPaths.<id>.existingOutputPaths` - the concrete files that exist on disk, already glob-expanded for glob artifacts (e.g. `specs/**/*.md`). Do NOT write to `resolvedOutputPath`: for a glob artifact it is still the glob pattern, not a real file.
+   Edit existing files through `artifactPaths.<id>.existingOutputPaths` - the concrete files already on disk, with glob artifacts expanded (e.g. `specs/**/*.md`). For a glob artifact, `resolvedOutputPath` is still a pattern, not a concrete file. The only new-file exception is the partially populated glob case in step 4.
 
 3. **Understand the request**
    - If the user asked for a specific revision ("the design now uses X"), that is the starting edit.
@@ -58,8 +58,11 @@ Revise a change's existing planning artifacts and keep them coherent. Never edit
    - Read the artifact(s) the request touches and the change's other existing artifacts.
    - Apply the requested edit. Then check every other existing artifact against it - in ANY direction: an edit to a later artifact may require revising an earlier one, not only the other way around. Build order is a useful reading order, not a constraint on which artifacts may be revised.
    - Note everything that is now inconsistent, missing, or contradictory.
-   - Revise the files that already exist (`existingOutputPaths`). Do NOT create an artifact that has no files at all - it is still `ready` or `blocked`, so note it and point the user to `/openspec-continue-change`.
-   - A glob artifact (e.g. `specs/**/*.md`) counts as done as soon as ONE file matches it, so `/openspec-continue-change` - which only picks up `ready` artifacts - will never come back to it. If the reconciliation finds a file missing under a glob artifact that already has at least one file, create it here rather than deferring: choose the concrete path (never `resolvedOutputPath`, which is still the glob), fetch that artifact's rules and template with `openspec instructions "<artifact-id>" --change "<name>" --json`, and write it under step 5's confirmation rule like any other revision.
+   - Revise files that already exist (`existingOutputPaths`). Leave an artifact with no existing output files for `/openspec-continue-change`; it is still `ready` or `blocked`.
+   - A glob artifact (e.g. `specs/**/*.md`) is marked `done` after at least one file matches, and `/openspec-continue-change` only handles `ready` artifacts. When reconciliation identifies a missing file for a glob artifact whose `existingOutputPaths` is non-empty:
+     1. Run `openspec instructions "<artifact-id>" --change "<name>" --json` and use its `instruction`, `rules`, and `template`.
+     2. Choose a concrete path inside `changeRoot` that matches `artifactPaths.<id>.outputPath`. Never write to the glob `resolvedOutputPath`.
+     3. Include the new file in step 5's proposed revisions and create it only after the user confirms.
    - If the change is already coherent, say so and make no edits.
 
 5. **Confirm and apply, one artifact at a time**
@@ -87,6 +90,6 @@ After each invocation, show:
 - Planning artifacts only - NEVER edit implementation code. If the revised plan implies code changes, stop and point to `/openspec-apply-change`.
 - Use the artifact ids and paths reported by `openspec status`; never branch on hardcoded artifact names.
 - Write only concrete file paths; never write to a glob `resolvedOutputPath`.
-- Do not advance the build frontier: never create an artifact that has no files yet - that is `/openspec-continue-change`'s job. Filling a gap under a glob artifact that is already satisfied is in scope, because `/openspec-continue-change` cannot reach it.
+- Do not advance the build frontier: leave artifacts with empty `existingOutputPaths` for `/openspec-continue-change`. The only new-file scope is a confirmed concrete path under a glob artifact whose `existingOutputPaths` is non-empty.
 - Confirm every edit with the user before writing.
 - If the request changes the change's *intent* rather than refining it, first verify whether the optional `/openspec-new-change` workflow is available. If it is, recommend starting fresh with `/openspec-new-change` (the "Update vs. Start Fresh" heuristic). If it is unavailable, ask for a distinct unused change name and recommend `openspec new change "<new-change-name>"` instead.

--- a/skills/openspec-update-change/SKILL.md
+++ b/skills/openspec-update-change/SKILL.md
@@ -56,12 +56,12 @@ Revise a change's existing planning artifacts and keep them coherent. Never edit
 
 4. **Read and reconcile**
    - Read the artifact(s) the request touches and the change's other existing artifacts.
-   - Apply the requested edit. Then check every other existing artifact against it - in ANY direction: an edit to a later artifact may require revising an earlier one, not only the other way around. Build order is a useful reading order, not a constraint on which artifacts may be revised.
+   - Draft the requested edit without writing. Then check every other existing artifact against it - in ANY direction: an edit to a later artifact may require revising an earlier one, not only the other way around. Build order is a useful reading order, not a constraint on which artifacts may be revised.
    - Note everything that is now inconsistent, missing, or contradictory.
-   - Revise files that already exist (`existingOutputPaths`). Leave an artifact with no existing output files for `/openspec-continue-change`; it is still `ready` or `blocked`.
+   - Revise files that already exist (`existingOutputPaths`). Leave an artifact with no existing output files and status `ready` or `blocked` for `/openspec-continue-change`. Leave `skipped` artifacts untouched; do not treat them as missing or send them to `/openspec-continue-change`.
    - A glob artifact (e.g. `specs/**/*.md`) is marked `done` after at least one file matches, and `/openspec-continue-change` only handles `ready` artifacts. When reconciliation identifies a missing file for a glob artifact whose `existingOutputPaths` is non-empty:
-     1. Run `openspec instructions "<artifact-id>" --change "<name>" --json` and use its `instruction`, `rules`, and `template`.
-     2. Choose a concrete path inside `changeRoot` that matches `artifactPaths.<id>.outputPath`. Never write to the glob `resolvedOutputPath`.
+     1. Run `openspec instructions "<artifact-id>" --change "<name>" --json` and use its `instruction` and `template`. Apply `context` and `rules` as constraints; do not copy them into the file. If instructions report `skipped: true`, do not create the file.
+     2. Choose a concrete path inside `changeRoot` that matches `artifactPaths.<id>.outputPath` and does not already exist. Verify it remains inside `changeRoot` after resolving any symlinked parent directories. Never write to the glob `resolvedOutputPath`.
      3. Include the new file in step 5's proposed revisions and create it only after the user confirms.
    - If the change is already coherent, say so and make no edits.
 
@@ -74,7 +74,7 @@ Revise a change's existing planning artifacts and keep them coherent. Never edit
      ```
 
 6. **Point to the next step (guidance only - NEVER act on it)**
-   - Artifacts with empty `existingOutputPaths` still missing -> suggest `/openspec-continue-change` to create them.
+   - Artifacts with empty `existingOutputPaths` and status `ready` or `blocked` -> suggest `/openspec-continue-change` to create them.
    - Change already implemented (tasks checked off / already applied) -> the code may no longer match the revised plan; suggest `/openspec-apply-change` to carry the delta into code.
    - Everything done and implemented -> suggest `/openspec-archive-change`.
 
@@ -83,13 +83,13 @@ Revise a change's existing planning artifacts and keep them coherent. Never edit
 After each invocation, show:
 - Which artifacts were revised (and which proposed revisions were rejected)
 - Any file created under a glob artifact that was already partially populated
-- Anything deferred to `/openspec-continue-change` (artifacts with no files yet)
+- Anything deferred to `/openspec-continue-change` (artifacts with no files yet and status `ready` or `blocked`, never `skipped` artifacts)
 - Where the change stands and the recommended next command
 
 **Guardrails**
 - Planning artifacts only - NEVER edit implementation code. If the revised plan implies code changes, stop and point to `/openspec-apply-change`.
 - Use the artifact ids and paths reported by `openspec status`; never branch on hardcoded artifact names.
 - Write only concrete file paths; never write to a glob `resolvedOutputPath`.
-- Do not advance the build frontier: leave artifacts with empty `existingOutputPaths` for `/openspec-continue-change`. The only new-file scope is a confirmed concrete path under a glob artifact whose `existingOutputPaths` is non-empty.
+- Do not advance the build frontier: leave artifacts with empty `existingOutputPaths` and status `ready` or `blocked` for `/openspec-continue-change`. The only new-file scope is a confirmed concrete path under a glob artifact whose `existingOutputPaths` is non-empty.
 - Confirm every edit with the user before writing.
 - If the request changes the change's *intent* rather than refining it, first verify whether the optional `/openspec-new-change` workflow is available. If it is, recommend starting fresh with `/openspec-new-change` (the "Update vs. Start Fresh" heuristic). If it is unavailable, ask for a distinct unused change name and recommend `openspec new change "<new-change-name>"` instead.

--- a/skills/openspec-update-change/SKILL.md
+++ b/skills/openspec-update-change/SKILL.md
@@ -60,9 +60,11 @@ Revise a change's existing planning artifacts and keep them coherent. Never edit
    - Note everything that is now inconsistent, missing, or contradictory.
    - Revise files that already exist (`existingOutputPaths`). Leave an artifact with no existing output files and status `ready` or `blocked` for `/openspec-continue-change`. Leave `skipped` artifacts untouched; do not treat them as missing or send them to `/openspec-continue-change`.
    - A glob artifact (e.g. `specs/**/*.md`) is marked `done` after at least one file matches, and `/openspec-continue-change` only handles `ready` artifacts. When reconciliation identifies a missing file for a glob artifact whose `existingOutputPaths` is non-empty:
-     1. Run `openspec instructions "<artifact-id>" --change "<name>" --json` and use its `instruction` and `template`. Apply `context` and `rules` as constraints; do not copy them into the file. If instructions report `skipped: true`, do not create the file.
+     1. Run `openspec instructions "<artifact-id>" --change "<name>" --json` and use its `instruction` and `template`. Apply `context` and `rules` as constraints; do not copy them into the file. If instructions report `skipped: true`, do not create the file. Read current dependency files from disk; if a required non-skipped dependency is missing, stop and ask the user to restore it first.
      2. Choose a concrete path inside `changeRoot` that matches `artifactPaths.<id>.outputPath` and does not already exist. Verify it remains inside `changeRoot` after resolving any symlinked parent directories. Never write to the glob `resolvedOutputPath`.
      3. Include the new file in step 5's proposed revisions and create it only after the user confirms.
+     4. After confirmation, immediately before creation, refresh status and instructions. Verify the artifact is still in scope, not skipped, and partially populated; repeat the concrete-path checks above.
+     5. Use a create operation that fails if the target already exists. If `instruction` delegates creation to another skill or command, invoke it only if it can honor the confirmed path and these guardrails; otherwise stop. If any check fails or the confirmed draft is no longer valid, stop and reconcile with the user instead of overwriting or choosing a different path.
    - If the change is already coherent, say so and make no edits.
 
 5. **Confirm and apply, one artifact at a time**

--- a/skills/openspec-update-change/SKILL.md
+++ b/skills/openspec-update-change/SKILL.md
@@ -58,7 +58,8 @@ Revise a change's existing planning artifacts and keep them coherent. Never edit
    - Read the artifact(s) the request touches and the change's other existing artifacts.
    - Apply the requested edit. Then check every other existing artifact against it - in ANY direction: an edit to a later artifact may require revising an earlier one, not only the other way around. Build order is a useful reading order, not a constraint on which artifacts may be revised.
    - Note everything that is now inconsistent, missing, or contradictory.
-   - Revise only files that already exist (`existingOutputPaths`). Do NOT create artifacts that don't exist yet, and do NOT invent new files under a glob artifact - note them and point the user to `/openspec-continue-change` to create them.
+   - Revise the files that already exist (`existingOutputPaths`). Do NOT create an artifact that has no files at all - it is still `ready` or `blocked`, so note it and point the user to `/openspec-continue-change`.
+   - A glob artifact (e.g. `specs/**/*.md`) counts as done as soon as ONE file matches it, so `/openspec-continue-change` - which only picks up `ready` artifacts - will never come back to it. If the reconciliation finds a file missing under a glob artifact that already has at least one file, create it here rather than deferring: choose the concrete path (never `resolvedOutputPath`, which is still the glob), fetch that artifact's rules and template with `openspec instructions "<artifact-id>" --change "<name>" --json`, and write it under step 5's confirmation rule like any other revision.
    - If the change is already coherent, say so and make no edits.
 
 5. **Confirm and apply, one artifact at a time**
@@ -78,13 +79,14 @@ Revise a change's existing planning artifacts and keep them coherent. Never edit
 
 After each invocation, show:
 - Which artifacts were revised (and which proposed revisions were rejected)
-- Anything deferred to `/openspec-continue-change` (not-yet-created artifacts or files)
+- Any file created under a glob artifact that was already partially populated
+- Anything deferred to `/openspec-continue-change` (artifacts with no files yet)
 - Where the change stands and the recommended next command
 
 **Guardrails**
 - Planning artifacts only - NEVER edit implementation code. If the revised plan implies code changes, stop and point to `/openspec-apply-change`.
 - Use the artifact ids and paths reported by `openspec status`; never branch on hardcoded artifact names.
-- Edit only the concrete files in `existingOutputPaths`; never write to a glob `resolvedOutputPath`.
-- Do not advance the build frontier: no new artifacts, no new files under glob artifacts - that is `/openspec-continue-change`'s job.
+- Write only concrete file paths; never write to a glob `resolvedOutputPath`.
+- Do not advance the build frontier: never create an artifact that has no files yet - that is `/openspec-continue-change`'s job. Filling a gap under a glob artifact that is already satisfied is in scope, because `/openspec-continue-change` cannot reach it.
 - Confirm every edit with the user before writing.
 - If the request changes the change's *intent* rather than refining it, first verify whether the optional `/openspec-new-change` workflow is available. If it is, recommend starting fresh with `/openspec-new-change` (the "Update vs. Start Fresh" heuristic). If it is unavailable, ask for a distinct unused change name and recommend `openspec new change "<new-change-name>"` instead.

--- a/src/core/templates/workflows/update-change.ts
+++ b/src/core/templates/workflows/update-change.ts
@@ -76,7 +76,7 @@ ${STORE_SELECTION_GUIDANCE}
      \`\`\`
 
 6. **Point to the next step (guidance only - NEVER act on it)**
-   - Artifacts still missing -> suggest \`/opsx:continue\` to create them.
+   - Artifacts with empty \`existingOutputPaths\` still missing -> suggest \`/opsx:continue\` to create them.
    - Change already implemented (tasks checked off / already applied) -> the code may no longer match the revised plan; suggest \`/opsx:apply\` to carry the delta into code.
    - Everything done and implemented -> suggest \`/opsx:archive\`.
 
@@ -172,7 +172,7 @@ ${STORE_SELECTION_GUIDANCE}
      \`\`\`
 
 6. **Point to the next step (guidance only - NEVER act on it)**
-   - Artifacts still missing -> suggest \`/opsx:continue\` to create them.
+   - Artifacts with empty \`existingOutputPaths\` still missing -> suggest \`/opsx:continue\` to create them.
    - Change already implemented (tasks checked off / already applied) -> the code may no longer match the revised plan; suggest \`/opsx:apply\` to carry the delta into code.
    - Everything done and implemented -> suggest \`/opsx:archive\`.
 

--- a/src/core/templates/workflows/update-change.ts
+++ b/src/core/templates/workflows/update-change.ts
@@ -58,12 +58,12 @@ ${STORE_SELECTION_GUIDANCE}
 
 4. **Read and reconcile**
    - Read the artifact(s) the request touches and the change's other existing artifacts.
-   - Apply the requested edit. Then check every other existing artifact against it - in ANY direction: an edit to a later artifact may require revising an earlier one, not only the other way around. Build order is a useful reading order, not a constraint on which artifacts may be revised.
+   - Draft the requested edit without writing. Then check every other existing artifact against it - in ANY direction: an edit to a later artifact may require revising an earlier one, not only the other way around. Build order is a useful reading order, not a constraint on which artifacts may be revised.
    - Note everything that is now inconsistent, missing, or contradictory.
-   - Revise files that already exist (\`existingOutputPaths\`). Leave an artifact with no existing output files for \`/opsx:continue\`; it is still \`ready\` or \`blocked\`.
+   - Revise files that already exist (\`existingOutputPaths\`). Leave an artifact with no existing output files and status \`ready\` or \`blocked\` for \`/opsx:continue\`. Leave \`skipped\` artifacts untouched; do not treat them as missing or send them to \`/opsx:continue\`.
    - A glob artifact (e.g. \`specs/**/*.md\`) is marked \`done\` after at least one file matches, and \`/opsx:continue\` only handles \`ready\` artifacts. When reconciliation identifies a missing file for a glob artifact whose \`existingOutputPaths\` is non-empty:
-     1. Run \`openspec instructions "<artifact-id>" --change "<name>" --json\` and use its \`instruction\`, \`rules\`, and \`template\`.
-     2. Choose a concrete path inside \`changeRoot\` that matches \`artifactPaths.<id>.outputPath\`. Never write to the glob \`resolvedOutputPath\`.
+     1. Run \`openspec instructions "<artifact-id>" --change "<name>" --json\` and use its \`instruction\` and \`template\`. Apply \`context\` and \`rules\` as constraints; do not copy them into the file. If instructions report \`skipped: true\`, do not create the file.
+     2. Choose a concrete path inside \`changeRoot\` that matches \`artifactPaths.<id>.outputPath\` and does not already exist. Verify it remains inside \`changeRoot\` after resolving any symlinked parent directories. Never write to the glob \`resolvedOutputPath\`.
      3. Include the new file in step 5's proposed revisions and create it only after the user confirms.
    - If the change is already coherent, say so and make no edits.
 
@@ -76,7 +76,7 @@ ${STORE_SELECTION_GUIDANCE}
      \`\`\`
 
 6. **Point to the next step (guidance only - NEVER act on it)**
-   - Artifacts with empty \`existingOutputPaths\` still missing -> suggest \`/opsx:continue\` to create them.
+   - Artifacts with empty \`existingOutputPaths\` and status \`ready\` or \`blocked\` -> suggest \`/opsx:continue\` to create them.
    - Change already implemented (tasks checked off / already applied) -> the code may no longer match the revised plan; suggest \`/opsx:apply\` to carry the delta into code.
    - Everything done and implemented -> suggest \`/opsx:archive\`.
 
@@ -85,14 +85,14 @@ ${STORE_SELECTION_GUIDANCE}
 After each invocation, show:
 - Which artifacts were revised (and which proposed revisions were rejected)
 - Any file created under a glob artifact that was already partially populated
-- Anything deferred to \`/opsx:continue\` (artifacts with no files yet)
+- Anything deferred to \`/opsx:continue\` (artifacts with no files yet and status \`ready\` or \`blocked\`, never \`skipped\` artifacts)
 - Where the change stands and the recommended next command
 
 **Guardrails**
 - Planning artifacts only - NEVER edit implementation code. If the revised plan implies code changes, stop and point to \`/opsx:apply\`.
 - Use the artifact ids and paths reported by \`openspec status\`; never branch on hardcoded artifact names.
 - Write only concrete file paths; never write to a glob \`resolvedOutputPath\`.
-- Do not advance the build frontier: leave artifacts with empty \`existingOutputPaths\` for \`/opsx:continue\`. The only new-file scope is a confirmed concrete path under a glob artifact whose \`existingOutputPaths\` is non-empty.
+- Do not advance the build frontier: leave artifacts with empty \`existingOutputPaths\` and status \`ready\` or \`blocked\` for \`/opsx:continue\`. The only new-file scope is a confirmed concrete path under a glob artifact whose \`existingOutputPaths\` is non-empty.
 - Confirm every edit with the user before writing.
 - If the request changes the change's *intent* rather than refining it, first verify whether the optional \`/opsx:new\` workflow is available. If it is, recommend starting fresh with \`/opsx:new\` (the "Update vs. Start Fresh" heuristic). If it is unavailable, ask for a distinct unused change name and recommend \`openspec new change "<new-change-name>"\` instead.`,
     license: 'MIT',
@@ -154,12 +154,12 @@ ${STORE_SELECTION_GUIDANCE}
 
 4. **Read and reconcile**
    - Read the artifact(s) the request touches and the change's other existing artifacts.
-   - Apply the requested edit. Then check every other existing artifact against it - in ANY direction: an edit to a later artifact may require revising an earlier one, not only the other way around. Build order is a useful reading order, not a constraint on which artifacts may be revised.
+   - Draft the requested edit without writing. Then check every other existing artifact against it - in ANY direction: an edit to a later artifact may require revising an earlier one, not only the other way around. Build order is a useful reading order, not a constraint on which artifacts may be revised.
    - Note everything that is now inconsistent, missing, or contradictory.
-   - Revise files that already exist (\`existingOutputPaths\`). Leave an artifact with no existing output files for \`/opsx:continue\`; it is still \`ready\` or \`blocked\`.
+   - Revise files that already exist (\`existingOutputPaths\`). Leave an artifact with no existing output files and status \`ready\` or \`blocked\` for \`/opsx:continue\`. Leave \`skipped\` artifacts untouched; do not treat them as missing or send them to \`/opsx:continue\`.
    - A glob artifact (e.g. \`specs/**/*.md\`) is marked \`done\` after at least one file matches, and \`/opsx:continue\` only handles \`ready\` artifacts. When reconciliation identifies a missing file for a glob artifact whose \`existingOutputPaths\` is non-empty:
-     1. Run \`openspec instructions "<artifact-id>" --change "<name>" --json\` and use its \`instruction\`, \`rules\`, and \`template\`.
-     2. Choose a concrete path inside \`changeRoot\` that matches \`artifactPaths.<id>.outputPath\`. Never write to the glob \`resolvedOutputPath\`.
+     1. Run \`openspec instructions "<artifact-id>" --change "<name>" --json\` and use its \`instruction\` and \`template\`. Apply \`context\` and \`rules\` as constraints; do not copy them into the file. If instructions report \`skipped: true\`, do not create the file.
+     2. Choose a concrete path inside \`changeRoot\` that matches \`artifactPaths.<id>.outputPath\` and does not already exist. Verify it remains inside \`changeRoot\` after resolving any symlinked parent directories. Never write to the glob \`resolvedOutputPath\`.
      3. Include the new file in step 5's proposed revisions and create it only after the user confirms.
    - If the change is already coherent, say so and make no edits.
 
@@ -172,7 +172,7 @@ ${STORE_SELECTION_GUIDANCE}
      \`\`\`
 
 6. **Point to the next step (guidance only - NEVER act on it)**
-   - Artifacts with empty \`existingOutputPaths\` still missing -> suggest \`/opsx:continue\` to create them.
+   - Artifacts with empty \`existingOutputPaths\` and status \`ready\` or \`blocked\` -> suggest \`/opsx:continue\` to create them.
    - Change already implemented (tasks checked off / already applied) -> the code may no longer match the revised plan; suggest \`/opsx:apply\` to carry the delta into code.
    - Everything done and implemented -> suggest \`/opsx:archive\`.
 
@@ -181,14 +181,14 @@ ${STORE_SELECTION_GUIDANCE}
 After each invocation, show:
 - Which artifacts were revised (and which proposed revisions were rejected)
 - Any file created under a glob artifact that was already partially populated
-- Anything deferred to \`/opsx:continue\` (artifacts with no files yet)
+- Anything deferred to \`/opsx:continue\` (artifacts with no files yet and status \`ready\` or \`blocked\`, never \`skipped\` artifacts)
 - Where the change stands and the recommended next command
 
 **Guardrails**
 - Planning artifacts only - NEVER edit implementation code. If the revised plan implies code changes, stop and point to \`/opsx:apply\`.
 - Use the artifact ids and paths reported by \`openspec status\`; never branch on hardcoded artifact names.
 - Write only concrete file paths; never write to a glob \`resolvedOutputPath\`.
-- Do not advance the build frontier: leave artifacts with empty \`existingOutputPaths\` for \`/opsx:continue\`. The only new-file scope is a confirmed concrete path under a glob artifact whose \`existingOutputPaths\` is non-empty.
+- Do not advance the build frontier: leave artifacts with empty \`existingOutputPaths\` and status \`ready\` or \`blocked\` for \`/opsx:continue\`. The only new-file scope is a confirmed concrete path under a glob artifact whose \`existingOutputPaths\` is non-empty.
 - Confirm every edit with the user before writing.
 - If the request changes the change's *intent* rather than refining it, first verify whether the optional \`/opsx:new\` workflow is available. If it is, recommend starting fresh with \`/opsx:new\` (the "Update vs. Start Fresh" heuristic). If it is unavailable, ask for a distinct unused change name and recommend \`openspec new change "<new-change-name>"\` instead.`
   };

--- a/src/core/templates/workflows/update-change.ts
+++ b/src/core/templates/workflows/update-change.ts
@@ -60,7 +60,8 @@ ${STORE_SELECTION_GUIDANCE}
    - Read the artifact(s) the request touches and the change's other existing artifacts.
    - Apply the requested edit. Then check every other existing artifact against it - in ANY direction: an edit to a later artifact may require revising an earlier one, not only the other way around. Build order is a useful reading order, not a constraint on which artifacts may be revised.
    - Note everything that is now inconsistent, missing, or contradictory.
-   - Revise only files that already exist (\`existingOutputPaths\`). Do NOT create artifacts that don't exist yet, and do NOT invent new files under a glob artifact - note them and point the user to \`/opsx:continue\` to create them.
+   - Revise the files that already exist (\`existingOutputPaths\`). Do NOT create an artifact that has no files at all - it is still \`ready\` or \`blocked\`, so note it and point the user to \`/opsx:continue\`.
+   - A glob artifact (e.g. \`specs/**/*.md\`) counts as done as soon as ONE file matches it, so \`/opsx:continue\` - which only picks up \`ready\` artifacts - will never come back to it. If the reconciliation finds a file missing under a glob artifact that already has at least one file, create it here rather than deferring: choose the concrete path (never \`resolvedOutputPath\`, which is still the glob), fetch that artifact's rules and template with \`openspec instructions "<artifact-id>" --change "<name>" --json\`, and write it under step 5's confirmation rule like any other revision.
    - If the change is already coherent, say so and make no edits.
 
 5. **Confirm and apply, one artifact at a time**
@@ -80,14 +81,15 @@ ${STORE_SELECTION_GUIDANCE}
 
 After each invocation, show:
 - Which artifacts were revised (and which proposed revisions were rejected)
-- Anything deferred to \`/opsx:continue\` (not-yet-created artifacts or files)
+- Any file created under a glob artifact that was already partially populated
+- Anything deferred to \`/opsx:continue\` (artifacts with no files yet)
 - Where the change stands and the recommended next command
 
 **Guardrails**
 - Planning artifacts only - NEVER edit implementation code. If the revised plan implies code changes, stop and point to \`/opsx:apply\`.
 - Use the artifact ids and paths reported by \`openspec status\`; never branch on hardcoded artifact names.
-- Edit only the concrete files in \`existingOutputPaths\`; never write to a glob \`resolvedOutputPath\`.
-- Do not advance the build frontier: no new artifacts, no new files under glob artifacts - that is \`/opsx:continue\`'s job.
+- Write only concrete file paths; never write to a glob \`resolvedOutputPath\`.
+- Do not advance the build frontier: never create an artifact that has no files yet - that is \`/opsx:continue\`'s job. Filling a gap under a glob artifact that is already satisfied is in scope, because \`/opsx:continue\` cannot reach it.
 - Confirm every edit with the user before writing.
 - If the request changes the change's *intent* rather than refining it, first verify whether the optional \`/opsx:new\` workflow is available. If it is, recommend starting fresh with \`/opsx:new\` (the "Update vs. Start Fresh" heuristic). If it is unavailable, ask for a distinct unused change name and recommend \`openspec new change "<new-change-name>"\` instead.`,
     license: 'MIT',
@@ -151,7 +153,8 @@ ${STORE_SELECTION_GUIDANCE}
    - Read the artifact(s) the request touches and the change's other existing artifacts.
    - Apply the requested edit. Then check every other existing artifact against it - in ANY direction: an edit to a later artifact may require revising an earlier one, not only the other way around. Build order is a useful reading order, not a constraint on which artifacts may be revised.
    - Note everything that is now inconsistent, missing, or contradictory.
-   - Revise only files that already exist (\`existingOutputPaths\`). Do NOT create artifacts that don't exist yet, and do NOT invent new files under a glob artifact - note them and point the user to \`/opsx:continue\` to create them.
+   - Revise the files that already exist (\`existingOutputPaths\`). Do NOT create an artifact that has no files at all - it is still \`ready\` or \`blocked\`, so note it and point the user to \`/opsx:continue\`.
+   - A glob artifact (e.g. \`specs/**/*.md\`) counts as done as soon as ONE file matches it, so \`/opsx:continue\` - which only picks up \`ready\` artifacts - will never come back to it. If the reconciliation finds a file missing under a glob artifact that already has at least one file, create it here rather than deferring: choose the concrete path (never \`resolvedOutputPath\`, which is still the glob), fetch that artifact's rules and template with \`openspec instructions "<artifact-id>" --change "<name>" --json\`, and write it under step 5's confirmation rule like any other revision.
    - If the change is already coherent, say so and make no edits.
 
 5. **Confirm and apply, one artifact at a time**
@@ -171,14 +174,15 @@ ${STORE_SELECTION_GUIDANCE}
 
 After each invocation, show:
 - Which artifacts were revised (and which proposed revisions were rejected)
-- Anything deferred to \`/opsx:continue\` (not-yet-created artifacts or files)
+- Any file created under a glob artifact that was already partially populated
+- Anything deferred to \`/opsx:continue\` (artifacts with no files yet)
 - Where the change stands and the recommended next command
 
 **Guardrails**
 - Planning artifacts only - NEVER edit implementation code. If the revised plan implies code changes, stop and point to \`/opsx:apply\`.
 - Use the artifact ids and paths reported by \`openspec status\`; never branch on hardcoded artifact names.
-- Edit only the concrete files in \`existingOutputPaths\`; never write to a glob \`resolvedOutputPath\`.
-- Do not advance the build frontier: no new artifacts, no new files under glob artifacts - that is \`/opsx:continue\`'s job.
+- Write only concrete file paths; never write to a glob \`resolvedOutputPath\`.
+- Do not advance the build frontier: never create an artifact that has no files yet - that is \`/opsx:continue\`'s job. Filling a gap under a glob artifact that is already satisfied is in scope, because \`/opsx:continue\` cannot reach it.
 - Confirm every edit with the user before writing.
 - If the request changes the change's *intent* rather than refining it, first verify whether the optional \`/opsx:new\` workflow is available. If it is, recommend starting fresh with \`/opsx:new\` (the "Update vs. Start Fresh" heuristic). If it is unavailable, ask for a distinct unused change name and recommend \`openspec new change "<new-change-name>"\` instead.`
   };

--- a/src/core/templates/workflows/update-change.ts
+++ b/src/core/templates/workflows/update-change.ts
@@ -50,7 +50,7 @@ ${STORE_SELECTION_GUIDANCE}
 
    The artifact ids and paths come from the active schema - do NOT assume them, and do NOT branch on hardcoded artifact names. Custom schemas must work unchanged.
 
-   The files to edit are \`artifactPaths.<id>.existingOutputPaths\` - the concrete files that exist on disk, already glob-expanded for glob artifacts (e.g. \`specs/**/*.md\`). Do NOT write to \`resolvedOutputPath\`: for a glob artifact it is still the glob pattern, not a real file.
+   Edit existing files through \`artifactPaths.<id>.existingOutputPaths\` - the concrete files already on disk, with glob artifacts expanded (e.g. \`specs/**/*.md\`). For a glob artifact, \`resolvedOutputPath\` is still a pattern, not a concrete file. The only new-file exception is the partially populated glob case in step 4.
 
 3. **Understand the request**
    - If the user asked for a specific revision ("the design now uses X"), that is the starting edit.
@@ -60,8 +60,11 @@ ${STORE_SELECTION_GUIDANCE}
    - Read the artifact(s) the request touches and the change's other existing artifacts.
    - Apply the requested edit. Then check every other existing artifact against it - in ANY direction: an edit to a later artifact may require revising an earlier one, not only the other way around. Build order is a useful reading order, not a constraint on which artifacts may be revised.
    - Note everything that is now inconsistent, missing, or contradictory.
-   - Revise the files that already exist (\`existingOutputPaths\`). Do NOT create an artifact that has no files at all - it is still \`ready\` or \`blocked\`, so note it and point the user to \`/opsx:continue\`.
-   - A glob artifact (e.g. \`specs/**/*.md\`) counts as done as soon as ONE file matches it, so \`/opsx:continue\` - which only picks up \`ready\` artifacts - will never come back to it. If the reconciliation finds a file missing under a glob artifact that already has at least one file, create it here rather than deferring: choose the concrete path (never \`resolvedOutputPath\`, which is still the glob), fetch that artifact's rules and template with \`openspec instructions "<artifact-id>" --change "<name>" --json\`, and write it under step 5's confirmation rule like any other revision.
+   - Revise files that already exist (\`existingOutputPaths\`). Leave an artifact with no existing output files for \`/opsx:continue\`; it is still \`ready\` or \`blocked\`.
+   - A glob artifact (e.g. \`specs/**/*.md\`) is marked \`done\` after at least one file matches, and \`/opsx:continue\` only handles \`ready\` artifacts. When reconciliation identifies a missing file for a glob artifact whose \`existingOutputPaths\` is non-empty:
+     1. Run \`openspec instructions "<artifact-id>" --change "<name>" --json\` and use its \`instruction\`, \`rules\`, and \`template\`.
+     2. Choose a concrete path inside \`changeRoot\` that matches \`artifactPaths.<id>.outputPath\`. Never write to the glob \`resolvedOutputPath\`.
+     3. Include the new file in step 5's proposed revisions and create it only after the user confirms.
    - If the change is already coherent, say so and make no edits.
 
 5. **Confirm and apply, one artifact at a time**
@@ -89,7 +92,7 @@ After each invocation, show:
 - Planning artifacts only - NEVER edit implementation code. If the revised plan implies code changes, stop and point to \`/opsx:apply\`.
 - Use the artifact ids and paths reported by \`openspec status\`; never branch on hardcoded artifact names.
 - Write only concrete file paths; never write to a glob \`resolvedOutputPath\`.
-- Do not advance the build frontier: never create an artifact that has no files yet - that is \`/opsx:continue\`'s job. Filling a gap under a glob artifact that is already satisfied is in scope, because \`/opsx:continue\` cannot reach it.
+- Do not advance the build frontier: leave artifacts with empty \`existingOutputPaths\` for \`/opsx:continue\`. The only new-file scope is a confirmed concrete path under a glob artifact whose \`existingOutputPaths\` is non-empty.
 - Confirm every edit with the user before writing.
 - If the request changes the change's *intent* rather than refining it, first verify whether the optional \`/opsx:new\` workflow is available. If it is, recommend starting fresh with \`/opsx:new\` (the "Update vs. Start Fresh" heuristic). If it is unavailable, ask for a distinct unused change name and recommend \`openspec new change "<new-change-name>"\` instead.`,
     license: 'MIT',
@@ -143,7 +146,7 @@ ${STORE_SELECTION_GUIDANCE}
 
    The artifact ids and paths come from the active schema - do NOT assume them, and do NOT branch on hardcoded artifact names. Custom schemas must work unchanged.
 
-   The files to edit are \`artifactPaths.<id>.existingOutputPaths\` - the concrete files that exist on disk, already glob-expanded for glob artifacts (e.g. \`specs/**/*.md\`). Do NOT write to \`resolvedOutputPath\`: for a glob artifact it is still the glob pattern, not a real file.
+   Edit existing files through \`artifactPaths.<id>.existingOutputPaths\` - the concrete files already on disk, with glob artifacts expanded (e.g. \`specs/**/*.md\`). For a glob artifact, \`resolvedOutputPath\` is still a pattern, not a concrete file. The only new-file exception is the partially populated glob case in step 4.
 
 3. **Understand the request**
    - If the user asked for a specific revision ("the design now uses X"), that is the starting edit.
@@ -153,8 +156,11 @@ ${STORE_SELECTION_GUIDANCE}
    - Read the artifact(s) the request touches and the change's other existing artifacts.
    - Apply the requested edit. Then check every other existing artifact against it - in ANY direction: an edit to a later artifact may require revising an earlier one, not only the other way around. Build order is a useful reading order, not a constraint on which artifacts may be revised.
    - Note everything that is now inconsistent, missing, or contradictory.
-   - Revise the files that already exist (\`existingOutputPaths\`). Do NOT create an artifact that has no files at all - it is still \`ready\` or \`blocked\`, so note it and point the user to \`/opsx:continue\`.
-   - A glob artifact (e.g. \`specs/**/*.md\`) counts as done as soon as ONE file matches it, so \`/opsx:continue\` - which only picks up \`ready\` artifacts - will never come back to it. If the reconciliation finds a file missing under a glob artifact that already has at least one file, create it here rather than deferring: choose the concrete path (never \`resolvedOutputPath\`, which is still the glob), fetch that artifact's rules and template with \`openspec instructions "<artifact-id>" --change "<name>" --json\`, and write it under step 5's confirmation rule like any other revision.
+   - Revise files that already exist (\`existingOutputPaths\`). Leave an artifact with no existing output files for \`/opsx:continue\`; it is still \`ready\` or \`blocked\`.
+   - A glob artifact (e.g. \`specs/**/*.md\`) is marked \`done\` after at least one file matches, and \`/opsx:continue\` only handles \`ready\` artifacts. When reconciliation identifies a missing file for a glob artifact whose \`existingOutputPaths\` is non-empty:
+     1. Run \`openspec instructions "<artifact-id>" --change "<name>" --json\` and use its \`instruction\`, \`rules\`, and \`template\`.
+     2. Choose a concrete path inside \`changeRoot\` that matches \`artifactPaths.<id>.outputPath\`. Never write to the glob \`resolvedOutputPath\`.
+     3. Include the new file in step 5's proposed revisions and create it only after the user confirms.
    - If the change is already coherent, say so and make no edits.
 
 5. **Confirm and apply, one artifact at a time**
@@ -182,7 +188,7 @@ After each invocation, show:
 - Planning artifacts only - NEVER edit implementation code. If the revised plan implies code changes, stop and point to \`/opsx:apply\`.
 - Use the artifact ids and paths reported by \`openspec status\`; never branch on hardcoded artifact names.
 - Write only concrete file paths; never write to a glob \`resolvedOutputPath\`.
-- Do not advance the build frontier: never create an artifact that has no files yet - that is \`/opsx:continue\`'s job. Filling a gap under a glob artifact that is already satisfied is in scope, because \`/opsx:continue\` cannot reach it.
+- Do not advance the build frontier: leave artifacts with empty \`existingOutputPaths\` for \`/opsx:continue\`. The only new-file scope is a confirmed concrete path under a glob artifact whose \`existingOutputPaths\` is non-empty.
 - Confirm every edit with the user before writing.
 - If the request changes the change's *intent* rather than refining it, first verify whether the optional \`/opsx:new\` workflow is available. If it is, recommend starting fresh with \`/opsx:new\` (the "Update vs. Start Fresh" heuristic). If it is unavailable, ask for a distinct unused change name and recommend \`openspec new change "<new-change-name>"\` instead.`
   };

--- a/src/core/templates/workflows/update-change.ts
+++ b/src/core/templates/workflows/update-change.ts
@@ -62,9 +62,11 @@ ${STORE_SELECTION_GUIDANCE}
    - Note everything that is now inconsistent, missing, or contradictory.
    - Revise files that already exist (\`existingOutputPaths\`). Leave an artifact with no existing output files and status \`ready\` or \`blocked\` for \`/opsx:continue\`. Leave \`skipped\` artifacts untouched; do not treat them as missing or send them to \`/opsx:continue\`.
    - A glob artifact (e.g. \`specs/**/*.md\`) is marked \`done\` after at least one file matches, and \`/opsx:continue\` only handles \`ready\` artifacts. When reconciliation identifies a missing file for a glob artifact whose \`existingOutputPaths\` is non-empty:
-     1. Run \`openspec instructions "<artifact-id>" --change "<name>" --json\` and use its \`instruction\` and \`template\`. Apply \`context\` and \`rules\` as constraints; do not copy them into the file. If instructions report \`skipped: true\`, do not create the file.
+     1. Run \`openspec instructions "<artifact-id>" --change "<name>" --json\` and use its \`instruction\` and \`template\`. Apply \`context\` and \`rules\` as constraints; do not copy them into the file. If instructions report \`skipped: true\`, do not create the file. Read current dependency files from disk; if a required non-skipped dependency is missing, stop and ask the user to restore it first.
      2. Choose a concrete path inside \`changeRoot\` that matches \`artifactPaths.<id>.outputPath\` and does not already exist. Verify it remains inside \`changeRoot\` after resolving any symlinked parent directories. Never write to the glob \`resolvedOutputPath\`.
      3. Include the new file in step 5's proposed revisions and create it only after the user confirms.
+     4. After confirmation, immediately before creation, refresh status and instructions. Verify the artifact is still in scope, not skipped, and partially populated; repeat the concrete-path checks above.
+     5. Use a create operation that fails if the target already exists. If \`instruction\` delegates creation to another skill or command, invoke it only if it can honor the confirmed path and these guardrails; otherwise stop. If any check fails or the confirmed draft is no longer valid, stop and reconcile with the user instead of overwriting or choosing a different path.
    - If the change is already coherent, say so and make no edits.
 
 5. **Confirm and apply, one artifact at a time**
@@ -158,9 +160,11 @@ ${STORE_SELECTION_GUIDANCE}
    - Note everything that is now inconsistent, missing, or contradictory.
    - Revise files that already exist (\`existingOutputPaths\`). Leave an artifact with no existing output files and status \`ready\` or \`blocked\` for \`/opsx:continue\`. Leave \`skipped\` artifacts untouched; do not treat them as missing or send them to \`/opsx:continue\`.
    - A glob artifact (e.g. \`specs/**/*.md\`) is marked \`done\` after at least one file matches, and \`/opsx:continue\` only handles \`ready\` artifacts. When reconciliation identifies a missing file for a glob artifact whose \`existingOutputPaths\` is non-empty:
-     1. Run \`openspec instructions "<artifact-id>" --change "<name>" --json\` and use its \`instruction\` and \`template\`. Apply \`context\` and \`rules\` as constraints; do not copy them into the file. If instructions report \`skipped: true\`, do not create the file.
+     1. Run \`openspec instructions "<artifact-id>" --change "<name>" --json\` and use its \`instruction\` and \`template\`. Apply \`context\` and \`rules\` as constraints; do not copy them into the file. If instructions report \`skipped: true\`, do not create the file. Read current dependency files from disk; if a required non-skipped dependency is missing, stop and ask the user to restore it first.
      2. Choose a concrete path inside \`changeRoot\` that matches \`artifactPaths.<id>.outputPath\` and does not already exist. Verify it remains inside \`changeRoot\` after resolving any symlinked parent directories. Never write to the glob \`resolvedOutputPath\`.
      3. Include the new file in step 5's proposed revisions and create it only after the user confirms.
+     4. After confirmation, immediately before creation, refresh status and instructions. Verify the artifact is still in scope, not skipped, and partially populated; repeat the concrete-path checks above.
+     5. Use a create operation that fails if the target already exists. If \`instruction\` delegates creation to another skill or command, invoke it only if it can honor the confirmed path and these guardrails; otherwise stop. If any check fails or the confirmed draft is no longer valid, stop and reconcile with the user instead of overwriting or choosing a different path.
    - If the change is already coherent, say so and make no edits.
 
 5. **Confirm and apply, one artifact at a time**

--- a/test/commands/artifact-workflow.test.ts
+++ b/test/commands/artifact-workflow.test.ts
@@ -198,6 +198,17 @@ describe('artifact-workflow CLI commands', () => {
       expect(status.artifacts.find((artifact: any) => artifact.id === 'specs')?.status).toBe(
         'skipped'
       );
+      expect(status.artifactPaths.specs.existingOutputPaths).toEqual([]);
+      const instructionsResult = await runCLI(
+        ['instructions', 'specs', '--change', 'skip-specs-change', '--json'],
+        { cwd: tempDir }
+      );
+      expect(instructionsResult.exitCode).toBe(0);
+      expect(JSON.parse(instructionsResult.stdout)).toMatchObject({
+        skipped: true,
+        existingOutputPaths: [],
+        warning: expect.stringContaining('Do not create spec files'),
+      });
       await expect(fs.stat(path.join(changeDir, 'specs'))).rejects.toMatchObject({ code: 'ENOENT' });
     });
 
@@ -308,6 +319,100 @@ describe('artifact-workflow CLI commands', () => {
   });
 
   describe('instructions command', () => {
+    it('keeps instructions available for missing companion outputs after a glob artifact is done', async () => {
+      const schemaName = 'companion-outputs';
+      const schemaDir = path.join(tempDir, 'openspec', 'schemas', schemaName);
+      const outputPath = 'reviews/*/notes.md';
+      const template = '# Review\n\n## Findings\n';
+      await fs.mkdir(path.join(schemaDir, 'templates'), { recursive: true });
+      await fs.writeFile(
+        path.join(schemaDir, 'schema.yaml'),
+        `name: ${schemaName}
+version: 1
+artifacts:
+  - id: assessments
+    generates: ${outputPath}
+    description: Component assessments
+    template: review.md
+    instruction: Write an assessment for each affected component.
+    requires: []
+  - id: signoff
+    generates: signoff.md
+    description: Review signoff
+    template: signoff.md
+    requires: [assessments]
+`
+      );
+      await fs.writeFile(path.join(schemaDir, 'templates', 'review.md'), template);
+      await fs.writeFile(path.join(schemaDir, 'templates', 'signoff.md'), '# Signoff\n');
+      await fs.writeFile(
+        path.join(tempDir, 'openspec', 'config.yaml'),
+        `schema: ${schemaName}
+context: Review both the API and UI components.
+rules:
+  assessments:
+    - Preserve existing findings when adding a companion assessment.
+`
+      );
+      const changeName = 'companion-review';
+      const changeDir = path.join(changesDir, changeName);
+      await fs.mkdir(changeDir, { recursive: true });
+      await fs.writeFile(path.join(changeDir, '.openspec.yaml'), `schema: ${schemaName}\n`);
+      const apiPath = path.join(changeDir, 'reviews', 'api', 'notes.md');
+      const uiPath = path.join(changeDir, 'reviews', 'ui', 'notes.md');
+
+      async function readJson(args: string[]) {
+        const result = await runCLI([...args, '--change', changeName, '--json'], { cwd: tempDir });
+        expect(result.exitCode).toBe(0);
+        return JSON.parse(result.stdout);
+      }
+
+      const empty = await readJson(['status']);
+      expect(empty.artifacts).toMatchObject([
+        { id: 'assessments', status: 'ready' },
+        { id: 'signoff', status: 'blocked', missingDeps: ['assessments'] },
+      ]);
+      expect(empty.artifactPaths.assessments.existingOutputPaths).toEqual([]);
+
+      // Fixture writes simulate authored outputs; the CLI only reports their state.
+      const existingContent = '# Review\n\n## Findings\nKeep this API finding.\n';
+      await fs.mkdir(path.dirname(apiPath), { recursive: true });
+      await fs.writeFile(apiPath, existingContent);
+      const partial = await readJson(['status']);
+      expect(partial.artifacts).toMatchObject([
+        { id: 'assessments', status: 'done' },
+        { id: 'signoff', status: 'ready' },
+      ]);
+      expect(partial.artifactPaths.assessments.existingOutputPaths.map(canonical)).toEqual([
+        canonical(apiPath),
+      ]);
+      const instructions = await readJson(['instructions', 'assessments']);
+      expect(instructions).toMatchObject({
+        artifactId: 'assessments',
+        outputPath,
+        instruction: 'Write an assessment for each affected component.',
+        context: 'Review both the API and UI components.',
+        rules: ['Preserve existing findings when adding a companion assessment.'],
+        template,
+      });
+      expect(canonical(instructions.changeDir)).toBe(canonical(changeDir));
+      expect(instructions.resolvedOutputPath).toBe(path.join(instructions.changeDir, outputPath));
+      expect(instructions.existingOutputPaths.map(canonical)).toEqual([canonical(apiPath)]);
+      expect(instructions.skipped).toBeUndefined();
+      await expect(fs.stat(uiPath)).rejects.toMatchObject({ code: 'ENOENT' });
+
+      await fs.mkdir(path.dirname(uiPath), { recursive: true });
+      await fs.writeFile(uiPath, '# Review\n\n## Findings\nNew UI finding.\n');
+      const expanded = await readJson(['status']);
+      expect(expanded.artifacts).toEqual(partial.artifacts);
+      expect(expanded.nextSteps).toEqual(partial.nextSteps);
+      expect(expanded.artifactPaths.assessments.existingOutputPaths.map(canonical)).toEqual(
+        [apiPath, uiPath].map(canonical).sort()
+      );
+      expect(await fs.readFile(apiPath, 'utf-8')).toBe(existingContent);
+      await expect(fs.stat(path.join(changeDir, 'signoff.md'))).rejects.toMatchObject({ code: 'ENOENT' });
+    });
+
     it('shows instructions for proposal on scaffolded change', async () => {
       // Create empty change directory (no proposal.md)
       const changeDir = path.join(changesDir, 'scaffolded-change');

--- a/test/commands/artifact-workflow.test.ts
+++ b/test/commands/artifact-workflow.test.ts
@@ -330,12 +330,17 @@ describe('artifact-workflow CLI commands', () => {
         `name: ${schemaName}
 version: 1
 artifacts:
+  - id: brief
+    generates: brief.md
+    description: Review brief
+    template: brief.md
+    requires: []
   - id: assessments
     generates: ${outputPath}
     description: Component assessments
     template: review.md
     instruction: Write an assessment for each affected component.
-    requires: []
+    requires: [brief]
   - id: signoff
     generates: signoff.md
     description: Review signoff
@@ -343,6 +348,7 @@ artifacts:
     requires: [assessments]
 `
       );
+      await fs.writeFile(path.join(schemaDir, 'templates', 'brief.md'), '# Brief\n');
       await fs.writeFile(path.join(schemaDir, 'templates', 'review.md'), template);
       await fs.writeFile(path.join(schemaDir, 'templates', 'signoff.md'), '# Signoff\n');
       await fs.writeFile(
@@ -358,6 +364,8 @@ rules:
       const changeDir = path.join(changesDir, changeName);
       await fs.mkdir(changeDir, { recursive: true });
       await fs.writeFile(path.join(changeDir, '.openspec.yaml'), `schema: ${schemaName}\n`);
+      const briefPath = path.join(changeDir, 'brief.md');
+      await fs.writeFile(briefPath, '# Brief\nReview the API and UI.\n');
       const apiPath = path.join(changeDir, 'reviews', 'api', 'notes.md');
       const uiPath = path.join(changeDir, 'reviews', 'ui', 'notes.md');
 
@@ -369,6 +377,7 @@ rules:
 
       const empty = await readJson(['status']);
       expect(empty.artifacts).toMatchObject([
+        { id: 'brief', status: 'done' },
         { id: 'assessments', status: 'ready' },
         { id: 'signoff', status: 'blocked', missingDeps: ['assessments'] },
       ]);
@@ -380,6 +389,7 @@ rules:
       await fs.writeFile(apiPath, existingContent);
       const partial = await readJson(['status']);
       expect(partial.artifacts).toMatchObject([
+        { id: 'brief', status: 'done' },
         { id: 'assessments', status: 'done' },
         { id: 'signoff', status: 'ready' },
       ]);
@@ -394,6 +404,7 @@ rules:
         context: 'Review both the API and UI components.',
         rules: ['Preserve existing findings when adding a companion assessment.'],
         template,
+        dependencies: [{ id: 'brief', done: true, path: 'brief.md' }],
       });
       expect(canonical(instructions.changeDir)).toBe(canonical(changeDir));
       expect(instructions.resolvedOutputPath).toBe(path.join(instructions.changeDir, outputPath));
@@ -411,6 +422,17 @@ rules:
       );
       expect(await fs.readFile(apiPath, 'utf-8')).toBe(existingContent);
       await expect(fs.stat(path.join(changeDir, 'signoff.md'))).rejects.toMatchObject({ code: 'ENOENT' });
+
+      await fs.unlink(briefPath);
+      const missingInput = await readJson(['status']);
+      expect(missingInput.artifacts.find((artifact: any) => artifact.id === 'assessments')).toMatchObject({
+        status: 'done',
+        requires: ['brief'],
+      });
+      const missingInputInstructions = await readJson(['instructions', 'assessments']);
+      expect(missingInputInstructions.dependencies).toMatchObject([
+        { id: 'brief', done: false, path: 'brief.md' },
+      ]);
     });
 
     it('shows instructions for proposal on scaffolded change', async () => {

--- a/test/core/templates/skill-templates-parity.test.ts
+++ b/test/core/templates/skill-templates-parity.test.ts
@@ -61,8 +61,8 @@ const EXPECTED_FUNCTION_HASHES: Record<string, string> = {
   getOpsxProposeSkillTemplate: 'b7215583fefddae0127076465de9b3de9c230f2f1ea9ae6e4fb2a46fe510e8d6',
   getOpsxProposeCommandTemplate: 'f016c66c2b6115b459751154c76a6270e444d6aee31973bb7cb8c0e6d505fb98',
   getFeedbackSkillTemplate: 'dabeb5e825b9349abc8156c3e7b8608f27987912a6d9bf47ef29addde6138133',
-  getUpdateChangeSkillTemplate: '6d312d600652f6d3412b7bac7e12a837ae172a728eecf3bdf9f9bb31f56e0f1d',
-  getOpsxUpdateCommandTemplate: '3f0a6e10a71a570781a64a2ae900a0cf94a8c6aa321c528696258f47b0c845c7',
+  getUpdateChangeSkillTemplate: '3ff5705cfdfc5a8f61eb7d47218a3ffe74dce84b6480c156f76b4a850e9fab11',
+  getOpsxUpdateCommandTemplate: 'e1e5e8f8d515faff597b50d2d6158b23d0f82586fba6509ad16c698f96a02842',
 };
 
 const EXPECTED_GENERATED_SKILL_CONTENT_HASHES: Record<string, string> = {
@@ -77,7 +77,7 @@ const EXPECTED_GENERATED_SKILL_CONTENT_HASHES: Record<string, string> = {
   'openspec-verify-change': 'af9be013dcbe8c6d8f6d9ab10c893fbd03f4c62933c384d82f63894dd0ceb84f',
   'openspec-onboard': 'f6f59476acaf5e4d65dbb180da4cef62432612f3cecf207d471a951295e2003a',
   'openspec-propose': '679d0f868bed23cfb34a8ecc6b4ba4ff7b88dd7dbaef91563423e98f194f988f',
-  'openspec-update-change': 'f02caaaf8c25a782c2c40f033e81e7e0763251f9641e2515c1dcadc06d3b403e',
+  'openspec-update-change': 'eb23d70f757986a00becf82a34e1243b9328205ca9a3eda2c4d5f92e2f3b8b76',
 };
 
 // Intentionally excludes getFeedbackSkillTemplate: this list only models templates

--- a/test/core/templates/skill-templates-parity.test.ts
+++ b/test/core/templates/skill-templates-parity.test.ts
@@ -61,8 +61,8 @@ const EXPECTED_FUNCTION_HASHES: Record<string, string> = {
   getOpsxProposeSkillTemplate: 'b7215583fefddae0127076465de9b3de9c230f2f1ea9ae6e4fb2a46fe510e8d6',
   getOpsxProposeCommandTemplate: 'f016c66c2b6115b459751154c76a6270e444d6aee31973bb7cb8c0e6d505fb98',
   getFeedbackSkillTemplate: 'dabeb5e825b9349abc8156c3e7b8608f27987912a6d9bf47ef29addde6138133',
-  getUpdateChangeSkillTemplate: '3ff5705cfdfc5a8f61eb7d47218a3ffe74dce84b6480c156f76b4a850e9fab11',
-  getOpsxUpdateCommandTemplate: 'e1e5e8f8d515faff597b50d2d6158b23d0f82586fba6509ad16c698f96a02842',
+  getUpdateChangeSkillTemplate: '570a45b13961394b5bef7a828e894694ad3209ac6bc5009721f74b1f6782b508',
+  getOpsxUpdateCommandTemplate: '5f87e09eb6926840f6851f40c645843123912be97770c9c5c960d55beb30c32e',
 };
 
 const EXPECTED_GENERATED_SKILL_CONTENT_HASHES: Record<string, string> = {
@@ -77,7 +77,7 @@ const EXPECTED_GENERATED_SKILL_CONTENT_HASHES: Record<string, string> = {
   'openspec-verify-change': 'af9be013dcbe8c6d8f6d9ab10c893fbd03f4c62933c384d82f63894dd0ceb84f',
   'openspec-onboard': 'f6f59476acaf5e4d65dbb180da4cef62432612f3cecf207d471a951295e2003a',
   'openspec-propose': '679d0f868bed23cfb34a8ecc6b4ba4ff7b88dd7dbaef91563423e98f194f988f',
-  'openspec-update-change': 'eb23d70f757986a00becf82a34e1243b9328205ca9a3eda2c4d5f92e2f3b8b76',
+  'openspec-update-change': '6a32363177894ce7958c8caac3723dbd94cfca1d7ce1c14425c7b75c098f38a5',
 };
 
 // Intentionally excludes getFeedbackSkillTemplate: this list only models templates

--- a/test/core/templates/skill-templates-parity.test.ts
+++ b/test/core/templates/skill-templates-parity.test.ts
@@ -61,8 +61,8 @@ const EXPECTED_FUNCTION_HASHES: Record<string, string> = {
   getOpsxProposeSkillTemplate: 'b7215583fefddae0127076465de9b3de9c230f2f1ea9ae6e4fb2a46fe510e8d6',
   getOpsxProposeCommandTemplate: 'f016c66c2b6115b459751154c76a6270e444d6aee31973bb7cb8c0e6d505fb98',
   getFeedbackSkillTemplate: 'dabeb5e825b9349abc8156c3e7b8608f27987912a6d9bf47ef29addde6138133',
-  getUpdateChangeSkillTemplate: '7dc8abc6f64c58bf34d7581ed4ab095a3b7a53cb372349bee2d840db58622819',
-  getOpsxUpdateCommandTemplate: 'e2388521b22f92f74561df9a0c2f98e1fa4d265af93b5ba26f42fb47a6c5bfed',
+  getUpdateChangeSkillTemplate: '6d312d600652f6d3412b7bac7e12a837ae172a728eecf3bdf9f9bb31f56e0f1d',
+  getOpsxUpdateCommandTemplate: '3f0a6e10a71a570781a64a2ae900a0cf94a8c6aa321c528696258f47b0c845c7',
 };
 
 const EXPECTED_GENERATED_SKILL_CONTENT_HASHES: Record<string, string> = {
@@ -77,7 +77,7 @@ const EXPECTED_GENERATED_SKILL_CONTENT_HASHES: Record<string, string> = {
   'openspec-verify-change': 'af9be013dcbe8c6d8f6d9ab10c893fbd03f4c62933c384d82f63894dd0ceb84f',
   'openspec-onboard': 'f6f59476acaf5e4d65dbb180da4cef62432612f3cecf207d471a951295e2003a',
   'openspec-propose': '679d0f868bed23cfb34a8ecc6b4ba4ff7b88dd7dbaef91563423e98f194f988f',
-  'openspec-update-change': '586547406aca94422dfeb3ffedce6c01049429b743f57ce829baa79ebc714d51',
+  'openspec-update-change': 'f02caaaf8c25a782c2c40f033e81e7e0763251f9641e2515c1dcadc06d3b403e',
 };
 
 // Intentionally excludes getFeedbackSkillTemplate: this list only models templates

--- a/test/core/templates/skill-templates-parity.test.ts
+++ b/test/core/templates/skill-templates-parity.test.ts
@@ -61,8 +61,8 @@ const EXPECTED_FUNCTION_HASHES: Record<string, string> = {
   getOpsxProposeSkillTemplate: 'b7215583fefddae0127076465de9b3de9c230f2f1ea9ae6e4fb2a46fe510e8d6',
   getOpsxProposeCommandTemplate: 'f016c66c2b6115b459751154c76a6270e444d6aee31973bb7cb8c0e6d505fb98',
   getFeedbackSkillTemplate: 'dabeb5e825b9349abc8156c3e7b8608f27987912a6d9bf47ef29addde6138133',
-  getUpdateChangeSkillTemplate: '3edd9132200202b5549bfc1643174a557f94c870bbc05e9cbac736ce07b28ba6',
-  getOpsxUpdateCommandTemplate: 'ab734664169970d49cc3900db00ec3a2dc18284e9af963e77f7754ae976a274b',
+  getUpdateChangeSkillTemplate: '8d7b72968546745d6335ce67c16475e6c151a585b34e0cc23201065a90b96686',
+  getOpsxUpdateCommandTemplate: '8a0515394ea8954ec93f5ad62f31c98529f1e3dcd046a8eff4eab1a1f88b2d93',
 };
 
 const EXPECTED_GENERATED_SKILL_CONTENT_HASHES: Record<string, string> = {
@@ -77,7 +77,7 @@ const EXPECTED_GENERATED_SKILL_CONTENT_HASHES: Record<string, string> = {
   'openspec-verify-change': 'af9be013dcbe8c6d8f6d9ab10c893fbd03f4c62933c384d82f63894dd0ceb84f',
   'openspec-onboard': 'f6f59476acaf5e4d65dbb180da4cef62432612f3cecf207d471a951295e2003a',
   'openspec-propose': '679d0f868bed23cfb34a8ecc6b4ba4ff7b88dd7dbaef91563423e98f194f988f',
-  'openspec-update-change': 'c4ecd550eff28412009f4b384282807df65af42fe9365d0d539af225e020227f',
+  'openspec-update-change': 'e819e141dd4be8a2e5413455368050a90376f824bb74eb5b90c0901a33e5cc35',
 };
 
 // Intentionally excludes getFeedbackSkillTemplate: this list only models templates

--- a/test/core/templates/skill-templates-parity.test.ts
+++ b/test/core/templates/skill-templates-parity.test.ts
@@ -61,8 +61,8 @@ const EXPECTED_FUNCTION_HASHES: Record<string, string> = {
   getOpsxProposeSkillTemplate: 'b7215583fefddae0127076465de9b3de9c230f2f1ea9ae6e4fb2a46fe510e8d6',
   getOpsxProposeCommandTemplate: 'f016c66c2b6115b459751154c76a6270e444d6aee31973bb7cb8c0e6d505fb98',
   getFeedbackSkillTemplate: 'dabeb5e825b9349abc8156c3e7b8608f27987912a6d9bf47ef29addde6138133',
-  getUpdateChangeSkillTemplate: '570a45b13961394b5bef7a828e894694ad3209ac6bc5009721f74b1f6782b508',
-  getOpsxUpdateCommandTemplate: '5f87e09eb6926840f6851f40c645843123912be97770c9c5c960d55beb30c32e',
+  getUpdateChangeSkillTemplate: '3edd9132200202b5549bfc1643174a557f94c870bbc05e9cbac736ce07b28ba6',
+  getOpsxUpdateCommandTemplate: 'ab734664169970d49cc3900db00ec3a2dc18284e9af963e77f7754ae976a274b',
 };
 
 const EXPECTED_GENERATED_SKILL_CONTENT_HASHES: Record<string, string> = {
@@ -77,7 +77,7 @@ const EXPECTED_GENERATED_SKILL_CONTENT_HASHES: Record<string, string> = {
   'openspec-verify-change': 'af9be013dcbe8c6d8f6d9ab10c893fbd03f4c62933c384d82f63894dd0ceb84f',
   'openspec-onboard': 'f6f59476acaf5e4d65dbb180da4cef62432612f3cecf207d471a951295e2003a',
   'openspec-propose': '679d0f868bed23cfb34a8ecc6b4ba4ff7b88dd7dbaef91563423e98f194f988f',
-  'openspec-update-change': '6a32363177894ce7958c8caac3723dbd94cfca1d7ce1c14425c7b75c098f38a5',
+  'openspec-update-change': 'c4ecd550eff28412009f4b384282807df65af42fe9365d0d539af225e020227f',
 };
 
 // Intentionally excludes getFeedbackSkillTemplate: this list only models templates

--- a/test/core/templates/update-change.test.ts
+++ b/test/core/templates/update-change.test.ts
@@ -56,11 +56,13 @@ describe('update-change templates', () => {
       expect(body, label).toContain('stop and point to `/opsx:apply`');
       expect(body, label).toContain('Do not advance the build frontier');
       expect(body, label).toContain(
-        'Leave an artifact with no existing output files for `/opsx:continue`'
+        'Leave an artifact with no existing output files and status `ready` or `blocked` for `/opsx:continue`'
       );
       expect(body, label).toContain(
-        'leave artifacts with empty `existingOutputPaths` for `/opsx:continue`'
+        'leave artifacts with empty `existingOutputPaths` and status `ready` or `blocked` for `/opsx:continue`'
       );
+      expect(body, label).toContain('Leave `skipped` artifacts untouched');
+      expect(body, label).toContain('do not treat them as missing or send them to `/opsx:continue`');
     }
   });
 
@@ -70,12 +72,16 @@ describe('update-change templates', () => {
       expect(body, label).toContain('`/opsx:continue` only handles `ready` artifacts');
       expect(body, label).toContain('whose `existingOutputPaths` is non-empty');
       expect(body, label).toContain(
-        'use its `instruction`, `rules`, and `template`'
+        'use its `instruction` and `template`'
       );
+      expect(body, label).toContain('Apply `context` and `rules` as constraints; do not copy them into the file');
+      expect(body, label).toContain('If instructions report `skipped: true`, do not create the file');
       expect(body, label).toContain(
         'inside `changeRoot` that matches `artifactPaths.<id>.outputPath`'
       );
       expect(body, label).toContain('create it only after the user confirms');
+      expect(body, label).toContain('does not already exist');
+      expect(body, label).toContain('after resolving any symlinked parent directories');
     }
   });
 
@@ -92,7 +98,7 @@ describe('update-change templates', () => {
     for (const [label, body] of bodies) {
       expect(body, label).toContain('guidance only - NEVER act on it');
       expect(body, label).toContain(
-        'Artifacts with empty `existingOutputPaths` still missing -> suggest `/opsx:continue`'
+        'Artifacts with empty `existingOutputPaths` and status `ready` or `blocked` -> suggest `/opsx:continue`'
       );
       expect(body, label).toContain('suggest `/opsx:continue`');
       expect(body, label).toContain('suggest `/opsx:apply`');
@@ -125,6 +131,9 @@ describe('update-change templates', () => {
 
   it('confirms every edit and redirects intent changes to /opsx:new', () => {
     for (const [label, body] of bodies) {
+      const reconciliation = body.slice(body.indexOf('4. **Read and reconcile**'), body.indexOf('5. **Confirm and apply'));
+      expect(reconciliation, label).toContain('Draft the requested edit without writing');
+      expect(reconciliation, label).not.toContain('Apply the requested edit');
       expect(body, label).toContain('Write only after the user confirms');
       expect(body, label).toContain('If the user rejects a revision, do not write it');
       expect(body, label).toContain('recommend starting fresh with `/opsx:new`');

--- a/test/core/templates/update-change.test.ts
+++ b/test/core/templates/update-change.test.ts
@@ -76,12 +76,33 @@ describe('update-change templates', () => {
       );
       expect(body, label).toContain('Apply `context` and `rules` as constraints; do not copy them into the file');
       expect(body, label).toContain('If instructions report `skipped: true`, do not create the file');
+      expect(body, label).toContain('Read current dependency files from disk');
+      expect(body, label).toContain('if a required non-skipped dependency is missing, stop and ask the user to restore it first');
+      expect(body, label).toContain('If `instruction` delegates creation to another skill or command');
+      expect(body, label).toContain('only if it can honor the confirmed path and these guardrails; otherwise stop');
       expect(body, label).toContain(
         'inside `changeRoot` that matches `artifactPaths.<id>.outputPath`'
       );
       expect(body, label).toContain('create it only after the user confirms');
       expect(body, label).toContain('does not already exist');
       expect(body, label).toContain('after resolving any symlinked parent directories');
+    }
+  });
+
+  it('rechecks new-file scope after confirmation and refuses concurrent overwrites', () => {
+    for (const [label, body] of bodies) {
+      const confirmation = body.indexOf('create it only after the user confirms');
+      const recheck = body.indexOf('After confirmation, immediately before creation');
+      const create = body.indexOf('Use a create operation that fails if the target already exists');
+
+      expect(confirmation, label).toBeGreaterThanOrEqual(0);
+      expect(recheck, label).toBeGreaterThan(confirmation);
+      expect(create, label).toBeGreaterThan(recheck);
+      const writeGuard = body.slice(recheck, create);
+      expect(writeGuard, label).toContain('refresh status and instructions');
+      expect(writeGuard, label).toContain('still in scope, not skipped, and partially populated');
+      expect(writeGuard, label).toContain('repeat the concrete-path checks above');
+      expect(body, label).toContain('stop and reconcile with the user instead of overwriting or choosing a different path');
     }
   });
 

--- a/test/core/templates/update-change.test.ts
+++ b/test/core/templates/update-change.test.ts
@@ -55,7 +55,18 @@ describe('update-change templates', () => {
       expect(body, label).toContain('NEVER edit implementation code');
       expect(body, label).toContain('stop and point to `/opsx:apply`');
       expect(body, label).toContain('Do not advance the build frontier');
-      expect(body, label).toContain('Do NOT create artifacts that don\'t exist yet');
+      expect(body, label).toContain('never create an artifact that has no files yet');
+      expect(body, label).toContain('Do NOT create an artifact that has no files at all');
+    }
+  });
+
+  it('fills a gap under an already-satisfied glob artifact instead of deferring it (3.3a)', () => {
+    for (const [label, body] of bodies) {
+      // A glob artifact is complete once one file matches, and /opsx:continue only
+      // picks up `ready` artifacts, so deferring the missing file strands it.
+      expect(body, label).toContain('counts as done as soon as ONE file matches');
+      expect(body, label).toContain('create it here rather than deferring');
+      expect(body, label).toContain('cannot reach it');
     }
   });
 

--- a/test/core/templates/update-change.test.ts
+++ b/test/core/templates/update-change.test.ts
@@ -91,6 +91,9 @@ describe('update-change templates', () => {
   it('ends with next-step guidance and never acts on it (3.5)', () => {
     for (const [label, body] of bodies) {
       expect(body, label).toContain('guidance only - NEVER act on it');
+      expect(body, label).toContain(
+        'Artifacts with empty `existingOutputPaths` still missing -> suggest `/opsx:continue`'
+      );
       expect(body, label).toContain('suggest `/opsx:continue`');
       expect(body, label).toContain('suggest `/opsx:apply`');
       expect(body, label).toContain('suggest `/opsx:archive`');

--- a/test/core/templates/update-change.test.ts
+++ b/test/core/templates/update-change.test.ts
@@ -55,26 +55,36 @@ describe('update-change templates', () => {
       expect(body, label).toContain('NEVER edit implementation code');
       expect(body, label).toContain('stop and point to `/opsx:apply`');
       expect(body, label).toContain('Do not advance the build frontier');
-      expect(body, label).toContain('never create an artifact that has no files yet');
-      expect(body, label).toContain('Do NOT create an artifact that has no files at all');
+      expect(body, label).toContain(
+        'Leave an artifact with no existing output files for `/opsx:continue`'
+      );
+      expect(body, label).toContain(
+        'leave artifacts with empty `existingOutputPaths` for `/opsx:continue`'
+      );
     }
   });
 
   it('fills a gap under an already-satisfied glob artifact instead of deferring it (3.3a)', () => {
     for (const [label, body] of bodies) {
-      // A glob artifact is complete once one file matches, and /opsx:continue only
-      // picks up `ready` artifacts, so deferring the missing file strands it.
-      expect(body, label).toContain('counts as done as soon as ONE file matches');
-      expect(body, label).toContain('create it here rather than deferring');
-      expect(body, label).toContain('cannot reach it');
+      expect(body, label).toContain('is marked `done` after at least one file matches');
+      expect(body, label).toContain('`/opsx:continue` only handles `ready` artifacts');
+      expect(body, label).toContain('whose `existingOutputPaths` is non-empty');
+      expect(body, label).toContain(
+        'use its `instruction`, `rules`, and `template`'
+      );
+      expect(body, label).toContain(
+        'inside `changeRoot` that matches `artifactPaths.<id>.outputPath`'
+      );
+      expect(body, label).toContain('create it only after the user confirms');
     }
   });
 
   it('writes to existingOutputPaths, never to a glob resolvedOutputPath (3.4)', () => {
     for (const [label, body] of bodies) {
       expect(body, label).toContain('artifactPaths.<id>.existingOutputPaths');
-      expect(body, label).toContain('Do NOT write to `resolvedOutputPath`');
-      expect(body, label).toContain('still the glob pattern, not a real file');
+      expect(body, label).toContain('`resolvedOutputPath` is still a pattern');
+      expect(body, label).toContain('Never write to the glob `resolvedOutputPath`');
+      expect(body, label).toContain('The only new-file exception');
     }
   });
 


### PR DESCRIPTION
## Status

LGTM for final review at `373bb5fd8`. The hardening is pushed, and local validation and independent review are complete. GitHub CI and Security runs await maintainer approval for the fork; required checks and human review remain merge gates. This PR is not merged.

## What was wrong

`/opsx:update` refused to create a missing companion file under a glob artifact and redirected the user to `/opsx:continue`. Once any file matches the glob, status marks the artifact `done`, so continue never selects it again. Required planning files could become unreachable through either workflow.

## How it was fixed

- Let update propose a missing file only for a partially populated glob artifact. Empty `ready` or `blocked` artifacts still belong to continue; intentionally `skipped` artifacts stay untouched.
- Fetch the artifact's instructions and template, applying project `context` and artifact `rules` as constraints without copying them into the file.
- Require an unused concrete path matching the schema's output pattern, confined inside `changeRoot` after resolving linked parent directories. Never write to the glob pattern itself.
- Draft before writing, present each proposed revision, and create files only after confirmation. Immediately before creation, refresh status and instructions and recheck the concrete path; require creation to fail if the target already exists.
- Read current dependency files, stop new creation when a required input is missing, and invoke delegated creators only when they can honor the confirmed path and scope.
- Correct the unarchived workflow spec and user docs to describe the populated-glob exception explicitly. A labeled design correction records why the original continue handoff was unreachable.
- Regenerate the distributed skill and parity hashes. Include a patch changeset.

## Replication / proof

- The custom-schema CLI regression demonstrates empty output → `ready`, one matching output → `done`, and instructions remaining available while a required companion file is absent. Adding the companion in the fixture preserves the original file and the next-artifact state.
- The skipped-artifact regression checks empty output paths plus the explicit do-not-create warning. The custom-schema fixture also demonstrates that a populated artifact stays done after its required input is removed, while instructions report that dependency missing.
- Four strengthened template cases fail on the original PR head and pass after hardening. Both command and skill delivery are checked, including committed skill parity.
- Full suite: **145 files, 4,232 tests passed** on Node 20.19.0. Run with `USERPROFILE` pointing to an empty test directory and without inherited `ZSH`/`ZSH_CUSTOM`; use `pnpm test`.
- Build, ESLint, TypeScript checks, changeset validation, strict validation of `add-update-workflow`, and deterministic skill/hash regeneration pass.
- The additional confirmation-order and dependency/delegation assertions fail against `494dcf453` and pass after the final hardening. Two fresh independent reviewers cleared the final design and safety diff.

## Notes / nits

This changes workflow guidance, not CLI completion semantics or an automatic file writer. Tests verify the emitted guidance and the CLI contracts it uses; fixture writes do not simulate an agent following instructions.

The host's installed MiniMax skills and inherited Oh My Zsh settings caused unrelated test failures; the Cursor/profile failures also reproduced on unchanged main. Test isolation removes that host state without changing product code. The version-check tests require permission to bind a local HTTP server.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `/opsx:update` can now fill missing files within partially completed artifact patterns.
  * Skipped artifacts remain untouched and are no longer treated as missing.
  * Prevented gaps where `/opsx:continue` could not recognize eligible incomplete artifacts.

* **Improvements**
  * New files require confirmation and cannot overwrite existing files or leave the change area.
  * Improved dependency, path, and artifact-status validation.

* **Documentation**
  * Clarified when to use `/opsx:continue`, `/opsx:apply`, and `/opsx:archive`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
