### PR TITLE
fix(init): clarify Codex desktop skill usage

### DIFF
--- a/.changeset/quiet-codex-skill-hint.md
+++ b/.changeset/quiet-codex-skill-hint.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+Clarify the Codex setup hint for CLI/IDE users and Codex desktop app users.

--- a/docs/supported-tools.md
+++ b/docs/supported-tools.md
@@ -40,6 +40,10 @@ way it loads the file OpenSpec wrote. Find your tool's command path in the
 So `/opsx:propose` is `/opsx-propose` in Cursor, `@opsx-propose` in Amazon Q, and
 `$openspec-propose` in Codex.
 
+Codex CLI and the Codex IDE extension accept the `$openspec-propose` form. In the
+Codex desktop app, select `openspec-propose` from the Skills sidebar instead;
+Codex does not generate an `/opsx-*` command file.
+
 Two things vary independently, which is why the rows do not collapse:
 
 - **The name.** Rows 1–2 differ only in how the file names the command, and the

--- a/src/core/init.ts
+++ b/src/core/init.ts
@@ -1345,6 +1345,8 @@ export class InitCommand {
           // as an instruction rather than a dead command with an argument.
           hint = usesNaturalLanguageSkillReferences(tool.value)
             ? `Start your first change: ask ${tool.name} to use ${skillReference} with "your idea"`
+            : tool.value === 'codex'
+              ? `Start your first change in Codex CLI/IDE: ${skillReference} "your idea"; in Codex app, select ${skillReference.slice(1)} from the Skills sidebar`
             : `Start your first change: ${skillReference} "your idea"`;
         } else {
           continue;

--- a/test/core/init.test.ts
+++ b/test/core/init.test.ts
@@ -2064,6 +2064,8 @@ describe('InitCommand - profile and detection features', () => {
     const logCalls = (console.log as unknown as { mock: { calls: unknown[][] } }).mock.calls.flat().map(String);
     const startHint = logCalls.find((entry) => entry.includes('Start your first change'));
     expect(startHint).toContain('$openspec-propose');
+    expect(startHint).toContain('Codex CLI/IDE');
+    expect(startHint).toContain('select openspec-propose from the Skills sidebar');
     expect(startHint).not.toContain('/openspec-propose');
     expect(startHint).not.toContain('/opsx:propose');
 
@@ -2113,6 +2115,8 @@ describe('InitCommand - profile and detection features', () => {
     const codexHint = startHints.find((entry) => entry.includes('(Codex)'));
     const vibeHint = startHints.find((entry) => entry.includes('Mistral Vibe'));
     expect(codexHint).toContain('$openspec-propose');
+    expect(codexHint).toContain('Codex CLI/IDE');
+    expect(codexHint).toContain('Skills sidebar');
     expect(codexHint).not.toContain('/openspec-propose');
     expect(vibeHint).toContain('/openspec-propose');
     for (const hint of startHints) {


### PR DESCRIPTION
**Status:** Ready for review; fresh approval required.

**What was wrong:** `openspec init` gave Codex desktop users a CLI-only `$` skill hint.

**How it was fixed:** The Codex hint distinguishes CLI/IDE from desktop Skills. The docs-lab reference gives a concrete example; other tools are unchanged.

**Proof:** 397 adjacent tests, lint, and build pass locally. Hosted CI passes on Linux, macOS, and Windows.

**Notes:** Related #1379 (closed by #1471). No feature or design change.