### PR TITLE
fix(archive): preserve blank-line runs in code fences

### DIFF
--- a/.changeset/calm-fences-preserve.md
+++ b/.changeset/calm-fences-preserve.md
@@ -1,0 +1,7 @@
+---
+"@fission-ai/openspec": patch
+---
+
+### Bug Fixes
+
+- Preserve internal literal blank-line runs in backtick and tilde fenced code blocks when applying unrelated spec changes.

--- a/.changeset/calm-fences-preserve.md
+++ b/.changeset/calm-fences-preserve.md
@@ -4,4 +4,4 @@
 
 ### Bug Fixes
 
-- Preserve internal literal blank-line runs in backtick and tilde fenced code blocks when applying unrelated spec changes.
+- Preserve internal literal blank-line runs in backtick- and tilde-fenced code blocks when applying unrelated spec changes.

--- a/src/core/specs-apply.ts
+++ b/src/core/specs-apply.ts
@@ -561,11 +561,11 @@ export async function buildUpdatedSpec(
   // glued the heading to the Purpose paragraph and the first requirement, so
   // every archive rewrote a well-formatted spec into that shape. Separate
   // non-empty slices with one blank line instead.
-  const rebuilt = [parts.before.trimEnd(), parts.headerLine, reqBody, parts.after.trim()]
-    .filter((s) => s !== '')
-    .join('\n\n')
-    .replace(/\n{3,}/g, '\n\n')
-    .trimEnd() + '\n';
+  const rebuilt = collapseExcessiveBlankLinesOutsideFences(
+    [parts.before.trimEnd(), parts.headerLine, reqBody, parts.after.trim()]
+      .filter((s) => s !== '')
+      .join('\n\n')
+  ).trimEnd() + '\n';
 
   return {
     rebuilt,
@@ -584,6 +584,32 @@ export async function buildUpdatedSpec(
     // requirements and miss the identical heading written after them.
     unaccountedContent: contentTheMergeCannotName(parts),
   };
+}
+
+/**
+ * Match the serializer's established blank-line collapse outside code fences
+ * while preserving runs of literal empty lines inside recognized fences.
+ */
+function collapseExcessiveBlankLinesOutsideFences(content: string): string {
+  const lines = content.split('\n');
+  const fenceMask = buildCodeFenceMask(lines);
+  const output = [lines[0] ?? ''];
+  let consecutiveOutsideNewlines = 0;
+
+  for (let index = 1; index < lines.length; index++) {
+    const insideFence = fenceMask[index - 1] && fenceMask[index];
+    if (insideFence || consecutiveOutsideNewlines < 2) {
+      output.push('\n');
+    }
+
+    consecutiveOutsideNewlines = insideFence ? 0 : consecutiveOutsideNewlines + 1;
+    output.push(lines[index]);
+    if (lines[index] !== '') {
+      consecutiveOutsideNewlines = 0;
+    }
+  }
+
+  return output.join('');
 }
 
 /**

--- a/test/core/specs-apply.serialization.test.ts
+++ b/test/core/specs-apply.serialization.test.ts
@@ -129,4 +129,56 @@ describe('spec serialization', () => {
       'serializer output.\n\n## Requirements\n\n### Requirement: Existing behavior'
     );
   });
+
+  it('preserves internal blank-line runs in untouched fences while collapsing prose', async () => {
+    const fencedSpec = [
+      '# demo Specification',
+      '',
+      '## Purpose',
+      'Purpose prose before.',
+      '',
+      '',
+      '',
+      'Purpose prose after.',
+      '',
+      '```text',
+      'purpose fence before',
+      '',
+      '',
+      'purpose fence after',
+      '```',
+      '',
+      '## Requirements',
+      ORIGINAL_REQUIREMENT,
+      '',
+      '### Requirement: Untouched fenced example',
+      'The project SHALL preserve fenced examples.',
+      '',
+      '~~~text',
+      'requirement fence before',
+      '',
+      '',
+      'requirement fence after',
+      '~~~',
+      '',
+      '#### Scenario: Untouched path',
+      '- **WHEN** an unrelated requirement is updated',
+      '- **THEN** the fenced example SHALL keep its internal blank lines',
+      '',
+    ].join('\n');
+
+    const result = await build(fencedSpec);
+
+    expect(result.counts.modified).toBe(1);
+    expect(result.rebuilt).toContain('The project SHALL expose the updated behavior.');
+    expect(result.rebuilt).toContain(
+      '```text\npurpose fence before\n\n\npurpose fence after\n```'
+    );
+    expect(result.rebuilt).toContain(
+      '~~~text\nrequirement fence before\n\n\nrequirement fence after\n~~~'
+    );
+    expect(result.rebuilt).toContain('Purpose prose before.\n\nPurpose prose after.');
+    expect(result.rebuilt).not.toContain('Purpose prose before.\n\n\nPurpose prose after.');
+    expectOneFinalLf(result.rebuilt);
+  });
 });

--- a/test/core/specs-apply.serialization.test.ts
+++ b/test/core/specs-apply.serialization.test.ts
@@ -154,6 +154,7 @@ describe('spec serialization', () => {
       '### Requirement: Untouched fenced example',
       'The project SHALL preserve fenced examples.',
       '',
+      '',
       '~~~text',
       'requirement fence before',
       '',
@@ -161,9 +162,16 @@ describe('spec serialization', () => {
       'requirement fence after',
       '~~~',
       '',
+      '',
       '#### Scenario: Untouched path',
       '- **WHEN** an unrelated requirement is updated',
       '- **THEN** the fenced example SHALL keep its internal blank lines',
+      '',
+      'Whitespace-only prose boundary.',
+      '   ',
+      '',
+      '',
+      'Whitespace-only prose after.',
       '',
     ].join('\n');
 
@@ -177,8 +185,13 @@ describe('spec serialization', () => {
     expect(result.rebuilt).toContain(
       '~~~text\nrequirement fence before\n\n\nrequirement fence after\n~~~'
     );
+    expect(result.rebuilt).toContain('fenced examples.\n\n~~~text');
+    expect(result.rebuilt).toContain('~~~\n\n#### Scenario: Untouched path');
     expect(result.rebuilt).toContain('Purpose prose before.\n\nPurpose prose after.');
     expect(result.rebuilt).not.toContain('Purpose prose before.\n\n\nPurpose prose after.');
+    expect(result.rebuilt).toContain(
+      'Whitespace-only prose boundary.\n   \n\nWhitespace-only prose after.'
+    );
     expectOneFinalLf(result.rebuilt);
   });
 });


### PR DESCRIPTION
## Summary

- Preserve internal literal blank-line runs inside backtick and tilde fences recognized by `buildCodeFenceMask`.
- Keep existing behavior for prose blank-line collapse, `## Requirements` boundaries, whitespace-only lines, and exactly one final LF.
- Add apply-path regression coverage for untouched fences in both Purpose and Requirements, plus a patch changeset.

This is not general byte preservation and does not change CRLF/BOM handling or malformed-Markdown policy.

Fixes #1711

## Testing

- Baseline red: the new regression failed because both fenced `\n\n\n` runs collapsed to `\n\n`.
- Focused serialization tests: 8 passed.
- Archive/specs-apply matrix: 218 passed, 30 skipped.
- Full suite: 4,163 passed, 67 skipped.
- Lint, build, type-checking, changeset validation, and `git diff --check`: passed.

## Risk

Low. Fence recognition remains delegated to the existing shared helper. There are no configuration, dependency, schema, or migration changes.

Codex model gpt-5.6-sol with max reasoning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved intentional blank lines inside untouched fenced code blocks when applying specification changes.
  - Supports both backtick- and tilde-fenced code blocks.
  - Continues collapsing excessive blank lines in surrounding prose for cleaner formatting.
  - Ensures rebuilt specifications maintain consistent final-line formatting.

- **Tests**
  - Added coverage verifying blank-line preservation and normalization across fenced code blocks and surrounding text.
  - Validated behavior for multiple fence types and consistent trailing line endings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->