### PR TITLE
docs(archive): document capability retirement workflow

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -664,6 +664,25 @@ openspec archive add-dark-mode --yes
 openspec archive update-ci-config --skip-specs
 ```
 
+**Retire a capability:** Add the retirement marker to the change metadata:
+
+```yaml
+# openspec/changes/retire-legacy/.openspec.yaml
+schema: spec-driven
+retire_capabilities: true
+```
+
+Then archive the change normally:
+
+```bash
+openspec archive retire-legacy --yes
+```
+
+When the change removes the capability's last requirement, OpenSpec deletes its
+live `spec.md`. Other capability deltas in the same change still update their
+main specs. Without the marker, archive stops before changing any files and
+tells you to add it.
+
 **What it does:**
 
 1. Validates the change (unless `--no-validate`)


### PR DESCRIPTION
## Status

LGTM. This is ready for review.

## What was missing

OpenSpec has supported first-class capability retirement since v1.8.0, but the `archive` command examples did not show how to use it. That made the released solution to #1750 easy to miss, especially for users coming from v1.7.0.

## What it does

- Adds a copy-paste `.openspec.yaml` example with `retire_capabilities: true`.
- Shows the normal non-interactive archive command.
- States that mixed changes still apply their other capability deltas.
- States that an absent marker aborts before any files change.

## Proof it works

- `test/core/archive.test.ts`: 215/215 passing.
- Focused mixed-change regression: 1/1 passing (`applies a retirement and an ordinary update in the same archive`).
- Build completed during dependency installation.
- `git diff --check` passes.

## Notes / nits

- No runtime behavior changes. PR #1484 implemented and shipped the underlying retirement path in v1.8.0.
- The full suite reached 4,209 passing tests, but the local sandbox prevented 16 loopback-listener tests from starting and exposed 4 machine-profile-sensitive failures outside this docs-only diff. The focused and complete archive suites are green.
- No changeset: this is a documentation-only clarification.

Closes #1750


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Documented how to retire a capability when archiving a change.
  - Explained the required retirement setting and how capability specifications are updated or removed.
  - Clarified that archiving stops without the setting when retirement would affect files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->