### PR TITLE
chore: require docs-lab owner review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,5 @@
 # Default code ownership
 * @Fission-AI/openspec-maintainers
+
+# docs-lab requires final review from the docs owner
+/docs-lab/ @TabishB


### PR DESCRIPTION
## Summary

- make `@TabishB` the code owner for every file under `docs-lab/`
- keep the maintainer team as the default owner for the rest of the repository

## Why

Every docs-lab change needs final review from the docs owner. The more specific CODEOWNERS rule takes precedence over the repository default and routes those review requests directly to Tabish.

## Verification

- checked the CODEOWNERS pattern and diff
- `git diff --check`

## Follow-up

CODEOWNERS routes review requests but does not enforce approval on its own. The `main` branch currently exposes no branch protection or ruleset requiring code-owner approval, so a repository ruleset is still needed if this must be merge-blocking.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added designated ownership and final review guidance for the documentation lab directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->