### PR TITLE
fix: use flat canonical workflow invocations

### DIFF
--- a/src/core/command-generation/generator.ts
+++ b/src/core/command-generation/generator.ts
@@ -5,13 +5,13 @@
  */
 
 import type { CommandContent, ToolCommandAdapter, GeneratedCommand } from './types.js';
-import { getInvocationForAdapter, needsInvocationRewrite } from './invocation.js';
+import { getInvocationForAdapter } from './invocation.js';
 import { transformCommandInvocations } from '../../utils/command-references.js';
 
 /**
  * Generate a single command file using the provided adapter.
  *
- * Command bodies are authored with `/opsx:<id>` references. Tools whose command
+ * Command bodies are authored with `/opsx-<id>` references. Tools whose command
  * files are invoked by filename register `/opsx-<id>` instead, and Amazon Q
  * surfaces them in its prompt library as `@opsx-<id>`, so the body is rewritten
  * to the form that tool answers to before the adapter formats it. Doing it here
@@ -27,9 +27,7 @@ export function generateCommand(
   adapter: ToolCommandAdapter
 ): GeneratedCommand {
   const invocation = getInvocationForAdapter(adapter);
-  const formatted = needsInvocationRewrite(invocation)
-    ? { ...content, body: transformCommandInvocations(content.body, invocation) }
-    : content;
+  const formatted = { ...content, body: transformCommandInvocations(content.body, invocation) };
 
   return {
     path: adapter.getFilePath(content.id),

--- a/src/core/command-generation/invocation.ts
+++ b/src/core/command-generation/invocation.ts
@@ -38,7 +38,7 @@ export interface CommandInvocation {
 }
 
 /** The form these docs, command bodies, and skill templates are authored in. */
-export const CANONICAL_INVOCATION: CommandInvocation = { style: 'namespaced', prefix: '/' };
+export const CANONICAL_INVOCATION: CommandInvocation = { style: 'flat', prefix: '/' };
 
 /**
  * Classifies a generated command file by the name the tool will answer to.
@@ -88,7 +88,7 @@ export function formatCommandInvocation(
 }
 
 /**
- * Whether a tool's invocation differs from the canonical `/opsx:<id>` that
+ * Whether a tool's invocation differs from the canonical `/opsx-<id>` that
  * command bodies and skill templates are authored in — that is, whether
  * generated text has to be rewritten for that tool at all.
  */

--- a/src/core/templates/workflows/apply-change.ts
+++ b/src/core/templates/workflows/apply-change.ts
@@ -11,7 +11,7 @@ import { STORE_SELECTION_GUIDANCE } from './store-selection.js';
  * The apply workflow instructions, authored once and rendered by both the
  * skill and command surfaces. The surfaces are intentionally distinct, but
  * they differ only in how they are invoked — the generation transformers
- * rewrite the canonical `/opsx:<id>` tokens per surface downstream (see
+ * rewrite the canonical `/opsx-<id>` tokens per surface downstream (see
  * command-references.ts). The instruction text itself is shared, so the two
  * cannot silently drift. Should a surface ever need genuinely different
  * wording, add a parameter here and pass it from that surface's template.
@@ -21,7 +21,7 @@ export function getApplyInstructions(): string {
 
 ${STORE_SELECTION_GUIDANCE}
 
-**Input**: Optionally specify a change name (e.g., \`/opsx:apply add-auth\`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+**Input**: Optionally specify a change name (e.g., \`/opsx-apply add-auth\`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
 
 **Steps**
 
@@ -32,7 +32,7 @@ ${STORE_SELECTION_GUIDANCE}
    - Auto-select if only one active change exists
    - If ambiguous, run \`openspec list --json\` to get available changes and ask the user to select one
 
-   Always announce: "Using change: <name>" and how to override (e.g., \`/opsx:apply <other>\`).
+   Always announce: "Using change: <name>" and how to override (e.g., \`/opsx-apply <other>\`).
 
 2. **Check status to understand the schema**
    \`\`\`bash
@@ -58,7 +58,7 @@ ${STORE_SELECTION_GUIDANCE}
    - Optional \`operationGuidance\`: current advisory guidance for apply
 
    **Handle states:**
-   - If \`state: "blocked"\` (missing artifacts): show message, suggest using \`/opsx:continue\` (if it is not installed, run \`openspec status --change "<name>" --json\` to see the next artifact and \`openspec instructions <artifact-id> --change "<name>" --json\` for how to create it)
+   - If \`state: "blocked"\` (missing artifacts): show message, suggest using \`/opsx-continue\` (if it is not installed, run \`openspec status --change "<name>" --json\` to see the next artifact and \`openspec instructions <artifact-id> --change "<name>" --json\` for how to create it)
    - If \`state: "all_done"\`: congratulate, suggest archive
    - Otherwise: proceed to implementation
 
@@ -147,7 +147,7 @@ Working on task 4/7: <task description>
 - [x] Task 2
 ...
 
-All tasks complete! You can archive this change with \`/opsx:archive\`.
+All tasks complete! You can archive this change with \`/opsx-archive\`.
 \`\`\`
 
 **Output On Pause (Issue Encountered)**

--- a/src/core/templates/workflows/archive-change.ts
+++ b/src/core/templates/workflows/archive-change.ts
@@ -31,7 +31,7 @@ ${STORE_SELECTION_GUIDANCE}
    When prompting, show only active changes (not already archived).
    Include the schema used for each change if available.
 
-   Always announce: "Using change: <name>" and how to override (e.g., \`/opsx:archive <other>\`).
+   Always announce: "Using change: <name>" and how to override (e.g., \`/opsx-archive <other>\`).
 
    **Load current archive inputs before the existing archive checks:**
 
@@ -199,7 +199,7 @@ ${STORE_SELECTION_GUIDANCE}
 
 \`<capability-path>\` is the spec directory relative to \`specs/\` (for example, \`user-auth\` or \`identity/user-auth\`). Preserve the full path from each delta spec when resolving its main spec.
 
-**Input**: Optionally specify a change name after \`/opsx:archive\` (e.g., \`/opsx:archive add-auth\`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+**Input**: Optionally specify a change name after \`/opsx-archive\` (e.g., \`/opsx-archive add-auth\`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
 
 **Steps**
 
@@ -213,7 +213,7 @@ ${STORE_SELECTION_GUIDANCE}
    When prompting, show only active changes (not already archived).
    Include the schema used for each change if available.
 
-   Always announce: "Using change: <name>" and how to override (e.g., \`/opsx:archive <other>\`).
+   Always announce: "Using change: <name>" and how to override (e.g., \`/opsx-archive <other>\`).
 
    **Load current archive inputs before the existing archive checks:**
 
@@ -300,7 +300,7 @@ ${STORE_SELECTION_GUIDANCE}
    form of main specs produced by this merge; do not use them as archive guidance,
    change CLI behavior, or copy the rule text into any output file.
 
-   Then run the \`/opsx:sync\` workflow inline (agent-driven intelligent merge) for change '<name>', passing the delta spec analysis and the fetched specs-rule snapshot from above, and wait for it to finish. The inline sync must reuse that snapshot without fetching \`specs\` instructions again. Do not delegate it to a background task — step 5 would move \`changeRoot\` out from under a sync that is still reading it, leaving the change archived and the main specs never updated. If your agent can only run it by delegation, delegate synchronously and wait for the result.
+   Then run the \`/opsx-sync\` workflow inline (agent-driven intelligent merge) for change '<name>', passing the delta spec analysis and the fetched specs-rule snapshot from above, and wait for it to finish. The inline sync must reuse that snapshot without fetching \`specs\` instructions again. Do not delegate it to a background task — step 5 would move \`changeRoot\` out from under a sync that is still reading it, leaving the change archived and the main specs never updated. If your agent can only run it by delegation, delegate synchronously and wait for the result.
 
    Then re-run the comparison from the top of this step against every capability that has a delta spec in \`artifactPaths.specs.existingOutputPaths\` — not only the ones the sync reports it touched. A successful sync leaves nothing left to apply, so each capability must now read as already synced:
    - ADDED requirements present
@@ -402,7 +402,7 @@ Target archive directory already exists.
 - Don't block archive on warnings - just inform and confirm
 - Preserve .openspec.yaml when moving to archive (it moves with the directory)
 - Show clear summary of what happened
-- If sync is requested, run the \`/opsx:sync\` workflow inline (agent-driven)
+- If sync is requested, run the \`/opsx-sync\` workflow inline (agent-driven)
 - Never archive while a spec sync is still in flight — run the sync inline and verify the main specs before moving \`changeRoot\`
 - If delta specs exist, always run the sync assessment and show the combined summary before prompting
 - Apply relevant runtime context and report conflicts; operation guidance remains advisory

--- a/src/core/templates/workflows/bulk-archive-change.ts
+++ b/src/core/templates/workflows/bulk-archive-change.ts
@@ -519,7 +519,7 @@ ${STORE_SELECTION_GUIDANCE}
    Process changes in the determined order (respecting conflict resolution):
 
    a. **Sync included delta specs**:
-      - Run the \`/opsx:sync\` workflow inline (agent-driven intelligent merge) only for changes with entries in \`includedDeltas\`, passing only the included delta paths and explicitly instructing it to ignore that change's \`excludedDeltas\`. Wait for it to finish.
+      - Run the \`/opsx-sync\` workflow inline (agent-driven intelligent merge) only for changes with entries in \`includedDeltas\`, passing only the included delta paths and explicitly instructing it to ignore that change's \`excludedDeltas\`. Wait for it to finish.
       - For conflicts, apply in resolved order.
       - Pass that change's fetched specs-rule snapshot into inline sync; inline
         sync must reuse it without fetching instructions again
@@ -664,7 +664,7 @@ No active changes found. Create a new change to get started.
 - Preserve .openspec.yaml when moving to archive
 - Archive directory target uses current date: YYYY-MM-DD-<name>; a name that already starts with a \`YYYY-MM-DD-\` prefix is used as-is (never stack a second date)
 - If archive target exists, fail that change but continue with others
-- If sync is requested, run the \`/opsx:sync\` workflow inline (agent-driven) for each change with included delta specs
+- If sync is requested, run the \`/opsx-sync\` workflow inline (agent-driven) for each change with included delta specs
 - Carry the per-delta \`includedDeltas\` and \`excludedDeltas\` decisions into execution; sync and verify only included deltas
 - Report every excluded delta as \`sync skipped\` without treating the archive itself as skipped
 - Never archive a change while a spec sync is still in flight — run the sync inline and verify main specs at \`<planningHome.root>/openspec/specs/<capability-path>/spec.md\` before moving \`changeRoot\`

--- a/src/core/templates/workflows/continue-change.ts
+++ b/src/core/templates/workflows/continue-change.ts
@@ -34,7 +34,7 @@ ${STORE_SELECTION_GUIDANCE}
 
    Mark the most recently modified change as "(Recommended)" since it's likely what the user wants to continue.
 
-   Always announce: "Using change: <name>" and how to override (e.g., \`/opsx:continue <other>\`).
+   Always announce: "Using change: <name>" and how to override (e.g., \`/opsx-continue <other>\`).
 
 2. **Check current status**
    \`\`\`bash
@@ -133,7 +133,7 @@ export function getOpsxContinueCommandTemplate(): CommandTemplate {
 
 ${STORE_SELECTION_GUIDANCE}
 
-**Input**: Optionally specify a change name after \`/opsx:continue\` (e.g., \`/opsx:continue add-auth\`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+**Input**: Optionally specify a change name after \`/opsx-continue\` (e.g., \`/opsx-continue add-auth\`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
 
 **Steps**
 
@@ -152,7 +152,7 @@ ${STORE_SELECTION_GUIDANCE}
 
    Mark the most recently modified change as "(Recommended)" since it's likely what the user wants to continue.
 
-   Always announce: "Using change: <name>" and how to override (e.g., \`/opsx:continue <other>\`).
+   Always announce: "Using change: <name>" and how to override (e.g., \`/opsx-continue <other>\`).
 
 2. **Check current status**
    \`\`\`bash
@@ -171,7 +171,7 @@ ${STORE_SELECTION_GUIDANCE}
    **If all planning artifacts are complete (\`isPlanningComplete: true\`, or legacy \`isComplete: true\`)**:
    - Congratulate the user
    - Show final status including the schema used
-   - Suggest: "Planning is complete! You can now implement this change with \`/opsx:apply\`. Once implementation and any tracked work are complete, archive it with \`/opsx:archive\`."
+   - Suggest: "Planning is complete! You can now implement this change with \`/opsx-apply\`. Once implementation and any tracked work are complete, archive it with \`/opsx-archive\`."
    - STOP
 
    ---
@@ -217,7 +217,7 @@ After each invocation, show:
 - Schema workflow being used
 - Current progress (N/M complete)
 - What artifacts are now unlocked
-- Prompt: "Run \`/opsx:continue\` to create the next artifact"
+- Prompt: "Run \`/opsx-continue\` to create the next artifact"
 
 **Artifact Creation Guidelines**
 

--- a/src/core/templates/workflows/explore.ts
+++ b/src/core/templates/workflows/explore.ts
@@ -250,7 +250,7 @@ You: [reads codebase]
 
 **User is stuck mid-implementation:**
 \`\`\`
-User: /opsx:explore add-auth-system
+User: /opsx-explore add-auth-system
       The OAuth integration is more complex than expected
 
 You: [reads change artifacts]
@@ -356,7 +356,7 @@ export function getOpsxExploreCommandTemplate(): CommandTemplate {
 
 ${STORE_SELECTION_GUIDANCE}
 
-**Input**: The argument after \`/opsx:explore\` is whatever the user wants to think about. Could be:
+**Input**: The argument after \`/opsx-explore\` is whatever the user wants to think about. Could be:
 - A vague idea: "real-time collaboration"
 - A specific problem: "the auth system is getting unwieldy"
 - A change name: "add-dark-mode" (to explore in context of that change)

--- a/src/core/templates/workflows/ff-change.ts
+++ b/src/core/templates/workflows/ff-change.ts
@@ -97,7 +97,7 @@ After completing all artifacts, summarize:
 - Change name and location
 - List of artifacts created with brief descriptions, plus any conditional artifact you skipped and why
 - What's ready: "All artifacts needed for implementation are ready."
-- Prompt: "Run \`/opsx:apply\` or ask me to implement to start working on the tasks."
+- Prompt: "Run \`/opsx-apply\` or ask me to implement to start working on the tasks."
 
 **Artifact Creation Guidelines**
 
@@ -132,7 +132,7 @@ export function getOpsxFfCommandTemplate(): CommandTemplate {
 
 ${STORE_SELECTION_GUIDANCE}
 
-**Input**: The argument after \`/opsx:ff\` is the change name (kebab-case), OR a description of what the user wants to build.
+**Input**: The argument after \`/opsx-ff\` is the change name (kebab-case), OR a description of what the user wants to build.
 
 **Steps**
 
@@ -214,7 +214,7 @@ After completing all artifacts, summarize:
 - Change name and location
 - List of artifacts created with brief descriptions, plus any conditional artifact you skipped and why
 - What's ready: "All artifacts needed for implementation are ready."
-- Prompt: "Run \`/opsx:apply\` to start implementing."
+- Prompt: "Run \`/opsx-apply\` to start implementing."
 
 **Artifact Creation Guidelines**
 

--- a/src/core/templates/workflows/new-change.ts
+++ b/src/core/templates/workflows/new-change.ts
@@ -92,7 +92,7 @@ export function getOpsxNewCommandTemplate(): CommandTemplate {
 
 ${STORE_SELECTION_GUIDANCE}
 
-**Input**: The argument after \`/opsx:new\` is the change name (kebab-case), OR a description of what the user wants to build.
+**Input**: The argument after \`/opsx-new\` is the change name (kebab-case), OR a description of what the user wants to build.
 
 **Steps**
 
@@ -144,13 +144,13 @@ After completing the steps, summarize:
 - Schema/workflow being used and its artifact sequence
 - Current status (0/N artifacts complete)
 - The template for the first artifact
-- Prompt: "Ready to create the first artifact? Run \`/opsx:continue\` or just describe what this change is about and I'll draft it."
+- Prompt: "Ready to create the first artifact? Run \`/opsx-continue\` or just describe what this change is about and I'll draft it."
 
 **Guardrails**
 - Do NOT create any artifacts yet - just show the instructions
 - Do NOT advance beyond showing the first artifact template
 - If the name is invalid (not kebab-case), ask for a valid name
-- If a change with that name already exists, suggest using \`/opsx:continue\` instead
+- If a change with that name already exists, suggest using \`/opsx-continue\` instead
 - Pass --schema if using a non-default workflow`
   };
 }

--- a/src/core/templates/workflows/onboard.ts
+++ b/src/core/templates/workflows/onboard.ts
@@ -37,7 +37,7 @@ openspec --version 2>&1 || echo "CLI_NOT_INSTALLED"
 \`\`\`
 
 **If CLI not installed:**
-> OpenSpec CLI is not installed. Install it first, then come back to \`/opsx:onboard\`.
+> OpenSpec CLI is not installed. Install it first, then come back to \`/opsx-onboard\`.
 
 Stop here if not installed.
 
@@ -164,7 +164,7 @@ Spend 1-2 minutes investigating the relevant code:
 │   [Optional: ASCII diagram if helpful]  │
 └─────────────────────────────────────────┘
 
-Explore mode (\`/opsx:explore\`) is for this kind of thinking—investigating before implementing. You can use it anytime you need to think through a problem.
+Explore mode (\`/opsx-explore\`) is for this kind of thinking—investigating before implementing. You can use it anytime you need to think through a problem.
 
 Now let's create a change to hold our work.
 \`\`\`
@@ -486,25 +486,25 @@ This same rhythm works for any size change—a small fix or a major feature.
 
  | Command           | What it does                               |
  |-------------------|--------------------------------------------|
- | \`/opsx:propose\` | Create a change and generate all artifacts |
- | \`/opsx:explore\` | Think through problems before/during work  |
- | \`/opsx:apply\`   | Implement tasks from a change              |
- | \`/opsx:archive\` | Archive a completed change                 |
+ | \`/opsx-propose\` | Create a change and generate all artifacts |
+ | \`/opsx-explore\` | Think through problems before/during work  |
+ | \`/opsx-apply\`   | Implement tasks from a change              |
+ | \`/opsx-archive\` | Archive a completed change                 |
 
 **Additional commands** (only if installed - availability depends on your profile):
 
  | Command            | What it does                                             |
  |--------------------|----------------------------------------------------------|
- | \`/opsx:new\`      | Start a new change, step through artifacts one at a time |
- | \`/opsx:continue\` | Continue working on an existing change                   |
- | \`/opsx:ff\`       | Fast-forward: create all artifacts at once               |
- | \`/opsx:verify\`   | Verify implementation matches artifacts                  |
+ | \`/opsx-new\`      | Start a new change, step through artifacts one at a time |
+ | \`/opsx-continue\` | Continue working on an existing change                   |
+ | \`/opsx-ff\`       | Fast-forward: create all artifacts at once               |
+ | \`/opsx-verify\`   | Verify implementation matches artifacts                  |
 
 ---
 
 ## What's Next?
 
-Try \`/opsx:propose\` on something you actually want to build. You've got the rhythm now!
+Try \`/opsx-propose\` on something you actually want to build. You've got the rhythm now!
 \`\`\`
 
 ---
@@ -519,8 +519,8 @@ If the user says they need to stop, want to pause, or seem disengaged:
 No problem! Your change is saved at the \`changeRoot\` reported by \`openspec status --change "<name>" --json\`.
 
 To pick up where we left off later:
-- \`/opsx:continue <name>\` - Resume artifact creation (if installed; otherwise \`openspec status --change "<name>" --json\` shows the next artifact)
-- \`/opsx:apply <name>\` - Jump to implementation (if tasks exist)
+- \`/opsx-continue <name>\` - Resume artifact creation (if installed; otherwise \`openspec status --change "<name>" --json\` shows the next artifact)
+- \`/opsx-apply <name>\` - Jump to implementation (if tasks exist)
 
 The work won't be lost. Come back whenever you're ready.
 \`\`\`
@@ -538,21 +538,21 @@ If the user says they just want to see the commands or skip the tutorial:
 
  | Command                  | What it does                               |
  |--------------------------|--------------------------------------------|
- | \`/opsx:propose <name>\` | Create a change and generate all artifacts |
- | \`/opsx:explore\`        | Think through problems (no code changes)   |
- | \`/opsx:apply <name>\`   | Implement tasks                            |
- | \`/opsx:archive <name>\` | Archive when done                          |
+ | \`/opsx-propose <name>\` | Create a change and generate all artifacts |
+ | \`/opsx-explore\`        | Think through problems (no code changes)   |
+ | \`/opsx-apply <name>\`   | Implement tasks                            |
+ | \`/opsx-archive <name>\` | Archive when done                          |
 
 **Additional commands** (only if installed - availability depends on your profile):
 
  | Command                   | What it does                        |
  |---------------------------|-------------------------------------|
- | \`/opsx:new <name>\`      | Start a new change, step by step    |
- | \`/opsx:continue <name>\` | Continue an existing change         |
- | \`/opsx:ff <name>\`       | Fast-forward: all artifacts at once |
- | \`/opsx:verify <name>\`   | Verify implementation               |
+ | \`/opsx-new <name>\`      | Start a new change, step by step    |
+ | \`/opsx-continue <name>\` | Continue an existing change         |
+ | \`/opsx-ff <name>\`       | Fast-forward: all artifacts at once |
+ | \`/opsx-verify <name>\`   | Verify implementation               |
 
-Try \`/opsx:propose\` to start your first change.
+Try \`/opsx-propose\` to start your first change.
 \`\`\`
 
 Exit gracefully.

--- a/src/core/templates/workflows/propose.ts
+++ b/src/core/templates/workflows/propose.ts
@@ -132,7 +132,7 @@ After completing all artifacts, summarize:
 - Change name and location
 - List of artifacts created with brief descriptions, plus any conditional artifact you skipped and why
 - What's ready: "All artifacts needed for implementation are ready."
-- Prompt: "The artifacts are ready for review. When you are ready, run \`/opsx:apply\` or ask me to apply this change."
+- Prompt: "The artifacts are ready for review. When you are ready, run \`/opsx-apply\` or ask me to apply this change."
 
 **Artifact Creation Guidelines**
 
@@ -182,7 +182,7 @@ When the user is ready to implement, they must start the apply workflow explicit
 
 ${STORE_SELECTION_GUIDANCE}
 
-**Input**: The argument after \`/opsx:propose\` is the change name (kebab-case), OR a description of what the user wants to build.
+**Input**: The argument after \`/opsx-propose\` is the change name (kebab-case), OR a description of what the user wants to build.
 
 **Steps**
 
@@ -285,7 +285,7 @@ After completing all artifacts, summarize:
 - Change name and location
 - List of artifacts created with brief descriptions, plus any conditional artifact you skipped and why
 - What's ready: "All artifacts needed for implementation are ready."
-- Prompt: "The artifacts are ready for review. When you are ready, run \`/opsx:apply\`."
+- Prompt: "The artifacts are ready for review. When you are ready, run \`/opsx-apply\`."
 
 **Artifact Creation Guidelines**
 

--- a/src/core/templates/workflows/sync-specs.ts
+++ b/src/core/templates/workflows/sync-specs.ts
@@ -32,7 +32,7 @@ ${STORE_SELECTION_GUIDANCE}
 
    When prompting, show changes that have delta specs (under \`specs/\` directory).
 
-   Always announce: "Using change: <name>" and how to override (e.g., \`/opsx:sync <other>\`).
+   Always announce: "Using change: <name>" and how to override (e.g., \`/opsx-sync <other>\`).
 
 2. **Resolve change context**
 
@@ -281,7 +281,7 @@ ${STORE_SELECTION_GUIDANCE}
 
 \`<capability-path>\` is the spec directory relative to \`specs/\` (for example, \`user-auth\` or \`identity/user-auth\`). Preserve the full path from each delta spec when resolving its main spec.
 
-**Input**: Optionally specify a change name after \`/opsx:sync\` (e.g., \`/opsx:sync add-auth\`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+**Input**: Optionally specify a change name after \`/opsx-sync\` (e.g., \`/opsx-sync add-auth\`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
 
 **Steps**
 
@@ -294,7 +294,7 @@ ${STORE_SELECTION_GUIDANCE}
 
    When prompting, show changes that have delta specs (under \`specs/\` directory).
 
-   Always announce: "Using change: <name>" and how to override (e.g., \`/opsx:sync <other>\`).
+   Always announce: "Using change: <name>" and how to override (e.g., \`/opsx-sync <other>\`).
 
 2. **Resolve change context**
 

--- a/src/core/templates/workflows/update-change.ts
+++ b/src/core/templates/workflows/update-change.ts
@@ -17,7 +17,7 @@ ${STORE_SELECTION_GUIDANCE}
 
 **Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
 
-\`/opsx:continue\` is an optional workflow and may not be installed. Before suggesting it anywhere below, verify that it is available. If it is unavailable, \`openspec status --change "<name>" --json\` shows the next artifact and \`openspec instructions "<artifact-id>" --change "<name>" --json\` explains how to create it.
+\`/opsx-continue\` is an optional workflow and may not be installed. Before suggesting it anywhere below, verify that it is available. If it is unavailable, \`openspec status --change "<name>" --json\` shows the next artifact and \`openspec instructions "<artifact-id>" --change "<name>" --json\` explains how to create it.
 
 **Steps**
 
@@ -36,7 +36,7 @@ ${STORE_SELECTION_GUIDANCE}
 
    Mark the most recently modified change as "(Recommended)" since it's likely what the user wants to update.
 
-   Always announce: "Using change: <name>" and how to override (e.g., \`/opsx:update <other>\`).
+   Always announce: "Using change: <name>" and how to override (e.g., \`/opsx-update <other>\`).
 
 2. **Get the change's artifacts**
    \`\`\`bash
@@ -60,7 +60,7 @@ ${STORE_SELECTION_GUIDANCE}
    - Read the artifact(s) the request touches and the change's other existing artifacts.
    - Apply the requested edit. Then check every other existing artifact against it - in ANY direction: an edit to a later artifact may require revising an earlier one, not only the other way around. Build order is a useful reading order, not a constraint on which artifacts may be revised.
    - Note everything that is now inconsistent, missing, or contradictory.
-   - Revise only files that already exist (\`existingOutputPaths\`). Do NOT create artifacts that don't exist yet, and do NOT invent new files under a glob artifact - note them and point the user to \`/opsx:continue\` to create them.
+   - Revise only files that already exist (\`existingOutputPaths\`). Do NOT create artifacts that don't exist yet, and do NOT invent new files under a glob artifact - note them and point the user to \`/opsx-continue\` to create them.
    - If the change is already coherent, say so and make no edits.
 
 5. **Confirm and apply, one artifact at a time**
@@ -72,24 +72,24 @@ ${STORE_SELECTION_GUIDANCE}
      \`\`\`
 
 6. **Point to the next step (guidance only - NEVER act on it)**
-   - Artifacts still missing -> suggest \`/opsx:continue\` to create them.
-   - Change already implemented (tasks checked off / already applied) -> the code may no longer match the revised plan; suggest \`/opsx:apply\` to carry the delta into code.
-   - Everything done and implemented -> suggest \`/opsx:archive\`.
+   - Artifacts still missing -> suggest \`/opsx-continue\` to create them.
+   - Change already implemented (tasks checked off / already applied) -> the code may no longer match the revised plan; suggest \`/opsx-apply\` to carry the delta into code.
+   - Everything done and implemented -> suggest \`/opsx-archive\`.
 
 **Output**
 
 After each invocation, show:
 - Which artifacts were revised (and which proposed revisions were rejected)
-- Anything deferred to \`/opsx:continue\` (not-yet-created artifacts or files)
+- Anything deferred to \`/opsx-continue\` (not-yet-created artifacts or files)
 - Where the change stands and the recommended next command
 
 **Guardrails**
-- Planning artifacts only - NEVER edit implementation code. If the revised plan implies code changes, stop and point to \`/opsx:apply\`.
+- Planning artifacts only - NEVER edit implementation code. If the revised plan implies code changes, stop and point to \`/opsx-apply\`.
 - Use the artifact ids and paths reported by \`openspec status\`; never branch on hardcoded artifact names.
 - Edit only the concrete files in \`existingOutputPaths\`; never write to a glob \`resolvedOutputPath\`.
-- Do not advance the build frontier: no new artifacts, no new files under glob artifacts - that is \`/opsx:continue\`'s job.
+- Do not advance the build frontier: no new artifacts, no new files under glob artifacts - that is \`/opsx-continue\`'s job.
 - Confirm every edit with the user before writing.
-- If the request changes the change's *intent* rather than refining it, first verify whether the optional \`/opsx:new\` workflow is available. If it is, recommend starting fresh with \`/opsx:new\` (the "Update vs. Start Fresh" heuristic). If it is unavailable, ask for a distinct unused change name and recommend \`openspec new change "<new-change-name>"\` instead.`,
+- If the request changes the change's *intent* rather than refining it, first verify whether the optional \`/opsx-new\` workflow is available. If it is, recommend starting fresh with \`/opsx-new\` (the "Update vs. Start Fresh" heuristic). If it is unavailable, ask for a distinct unused change name and recommend \`openspec new change "<new-change-name>"\` instead.`,
     license: 'MIT',
     compatibility: 'Requires openspec CLI.',
     metadata: { author: 'openspec', version: '1.0' },
@@ -106,9 +106,9 @@ export function getOpsxUpdateCommandTemplate(): CommandTemplate {
 
 ${STORE_SELECTION_GUIDANCE}
 
-**Input**: Optionally specify a change name after \`/opsx:update\` (e.g., \`/opsx:update add-auth\`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+**Input**: Optionally specify a change name after \`/opsx-update\` (e.g., \`/opsx-update add-auth\`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
 
-\`/opsx:continue\` is an optional workflow and may not be installed. Before suggesting it anywhere below, verify that it is available. If it is unavailable, \`openspec status --change "<name>" --json\` shows the next artifact and \`openspec instructions "<artifact-id>" --change "<name>" --json\` explains how to create it.
+\`/opsx-continue\` is an optional workflow and may not be installed. Before suggesting it anywhere below, verify that it is available. If it is unavailable, \`openspec status --change "<name>" --json\` shows the next artifact and \`openspec instructions "<artifact-id>" --change "<name>" --json\` explains how to create it.
 
 **Steps**
 
@@ -127,7 +127,7 @@ ${STORE_SELECTION_GUIDANCE}
 
    Mark the most recently modified change as "(Recommended)" since it's likely what the user wants to update.
 
-   Always announce: "Using change: <name>" and how to override (e.g., \`/opsx:update <other>\`).
+   Always announce: "Using change: <name>" and how to override (e.g., \`/opsx-update <other>\`).
 
 2. **Get the change's artifacts**
    \`\`\`bash
@@ -151,7 +151,7 @@ ${STORE_SELECTION_GUIDANCE}
    - Read the artifact(s) the request touches and the change's other existing artifacts.
    - Apply the requested edit. Then check every other existing artifact against it - in ANY direction: an edit to a later artifact may require revising an earlier one, not only the other way around. Build order is a useful reading order, not a constraint on which artifacts may be revised.
    - Note everything that is now inconsistent, missing, or contradictory.
-   - Revise only files that already exist (\`existingOutputPaths\`). Do NOT create artifacts that don't exist yet, and do NOT invent new files under a glob artifact - note them and point the user to \`/opsx:continue\` to create them.
+   - Revise only files that already exist (\`existingOutputPaths\`). Do NOT create artifacts that don't exist yet, and do NOT invent new files under a glob artifact - note them and point the user to \`/opsx-continue\` to create them.
    - If the change is already coherent, say so and make no edits.
 
 5. **Confirm and apply, one artifact at a time**
@@ -163,23 +163,23 @@ ${STORE_SELECTION_GUIDANCE}
      \`\`\`
 
 6. **Point to the next step (guidance only - NEVER act on it)**
-   - Artifacts still missing -> suggest \`/opsx:continue\` to create them.
-   - Change already implemented (tasks checked off / already applied) -> the code may no longer match the revised plan; suggest \`/opsx:apply\` to carry the delta into code.
-   - Everything done and implemented -> suggest \`/opsx:archive\`.
+   - Artifacts still missing -> suggest \`/opsx-continue\` to create them.
+   - Change already implemented (tasks checked off / already applied) -> the code may no longer match the revised plan; suggest \`/opsx-apply\` to carry the delta into code.
+   - Everything done and implemented -> suggest \`/opsx-archive\`.
 
 **Output**
 
 After each invocation, show:
 - Which artifacts were revised (and which proposed revisions were rejected)
-- Anything deferred to \`/opsx:continue\` (not-yet-created artifacts or files)
+- Anything deferred to \`/opsx-continue\` (not-yet-created artifacts or files)
 - Where the change stands and the recommended next command
 
 **Guardrails**
-- Planning artifacts only - NEVER edit implementation code. If the revised plan implies code changes, stop and point to \`/opsx:apply\`.
+- Planning artifacts only - NEVER edit implementation code. If the revised plan implies code changes, stop and point to \`/opsx-apply\`.
 - Use the artifact ids and paths reported by \`openspec status\`; never branch on hardcoded artifact names.
 - Edit only the concrete files in \`existingOutputPaths\`; never write to a glob \`resolvedOutputPath\`.
-- Do not advance the build frontier: no new artifacts, no new files under glob artifacts - that is \`/opsx:continue\`'s job.
+- Do not advance the build frontier: no new artifacts, no new files under glob artifacts - that is \`/opsx-continue\`'s job.
 - Confirm every edit with the user before writing.
-- If the request changes the change's *intent* rather than refining it, first verify whether the optional \`/opsx:new\` workflow is available. If it is, recommend starting fresh with \`/opsx:new\` (the "Update vs. Start Fresh" heuristic). If it is unavailable, ask for a distinct unused change name and recommend \`openspec new change "<new-change-name>"\` instead.`
+- If the request changes the change's *intent* rather than refining it, first verify whether the optional \`/opsx-new\` workflow is available. If it is, recommend starting fresh with \`/opsx-new\` (the "Update vs. Start Fresh" heuristic). If it is unavailable, ask for a distinct unused change name and recommend \`openspec new change "<new-change-name>"\` instead.`
   };
 }

--- a/src/core/templates/workflows/verify-change.ts
+++ b/src/core/templates/workflows/verify-change.ts
@@ -30,7 +30,7 @@ ${STORE_SELECTION_GUIDANCE}
    Include the schema used for each change if available.
    Mark changes with incomplete tasks as "(In Progress)".
 
-   Always announce: "Using change: <name>" and how to override (e.g., \`/opsx:verify <other>\`).
+   Always announce: "Using change: <name>" and how to override (e.g., \`/opsx-verify <other>\`).
 
 2. **Check status to understand the schema**
    \`\`\`bash
@@ -190,7 +190,7 @@ export function getOpsxVerifyCommandTemplate(): CommandTemplate {
 
 ${STORE_SELECTION_GUIDANCE}
 
-**Input**: Optionally specify a change name after \`/opsx:verify\` (e.g., \`/opsx:verify add-auth\`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+**Input**: Optionally specify a change name after \`/opsx-verify\` (e.g., \`/opsx-verify add-auth\`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
 
 **Steps**
 
@@ -205,7 +205,7 @@ ${STORE_SELECTION_GUIDANCE}
    Include the schema used for each change if available.
    Mark changes with incomplete tasks as "(In Progress)".
 
-   Always announce: "Using change: <name>" and how to override (e.g., \`/opsx:verify <other>\`).
+   Always announce: "Using change: <name>" and how to override (e.g., \`/opsx-verify <other>\`).
 
 2. **Check status to understand the schema**
    \`\`\`bash

--- a/src/utils/command-references.ts
+++ b/src/utils/command-references.ts
@@ -11,13 +11,10 @@ import type { CommandSurfaceCapability } from '../core/command-surface.js';
 import type { CommandInvocation } from '../core/command-generation/invocation.js';
 // Value import of a pure, dependency-free helper: invocation.ts imports only
 // `path` and a type, so this does not close the cycle the note above guards.
-import {
-  formatCommandInvocation,
-  needsInvocationRewrite,
-} from '../core/command-generation/invocation.js';
+import { formatCommandInvocation } from '../core/command-generation/invocation.js';
 
 /**
- * Rewrites the canonical `/opsx:<command>` references that command bodies and
+ * Rewrites the canonical `/opsx-<command>` references that command bodies and
  * skill templates are authored with into the form one tool actually registers
  * — `/opsx-<command>` for tools that name the command by filename,
  * `@opsx-<command>` for Amazon Q's prompt library.
@@ -39,7 +36,7 @@ export function transformCommandInvocations(
   text: string,
   invocation: CommandInvocation
 ): string {
-  return text.replace(/\/opsx:([a-z-]+)/g, (match, commandId: string) =>
+  return text.replace(/\/opsx[:-]([a-z-]+)/g, (match, commandId: string) =>
     commandId in COMMAND_TO_SKILL_NAME
       ? formatCommandInvocation(invocation, commandId)
       : match
@@ -96,14 +93,14 @@ export function usesNaturalLanguageSkillReferences(toolId: string): boolean {
 }
 
 function replaceCommandsWithNaturalLanguageSkillReferences(text: string): string {
-  return text.replace(/\/opsx:([a-z-]+)/g, (match, commandId: string) => {
+  return text.replace(/\/opsx[:-]([a-z-]+)/g, (match, commandId: string) => {
     const skillName = COMMAND_TO_SKILL_NAME[commandId];
     return skillName === undefined ? match : `the ${skillName} skill`;
   });
 }
 
 function replaceCommandsWithSkillReferences(text: string, prefix: string): string {
-  return text.replace(/\/opsx:([a-z-]+)/g, (match, commandId: string) => {
+  return text.replace(/\/opsx[:-]([a-z-]+)/g, (match, commandId: string) => {
     const skillName = COMMAND_TO_SKILL_NAME[commandId];
     return skillName === undefined ? match : `${prefix}${skillName}`;
   });
@@ -114,7 +111,7 @@ function replaceCommandsWithSkillReferences(text: string, prefix: string): strin
  * `.agents` tree usable by agents that invoke the same skills with `/<name>`.
  */
 export function transformToCodexCompatibleSkillReferences(text: string): string {
-  return text.replace(/\/opsx:([a-z-]+)/g, (match, commandId: string) => {
+  return text.replace(/\/opsx[:-]([a-z-]+)/g, (match, commandId: string) => {
     const skillName = COMMAND_TO_SKILL_NAME[commandId];
     return skillName === undefined
       ? match
@@ -198,7 +195,7 @@ export function getSkillReferenceTransformer(toolId: string): (text: string) => 
  *        adapter. Required rather than optional so a caller that forgets it
  *        fails to compile instead of silently getting the canonical form.
  * @returns The transformer to pass to generateSkillContent, or undefined when
- *          the tool already answers to the canonical `/opsx:<id>`
+ *          the tool already answers to the canonical `/opsx-<id>`
  */
 export function getTransformerForTool(
   toolId: string,
@@ -214,7 +211,7 @@ export function getTransformerForTool(
   if (toolId === 'devin' && delivery === 'both') {
     return getSkillReferenceTransformer(toolId);
   }
-  if (invocation !== undefined && needsInvocationRewrite(invocation)) {
+  if (invocation !== undefined) {
     return (text: string) => transformCommandInvocations(text, invocation);
   }
   return undefined;

--- a/test/core/command-generation/invocation.test.ts
+++ b/test/core/command-generation/invocation.test.ts
@@ -44,7 +44,7 @@ const sampleContent: CommandContent = {
   description: 'Implement tasks',
   category: 'Workflow',
   tags: ['openspec'],
-  body: 'Run /opsx:archive when done. See /opsx:continue for the next artifact.',
+  body: 'Run /opsx-archive when done. See /opsx-continue for the next artifact.',
 };
 
 describe('command-generation/invocation', () => {
@@ -125,8 +125,8 @@ describe('command-generation/invocation', () => {
     });
 
     it('rewrites only what differs from the canonical authored form', () => {
-      expect(needsInvocationRewrite({ style: 'namespaced', prefix: '/' })).toBe(false);
-      expect(needsInvocationRewrite({ style: 'flat', prefix: '/' })).toBe(true);
+      expect(needsInvocationRewrite({ style: 'flat', prefix: '/' })).toBe(false);
+      expect(needsInvocationRewrite({ style: 'namespaced', prefix: '/' })).toBe(true);
       expect(needsInvocationRewrite({ style: 'namespaced', prefix: '@' })).toBe(true);
     });
   });
@@ -153,7 +153,7 @@ describe('command-generation/invocation', () => {
       expect(fileContent).not.toContain('/opsx:');
     });
 
-    it('leaves command references alone for namespaced tools', () => {
+    it('normalizes canonical flat references for namespaced tools', () => {
       for (const toolId of NAMESPACED_TOOLS) {
         const adapter = CommandAdapterRegistry.get(toolId)!;
         const { fileContent } = generateCommand(sampleContent, adapter);
@@ -175,7 +175,7 @@ describe('command-generation/invocation', () => {
       // generateCommand happens to be identical (the rewrite is idempotent).
       for (const toolId of ['bob', 'oh-my-pi', 'opencode', 'pi', 'qwen', 'cursor', 'devin']) {
         const adapter = CommandAdapterRegistry.get(toolId)!;
-        expect(adapter.formatFile(sampleContent), toolId).toContain('/opsx:archive');
+        expect(adapter.formatFile(sampleContent), toolId).toContain('/opsx-archive');
       }
     });
   });

--- a/test/core/templates/propose.test.ts
+++ b/test/core/templates/propose.test.ts
@@ -188,12 +188,12 @@ describe('propose implementation boundary', () => {
   });
 
   it('hands command-only tools to apply instead of advertising direct coding (#258)', () => {
-    expect(proposeCommandBody).toContain('When you are ready, run `/opsx:apply`.');
+    expect(proposeCommandBody).toContain('When you are ready, run `/opsx-apply`.');
     expect(proposeCommandBody).not.toContain('ask me to implement');
     expect(proposeCommandBody).not.toContain('ask me to apply this change');
 
     expect(proposeSkillBody).toContain(
-      'run `/opsx:apply` or ask me to apply this change'
+      'run `/opsx-apply` or ask me to apply this change'
     );
     expect(proposeSkillBody).not.toContain('ask me to implement');
   });

--- a/test/core/templates/skill-templates-parity.test.ts
+++ b/test/core/templates/skill-templates-parity.test.ts
@@ -38,46 +38,46 @@ import {
 import { STORE_SELECTION_GUIDANCE } from '../../../src/core/templates/workflows/store-selection.js';
 
 const EXPECTED_FUNCTION_HASHES: Record<string, string> = {
-  getExploreSkillTemplate: '6315fcc5c2eb848963bc8bca4c23e657412a99608e610daee59fb4e58cd21fd4',
+  getExploreSkillTemplate: '848f0d33e37084c914260926d4bcbd4d249b7694b0e433bdca25e90abcf4283e',
   getNewChangeSkillTemplate: 'eabd1e895c5881dcb17dcbaa3fb26098dd59e8eacb318e400820b4dc811ef781',
-  getContinueChangeSkillTemplate: '012136f6411a99c8fa228e2f9444cb64b0a89e0f56fdeac2fe03b2f5bee0c5d7',
-  getApplyChangeSkillTemplate: 'd1e7d5ceb85193c0964057dbb88e9651526754bd33f84020e2440ff0621d5dbb',
-  getFfChangeSkillTemplate: 'efa6a70c111b18b61a7720250b9622afa9a212fb64edf609cf80e2182a9bdf8c',
-  getSyncSpecsSkillTemplate: 'b099e2ff31859c9b10d928066e662524f9aad9ecf2be12fceacb732d718c4146',
-  getOnboardSkillTemplate: '3a836faae463d88c289a1c129cb7ee556a563b7e53e1a52a4711ff152a3b51f7',
-  getOpsxExploreCommandTemplate: 'b4706a5b8fd280f7929eea610ecc9d41676b2d2dd6653d259cbbc2bfe01813d9',
-  getOpsxNewCommandTemplate: 'f2d30e569798a4c92ba932859d6ba4e0ad10e18feccbade1cfee0957597b3463',
-  getOpsxContinueCommandTemplate: 'e50e50266efa1b8e64ff9b6274ee8254f0a240d6adc1b862d126e2f1c9d3a559',
-  getOpsxApplyCommandTemplate: 'e3579ac78f2e2c75fa3d3a7ac7dc3e49c395e96f7323398f0f041d94f8de9bb0',
-  getOpsxFfCommandTemplate: '21132fc9c6d3b3ab2d2295d6bbd72d1e0052eb35ea1be0258c8b1ab3e200c4db',
-  getArchiveChangeSkillTemplate: '56bfada1a5f35a127791b70de9d428a75b5aedd1584d6c9803a1ecb1fd1b4a23',
+  getContinueChangeSkillTemplate: '2e7654d967d9cd3237647e0d7c110f6cd95208bdc90ec7d4312757246cf47209',
+  getApplyChangeSkillTemplate: '09ed7bb220ed08017b188098d8037da67f16c2b684a585f4cfee84be1a74623b',
+  getFfChangeSkillTemplate: '39dd4c8e8820db94edf92e470a8734aa02cc175c2ed6261eac953d29056dc2ba',
+  getSyncSpecsSkillTemplate: '25b4ce485d7136a64d5ffaea6ebc4e02816ffd55913a5c8d08ac1193976fdeac',
+  getOnboardSkillTemplate: '92afdbc5c4e880db601ac84f077e602b5d3163a4b881dc22b627ad70f333cbc3',
+  getOpsxExploreCommandTemplate: '079c2ba2c18ffdb96aa6b774c75e9eebd9d47ceaed896bdcb18df01d5b7d8319',
+  getOpsxNewCommandTemplate: 'f4b57308cd4d3aaddaa49fbc41743280fbb2a6dc6e2207ea3bf0138a5b6ead8f',
+  getOpsxContinueCommandTemplate: '3da31a5091865318079b42b5403c4932b095d4d01952837da6532c3f839eddaf',
+  getOpsxApplyCommandTemplate: '5ab56f02bf25eb7b3f556e9079b4a8904afb190674c66181bc469ee097f0b46a',
+  getOpsxFfCommandTemplate: 'f3f2bb5e063922aa0e816eed040244b733fbf6786318899435c4eb992892686c',
+  getArchiveChangeSkillTemplate: '34e060424bf4d7f28cf12d056460812741b2393fa8659935c88772fb1eb7289a',
   getBulkArchiveChangeSkillTemplate: '93875998cade5322d95b43299fba794bc1da754e917dd63a770406386a6d295d',
-  getOpsxSyncCommandTemplate: '0d2427efb79986e8fff3f96bd075a739c80d45eb29159fae717e950030da8202',
-  getVerifyChangeSkillTemplate: '223b7ffd99299a7d430e13092b9a0a3421b39f0d3217232f46c39d79b5f619ff',
-  getOpsxArchiveCommandTemplate: '9f973c819b11620985b03322945f0e0a92a02a2ef455b94e74482f5e6292ac5d',
-  getOpsxOnboardCommandTemplate: 'ee99aa99252c602720fbb8c63fb3ac438a5bd4e952fd961ddf1ae956cbfc2c8f',
-  getOpsxBulkArchiveCommandTemplate: '9fa8cdebe2f5667ebfc37bdc023396762c59d5b038c771dac2d8fd2c19e2627b',
-  getOpsxVerifyCommandTemplate: '1efcf7eff0671f48e9d9420f50865c563dd3079ee60f8c380bb7a90dd0102696',
-  getOpsxProposeSkillTemplate: '9c0fbf0137151bd03ec30c45180f83daec96e8976ceaf517c63147f84b803446',
-  getOpsxProposeCommandTemplate: 'b3c145f541dcc13d9859eae8f7bedbe4553371477ed2c5ac07a4a80f82c46f52',
+  getOpsxSyncCommandTemplate: '141ad95ee9ce1ab00da904ac7fd6aa4cd17a364877f291b5155e257052566f2f',
+  getVerifyChangeSkillTemplate: '4fb8dcbb595e606c59f921ebedca894e01f02410fea314ff34b15b7d7fdc8052',
+  getOpsxArchiveCommandTemplate: '95f6d32a2b73fde2581f151fbc6b073ebbb095ad47c3e1e2ff37c066ad5ea96e',
+  getOpsxOnboardCommandTemplate: 'e1bfebf50dce15a07556eaeea0f8a22b42c6a4d0df6ec45fd05170462f8568ca',
+  getOpsxBulkArchiveCommandTemplate: '7a3d69b8635a25be94467d0deaf4cb4a36d3c20aa26a2cad0fb26247604c5379',
+  getOpsxVerifyCommandTemplate: '8e8847bf194dfd6bc5dd7ca4a7ab65f9ecc02fb43ce01fd21cb2da22666257ae',
+  getOpsxProposeSkillTemplate: 'f7e6f9980eb6724d4571a7d5df0c57e9b1df7a0350b84efe3b81ef362824885e',
+  getOpsxProposeCommandTemplate: 'cf1068c1663076849796c090ec5a66fb5b7e34af7d51b0e399f3ef5ae125e4c8',
   getFeedbackSkillTemplate: 'dabeb5e825b9349abc8156c3e7b8608f27987912a6d9bf47ef29addde6138133',
-  getUpdateChangeSkillTemplate: '7dc8abc6f64c58bf34d7581ed4ab095a3b7a53cb372349bee2d840db58622819',
-  getOpsxUpdateCommandTemplate: 'e2388521b22f92f74561df9a0c2f98e1fa4d265af93b5ba26f42fb47a6c5bfed',
+  getUpdateChangeSkillTemplate: 'be415370915d60e1d621494d7f4cf3e2425b5d73619d3cbf05504961c02c70ad',
+  getOpsxUpdateCommandTemplate: '20561207724d999da753c14715ff2feaf6c189b47bb13044c6eaeee72871d044',
 };
 
 const EXPECTED_GENERATED_SKILL_CONTENT_HASHES: Record<string, string> = {
-  'openspec-explore': 'dd84af68d3c93b40659dcdd8d383423b25b443cacdc4b514cd70614ae10c5cac',
+  'openspec-explore': '063aa2d266c6da078701e4e455d7309ab38311d319a97a7cc308e060d0bea30d',
   'openspec-new-change': 'ec4529beef978e34634a6f7286fab55d68fad8fb374dceb45691d52caab33fbb',
-  'openspec-continue-change': 'bb6194a16c54891cdb253678e8f70ce53b2af86735243980f366ce551d37e42e',
-  'openspec-apply-change': '81ea96d9fa6ec8536cd23c1fe561ed28e1cc1cad0a8ceb700588e08974cc0e49',
-  'openspec-ff-change': '31355250514bce51b16ff37ee2b833bc9d475cd0dbd4b1f68fe2041694575623',
-  'openspec-sync-specs': 'd933d8856584d6c1253de91e652e7aee9e85c77ad4d3531f6476f79d84e6e5e8',
-  'openspec-archive-change': '7c65053d674ba4e1e20e2bf73ba7e5a7f94baef2eaa9b33cee48d4cadea51b7a',
+  'openspec-continue-change': 'df4c63f1e0afcbff49cae9a51068b326e6652387aea883301ec79a4506e909e9',
+  'openspec-apply-change': '2e945fa3da60a8fc802e32f09c31729132f47ba227a0fe9856c9766337721bea',
+  'openspec-ff-change': '3e4a9dbff49663b0cbe3cdf0673a0e63ae636b2fdcf16df2da32f987905a4102',
+  'openspec-sync-specs': 'd1cafcf899c1f4d6ad2c542a64e1f130240c4945e41e0c3d6130d68c1c0db736',
+  'openspec-archive-change': 'fc936b4796ea193a843cb2dd0d9f8639b986b4fc6db619f7bf4aece5edc18f46',
   'openspec-bulk-archive-change': '2039b9ecf6e64339dffe0e16272507a386d9fe326f419ff758315aa736fdd96c',
-  'openspec-verify-change': 'af9be013dcbe8c6d8f6d9ab10c893fbd03f4c62933c384d82f63894dd0ceb84f',
-  'openspec-onboard': 'f6f59476acaf5e4d65dbb180da4cef62432612f3cecf207d471a951295e2003a',
-  'openspec-propose': 'e358b45102a88082cf20f5c4441cba02533724ad6eef8ed15ba174e3496cb6ed',
-  'openspec-update-change': '586547406aca94422dfeb3ffedce6c01049429b743f57ce829baa79ebc714d51',
+  'openspec-verify-change': 'a3751829d0de560d03ef77544544628d7c5ae846c58eb73684460dfc08544168',
+  'openspec-onboard': '1edb60bbeab2f7f03e634d116e2e68f1655a6589d25e1a48cc7ead3ca89e7a8a',
+  'openspec-propose': 'e0e010f577c48322df3e7b7f4fc36444ed544fcd56b67813565b5da15812ef45',
+  'openspec-update-change': 'f72bfe55510eb7a0b0ff4b4aea8e422ccfea40dce1274778f7f19747b0ac7fb0',
 };
 
 // Intentionally excludes getFeedbackSkillTemplate: this list only models templates
@@ -455,9 +455,9 @@ describe('skill templates split parity', () => {
     const generatedSkill = generateSkillContent(getArchiveChangeSkillTemplate(), 'PARITY-BASELINE');
     const commandContent = getOpsxArchiveCommandTemplate().content;
 
-    // The single archive skill references openspec-sync-specs; opsx command references /opsx:sync.
+    // The single archive skill references openspec-sync-specs; opsx command references /opsx-sync.
     expect(generatedSkill, 'skill').toContain('run the `openspec-sync-specs` workflow inline');
-    expect(commandContent, 'opsx command').toContain('run the `/opsx:sync` workflow inline');
+    expect(commandContent, 'opsx command').toContain('run the `/opsx-sync` workflow inline');
 
     const variants: Array<[string, string]> = [
       ['skill', generatedSkill],
@@ -485,9 +485,9 @@ describe('skill templates split parity', () => {
     const generatedSkill = generateSkillContent(getBulkArchiveChangeSkillTemplate(), 'PARITY-BASELINE');
     const commandContent = getOpsxBulkArchiveCommandTemplate().content;
 
-    // The bulk archive skill references openspec-sync-specs; opsx command references /opsx:sync.
+    // The bulk archive skill references openspec-sync-specs; opsx command references /opsx-sync.
     expect(generatedSkill, 'bulk skill').toContain('run the `openspec-sync-specs` workflow inline');
-    expect(commandContent, 'bulk opsx command').toContain('run the `/opsx:sync` workflow inline');
+    expect(commandContent, 'bulk opsx command').toContain('run the `/opsx-sync` workflow inline');
 
     const variants: Array<[string, string]> = [
       ['bulk skill', generatedSkill],
@@ -989,7 +989,7 @@ describe('skill templates split parity', () => {
 describe('apply skill/command shared instruction core', () => {
   // The apply skill and command are intentionally distinct surfaces, but they
   // differ only in how they are invoked — the generation transformers rewrite
-  // the canonical `/opsx:<id>` tokens per surface downstream (asserted in
+  // the canonical `/opsx-<id>` tokens per surface downstream (asserted in
   // test/utils/command-references.test.ts). The instruction text itself is
   // shared, so this pins the contract: both surfaces render the one canonical
   // core and cannot silently drift apart at the template level.

--- a/test/utils/command-references.test.ts
+++ b/test/utils/command-references.test.ts
@@ -126,9 +126,9 @@ Finally /opsx-apply to implement`;
       );
     });
 
-    it('is a no-op for the canonical namespaced slash form', () => {
-      const input = 'Use /opsx:new then /opsx:apply';
-      expect(transformCommandInvocations(input, NAMESPACED_SLASH)).toBe(input);
+    it('normalizes canonical flat input for a namespaced slash target', () => {
+      const input = 'Use /opsx-new then /opsx-apply';
+      expect(transformCommandInvocations(input, NAMESPACED_SLASH)).toBe('Use /opsx:new then /opsx:apply');
     });
   });
 });
@@ -313,9 +313,12 @@ describe('getTransformerForTool', () => {
     );
   });
 
-  it('selects no transformer for namespaced tools when commands are generated', () => {
-    expect(getTransformerForTool('claude', 'both', 'adapter-backed', NAMESPACED_SLASH)).toBeUndefined();
-    expect(getTransformerForTool('claude', 'commands', 'adapter-backed', NAMESPACED_SLASH)).toBeUndefined();
+  it('selects a normalizer for namespaced tools when commands are generated', () => {
+    for (const delivery of ['both', 'commands'] as const) {
+      const transformer = getTransformerForTool('claude', delivery, 'adapter-backed', NAMESPACED_SLASH);
+      expect(transformer?.('/opsx-apply')).toBe('/opsx:apply');
+      expect(transformer?.('/opsx:apply')).toBe('/opsx:apply');
+    }
   });
 
   it('selects shared-tree-safe Codex skill references in every delivery mode', () => {
@@ -341,10 +344,10 @@ describe('getTransformerForTool', () => {
 describe('apply skill template generates valid per-target invocations', () => {
   const skill = getApplyChangeSkillTemplate().instructions;
 
-  it('authors invocation references as transformable /opsx:* tokens', () => {
-    expect(skill).toContain('/opsx:apply add-auth');
-    expect(skill).toContain('suggest using `/opsx:continue`');
-    expect(skill).toContain('archive this change with `/opsx:archive`');
+  it('authors invocation references as transformable /opsx-* tokens', () => {
+    expect(skill).toContain('/opsx-apply add-auth');
+    expect(skill).toContain('suggest using `/opsx-continue`');
+    expect(skill).toContain('archive this change with `/opsx-archive`');
     // No bare, non-transformable skill-name prose remains.
     expect(skill).not.toContain('suggest using openspec-continue-change');
   });

--- a/test/utils/flat-canonical-invocations.test.ts
+++ b/test/utils/flat-canonical-invocations.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { CANONICAL_INVOCATION } from '../../src/core/command-generation/invocation.js';
+import { getOpsxApplyCommandTemplate } from '../../src/core/templates/skill-templates.js';
+import {
+  getSkillReferenceTransformer,
+  transformCommandInvocations,
+} from '../../src/utils/command-references.js';
+
+describe('flat canonical workflow invocations', () => {
+  it('uses flat slash syntax as the raw canonical form', () => {
+    expect(CANONICAL_INVOCATION).toEqual({ style: 'flat', prefix: '/' });
+    const body = getOpsxApplyCommandTemplate().content;
+    expect(body).toContain('/opsx-');
+    expect(body).not.toContain('/opsx:');
+  });
+
+  it('maps both legacy and canonical command references to skills', () => {
+    const transform = getSkillReferenceTransformer('vibe');
+    expect(transform('/opsx:apply')).toBe('/openspec-apply-change');
+    expect(transform('/opsx-apply')).toBe('/openspec-apply-change');
+  });
+
+  it('maps flat canonical input to namespaced tools', () => {
+    expect(
+      transformCommandInvocations('/opsx-apply', { style: 'namespaced', prefix: '/' })
+    ).toBe('/opsx:apply');
+  });
+
+  it('normalizes legacy colon input for flat tools', () => {
+    expect(transformCommandInvocations('/opsx:apply', { style: 'flat', prefix: '/' })).toBe(
+      '/opsx-apply'
+    );
+  });
+});


### PR DESCRIPTION
behavior change: make `/opsx-<verb>` the canonical raw workflow invocation instead of `/opsx:<verb>`.

This keeps tool compatibility rather than doing a blind syntax replacement:
- raw workflow templates author `/opsx-*` references;
- skill generation still rewrites to `/openspec-*` (or the tool-specific skill prefix);
- namespaced command adapters still emit `/opsx:<verb>` when that tool genuinely registers namespaced commands;
- both legacy `/opsx:<verb>` and canonical `/opsx-<verb>` are accepted as transformer input, so stale/custom content is normalized instead of leaking the wrong syntax;
- command generation always runs the normalization pass, even when the target already matches the canonical flat style.

Verification before cleanup:
- `pnpm build` — passed
- `pnpm regen:parity-hashes` — regenerated affected baselines
- `pnpm generate:skills` — passed
- focused invocation/command-reference/parity suite — 105/105 passing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized workflow commands on the hyphenated `/opsx-*` format.
  * Added support for recognizing and adapting both legacy `/opsx:*` and canonical `/opsx-*` references.
  * Improved command reference handling across supported tools.

* **Documentation**
  * Updated workflow guidance, examples, onboarding content, and command references to reflect the standardized syntax.

* **Tests**
  * Expanded coverage for command normalization, invocation conversion, and canonical workflow references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->