### PR TITLE
fix(docs): route OpenSpec pixel through Pages

### DIFF
--- a/website/cloudflare/router/worker.js
+++ b/website/cloudflare/router/worker.js
@@ -82,6 +82,7 @@ function isDocsRoute(pathname) {
     pathname === '/llms-full.txt' ||
     pathname === '/llms.mdx/docs' ||
     pathname.startsWith('/llms.mdx/docs/') ||
-    pathname === '/icon.svg'
+    pathname === '/icon.svg' ||
+    pathname === '/openspec-pixel.svg'
   );
 }

--- a/website/cloudflare/router/wrangler.jsonc
+++ b/website/cloudflare/router/wrangler.jsonc
@@ -11,6 +11,7 @@
     { "pattern": "openspec.dev/og/docs/*", "zone_name": "openspec.dev" },
     { "pattern": "openspec.dev/llms*", "zone_name": "openspec.dev" },
     { "pattern": "openspec.dev/llms.mdx/docs/*", "zone_name": "openspec.dev" },
-    { "pattern": "openspec.dev/icon.svg*", "zone_name": "openspec.dev" }
+    { "pattern": "openspec.dev/icon.svg*", "zone_name": "openspec.dev" },
+    { "pattern": "openspec.dev/openspec-pixel.svg*", "zone_name": "openspec.dev" }
   ]
 }


### PR DESCRIPTION
Fixes #1756.

The docs nav logo (`<img alt="OpenSpec">`) is referenced via the root-relative path `/openspec-pixel.svg`. That path isn't matched by `isDocsRoute()` in the router Worker, so it falls through to `fetch(request)` and gets proxied to the separate Astro landing project that owns the rest of `openspec.dev` - which doesn't have this file. Result: a 404 on every docs page.

`/icon.svg` already has this exact special case in `isDocsRoute()`. This adds the same one-line case for `/openspec-pixel.svg`, so it's proxied to the `openspec-docs.pages.dev` project where the asset actually lives (`website/public/openspec-pixel.svg`).

No app code changes - just the routing Worker's allowlist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for serving the OpenSpec pixel image through the existing documentation proxy route.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->