### PR TITLE
docs: reroute unfinished store reference links

### DIFF
--- a/docs-lab/multi-repo/stores.md
+++ b/docs-lab/multi-repo/stores.md
@@ -196,7 +196,7 @@ OpenSpec writes artifacts to one of two places: your project's `openspec/` folde
 3. **The `store:` line in your project.** How a store-only project records its store.
 4. **`defaultStore` on your machine.** The fallback when none of the above applies.
 
-Whichever applied, OpenSpec's first output line names the folder it acted on (`Using OpenSpec root: ...`). The exact rules, including the error cases, are in [Configuration › Stores](../reference/configuration/stores.md).
+When OpenSpec selects a store, it prints `Using OpenSpec root: ...` before the command output.
 
 ### The `store:` line (store-only projects)
 

--- a/docs-lab/reference/configuration/config-json.md
+++ b/docs-lab/reference/configuration/config-json.md
@@ -36,7 +36,7 @@ Boolean toggles keyed by flag name, set with `openspec config set featureFlags.<
 
 ### defaultStore
 
-The machine-level fallback store id for root resolution, consulted only when no `--store` flag, local `openspec/`, or project `store:` pointer resolves. The full ladder is [Root resolution](stores.md#root-resolution).
+The machine-level fallback store id for root resolution, consulted only when no `--store` flag, local `openspec/`, or project `store:` pointer resolves. The full ladder is [Root resolution](../../multi-repo/stores.md#where-artifacts-get-created-when-using-stores).
 
 ### openers
 

--- a/docs-lab/reference/configuration/config-yaml.md
+++ b/docs-lab/reference/configuration/config-yaml.md
@@ -56,7 +56,7 @@ Only `apply` and `archive` are read.
 
 ### store
 
-A store id used as the OpenSpec root, consulted only when this openspec/ directory is config-only (no specs/ or changes/). It is a fallback, never an override. The full ladder is [Root resolution](stores.md#root-resolution).
+A store id used as the OpenSpec root, consulted only when this openspec/ directory is config-only (no specs/ or changes/). It is a fallback, never an override. The full ladder is [Root resolution](../../multi-repo/stores.md#where-artifacts-get-created-when-using-stores).
 
 ### references
 

--- a/docs-lab/reference/configuration/index.md
+++ b/docs-lab/reference/configuration/index.md
@@ -8,4 +8,4 @@
 | [Change metadata (.openspec.yaml)](change-metadata.md) | `openspec/changes/<name>/.openspec.yaml` | The workflow schema, goal, scope, and spec exceptions for one change |
 | [CLI settings (config.json)](config-json.md) | `~/.config/openspec/config.json` (Windows varies) | How the openspec CLI behaves on your machine |
 | [Environment variables](environment-variables.md) | Your shell or CI environment | Telemetry opt-out, and where the config and data directories live |
-| [Stores](stores.md) | `~/.local/share/openspec/stores/` (Windows varies) | The registry and metadata behind multi-repo stores |
+| Stores | `~/.local/share/openspec/stores/` (Windows varies) | The registry and metadata behind multi-repo stores |

--- a/docs-lab/reference/glossary.md
+++ b/docs-lab/reference/glossary.md
@@ -20,11 +20,11 @@ OpenSpec reuses words that mean something else in git, CI, and agent tooling. Ea
 | **Legacy workflow** | The pre-OPSX `/openspec:*` commands. | [Migration](../help/legacy/migration.md) |
 | **Loop** | The cycle a change proposal moves through: explore, propose, review, apply, archive. | [Quickstart](../start/quickstart.md) |
 | **Main specs** | The `openspec/specs/` tree: the current, agreed behavior of your system. Archiving merges deltas into it. | [Concepts](../guides/concepts.md) |
-| **OpenSpec root** | The `openspec/` tree a command resolves to and operates on: your repo's, or a store's. | [Stores](configuration/stores.md) |
+| **OpenSpec root** | The `openspec/` tree a command resolves to and operates on: your repo's, or a store's. | [Stores](../multi-repo/stores.md#where-artifacts-get-created-when-using-stores) |
 | **OPSX** | The current OpenSpec workflow system, and the command prefix it installs (`/opsx:`). | [Architecture](architecture/index.md) |
 | **Profile** | Which workflows init installs: `core` or `custom`. | [Profiles](../customize/profiles.md) |
 | **Propose** | Create a change proposal and generate all its planning artifacts in one step. Skill: `openspec-propose`. | [Quickstart](../start/quickstart.md) |
-| **Registry** | The machine-level list of registered stores, in `registry.yaml`. Not a package registry. | [Stores](configuration/stores.md) |
+| **Registry** | The machine-level list of registered stores, in `registry.yaml`. Not a package registry. | [CLI](cli.md#openspec-store) |
 | **Requirement** | One behavior the system must have, written with SHALL: `### Requirement:` in a spec. | [Delta specs](schemas/spec-driven/index.md#delta-specs-specmd) |
 | **Scenario** | A testable example under a requirement, in WHEN/THEN form. | [Delta specs](schemas/spec-driven/index.md#delta-specs-specmd) |
 | **Schema** | The definition of which artifacts a change proposal produces, and in what order. Not JSON Schema. | [Schemas](schemas/index.md) |


### PR DESCRIPTION
## Summary

- reroute root-resolution links to the live Stores guide
- route the Registry glossary entry to the live CLI reference
- remove links whose promised configuration contract is not published yet
- correct when the CLI prints the selected-store banner

## Validation

- `node website/scripts/sync-docs.mjs`
- confirmed generated docs contain no link to `docs-lab/reference/configuration/stores.md`
- `pnpm run types:check` *(blocked by the existing `staticClient` export error in `website/components/search.tsx`)*
- autoreview *(could not start because TruffleHog is not installed)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated store-selection documentation to reflect the `Using OpenSpec root: ...` output.
  - Corrected configuration and glossary links for store root resolution and CLI store information.
  - Clarified references to OpenSpec roots and registries.
  - Removed the outdated Stores link from the configuration overview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->