### PR TITLE
fix: release archive lock on Windows

### DIFF
--- a/.changeset/windows-archive-claim-release.md
+++ b/.changeset/windows-archive-claim-release.md
@@ -1,0 +1,5 @@
+---
+'@fission-ai/openspec': patch
+---
+
+Fix `openspec archive` leaving `.openspec-archive.lock` behind on Windows. Node can report `dev: 0n` from a path stat while the open file handle reports the real volume id, so the claim-ownership check never matched and the stale lock blocked every later archive. The check now treats an absent device id as unavailable while still requiring the inode and the claim's contents to match before unlinking.

--- a/openspec/changes/fix-windows-archive-claim-release/.openspec.yaml
+++ b/openspec/changes/fix-windows-archive-claim-release/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-02

--- a/openspec/changes/fix-windows-archive-claim-release/proposal.md
+++ b/openspec/changes/fix-windows-archive-claim-release/proposal.md
@@ -1,0 +1,28 @@
+# Release archive claims on Windows
+
+## Why
+
+`openspec archive` creates `.openspec-archive.lock` before moving a change into
+the archive. On Windows, a successful archive can leave that lock behind because
+the cleanup check compares the device id returned by the open file handle with
+the one returned by `fs.lstat()`. Node reports a real device id from the handle
+and `0n` from the path stat on the affected Windows/NTFS setup, so the ownership
+check never passes.
+
+The archive itself succeeds, but the next archive is blocked by the stale claim
+and the user has to delete `.openspec-archive.lock` by hand.
+
+## What Changes
+
+- Treat an inode match plus matching claim contents as sufficient when either
+  side reports `dev: 0n`, while still requiring the two path stats around the
+  read to match.
+- Keep the existing protection against deleting a claim that was replaced by
+  another process.
+- Add a regression test that simulates the Windows path-stat device id behavior.
+
+## Impact
+
+- Affected spec: `cli-archive`
+- Affected code: `src/core/archive.ts`
+- Affected tests: `test/core/archive.test.ts`

--- a/openspec/changes/fix-windows-archive-claim-release/specs/cli-archive/spec.md
+++ b/openspec/changes/fix-windows-archive-claim-release/specs/cli-archive/spec.md
@@ -1,0 +1,36 @@
+## MODIFIED Requirements
+
+### Requirement: Archive Process
+
+The archive operation SHALL follow a structured process to safely move changes to the archive.
+
+#### Scenario: Performing archive
+
+- **WHEN** archiving a change
+- **THEN** execute these steps:
+  1. Create archive/ directory if it doesn't exist
+  2. Generate target name as `YYYY-MM-DD-[change-name]` using current date, keeping the name as-is when it already starts with a `YYYY-MM-DD-` prefix
+  3. Claim the target and verify that it does not already exist
+  4. Prepare and validate spec updates from the active change's delta specs
+  5. Apply the spec updates as a rollback-capable transaction
+  6. Move the entire change directory to the archive location
+  7. If a spec mutation or final move fails before a complete archive is secured, restore the spec transaction and leave or return the change at its active path
+  8. If a verified fallback copy completes but staged-source cleanup fails, retain the complete archive and committed spec state for recovery instead of risking the only complete copy
+
+#### Scenario: Archive already exists
+
+- **WHEN** target archive already exists
+- **THEN** fail with error message
+- **AND** do not overwrite existing archive
+
+#### Scenario: Successful archive
+
+- **WHEN** move succeeds
+- **THEN** display success message with archived name and list of updated specs
+
+#### Scenario: Successful archive releases its own claim
+
+- **WHEN** an archive run successfully moves a change to its archive destination
+- **THEN** remove the temporary archive claim it created
+- **AND** do so on supported platforms even when a path stat does not report a device id
+- **AND** never remove a claim whose path identity or contents changed before cleanup

--- a/openspec/changes/fix-windows-archive-claim-release/tasks.md
+++ b/openspec/changes/fix-windows-archive-claim-release/tasks.md
@@ -1,0 +1,12 @@
+# Tasks
+
+## 1. Release owned claims cross-platform
+- [x] 1.1 Compare archive claim files by inode and tolerate a missing device id from either stat result
+- [x] 1.2 Preserve the content and repeated-path-stat checks before unlinking
+
+## 2. Verify behavior
+- [x] 2.1 Add regression coverage for the Windows `dev: 0n` path-stat case
+- [x] 2.2 Run the focused archive regression test
+
+## 3. Record behavior
+- [x] 3.1 Add a `cli-archive` spec delta for successful claim cleanup

--- a/src/core/archive.ts
+++ b/src/core/archive.ts
@@ -594,6 +594,21 @@ interface ArchiveClaim {
   contents: string;
 }
 
+interface ArchiveClaimFileIdentity {
+  dev: bigint;
+  ino: bigint;
+}
+
+function isSameArchiveClaimFile(
+  first: ArchiveClaimFileIdentity,
+  second: ArchiveClaimFileIdentity
+): boolean {
+  return (
+    first.ino === second.ino &&
+    (first.dev === second.dev || first.dev === 0n || second.dev === 0n)
+  );
+}
+
 async function releaseArchiveClaim(
   claim: ArchiveClaim,
   claimPath: string
@@ -609,10 +624,8 @@ async function releaseArchiveClaim(
     const contents = await fs.readFile(claimPath, 'utf8');
     const currentAfterRead = await fs.lstat(claimPath, { bigint: true });
     if (
-      current.dev === owned.dev &&
-      current.ino === owned.ino &&
-      current.dev === currentAfterRead.dev &&
-      current.ino === currentAfterRead.ino &&
+      isSameArchiveClaimFile(current, owned) &&
+      isSameArchiveClaimFile(current, currentAfterRead) &&
       contents === claim.contents
     ) {
       await fs.unlink(claimPath);

--- a/test/core/archive.test.ts
+++ b/test/core/archive.test.ts
@@ -2146,6 +2146,25 @@ New feature description.
       await expect(fs.access(claimPath)).resolves.not.toThrow();
     });
 
+    it('releases its archive claim when the path stat has no Windows device id', async () => {
+      const changeName = 'windows-archive-claim-release';
+      const changeDir = path.join(tempDir, 'openspec', 'changes', changeName);
+      await fs.mkdir(changeDir, { recursive: true });
+      const archiveName = `${formatLocalDate()}-${changeName}`;
+      const claimPath = archiveClaimPath(archiveName);
+      const realLstat = fs.lstat.bind(fs);
+      onTestFinished(() => vi.restoreAllMocks());
+      vi.spyOn(fs, 'lstat').mockImplementation(async (target, options) => {
+        const stats = await realLstat(target, options as any);
+        if (String(target) !== claimPath) return stats;
+        return { ...stats, dev: 0n };
+      });
+
+      await archiveCommand.execute(changeName, { yes: true, skipSpecs: true });
+
+      await expect(fs.access(claimPath)).rejects.toMatchObject({ code: 'ENOENT' });
+    });
+
     // Windows defers deletion of an open file until its original handle closes,
     // so unlink-and-recreate cannot model a persistent replacement there.
     it.skipIf(process.platform === 'win32')(

--- a/test/core/archive.test.ts
+++ b/test/core/archive.test.ts
@@ -2153,15 +2153,26 @@ New feature description.
       const archiveName = `${formatLocalDate()}-${changeName}`;
       const claimPath = archiveClaimPath(archiveName);
       const realLstat = fs.lstat.bind(fs);
+      // Match the claim by file name rather than by full path. The command
+      // stats the resolved real path, so a literal comparison against the
+      // temp-dir path misses on macOS (/var -> /private/var) and on Windows
+      // short paths, leaving the mock inert and the regression unexercised.
+      let maskedDeviceIds = 0;
       onTestFinished(() => vi.restoreAllMocks());
       vi.spyOn(fs, 'lstat').mockImplementation(async (target, options) => {
         const stats = await realLstat(target, options as any);
-        if (String(target) !== claimPath) return stats;
+        if (path.basename(String(target)) !== '.openspec-archive.lock') {
+          return stats;
+        }
+        maskedDeviceIds += 1;
         return { ...stats, dev: 0n };
       });
 
       await archiveCommand.execute(changeName, { yes: true, skipSpecs: true });
 
+      // Guards the assertion below: without this the test passes even when the
+      // mock never intercepts, which is how it originally went vacuous.
+      expect(maskedDeviceIds).toBeGreaterThan(0);
       await expect(fs.access(claimPath)).rejects.toMatchObject({ code: 'ENOENT' });
     });
 


### PR DESCRIPTION
## Status

Ready for review at `19586c83`; not merged.

## What was wrong

A successful Windows archive could leave `.openspec-archive.lock` behind, blocking the next archive. The open handle reported a device ID while the path stat reported `0n`. Closes #1949.

## How it was fixed

Cleanup accepts `0n` as an unavailable device ID. It still checks the inode, claim contents, and path identity before unlinking.

## Replication / proof

The regression fails without the fix. Additional tests keep replaced or changed claims. Locally, 253 archive tests, build, TypeScript, lint, and strict change validation pass.

## Notes / nits

Hosted checks for this head need fork-workflow approval. The replacement test is skipped on Windows because Windows defers deletion of open files; the release and changed-identity tests run there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows archive operations leaving behind temporary archive lock files.
  * Archive cleanup now safely handles platforms that do not report device IDs.
  * Added validation for nested changes and unknown task markers.
  * Improved retirement and synchronization validation to prevent invalid archive operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->