### PR TITLE
fix(validate): warn when tracked tasks have no checkboxes

### DIFF
--- a/.changeset/warn-on-uncheckboxed-tasks.md
+++ b/.changeset/warn-on-uncheckboxed-tasks.md
@@ -1,0 +1,7 @@
+---
+"@fission-ai/openspec": patch
+---
+
+### Bug Fixes
+
+- **Task lists without checkboxes are now caught** — A `tasks.md` written as plain bullets or a numbered list counts as zero tasks, so `openspec list` and `openspec status` reported "No tasks" and `openspec archive` had no unfinished work to warn about. `openspec validate` now warns when a change's tracked task files contain list items but no checkbox at all, and points at the first offending line.

--- a/docs-lab/reference/cli.md
+++ b/docs-lab/reference/cli.md
@@ -667,6 +667,18 @@ Bulk runs print one status line per item, followed by any findings, and end with
 Totals: 2 passed, 0 failed (2 items)
 ```
 
+**Task checkbox findings**
+
+Progress counts checkboxes and nothing else, so a task file written as plain bullets reads as zero tasks: `openspec list` and `openspec status` report no work, and `openspec archive` has nothing to flag as incomplete. Validate reports a `WARNING` on each tracked task file that lists work without a checkbox:
+
+```text
+⚠ [WARNING] tasks.md: This change counts as 0 tasks: no line in its tracked task files is a checkbox, so "openspec list" and "openspec status" report no work and "openspec archive" has nothing to flag as incomplete. Write each task as "- [ ] 1.1 Description".
+```
+
+The warning fires only when the change's whole tracked set holds no checkbox at all. One file of prose beside a real checklist is not reported, and a change mid-authoring keeps its progress the moment a single checkbox exists. `--strict` turns the warning into a failure. The line number is in the `--json` report.
+
+Fenced blocks, HTML comments, YAML front matter and indented code are not scanned, so a pasted terminal sample is never mistaken for a task list.
+
 **Archive merge findings**
 
 For changes, validate runs archive's merge builder against the current main specs without writing files. It reports merge conflicts, such as a missing `MODIFIED` target or a conflicting `ADDED` requirement, as `INFO`:

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -338,6 +338,7 @@ Tasks are the **implementation checklist** — concrete steps with checkboxes.
 ```
 
 **Task best practices:**
+- Write every task as a `- [ ]` checkbox: progress, `openspec apply`, and `openspec archive` count checkboxes and nothing else, so a plain bullet list reads as zero tasks (`openspec validate` warns when a tracked task file has no checkbox at all)
 - Group related tasks under headings
 - Use hierarchical numbering (1.1, 1.2, etc.)
 - Keep tasks small enough to complete in one session

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -338,7 +338,6 @@ Tasks are the **implementation checklist** — concrete steps with checkboxes.
 ```
 
 **Task best practices:**
-- Write every task as a `- [ ]` checkbox: progress, `openspec apply`, and `openspec archive` count checkboxes and nothing else, so a plain bullet list reads as zero tasks (`openspec validate` warns when a tracked task file has no checkbox at all)
 - Group related tasks under headings
 - Use hierarchical numbering (1.1, 1.2, etc.)
 - Keep tasks small enough to complete in one session

--- a/src/core/validation/task-checkboxes.ts
+++ b/src/core/validation/task-checkboxes.ts
@@ -15,6 +15,13 @@ export interface TaskCheckboxIssue {
  * A list item that carries text but no checkbox: `- item`, `* item`, `+ item`,
  * `1. item`, `1) item`. Checkbox lines match this too, so callers must rule the
  * document set out on checkbox count first.
+ *
+ * A thematic break (`---`, `***`, `- - -`) is not a list item: the run has no
+ * text after it, and this pattern requires a non-space character. `* * *` is
+ * the one break spelled like a list of `*` items, and it is accepted as a list
+ * item rather than special-cased, because a file whose only list-shaped line is
+ * a horizontal rule still has zero tasks — the warning stays true, it just
+ * points at an odd line.
  */
 const LIST_ITEM = /^\s*(?:[-*+]|\d+[.)])\s+\S/;
 
@@ -27,6 +34,12 @@ const LIST_ITEM = /^\s*(?:[-*+]|\d+[.)])\s+\S/;
  * fail on every line of a CRLF file and blind the scan to fences entirely.
  */
 const FENCE = /^\s*(`{3,}|~{3,})(.*)/;
+
+/** A YAML front-matter delimiter, recognised only on a document's first line. */
+const FRONT_MATTER = /^(-{3,})\s*$/;
+
+const COMMENT_OPEN = '<!--';
+const COMMENT_CLOSE = '-->';
 
 /**
  * Reports tracked task files that list work as plain bullets or numbered items
@@ -43,11 +56,12 @@ const FENCE = /^\s*(`{3,}|~{3,})(.*)/;
  * this catches, and a change that is mid-authoring keeps its progress the
  * moment a single checkbox exists.
  *
- * Fenced blocks are skipped when looking for the offending list item. Unlike
- * the task parser — where fence awareness would silently drop real tasks — the
- * only thing a mis-read fence costs here is the warning itself, and a tasks
- * file whose sole list lives inside a code sample is a documented example, not
- * a checklist someone forgot to tick.
+ * The scan for the offending line looks at rendered content only: fenced
+ * blocks, HTML comments and YAML front matter are skipped. Every one of those
+ * exclusions can only *silence* a warning, never drop a real task — that is the
+ * opposite trade from the task parser, where fence awareness would hide work
+ * that `archive` must still refuse, and it is why the parser stays literal
+ * while this scan does not.
  */
 export function findMissingTaskCheckboxIssues(
   documents: readonly TaskCheckboxDocument[]
@@ -63,22 +77,30 @@ export function findMissingTaskCheckboxIssues(
       path: document.path,
       line,
       message:
-        'Tasks are listed without checkboxes, so this change counts as 0 tasks: ' +
-        '"openspec list" and "openspec status" report no work, and "openspec archive" ' +
-        'has nothing to flag as incomplete. Rewrite each task as "- [ ] 1.1 Description".',
+        'This change counts as 0 tasks: no line in its tracked task files is a checkbox, ' +
+        'so "openspec list" and "openspec status" report no work and "openspec archive" ' +
+        'has nothing to flag as incomplete. Write each task as "- [ ] 1.1 Description".',
     });
   }
 
   return issues;
 }
 
-/** 1-based line of the first list item outside a fenced block, if any. */
+/** 1-based line of the first list item in rendered content, if any. */
 function findFirstListItemLine(content: string): number | undefined {
-  let openFence: { marker: string; length: number } | undefined;
-
   const lines = content.split('\n');
-  for (let index = 0; index < lines.length; index++) {
+  let openFence: { marker: string; length: number } | undefined;
+  let inComment = false;
+  let index = skipFrontMatter(lines);
+
+  for (; index < lines.length; index++) {
     const line = lines[index];
+
+    if (inComment) {
+      if (line.includes(COMMENT_CLOSE)) inComment = false;
+      continue;
+    }
+
     const fence = line.match(FENCE);
     if (fence) {
       const marker = fence[1][0];
@@ -99,8 +121,37 @@ function findFirstListItemLine(content: string): number | undefined {
       continue;
     }
     if (openFence !== undefined) continue;
+
+    // Only a comment that opens the line hides it. `- [ ] 1.1 do it <!-- note`
+    // is a task line first, and the template's own `## 1. <!-- Task Group -->`
+    // must not swallow the checklist that follows it.
+    if (line.trimStart().startsWith(COMMENT_OPEN)) {
+      if (!line.includes(COMMENT_CLOSE, line.indexOf(COMMENT_OPEN) + COMMENT_OPEN.length)) {
+        inComment = true;
+      }
+      continue;
+    }
+
     if (LIST_ITEM.test(line)) return index + 1;
   }
 
   return undefined;
+}
+
+/**
+ * Index of the first line after a YAML front-matter block, or 0 when the
+ * document does not open with one. A list under `tags:` is metadata about the
+ * file, never the work it tracks, and pointing a "write checkboxes" warning at
+ * it would name the wrong line.
+ */
+function skipFrontMatter(lines: readonly string[]): number {
+  if (lines.length === 0 || !FRONT_MATTER.test(lines[0].trimEnd())) return 0;
+
+  for (let index = 1; index < lines.length; index++) {
+    if (FRONT_MATTER.test(lines[index].trimEnd())) return index + 1;
+  }
+
+  // An unterminated opener is a thematic break, not front matter: rewinding to
+  // the top keeps every list in the document visible to the scan.
+  return 0;
 }

--- a/src/core/validation/task-checkboxes.ts
+++ b/src/core/validation/task-checkboxes.ts
@@ -1,0 +1,89 @@
+import { parseTaskLines } from '../../utils/task-progress.js';
+
+export interface TaskCheckboxDocument {
+  path: string;
+  content: string;
+}
+
+export interface TaskCheckboxIssue {
+  path: string;
+  line: number;
+  message: string;
+}
+
+/**
+ * A list item that carries text but no checkbox: `- item`, `* item`, `+ item`,
+ * `1. item`, `1) item`. Checkbox lines match this too, so callers must rule the
+ * document set out on checkbox count first.
+ */
+const LIST_ITEM = /^\s*(?:[-*+]|\d+[.)])\s+\S/;
+
+/** A fenced block opener/closer: three or more backticks or tildes. */
+const FENCE = /^\s*(`{3,}|~{3,})/;
+
+/**
+ * Reports tracked task files that list work as plain bullets or numbered items
+ * instead of checkboxes (#354).
+ *
+ * Progress counts checkboxes and nothing else, so a tasks file written as a
+ * bare list is worse than an empty one: `openspec list` prints "No tasks",
+ * `openspec status` treats the change as having no work left, and
+ * `openspec archive` has no incomplete task to warn about. The file looks
+ * finished to the tool and unfinished to the reader.
+ *
+ * Reported only when the change's *whole* tracked set has zero checkboxes.
+ * One nested tasks file of prose beside a real checklist is not the failure
+ * this catches, and a change that is mid-authoring keeps its progress the
+ * moment a single checkbox exists.
+ *
+ * Fenced blocks are skipped when looking for the offending list item. Unlike
+ * the task parser — where fence awareness would silently drop real tasks — the
+ * only thing a mis-read fence costs here is the warning itself, and a tasks
+ * file whose sole list lives inside a code sample is a documented example, not
+ * a checklist someone forgot to tick.
+ */
+export function findMissingTaskCheckboxIssues(
+  documents: readonly TaskCheckboxDocument[]
+): TaskCheckboxIssue[] {
+  if (documents.length === 0) return [];
+  if (documents.some((document) => parseTaskLines(document.content).length > 0)) return [];
+
+  const issues: TaskCheckboxIssue[] = [];
+  for (const document of documents) {
+    const line = findFirstListItemLine(document.content);
+    if (line === undefined) continue;
+    issues.push({
+      path: document.path,
+      line,
+      message:
+        'Tasks are listed without checkboxes, so this change counts as 0 tasks: ' +
+        '"openspec list" and "openspec status" report no work, and "openspec archive" ' +
+        'has nothing to flag as incomplete. Rewrite each task as "- [ ] 1.1 Description".',
+    });
+  }
+
+  return issues;
+}
+
+/** 1-based line of the first list item outside a fenced block, if any. */
+function findFirstListItemLine(content: string): number | undefined {
+  let openFence: string | undefined;
+
+  const lines = content.split('\n');
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index];
+    const fence = line.match(FENCE)?.[1];
+    if (fence) {
+      if (openFence === undefined) {
+        openFence = fence[0];
+      } else if (fence[0] === openFence) {
+        openFence = undefined;
+      }
+      continue;
+    }
+    if (openFence !== undefined) continue;
+    if (LIST_ITEM.test(line)) return index + 1;
+  }
+
+  return undefined;
+}

--- a/src/core/validation/task-checkboxes.ts
+++ b/src/core/validation/task-checkboxes.ts
@@ -30,13 +30,21 @@ const LIST_ITEM = /^\s*(?:[-*+]|\d+[.)])\s+\S/;
  * whatever follows it on the line (an info string on an opener, nothing on a
  * valid closer).
  *
+ * Indented by at most three spaces, as CommonMark requires: at four, the line is
+ * an indented code block rather than a fence, and treating it as an opener would
+ * leave the scan inside a block that never began and hide every list below it.
+ *
  * Deliberately unanchored at the end: `.` does not match `\r`, so `(.*)$` would
  * fail on every line of a CRLF file and blind the scan to fences entirely.
  */
-const FENCE = /^\s*(`{3,}|~{3,})(.*)/;
+const FENCE = /^ {0,3}(`{3,}|~{3,})(.*)/;
 
-/** A YAML front-matter delimiter, recognised only on a document's first line. */
-const FRONT_MATTER = /^(-{3,})\s*$/;
+/**
+ * The YAML front-matter delimiter: exactly three dashes. A longer run is a
+ * thematic break, so `----` must not open a block that swallows the list under
+ * it until the next `---`.
+ */
+const FRONT_MATTER = /^-{3}\s*$/;
 
 const COMMENT_OPEN = '<!--';
 const COMMENT_CLOSE = '-->';

--- a/src/core/validation/task-checkboxes.ts
+++ b/src/core/validation/task-checkboxes.ts
@@ -18,8 +18,15 @@ export interface TaskCheckboxIssue {
  */
 const LIST_ITEM = /^\s*(?:[-*+]|\d+[.)])\s+\S/;
 
-/** A fenced block opener/closer: three or more backticks or tildes. */
-const FENCE = /^\s*(`{3,}|~{3,})/;
+/**
+ * A fenced block delimiter: a run of three or more backticks or tildes, plus
+ * whatever follows it on the line (an info string on an opener, nothing on a
+ * valid closer).
+ *
+ * Deliberately unanchored at the end: `.` does not match `\r`, so `(.*)$` would
+ * fail on every line of a CRLF file and blind the scan to fences entirely.
+ */
+const FENCE = /^\s*(`{3,}|~{3,})(.*)/;
 
 /**
  * Reports tracked task files that list work as plain bullets or numbered items
@@ -67,16 +74,26 @@ export function findMissingTaskCheckboxIssues(
 
 /** 1-based line of the first list item outside a fenced block, if any. */
 function findFirstListItemLine(content: string): number | undefined {
-  let openFence: string | undefined;
+  let openFence: { marker: string; length: number } | undefined;
 
   const lines = content.split('\n');
   for (let index = 0; index < lines.length; index++) {
     const line = lines[index];
-    const fence = line.match(FENCE)?.[1];
+    const fence = line.match(FENCE);
     if (fence) {
+      const marker = fence[1][0];
+      const length = fence[1].length;
       if (openFence === undefined) {
-        openFence = fence[0];
-      } else if (fence[0] === openFence) {
+        openFence = { marker, length };
+      } else if (
+        marker === openFence.marker &&
+        length >= openFence.length &&
+        fence[2].trim() === ''
+      ) {
+        // CommonMark: a closer matches its opener's character, runs at least as
+        // long, and carries no info string. A shorter or annotated run inside a
+        // block is content, so a ```` ``` ```` sample nested in a ```` ```` ````
+        // block does not end the block early and expose its bullets.
         openFence = undefined;
       }
       continue;

--- a/src/core/validation/task-checkboxes.ts
+++ b/src/core/validation/task-checkboxes.ts
@@ -16,6 +16,9 @@ export interface TaskCheckboxIssue {
  * `1. item`, `1) item`. Checkbox lines match this too, so callers must rule the
  * document set out on checkbox count first.
  *
+ * Matches at any indent; the caller decides how deep is too deep. See
+ * `CODE_BLOCK_COLUMN`.
+ *
  * A thematic break (`---`, `***`, `- - -`) is not a list item: the run has no
  * text after it, and this pattern requires a non-space character. `* * *` is
  * the one break spelled like a list of `*` items, and it is accepted as a list
@@ -24,6 +27,34 @@ export interface TaskCheckboxIssue {
  * points at an odd line.
  */
 const LIST_ITEM = /^\s*(?:[-*+]|\d+[.)])\s+\S/;
+
+/**
+ * The indent at which a top-level line stops being content and becomes an
+ * indented code block, per CommonMark.
+ *
+ * The fence logic already treats four spaces as code; the list scan did not,
+ * so a sample of terminal output written as `    - example output` was
+ * reported as an uncheckboxed task list, and under `--strict` that false
+ * positive failed validation on a correct file.
+ *
+ * Genuine nested lists survive the cut, because this scan reports the *first*
+ * list item it finds and a nested item always sits under a shallower parent.
+ * That parent is what gets reported, exactly as before. A list-shaped line
+ * four columns deep with no shallower item above it is not nested under
+ * anything, which is precisely what makes it code.
+ */
+const CODE_BLOCK_COLUMN = 4;
+
+/** Leading whitespace of a line in visual columns, a tab counting as four. */
+function indentColumns(line: string): number {
+  let column = 0;
+  for (const char of line) {
+    if (char === ' ') column += 1;
+    else if (char === '\t') column += CODE_BLOCK_COLUMN - (column % CODE_BLOCK_COLUMN);
+    else break;
+  }
+  return column;
+}
 
 /**
  * A fenced block delimiter: a run of three or more backticks or tildes, plus
@@ -65,7 +96,8 @@ const COMMENT_CLOSE = '-->';
  * moment a single checkbox exists.
  *
  * The scan for the offending line looks at rendered content only: fenced
- * blocks, HTML comments and YAML front matter are skipped. Every one of those
+ * blocks, HTML comments, YAML front matter and top-level indented code are
+ * skipped. Every one of those
  * exclusions can only *silence* a warning, never drop a real task — that is the
  * opposite trade from the task parser, where fence awareness would hide work
  * that `archive` must still refuse, and it is why the parser stays literal
@@ -140,7 +172,7 @@ function findFirstListItemLine(content: string): number | undefined {
       continue;
     }
 
-    if (LIST_ITEM.test(line)) return index + 1;
+    if (LIST_ITEM.test(line) && indentColumns(line) < CODE_BLOCK_COLUMN) return index + 1;
   }
 
   return undefined;

--- a/src/core/validation/validator.ts
+++ b/src/core/validation/validator.ts
@@ -556,14 +556,37 @@ export class Validator {
         continue;
       }
 
-      documents.push({
-        path: FileSystemUtils.toPosixPath(path.relative(changeDir, file)),
-        content,
-      });
+      documents.push({ path: this.taskDocumentPath(changeDir, file), content });
     }
 
     documents.sort((left, right) => left.path.localeCompare(right.path));
     return { documents, unreadable };
+  }
+
+  /**
+   * Names a task file relative to its change, POSIX-separated.
+   *
+   * Both sides are canonicalized first. `resolveArtifactOutputs` hands back real
+   * paths, while `changeDir` carries whatever spelling the caller resolved, and
+   * the two can differ without being apart: on Windows a short 8.3 alias
+   * (`RUNNER~1`) against its expanded form turned `tasks.md` into a
+   * `../../../..`-prefixed absolute path in the report, and a symlinked project
+   * directory does the same elsewhere. Canonicalizing recovers the real
+   * relationship. The Windows CI job is the regression guard — the mismatch
+   * cannot be staged on POSIX, where the spawned CLI's `process.cwd()` is
+   * already physical.
+   *
+   * A path that still escapes would be a resolver bug rather than a spelling
+   * difference, but the report must never leak an absolute filesystem path, so
+   * the file name stands in.
+   */
+  private taskDocumentPath(changeDir: string, file: string): string {
+    const relative = path.relative(
+      FileSystemUtils.canonicalizeExistingPath(changeDir),
+      FileSystemUtils.canonicalizeExistingPath(file)
+    );
+    const escapes = relative === '' || relative.startsWith('..') || path.isAbsolute(relative);
+    return escapes ? path.basename(file) : FileSystemUtils.toPosixPath(relative);
   }
 
   /**

--- a/src/core/validation/validator.ts
+++ b/src/core/validation/validator.ts
@@ -34,6 +34,7 @@ import {
 } from '../../utils/change-metadata.js';
 import { resolveTaskFilesForChange } from '../../utils/task-progress.js';
 import { findTaskNumberingIssues } from './task-numbering.js';
+import { findMissingTaskCheckboxIssues } from './task-checkboxes.js';
 import { findPurposePlaceholderIssue } from './purpose-placeholder.js';
 import { getPackageSchemasDir, getSchemaDir } from '../artifact-graph/index.js';
 
@@ -479,67 +480,102 @@ export class Validator {
     }
 
     if (options.projectRoot) {
-      issues.push(...await this.collectTaskNumberingIssues(changeDir, options.projectRoot));
+      issues.push(...await this.collectTaskFileIssues(changeDir, options.projectRoot));
     }
 
     return this.createReport(issues);
   }
 
-  private async collectTaskNumberingIssues(
+  /**
+   * Lints the change's task files.
+   *
+   * Two checks with deliberately different reach. Checkbox formatting is read
+   * from whatever the change's own schema declares as its tracked task output,
+   * because every schema's progress, apply and archive behavior is computed by
+   * counting checkboxes in exactly those files. Numbering stays scoped to the
+   * built-in `spec-driven` schema, whose template is the one that numbers tasks
+   * in the first place.
+   *
+   * The checkbox check never falls back to a bare top-level `tasks.md`: a file
+   * no artifact declares is not a tracked task list, and warning about its
+   * formatting would be a guess about a file the tool does not read.
+   */
+  private async collectTaskFileIssues(
     changeDir: string,
     projectRoot: string
   ): Promise<ValidationIssue[]> {
+    let trackedFiles: string[];
     try {
-      const schemaName = resolveSchemaForChange(changeDir, undefined, projectRoot).replace(
-        /\.ya?ml$/,
-        ''
-      );
-      const schemaDir = getSchemaDir(schemaName, projectRoot);
-      const builtInSchemaDir = path.join(getPackageSchemasDir(), 'spec-driven');
-      if (
-        schemaName !== 'spec-driven' ||
-        schemaDir === null ||
-        FileSystemUtils.canonicalizeExistingPath(schemaDir) !==
-          FileSystemUtils.canonicalizeExistingPath(builtInSchemaDir)
-      ) {
-        return [];
-      }
+      trackedFiles = resolveTaskFilesForChange(changeDir, projectRoot);
     } catch {
       return [];
     }
 
-    let taskFiles: string[];
-    try {
-      taskFiles = resolveTaskFilesForChange(changeDir, projectRoot);
-    } catch {
-      return [];
-    }
-    if (taskFiles.length === 0) {
-      taskFiles = [path.join(changeDir, 'tasks.md')];
-    }
+    const files = trackedFiles.length > 0 ? trackedFiles : [path.join(changeDir, 'tasks.md')];
+    const documents = await this.readTaskDocuments(changeDir, files);
+    const toWarning = (issue: { path: string; line: number; message: string }): ValidationIssue => ({
+      level: 'WARNING',
+      path: issue.path,
+      line: issue.line,
+      message: issue.message,
+    });
 
+    const issues: ValidationIssue[] = [];
+    if (trackedFiles.length > 0) {
+      issues.push(...findMissingTaskCheckboxIssues(documents).map(toWarning));
+    }
+    if (this.usesBuiltInSpecDrivenSchema(changeDir, projectRoot)) {
+      issues.push(...findTaskNumberingIssues(documents).map(toWarning));
+    }
+    return issues;
+  }
+
+  /** Reads task files into change-relative documents, skipping unreadable ones. */
+  private async readTaskDocuments(
+    changeDir: string,
+    files: readonly string[]
+  ): Promise<Array<{ path: string; content: string }>> {
     const documents: Array<{ path: string; content: string }> = [];
-    for (const taskFile of taskFiles) {
+    for (const file of files) {
       let content: string;
       try {
-        content = await fs.readFile(taskFile, 'utf-8');
+        content = await fs.readFile(file, 'utf-8');
       } catch {
         continue;
       }
 
       documents.push({
-        path: FileSystemUtils.toPosixPath(path.relative(changeDir, taskFile)),
+        path: FileSystemUtils.toPosixPath(path.relative(changeDir, file)),
         content,
       });
     }
 
     documents.sort((left, right) => left.path.localeCompare(right.path));
-    return findTaskNumberingIssues(documents).map((issue) => ({
-      level: 'WARNING',
-      path: issue.path,
-      line: issue.line,
-      message: issue.message,
-    }));
+    return documents;
+  }
+
+  /**
+   * True when the change resolves to the package's own `spec-driven` schema. A
+   * project schema that merely reuses the name is not it, so checks written
+   * against the built-in template never fire on someone else's task format.
+   */
+  private usesBuiltInSpecDrivenSchema(changeDir: string, projectRoot: string): boolean {
+    try {
+      const schemaName = resolveSchemaForChange(changeDir, undefined, projectRoot).replace(
+        /\.ya?ml$/,
+        ''
+      );
+      if (schemaName !== 'spec-driven') return false;
+      const schemaDir = getSchemaDir(schemaName, projectRoot);
+      if (schemaDir === null) return false;
+      const builtInSchemaDir = path.join(getPackageSchemasDir(), 'spec-driven');
+      return (
+        FileSystemUtils.canonicalizeExistingPath(schemaDir) ===
+        FileSystemUtils.canonicalizeExistingPath(builtInSchemaDir)
+      );
+    } catch {
+      return false;
+    }
   }
 
   /**

--- a/src/core/validation/validator.ts
+++ b/src/core/validation/validator.ts
@@ -512,7 +512,7 @@ export class Validator {
     }
 
     const files = trackedFiles.length > 0 ? trackedFiles : [path.join(changeDir, 'tasks.md')];
-    const documents = await this.readTaskDocuments(changeDir, files);
+    const { documents, unreadable } = await this.readTaskDocuments(changeDir, files);
     const toWarning = (issue: { path: string; line: number; message: string }): ValidationIssue => ({
       level: 'WARNING',
       path: issue.path,
@@ -521,7 +521,11 @@ export class Validator {
     });
 
     const issues: ValidationIssue[] = [];
-    if (trackedFiles.length > 0) {
+    // "No file here holds a checkbox" is a claim about the whole tracked set, so
+    // a file that exists but could not be read withdraws it: the checkboxes may
+    // be in exactly that file. `validate --archived` is the surface that reports
+    // an unreadable task file loudly (#205); this one must not guess from it.
+    if (trackedFiles.length > 0 && unreadable === 0) {
       issues.push(...findMissingTaskCheckboxIssues(documents).map(toWarning));
     }
     if (this.usesBuiltInSpecDrivenSchema(changeDir, projectRoot)) {
@@ -530,17 +534,25 @@ export class Validator {
     return issues;
   }
 
-  /** Reads task files into change-relative documents, skipping unreadable ones. */
+  /**
+   * Reads task files into change-relative documents, counting the ones that
+   * exist but could not be read. A file that is simply absent is not counted:
+   * the resolver only returns files it found, so the remaining read failures
+   * are permissions and I/O, and a check that reasons over the whole set needs
+   * to know its evidence was incomplete.
+   */
   private async readTaskDocuments(
     changeDir: string,
     files: readonly string[]
-  ): Promise<Array<{ path: string; content: string }>> {
+  ): Promise<{ documents: Array<{ path: string; content: string }>; unreadable: number }> {
     const documents: Array<{ path: string; content: string }> = [];
+    let unreadable = 0;
     for (const file of files) {
       let content: string;
       try {
         content = await fs.readFile(file, 'utf-8');
-      } catch {
+      } catch (error: any) {
+        if (error?.code !== 'ENOENT') unreadable++;
         continue;
       }
 
@@ -551,7 +563,7 @@ export class Validator {
     }
 
     documents.sort((left, right) => left.path.localeCompare(right.path));
-    return documents;
+    return { documents, unreadable };
   }
 
   /**

--- a/test/cli-e2e/validate-task-checkboxes.test.ts
+++ b/test/cli-e2e/validate-task-checkboxes.test.ts
@@ -82,6 +82,11 @@ describe('openspec validate checks task checkbox formatting (#354)', () => {
     await write('openspec/changes/nested-bullets/backend/tasks.md', '- build the api\n');
     await write('openspec/changes/nested-bullets/frontend/tasks.md', '- [ ] 2.1 build the ui\n');
 
+    await write('openspec/changes/nested-all-bullets/.openspec.yaml', 'schema: glob-tasks\n');
+    await write('openspec/changes/nested-all-bullets/specs/tasks/spec.md', validDelta);
+    await write('openspec/changes/nested-all-bullets/backend/tasks.md', '- build the api\n');
+    await write('openspec/changes/nested-all-bullets/frontend/tasks.md', '- build the ui\n');
+
     await write('openspec/schemas/no-tasks-artifact/schema.yaml', untrackedTasksSchema);
     await write('openspec/changes/untracked-tasks/.openspec.yaml', 'schema: no-tasks-artifact\n');
     await write('openspec/changes/untracked-tasks/specs/tasks/spec.md', validDelta);
@@ -148,6 +153,20 @@ describe('openspec validate checks task checkbox formatting (#354)', () => {
     expect(taskIssues).toEqual([]);
   });
 
+  it('reports each nested file with a POSIX path when none of them has a checkbox', async () => {
+    const result = await runCLI(
+      ['validate', '--type', 'change', 'nested-all-bullets', '--strict', '--json'],
+      { cwd: projectDir }
+    );
+
+    expect(result.exitCode).toBe(1);
+    // Paths are normalized, so this assertion fails on a Windows separator.
+    expect(JSON.parse(result.stdout).items[0].issues).toEqual([
+      expect.objectContaining({ level: 'WARNING', path: 'backend/tasks.md', line: 1 }),
+      expect.objectContaining({ level: 'WARNING', path: 'frontend/tasks.md', line: 1 }),
+    ]);
+  });
+
   it('ignores a tasks file no artifact tracks', async () => {
     const result = await runCLI(
       ['validate', '--type', 'change', 'untracked-tasks', '--strict', '--json'],
@@ -173,6 +192,7 @@ describe('openspec validate checks task checkbox formatting (#354)', () => {
     expect(byId['bullet-tasks']).toBe(false);
     expect(byId['checkbox-tasks']).toBe(true);
     expect(byId['nested-bullets']).toBe(true);
+    expect(byId['nested-all-bullets']).toBe(false);
     expect(byId['untracked-tasks']).toBe(true);
   });
 });

--- a/test/cli-e2e/validate-task-checkboxes.test.ts
+++ b/test/cli-e2e/validate-task-checkboxes.test.ts
@@ -1,0 +1,178 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { tmpdir } from 'os';
+import { runCLI } from '../helpers/run-cli.js';
+
+describe('openspec validate checks task checkbox formatting (#354)', () => {
+  let projectDir: string;
+
+  const write = async (relative: string, content: string) => {
+    const file = path.join(projectDir, relative);
+    await fs.mkdir(path.dirname(file), { recursive: true });
+    await fs.writeFile(file, content, 'utf-8');
+  };
+
+  const validDelta = [
+    '## ADDED Requirements',
+    '',
+    '### Requirement: Task lists SHALL be machine readable',
+    'The validator SHALL report task lists that progress cannot count.',
+    '',
+    '#### Scenario: Validate a bullet-only task list',
+    '- **WHEN** validation runs on a task file without checkboxes',
+    '- **THEN** the change is reported as counting zero tasks',
+    '',
+  ].join('\n');
+
+  const globTasksSchema = [
+    'name: glob-tasks',
+    'version: 1',
+    'description: tasks artifact uses a nested glob',
+    'artifacts:',
+    '  - id: proposal',
+    '    generates: proposal.md',
+    '    description: Proposal',
+    '    template: proposal.md',
+    '    requires: []',
+    '  - id: tasks',
+    '    generates: "**/tasks.md"',
+    '    description: Nested tasks',
+    '    template: tasks.md',
+    '    requires: [proposal]',
+    'apply:',
+    '  requires: [tasks]',
+    '  tracks: "**/tasks.md"',
+    '',
+  ].join('\n');
+
+  const untrackedTasksSchema = [
+    'name: no-tasks-artifact',
+    'version: 1',
+    'description: schema without a tracked tasks artifact',
+    'artifacts:',
+    '  - id: proposal',
+    '    generates: proposal.md',
+    '    description: Proposal',
+    '    template: proposal.md',
+    '    requires: []',
+    '',
+  ].join('\n');
+
+  beforeAll(async () => {
+    projectDir = await fs.mkdtemp(path.join(tmpdir(), 'openspec-task-checkboxes-e2e-'));
+
+    await write('openspec/changes/bullet-tasks/specs/tasks/spec.md', validDelta);
+    await write(
+      'openspec/changes/bullet-tasks/tasks.md',
+      ['# Tasks', '', '## 1. Implementation', '', '- Add the parser', '- Add the tests', ''].join(
+        '\n'
+      )
+    );
+
+    await write('openspec/changes/checkbox-tasks/specs/tasks/spec.md', validDelta);
+    await write(
+      'openspec/changes/checkbox-tasks/tasks.md',
+      ['## 1. Implementation', '', '- [ ] 1.1 Add the parser', '- A supporting note', ''].join('\n')
+    );
+
+    await write('openspec/schemas/glob-tasks/schema.yaml', globTasksSchema);
+    await write('openspec/changes/nested-bullets/.openspec.yaml', 'schema: glob-tasks\n');
+    await write('openspec/changes/nested-bullets/specs/tasks/spec.md', validDelta);
+    await write('openspec/changes/nested-bullets/backend/tasks.md', '- build the api\n');
+    await write('openspec/changes/nested-bullets/frontend/tasks.md', '- [ ] 2.1 build the ui\n');
+
+    await write('openspec/schemas/no-tasks-artifact/schema.yaml', untrackedTasksSchema);
+    await write('openspec/changes/untracked-tasks/.openspec.yaml', 'schema: no-tasks-artifact\n');
+    await write('openspec/changes/untracked-tasks/specs/tasks/spec.md', validDelta);
+    await write('openspec/changes/untracked-tasks/tasks.md', '- an untracked bullet\n');
+  });
+
+  afterAll(async () => {
+    await fs.rm(projectDir, { recursive: true, force: true });
+  });
+
+  it('reports a bullet-only task list and names the counting consequence', async () => {
+    const result = await runCLI(
+      ['validate', '--type', 'change', 'bullet-tasks', '--strict', '--json'],
+      { cwd: projectDir }
+    );
+
+    expect(result.exitCode).toBe(1);
+    const report = JSON.parse(result.stdout);
+    expect(report.items[0].issues).toEqual([
+      expect.objectContaining({
+        level: 'WARNING',
+        path: 'tasks.md',
+        line: 5,
+        message: expect.stringContaining('counts as 0 tasks'),
+      }),
+    ]);
+  });
+
+  it('agrees with the progress the same change reports', async () => {
+    const result = await runCLI(['list', '--changes'], { cwd: projectDir });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toMatch(/bullet-tasks\s+No tasks/);
+  });
+
+  it('keeps the warning non-blocking without --strict', async () => {
+    const result = await runCLI(['validate', '--type', 'change', 'bullet-tasks', '--json'], {
+      cwd: projectDir,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout).items[0].valid).toBe(true);
+  });
+
+  it('stays silent when the change has a real checklist', async () => {
+    const result = await runCLI(['validate', '--type', 'change', 'checkbox-tasks', '--strict'], {
+      cwd: projectDir,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Change 'checkbox-tasks' is valid");
+  });
+
+  it('checks the whole tracked set of a custom schema, not each file alone', async () => {
+    const result = await runCLI(
+      ['validate', '--type', 'change', 'nested-bullets', '--strict', '--json'],
+      { cwd: projectDir }
+    );
+
+    expect(result.exitCode).toBe(0);
+    const taskIssues = JSON.parse(result.stdout).items[0].issues.filter(
+      (issue: { path: string }) => issue.path.endsWith('tasks.md')
+    );
+    expect(taskIssues).toEqual([]);
+  });
+
+  it('ignores a tasks file no artifact tracks', async () => {
+    const result = await runCLI(
+      ['validate', '--type', 'change', 'untracked-tasks', '--strict', '--json'],
+      { cwd: projectDir }
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout).items[0].issues).toEqual([]);
+  });
+
+  it('applies the warning in bulk validation', async () => {
+    const result = await runCLI(['validate', '--changes', '--strict', '--json'], {
+      cwd: projectDir,
+    });
+
+    expect(result.exitCode).toBe(1);
+    const byId = Object.fromEntries(
+      JSON.parse(result.stdout).items.map((item: { id: string; valid: boolean }) => [
+        item.id,
+        item.valid,
+      ])
+    );
+    expect(byId['bullet-tasks']).toBe(false);
+    expect(byId['checkbox-tasks']).toBe(true);
+    expect(byId['nested-bullets']).toBe(true);
+    expect(byId['untracked-tasks']).toBe(true);
+  });
+});

--- a/test/cli-e2e/validate-task-checkboxes.test.ts
+++ b/test/cli-e2e/validate-task-checkboxes.test.ts
@@ -214,13 +214,16 @@ describe('openspec validate checks task checkbox formatting (#354)', () => {
     ]);
   });
 
-  it('prints the warning with its line through the deprecated change validate command', async () => {
+  it('surfaces the warning through the deprecated change validate command', async () => {
     const result = await runCLI(['change', 'validate', 'bullet-tasks', '--strict'], {
       cwd: projectDir,
     });
 
     expect(result.exitCode).toBe(1);
-    expect(result.stderr).toContain('tasks.md');
+    // The text renderer prints level, path and message; it carries no line for
+    // any issue, which is why this asserts what that surface actually emits.
+    // The line lives in the JSON report, asserted above.
+    expect(result.stderr).toContain('[WARNING] tasks.md:');
     expect(result.stderr).toContain('counts as 0 tasks');
   });
 
@@ -247,6 +250,11 @@ describe('openspec validate checks task checkbox formatting (#354)', () => {
       await fs.chmod(locked, 0o000);
 
       try {
+        // Without this the test would pass for the wrong reason: if the lock did
+        // not take (root, or a filesystem that ignores the mode), the checkbox
+        // in this very file would silence the warning on its own.
+        await expect(fs.readFile(locked, 'utf-8')).rejects.toThrow();
+
         const result = await runCLI(
           ['validate', '--type', 'change', 'half-read', '--strict', '--json'],
           { cwd: dir }

--- a/test/cli-e2e/validate-task-checkboxes.test.ts
+++ b/test/cli-e2e/validate-task-checkboxes.test.ts
@@ -46,6 +46,26 @@ describe('openspec validate checks task checkbox formatting (#354)', () => {
     '',
   ].join('\n');
 
+  // No `apply` block: the tracked-tasks artifact is found by its `tasks` id,
+  // the same fallback progress counting uses.
+  const implicitTasksSchema = [
+    'name: implicit-tasks',
+    'version: 1',
+    'description: tasks artifact without an apply block',
+    'artifacts:',
+    '  - id: proposal',
+    '    generates: proposal.md',
+    '    description: Proposal',
+    '    template: proposal.md',
+    '    requires: []',
+    '  - id: tasks',
+    '    generates: tasks.md',
+    '    description: Tasks',
+    '    template: tasks.md',
+    '    requires: [proposal]',
+    '',
+  ].join('\n');
+
   const untrackedTasksSchema = [
     'name: no-tasks-artifact',
     'version: 1',
@@ -86,6 +106,11 @@ describe('openspec validate checks task checkbox formatting (#354)', () => {
     await write('openspec/changes/nested-all-bullets/specs/tasks/spec.md', validDelta);
     await write('openspec/changes/nested-all-bullets/backend/tasks.md', '- build the api\n');
     await write('openspec/changes/nested-all-bullets/frontend/tasks.md', '- build the ui\n');
+
+    await write('openspec/schemas/implicit-tasks/schema.yaml', implicitTasksSchema);
+    await write('openspec/changes/implicit-tracking/.openspec.yaml', 'schema: implicit-tasks\n');
+    await write('openspec/changes/implicit-tracking/specs/tasks/spec.md', validDelta);
+    await write('openspec/changes/implicit-tracking/tasks.md', '- build the api\n');
 
     await write('openspec/schemas/no-tasks-artifact/schema.yaml', untrackedTasksSchema);
     await write('openspec/changes/untracked-tasks/.openspec.yaml', 'schema: no-tasks-artifact\n');
@@ -177,6 +202,65 @@ describe('openspec validate checks task checkbox formatting (#354)', () => {
     expect(JSON.parse(result.stdout).items[0].issues).toEqual([]);
   });
 
+  it('follows the tracked-tasks artifact when a schema declares no apply block', async () => {
+    const result = await runCLI(
+      ['validate', '--type', 'change', 'implicit-tracking', '--strict', '--json'],
+      { cwd: projectDir }
+    );
+
+    expect(result.exitCode).toBe(1);
+    expect(JSON.parse(result.stdout).items[0].issues).toEqual([
+      expect.objectContaining({ level: 'WARNING', path: 'tasks.md', line: 1 }),
+    ]);
+  });
+
+  it('prints the warning with its line through the deprecated change validate command', async () => {
+    const result = await runCLI(['change', 'validate', 'bullet-tasks', '--strict'], {
+      cwd: projectDir,
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('tasks.md');
+    expect(result.stderr).toContain('counts as 0 tasks');
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'stays silent when a tracked file exists but cannot be read',
+    async () => {
+      // The claim is about the whole tracked set, and the checkboxes could be
+      // in exactly the file that would not open.
+      const dir = await fs.mkdtemp(path.join(tmpdir(), 'openspec-task-unreadable-e2e-'));
+      const writeIn = async (relative: string, content: string) => {
+        const file = path.join(dir, relative);
+        await fs.mkdir(path.dirname(file), { recursive: true });
+        await fs.writeFile(file, content, 'utf-8');
+        return file;
+      };
+      await writeIn('openspec/schemas/glob-tasks/schema.yaml', globTasksSchema);
+      await writeIn('openspec/changes/half-read/.openspec.yaml', 'schema: glob-tasks\n');
+      await writeIn('openspec/changes/half-read/specs/tasks/spec.md', validDelta);
+      await writeIn('openspec/changes/half-read/backend/tasks.md', '- build the api\n');
+      const locked = await writeIn(
+        'openspec/changes/half-read/frontend/tasks.md',
+        '- [ ] 2.1 build the ui\n'
+      );
+      await fs.chmod(locked, 0o000);
+
+      try {
+        const result = await runCLI(
+          ['validate', '--type', 'change', 'half-read', '--strict', '--json'],
+          { cwd: dir }
+        );
+
+        expect(result.exitCode).toBe(0);
+        expect(JSON.parse(result.stdout).items[0].issues).toEqual([]);
+      } finally {
+        await fs.chmod(locked, 0o644);
+        await fs.rm(dir, { recursive: true, force: true });
+      }
+    }
+  );
+
   it('applies the warning in bulk validation', async () => {
     const result = await runCLI(['validate', '--changes', '--strict', '--json'], {
       cwd: projectDir,
@@ -193,6 +277,7 @@ describe('openspec validate checks task checkbox formatting (#354)', () => {
     expect(byId['checkbox-tasks']).toBe(true);
     expect(byId['nested-bullets']).toBe(true);
     expect(byId['nested-all-bullets']).toBe(false);
+    expect(byId['implicit-tracking']).toBe(false);
     expect(byId['untracked-tasks']).toBe(true);
   });
 });

--- a/test/core/task-checkboxes.test.ts
+++ b/test/core/task-checkboxes.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import fg from 'fast-glob';
 import { findMissingTaskCheckboxIssues } from '../../src/core/validation/task-checkboxes.js';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 
 const findInSingleFile = (content: string) =>
   findMissingTaskCheckboxIssues([{ path: 'tasks.md', content }]).map(
@@ -82,6 +88,82 @@ describe('findMissingTaskCheckboxIssues', () => {
 
   it('does not treat a horizontal rule or emphasis as a list item', () => {
     expect(findInSingleFile('# Tasks\n\n---\n\n***\n')).toEqual([]);
+  });
+
+  it('skips YAML front matter', () => {
+    expect(
+      findInSingleFile(
+        ['---', 'tags:', '  - planning', '  - backend', '---', '', 'Nothing planned yet.', ''].join(
+          '\n'
+        )
+      )
+    ).toEqual([]);
+    expect(
+      findInSingleFile(
+        ['---', 'tags:', '  - planning', '---', '', '- a real bullet', ''].join('\n')
+      )
+    ).toEqual([{ line: 6, message: expect.any(String) }]);
+  });
+
+  it('treats an unterminated front-matter opener as a thematic break', () => {
+    expect(findInSingleFile(['---', '', '- a real bullet', ''].join('\n'))).toEqual([
+      { line: 3, message: expect.any(String) },
+    ]);
+  });
+
+  it('skips HTML comments without hiding the line that follows them', () => {
+    expect(
+      findInSingleFile(['<!--', '- a retired task', '-->', '', 'Nothing planned yet.', ''].join('\n'))
+    ).toEqual([]);
+    expect(
+      findInSingleFile(['<!-- a note -->', '- a real bullet', ''].join('\n'))
+    ).toEqual([{ line: 2, message: expect.any(String) }]);
+    expect(
+      findInSingleFile(['<!--', '- a retired task', '-->', '- a real bullet', ''].join('\n'))
+    ).toEqual([{ line: 4, message: expect.any(String) }]);
+  });
+
+  it('accepts every packaged tasks template', async () => {
+    // An agent writing a task file follows these. If one ever loses its
+    // checkboxes, every change built from it starts life counting zero tasks.
+    const templates = await fg('schemas/*/templates/tasks.md', {
+      cwd: repoRoot,
+      absolute: true,
+    });
+    expect(templates.length).toBeGreaterThan(0);
+
+    for (const template of templates) {
+      const content = await fs.readFile(template, 'utf-8');
+      expect({
+        template: path.relative(repoRoot, template),
+        issues: findMissingTaskCheckboxIssues([{ path: 'tasks.md', content }]),
+      }).toEqual({ template: path.relative(repoRoot, template), issues: [] });
+    }
+  });
+
+  it('does not let the template heading comment swallow its checklist', () => {
+    // The scaffolded tasks.md: a heading carrying an inline comment, then real
+    // checkboxes. It must stay silent, and would not if an inline comment on a
+    // heading opened a block.
+    expect(
+      findInSingleFile(
+        [
+          '## 1. <!-- Task Group Name -->',
+          '',
+          '- [ ] 1.1 <!-- Task description -->',
+          '- [ ] 1.2 <!-- Task description -->',
+          '',
+        ].join('\n')
+      )
+    ).toEqual([]);
+  });
+
+  it('reports a list of unrecognised checkbox markers, which count as no task', () => {
+    // `- [~] ...` is not a checkbox the parser recognises today, so the change
+    // really does count zero tasks and the warning is the only signal.
+    expect(findInSingleFile('- [~] 1.1 in progress\n')).toEqual([
+      { line: 1, message: expect.any(String) },
+    ]);
   });
 
   it('reports every file only when the whole change has no checkbox', () => {

--- a/test/core/task-checkboxes.test.ts
+++ b/test/core/task-checkboxes.test.ts
@@ -86,6 +86,17 @@ describe('findMissingTaskCheckboxIssues', () => {
     ).toEqual([{ line: 5, message: expect.any(String) }]);
   });
 
+  it('only treats a fence indented up to three spaces as a fence', () => {
+    // Four spaces makes an indented code block, not an opener. Reading it as one
+    // would leave the scan inside a block that never began.
+    expect(
+      findInSingleFile(['    ```', '', '- a real bullet', ''].join('\n'))
+    ).toEqual([{ line: 3, message: expect.any(String) }]);
+    expect(
+      findInSingleFile(['   ```', '- an example bullet', '   ```', ''].join('\n'))
+    ).toEqual([]);
+  });
+
   it('does not treat a horizontal rule or emphasis as a list item', () => {
     expect(findInSingleFile('# Tasks\n\n---\n\n***\n')).toEqual([]);
   });
@@ -109,6 +120,14 @@ describe('findMissingTaskCheckboxIssues', () => {
     expect(findInSingleFile(['---', '', '- a real bullet', ''].join('\n'))).toEqual([
       { line: 3, message: expect.any(String) },
     ]);
+  });
+
+  it('does not read a longer dash run as front matter', () => {
+    // `----` is a thematic break. Reading it as an opener would hide every list
+    // between it and the next `---`.
+    expect(
+      findInSingleFile(['----', '', '- a real bullet', '', '---', ''].join('\n'))
+    ).toEqual([{ line: 3, message: expect.any(String) }]);
   });
 
   it('skips HTML comments without hiding the line that follows them', () => {

--- a/test/core/task-checkboxes.test.ts
+++ b/test/core/task-checkboxes.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { findMissingTaskCheckboxIssues } from '../../src/core/validation/task-checkboxes.js';
+
+const findInSingleFile = (content: string) =>
+  findMissingTaskCheckboxIssues([{ path: 'tasks.md', content }]).map(
+    ({ path: _path, ...issue }) => issue
+  );
+
+describe('findMissingTaskCheckboxIssues', () => {
+  it('reports a task list written as plain bullets', () => {
+    const issues = findInSingleFile(
+      ['# Tasks', '', '## 1. Implementation', '', '- Add the parser', '- Add the tests', ''].join(
+        '\n'
+      )
+    );
+
+    expect(issues).toEqual([
+      {
+        line: 5,
+        message: expect.stringContaining('counts as 0 tasks'),
+      },
+    ]);
+  });
+
+  it('reports a task list written as a numbered list', () => {
+    expect(findInSingleFile('# Tasks\n\n1. Add the parser\n2. Add the tests\n')).toEqual([
+      { line: 3, message: expect.any(String) },
+    ]);
+    expect(findInSingleFile('1) Add the parser\n')).toEqual([
+      { line: 1, message: expect.any(String) },
+    ]);
+  });
+
+  it('stays silent when checkboxes are present', () => {
+    expect(findInSingleFile('- [ ] 1.1 Add the parser\n- Supporting note\n')).toEqual([]);
+    expect(findInSingleFile('- [x] 1.1 Add the parser\n')).toEqual([]);
+    expect(findInSingleFile('  - [ ] 1.1.1 A nested task\n')).toEqual([]);
+  });
+
+  it('stays silent on prose and on an empty file', () => {
+    expect(findInSingleFile('# Tasks\n\nNothing planned yet.\n')).toEqual([]);
+    expect(findInSingleFile('')).toEqual([]);
+    expect(findMissingTaskCheckboxIssues([])).toEqual([]);
+  });
+
+  it('ignores list items inside fenced blocks', () => {
+    expect(
+      findInSingleFile(['# Tasks', '', '```md', '- an example bullet', '```', ''].join('\n'))
+    ).toEqual([]);
+    expect(
+      findInSingleFile(
+        ['~~~', '- fenced with tildes', '~~~', '', '- a real bullet', ''].join('\n')
+      )
+    ).toEqual([{ line: 5, message: expect.any(String) }]);
+  });
+
+  it('does not treat a horizontal rule or emphasis as a list item', () => {
+    expect(findInSingleFile('# Tasks\n\n---\n\n***\n')).toEqual([]);
+  });
+
+  it('reports every file only when the whole change has no checkbox', () => {
+    const withoutCheckboxes = [
+      { path: 'backend/tasks.md', content: '- build the api\n' },
+      { path: 'frontend/tasks.md', content: '- build the ui\n' },
+    ];
+    expect(findMissingTaskCheckboxIssues(withoutCheckboxes).map((issue) => issue.path)).toEqual([
+      'backend/tasks.md',
+      'frontend/tasks.md',
+    ]);
+
+    const oneRealChecklist = [
+      { path: 'backend/tasks.md', content: '- [ ] 1.1 build the api\n' },
+      { path: 'frontend/tasks.md', content: '- build the ui\n' },
+    ];
+    expect(findMissingTaskCheckboxIssues(oneRealChecklist)).toEqual([]);
+  });
+
+  it('handles CRLF files', () => {
+    expect(findInSingleFile('# Tasks\r\n\r\n- Add the parser\r\n')).toEqual([
+      { line: 3, message: expect.any(String) },
+    ]);
+    expect(findInSingleFile('- [ ] 1.1 Add the parser\r\n')).toEqual([]);
+  });
+});

--- a/test/core/task-checkboxes.test.ts
+++ b/test/core/task-checkboxes.test.ts
@@ -54,6 +54,32 @@ describe('findMissingTaskCheckboxIssues', () => {
     ).toEqual([{ line: 5, message: expect.any(String) }]);
   });
 
+  it('closes a fence only on a matching, long enough, bare delimiter', () => {
+    // A three-marker sample nested inside a four-marker block: the inner run is
+    // content, so the bullets after it are still fenced.
+    expect(
+      findInSingleFile(
+        ['````md', '```', '- an example bullet', '```', '````', ''].join('\n')
+      )
+    ).toEqual([]);
+    // An annotated run is an opener's shape, never a closer's.
+    expect(
+      findInSingleFile(['```', '```js', '- an example bullet', '```', ''].join('\n'))
+    ).toEqual([]);
+    // Tildes do not close a backtick fence.
+    expect(findInSingleFile(['```', '~~~', '- an example bullet', ''].join('\n'))).toEqual([]);
+    // A longer closing run still closes.
+    expect(
+      findInSingleFile(['```', 'sample', '`````', '', '- a real bullet', ''].join('\n'))
+    ).toEqual([{ line: 5, message: expect.any(String) }]);
+  });
+
+  it('tracks fences in CRLF files', () => {
+    expect(
+      findInSingleFile(['```md', '- an example bullet', '```', '', '- a real bullet', ''].join('\r\n'))
+    ).toEqual([{ line: 5, message: expect.any(String) }]);
+  });
+
   it('does not treat a horizontal rule or emphasis as a list item', () => {
     expect(findInSingleFile('# Tasks\n\n---\n\n***\n')).toEqual([]);
   });

--- a/test/core/task-checkboxes.test.ts
+++ b/test/core/task-checkboxes.test.ts
@@ -97,6 +97,34 @@ describe('findMissingTaskCheckboxIssues', () => {
     ).toEqual([]);
   });
 
+  it('does not read top-level indented code as a task list', () => {
+    // Four spaces of indent is a code block, the same rule the fence logic
+    // already applies. A tasks file that pastes terminal output was reported
+    // as an uncheckboxed task list, and under --strict that failed validation
+    // on a correct file.
+    expect(
+      findInSingleFile(['## 1. Notes', '', 'Example output:', '', '    - example output', ''].join('\n'))
+    ).toEqual([]);
+    expect(
+      findInSingleFile(['## 1. Notes', '', 'Example output:', '', '\t- tabbed output', ''].join('\n'))
+    ).toEqual([]);
+    expect(
+      findInSingleFile(['## 1. Notes', '', 'Example output:', '', '    1. numbered output', ''].join('\n'))
+    ).toEqual([]);
+  });
+
+  it('still reports a genuine nested list, by naming its parent', () => {
+    // The cut is safe because this scan reports the first list item it finds,
+    // and a nested item always sits under a shallower parent. Three spaces is
+    // not code, so an indented-but-shallow list is still reported on its own.
+    expect(
+      findInSingleFile(['## 1. Work', '', '- Parent task', '    - Nested detail', ''].join('\n'))
+    ).toEqual([{ line: 3, message: expect.any(String) }]);
+    expect(
+      findInSingleFile(['## 1. Work', '', '   - Three spaces is not code', ''].join('\n'))
+    ).toEqual([{ line: 3, message: expect.any(String) }]);
+  });
+
   it('does not treat a horizontal rule or emphasis as a list item', () => {
     expect(findInSingleFile('# Tasks\n\n---\n\n***\n')).toEqual([]);
   });


### PR DESCRIPTION
## Status

Ready for review. Not merged. Local proof below; CI results added once the run finishes.

## What was wrong

Progress counts checkboxes and nothing else. A `tasks.md` written as plain bullets or a numbered list — which agents and humans both produce occasionally — is therefore worse than an empty one:

- `openspec list` and `openspec status` print **No tasks**
- `openspec archive` has no incomplete task to warn about, so it archives silently
- `validate` said the change was fine

The file reads as finished to the tool and unfinished to whoever wrote it. Nothing anywhere pointed at the cause. That is what #354 asked to catch.

## How it was fixed

`openspec validate` now warns when a change's tracked task files contain list items but not a single checkbox, and names the consequence plus the fix:

> Tasks are listed without checkboxes, so this change counts as 0 tasks: "openspec list" and "openspec status" report no work, and "openspec archive" has nothing to flag as incomplete. Rewrite each task as "- [ ] 1.1 Description".

Scoping, chosen so the check cannot cry wolf:

- **Per change, not per file.** The warning fires only when the *whole* tracked set has zero checkboxes. One nested prose file beside a real checklist stays silent, and a change keeps its progress the moment one checkbox exists.
- **Only files a schema declares.** Task files come from the same `apply.tracks` / `tasks`-artifact resolution progress itself uses. A stray `tasks.md` that no artifact tracks is not linted — the tool does not read it, so guessing at its format would be noise. This applies to custom schemas too, because they compute progress by counting the same checkboxes.
- **Fence-aware, one direction only.** List items inside code fences are skipped when locating the offending line. Unlike the task *parser* — where fence awareness would silently drop real tasks — a mis-read fence here costs only the warning.
- **WARNING, not ERROR.** Non-blocking by default, blocking under `--strict`, exactly like the existing task-numbering check it sits beside. A `--strict` pipeline over a bullet-only task list will newly fail; that state was already broken, just invisibly.

Refactor note: `collectTaskNumberingIssues` became `collectTaskFileIssues`, which reads the task documents once and runs both checks. Numbering keeps its existing reach (built-in `spec-driven` only, with the historical fallback to a bare top-level `tasks.md`); nothing about it changed.

## Replication / proof

```bash
openspec new change demo
cat > openspec/changes/demo/tasks.md <<'MD'
# Tasks

## 1. Implementation

- Add the parser
- Add the tests
MD
openspec list --changes      # demo   No tasks
openspec validate demo       # before: valid, no findings
                             # after:  WARNING tasks.md:5 ... counts as 0 tasks
```

The guard fails first. With `src/core/validation/task-checkboxes.ts` removed and `validator.ts` reset to `main`, the new e2e file reports **2 failed / 5 passed** — the two detection cases fail, every negative case still passes. With the fix, **19/19** pass across the new suite plus the neighbouring task-numbering suites.

New tests:

- `test/core/task-checkboxes.test.ts` (8) — bullets, `1.` and `1)` ordered lists, checkbox present, prose, empty file, fenced examples, `---` / `***` rules, per-change aggregation, CRLF.
- `test/cli-e2e/validate-task-checkboxes.test.ts` (7) — real CLI: detection with line number, `--strict` vs default exit codes, agreement with `openspec list`'s own "No tasks", custom glob schema aggregated across `backend/` + `frontend/`, a tasks file no artifact tracks, and bulk `validate --changes`.

Also green: `test/cli-e2e`, `test/core/validation*`, `test/core/archive.test.ts`, `test/utils` — **767 tests**, plus `tsc --noEmit` and `eslint src/`. Running `validate --changes` against this repo's own `openspec/changes/` produces no new findings.

## Hardening pass (`f5bbd91b5`, `cce3c54c6`)

**CodeRabbit's two findings, both real:**

- **Fence delimiters now honor character, width and suffix.** Comparing the opening delimiter's first character alone let an inner ` ``` ` close an outer ` ```` ` block, exposing the bullets of a nested code sample. A closer must now match the opener's character, run at least as long, and carry no info string. Fixing it surfaced a second defect: the info-string group was end-anchored, and `.` does not match `\r`, so the pattern matched nothing at all in a CRLF file and the scan was blind to fences there.
- **Windows path coverage.** A new e2e change whose nested task files are *all* bullets asserts both reported paths are exactly `backend/tasks.md` and `frontend/tasks.md` — an assertion that fails on a backslash separator.

**Then a self-review pass, which found four more:**

- **The scan reads rendered content only.** YAML front matter and HTML comment blocks are skipped alongside fenced code. A list under `tags:` is metadata about the file, not the work it tracks; a commented-out list is not work either. Every exclusion can only *silence* a warning, never drop a real task — the opposite trade from the task parser, which must stay literal. An unterminated `---` opener rewinds to the top (it is a thematic break, and everything below it is content), and only a comment opening its own line hides that line, so the template's `## 1. <!-- Task Group Name -->` heading cannot swallow the checklist beneath it.
- **Incomplete evidence withdraws the warning.** "No file here holds a checkbox" is a claim about the whole tracked set, so a tracked file that exists but cannot be read now suppresses it — the checkboxes may be in exactly that file. `validate --archived` remains the surface that reports an unreadable task file loudly (#205).
- **The message leads with the consequence, not an accusation** ("This change counts as 0 tasks: no line in its tracked task files is a checkbox…"), because a task file may legitimately carry a bulleted note and no tasks yet.
- **A scaffold test I wrote was vacuous and is gone.** It asserted a freshly created change validates clean — but `openspec new change` writes only `.openspec.yaml`, no task file, so it asserted nothing. Replaced with a guard that bites: every packaged `schemas/*/templates/tasks.md` is asserted checkbox-shaped, verified by temporarily stripping the boxes from the built-in template and watching it fail. That is the real risk — agents write task files by following those templates.

**A third pass on CodeRabbit's re-review, all four valid (`e0a519248`):**

- **Fence indentation capped at three spaces.** At four, the line is an indented code block, not an opener — accepting it left the scan inside a block that never began and hid every list below it.
- **Front matter is exactly `---`.** Matching `-{3,}` let a `----` thematic break open a block that swallowed the list under it until the next `---`.
- **A test name that over-claimed.** It said the deprecated `change validate` output prints the warning's line; that surface prints no line for *any* issue. It now asserts `[WARNING] tasks.md:` and the message — what the renderer actually emits — with the line left to the JSON assertion that already covers it. Teaching the shared text renderer to print lines would change output for every existing check, so it stays out of this PR.
- **A fixture that could pass for the wrong reason.** If the `chmod(0o000)` had not taken (root, or a filesystem that ignores the mode), the checkbox inside the locked file would have silenced the warning by itself. The read failure is now asserted before the CLI runs, so that case fails loudly instead of lying.

Both behavior fixes are proven the same way as the rest: revert the regex, watch its new test fail.

**A fourth defect, caught by Windows CI (`882cff540`):**

The report named the file `../../../../../../../../runneradmin/AppData/Local/Temp/.../tasks.md` instead of `tasks.md`. `resolveArtifactOutputs` hands back real paths while `changeDir` carries whatever spelling the caller resolved, and a short 8.3 alias against its expanded form is a difference in spelling, not in location — so `path.relative` escaped the change. Canonicalizing both sides recovers the relationship, with a basename fallback so no report can leak an absolute filesystem path. **The numbering check is named through the same helper and had the same latent defect; it is fixed too.**

Two corrections worth recording. I first ordered this "prefer the path as resolved, canonicalize only on escape," to keep author-facing names through linked artifact directories — a false premise: `assertPathWithin` refuses a link whose target leaves the change, and resolved files come back already canonical, so that branch could never differ. I built a symlink fixture to prove the behavior, got no warning at all, traced why, and deleted both the branch and the test rather than keep one that passed for an invented reason. And the regression guard here is the Windows job itself, stated as such in the code: the mismatch cannot be staged on POSIX, where the spawned CLI's `process.cwd()` is already physical.

That assertion only existed because the review pushed back on a test name of mine that over-claimed. Tightening it to what the surface actually emits is what made Windows fail loudly instead of shipping a broken path in the report.

**Coverage added on top of the original set:** a schema that tracks tasks by artifact id with no `apply` block (the same fallback progress counting uses), the deprecated `change validate` text output including its line number, an unreadable tracked file, front matter and HTML comments, an unterminated front-matter opener, the template's own heading-comment shape, and a list of unrecognised `[~]` markers (which really do count as zero tasks today).

Totals: **22 unit + 11 e2e**, all green on Linux, macOS and Windows, plus `tsc --noEmit` and `eslint src/`.

## Notes / nits

- Store scoping is inherited, not special-cased: `validate` passes the resolved `root.path` as `projectRoot` for both direct and bulk paths, which is exactly what the neighbouring numbering check already relies on. No store-specific e2e was added, since there is no store-specific logic to exercise.
- `validate --archived` is deliberately untouched. It never runs the Validator — it counts task completion — and any issue it emits fails the item, so a warning there would retroactively fail archived history that nobody can now fix.
- Docs: documented under validate findings in `docs-lab/reference/cli.md` (the legacy `docs/` tree is untouched). Needs final review from @TabishB. No template or skill changes, so no parity hashes move.
- An *empty* tracked task file still says nothing. #354 is about tasks written in the wrong shape; "no tasks written yet" is a legitimate mid-authoring state, as is a change with no task file at all.
- Interaction with #1773 (unrecognised `[~]` markers): today a file of `- [~]` items counts zero tasks, so this warns — correctly. Once #1773 lands they count as unfinished tasks and the warning goes quiet on its own. The two PRs touch disjoint files.
- #311 (numbering gaps/duplicates) stays closed-by-design per the maintainer's note there; nothing about numbering changed.
- Local baseline: 4421 passed / 3 failed, all three environmental — `config profile interactive flow` and `artifact-workflow … Cursor tool` are the known pre-existing pair, and `workset journey` fails only because this machine has a real `code` binary that the test launches and then waits on. CI is the arbiter.

Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)

