### PR TITLE
fix(templates): open generated artifacts with a top-level heading

### DIFF
--- a/.changeset/titled-artifact-templates.md
+++ b/.changeset/titled-artifact-templates.md
@@ -1,0 +1,5 @@
+---
+"@fission-ai/openspec": patch
+---
+
+Start generated proposal, spec, design, and tasks files with a top-level heading, so artifacts are complete markdown documents instead of files whose first line is a section header. Editors that run markdownlint no longer flag every OpenSpec artifact with MD041. `openspec schema init` scaffolds custom templates the same way.

--- a/docs-lab/customize/schemas.md
+++ b/docs-lab/customize/schemas.md
@@ -125,7 +125,7 @@ The scaffold is bare. Artifacts come from the built-in four ids only, and the ge
 
 A fork has two kinds of files to edit:
 
-- **templates/** change the skeleton of each document. Add a section to the tasks template and every new tasks.md starts with it.
+- **templates/** change the skeleton of each document. Add a section to the tasks template and every new tasks.md starts with it. Keep the `#` title on the first line: the artifact inherits it, so every generated file opens as a titled document.
 - **schema.yaml** changes the workflow itself: which artifacts exist, what each one requires first, and the instruction the agent gets when creating it.
 
 For example, to drop the design document for a leaner flow:

--- a/docs-lab/reference/schemas/spec-driven/index.md
+++ b/docs-lab/reference/schemas/spec-driven/index.md
@@ -54,6 +54,8 @@ Establishes why the change is needed.
 The template the agent receives as the output format ([templates/proposal.md](https://github.com/Fission-AI/OpenSpec/blob/main/schemas/spec-driven/templates/proposal.md)):
 
 ```md
+# Proposal
+
 ## Why
 
 <!-- Explain the motivation for this change. What problem does this solve? Why now? -->
@@ -127,6 +129,8 @@ Defines what behavior changes, with one delta spec per capability the proposal l
 The template the agent receives as the output format ([templates/spec.md](https://github.com/Fission-AI/OpenSpec/blob/main/schemas/spec-driven/templates/spec.md)):
 
 ```md
+# Spec Delta
+
 ## Purpose
 <!-- New capabilities only: one or two sentences (50+ characters) on what this capability is for. Delete this section for an existing capability. -->
 
@@ -188,7 +192,7 @@ Format requirements:
 - **CRITICAL**: Scenarios MUST use exactly 4 hashtags (`####`). Using 3 hashtags or bullets will fail silently.
 - Every requirement MUST have at least one scenario.
 
-New capabilities only: start the delta spec with a `## Purpose` section -
+New capabilities only: the delta spec's first section is `## Purpose` -
 one or two sentences (50+ characters, or `openspec validate --strict`
 reports it as too brief) describing what the capability is for. Archive
 copies it into the main spec it creates; without it the new main spec is
@@ -207,8 +211,10 @@ MODIFIED requirements workflow:
 Common pitfall: Using MODIFIED with partial content loses detail at archive time.
 If adding new concerns without changing existing behavior, use ADDED instead.
 
-Example (a new capability, so it opens with `## Purpose`):
+Example (a new capability, so its first section is `## Purpose`):
 ```
+# Spec Delta
+
 ## Purpose
 
 Lets users take their data out of the product in a portable format.
@@ -241,6 +247,8 @@ Explains how to implement the change. Drafted only when the change needs one.
 The template the agent receives as the output format ([templates/design.md](https://github.com/Fission-AI/OpenSpec/blob/main/schemas/spec-driven/templates/design.md)):
 
 ```md
+# Design
+
 ## Context
 
 <!-- Current state and constraints that shape the approach. See proposal.md for motivation - don't restate it -->
@@ -305,6 +313,8 @@ Breaks the implementation into checkable tasks. [apply](#apply) tracks progress 
 The template the agent receives as the output format ([templates/tasks.md](https://github.com/Fission-AI/OpenSpec/blob/main/schemas/spec-driven/templates/tasks.md)):
 
 ```md
+# Tasks
+
 ## 1. <!-- Task Group Name -->
 
 - [ ] 1.1 <!-- Task description -->
@@ -338,6 +348,8 @@ Guidelines:
 
 Example:
 ```
+# Tasks
+
 ## 1. Setup
 
 - [ ] 1.1 Create new module structure

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -276,6 +276,8 @@ Templates are markdown files that guide the AI. They're injected into the prompt
 
 ```markdown
 <!-- templates/proposal.md -->
+# Proposal
+
 ## Why
 
 <!-- Explain the motivation for this change. What problem does this solve? -->
@@ -293,6 +295,11 @@ Templates can include:
 - Section headers the AI should fill in
 - HTML comments with guidance for the AI
 - Example formats showing expected structure
+
+Open each template with a top-level `#` heading. The artifact inherits it, so
+the generated file is a complete markdown document and passes linters that
+require a first-line heading (markdownlint MD041). `openspec schema` scaffolds
+new templates this way already.
 
 ### Validate Your Schema
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -276,8 +276,6 @@ Templates are markdown files that guide the AI. They're injected into the prompt
 
 ```markdown
 <!-- templates/proposal.md -->
-# Proposal
-
 ## Why
 
 <!-- Explain the motivation for this change. What problem does this solve? -->
@@ -295,11 +293,6 @@ Templates can include:
 - Section headers the AI should fill in
 - HTML comments with guidance for the AI
 - Example formats showing expected structure
-
-Open each template with a top-level `#` heading. The artifact inherits it, so
-the generated file is a complete markdown document and passes linters that
-require a first-line heading (markdownlint MD041). `openspec schema` scaffolds
-new templates this way already.
 
 ### Validate Your Schema
 

--- a/docs/opsx.md
+++ b/docs/opsx.md
@@ -521,7 +521,7 @@ Artifacts form a directed acyclic graph (DAG). Dependencies are **enablers**, no
   │  │  $ openspec instructions specs --change "add-auth" --json          │  │
   │  │                                                                    │  │
   │  │  {                                                                 │  │
-  │  │    "template": "# Specification\n\n## ADDED Requirements...",      │  │
+  │  │    "template": "# Spec Delta\n\n## ADDED Requirements...",         │  │
   │  │    "dependencies": [{"id": "proposal", "path": "...", "done": true}│  │
   │  │    "unlocks": ["tasks"]                                            │  │
   │  │  }                                                                 │  │

--- a/docs/opsx.md
+++ b/docs/opsx.md
@@ -521,7 +521,7 @@ Artifacts form a directed acyclic graph (DAG). Dependencies are **enablers**, no
   │  │  $ openspec instructions specs --change "add-auth" --json          │  │
   │  │                                                                    │  │
   │  │  {                                                                 │  │
-  │  │    "template": "# Spec Delta\n\n## ADDED Requirements...",         │  │
+  │  │    "template": "# Specification\n\n## ADDED Requirements...",      │  │
   │  │    "dependencies": [{"id": "proposal", "path": "...", "done": true}│  │
   │  │    "unlocks": ["tasks"]                                            │  │
   │  │  }                                                                 │  │

--- a/schemas/spec-driven/schema.yaml
+++ b/schemas/spec-driven/schema.yaml
@@ -83,7 +83,7 @@ artifacts:
       - **CRITICAL**: Scenarios MUST use exactly 4 hashtags (`####`). Using 3 hashtags or bullets will fail silently.
       - Every requirement MUST have at least one scenario.
 
-      New capabilities only: start the delta spec with a `## Purpose` section -
+      New capabilities only: the delta spec's first section is `## Purpose` -
       one or two sentences (50+ characters, or `openspec validate --strict`
       reports it as too brief) describing what the capability is for. Archive
       copies it into the main spec it creates; without it the new main spec is
@@ -108,8 +108,10 @@ artifacts:
       Common pitfall: Using MODIFIED with partial content loses detail at archive time.
       If adding new concerns without changing existing behavior, use ADDED instead.
 
-      Example (a new capability, so it opens with `## Purpose`):
+      Example (a new capability, so its first section is `## Purpose`):
       ```
+      # Spec Delta
+
       ## Purpose
 
       Lets users take their data out of the product in a portable format.
@@ -196,6 +198,8 @@ artifacts:
 
       Example:
       ```
+      # Tasks
+
       ## 1. Setup
 
       - [ ] 1.1 Create new module structure and verify expected files are present

--- a/schemas/spec-driven/templates/design.md
+++ b/schemas/spec-driven/templates/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Context
 
 <!-- Current state and constraints that shape the approach. See proposal.md for motivation - don't restate it -->

--- a/schemas/spec-driven/templates/proposal.md
+++ b/schemas/spec-driven/templates/proposal.md
@@ -1,3 +1,5 @@
+# Proposal
+
 ## Why
 
 <!-- Explain the motivation for this change. What problem does this solve? Why now? -->

--- a/schemas/spec-driven/templates/spec.md
+++ b/schemas/spec-driven/templates/spec.md
@@ -1,3 +1,5 @@
+# Spec Delta
+
 ## Purpose
 <!-- New capabilities only: one or two sentences (50+ characters) on what this capability is for. Delete this section for an existing capability. -->
 

--- a/schemas/spec-driven/templates/tasks.md
+++ b/schemas/spec-driven/templates/tasks.md
@@ -1,3 +1,5 @@
+# Tasks
+
 ## 1. <!-- Task Group Name -->
 
 - [ ] 1.1 <!-- Task description -->

--- a/skills/openspec-onboard/SKILL.md
+++ b/skills/openspec-onboard/SKILL.md
@@ -220,6 +220,8 @@ Here's a draft proposal:
 
 ---
 
+# Proposal
+
 ## Why
 
 [1-2 sentences explaining the problem/opportunity]
@@ -287,6 +289,8 @@ Here's the spec:
 
 ---
 
+# Spec Delta
+
 ## ADDED Requirements
 
 ### Requirement: <Name>
@@ -325,6 +329,8 @@ For small changes, this might be brief. That's fine—not every change needs dee
 Here's the design:
 
 ---
+
+# Design
 
 ## Context
 
@@ -370,6 +376,8 @@ These should be small, clear, and in logical order.
 Here are the implementation tasks:
 
 ---
+
+# Tasks
 
 ## 1. [Category or file]
 

--- a/skills/openspec-sync-specs/SKILL.md
+++ b/skills/openspec-sync-specs/SKILL.md
@@ -166,6 +166,8 @@ This is an **agent-driven** operation - you will read delta specs and directly e
 **Delta Spec Format Reference**
 
 ```markdown
+# Spec Delta
+
 ## Purpose
 
 Only on a delta that introduces a brand-new capability. Seeds the new main spec.

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -1408,11 +1408,17 @@ export function registerSchemaCommand(program: Command): void {
 
 /**
  * Create default template content for an artifact.
+ *
+ * Every template opens with a top-level heading so the artifact it produces is
+ * a well-formed markdown document rather than a file whose first line is a
+ * section header (markdownlint MD041, #1138).
  */
 function createDefaultTemplate(artifactId: string): string {
   switch (artifactId) {
     case 'proposal':
-      return `## Why
+      return `# Proposal
+
+## Why
 
 <!-- Describe the motivation for this change -->
 
@@ -1434,7 +1440,9 @@ function createDefaultTemplate(artifactId: string): string {
 `;
 
     case 'specs':
-      return `## ADDED Requirements
+      return `# Spec Delta
+
+## ADDED Requirements
 
 ### Requirement: Example requirement
 
@@ -1446,7 +1454,9 @@ Description of the requirement.
 `;
 
     case 'design':
-      return `## Context
+      return `# Design
+
+## Context
 
 <!-- Background and context -->
 
@@ -1473,7 +1483,9 @@ Description and rationale.
 `;
 
     case 'tasks':
-      return `## Implementation Tasks
+      return `# Tasks
+
+## Implementation Tasks
 
 - [ ] Task 1
 - [ ] Task 2
@@ -1481,7 +1493,7 @@ Description and rationale.
 `;
 
     default:
-      return `## ${artifactId}
+      return `# ${artifactId}
 
 <!-- Add content here -->
 `;

--- a/src/core/templates/workflows/onboard.ts
+++ b/src/core/templates/workflows/onboard.ts
@@ -230,6 +230,8 @@ Here's a draft proposal:
 
 ---
 
+# Proposal
+
 ## Why
 
 [1-2 sentences explaining the problem/opportunity]
@@ -297,6 +299,8 @@ Here's the spec:
 
 ---
 
+# Spec Delta
+
 ## ADDED Requirements
 
 ### Requirement: <Name>
@@ -335,6 +339,8 @@ For small changes, this might be brief. That's fine—not every change needs dee
 Here's the design:
 
 ---
+
+# Design
 
 ## Context
 
@@ -380,6 +386,8 @@ These should be small, clear, and in logical order.
 Here are the implementation tasks:
 
 ---
+
+# Tasks
 
 ## 1. [Category or file]
 

--- a/src/core/templates/workflows/sync-specs.ts
+++ b/src/core/templates/workflows/sync-specs.ts
@@ -168,6 +168,8 @@ ${STORE_SELECTION_GUIDANCE}
 **Delta Spec Format Reference**
 
 \`\`\`markdown
+# Spec Delta
+
 ## Purpose
 
 Only on a delta that introduces a brand-new capability. Seeds the new main spec.
@@ -430,6 +432,8 @@ ${STORE_SELECTION_GUIDANCE}
 **Delta Spec Format Reference**
 
 \`\`\`markdown
+# Spec Delta
+
 ## Purpose
 
 Only on a delta that introduces a brand-new capability. Seeds the new main spec.

--- a/test/commands/schema.test.ts
+++ b/test/commands/schema.test.ts
@@ -487,6 +487,47 @@ artifacts:
       ).toContain('schema: my-workflow');
     });
 
+    it('scaffolds every template with a top-level heading', async () => {
+      const initialized = await runCLI(
+        [
+          'schema',
+          'init',
+          'lint-clean',
+          '--artifacts',
+          'proposal,specs,design,tasks',
+          '--json',
+        ],
+        { cwd: tempDir }
+      );
+      expect(initialized.exitCode).toBe(0);
+
+      const templatesDir = path.join(
+        tempDir,
+        'openspec',
+        'schemas',
+        'lint-clean',
+        'templates'
+      );
+      const templates = fs
+        .readdirSync(templatesDir, { recursive: true, withFileTypes: true })
+        .filter((entry) => entry.isFile())
+        .map((entry) => path.join(path.relative(templatesDir, entry.parentPath), entry.name))
+        .sort();
+      expect(templates).toEqual([
+        'design.md',
+        'proposal.md',
+        path.join('specs', 'spec.md'),
+        'tasks.md',
+      ].sort());
+
+      // The artifact a template produces is a document in its own right, so it
+      // opens with an `# ` heading rather than a section header (#1138).
+      for (const template of templates) {
+        const content = fs.readFileSync(path.join(templatesDir, template), 'utf-8');
+        expect(content.split('\n')[0]).toMatch(/^# \S/);
+      }
+    });
+
     describe.each(failureModes)('$label with --default', ({ force }) => {
       it('preserves the schema and invalid YAML config byte-for-byte', async () => {
         const { schemaDir, before } = prepareSchemaForFailure(force);

--- a/test/commands/schema.test.ts
+++ b/test/commands/schema.test.ts
@@ -521,10 +521,18 @@ artifacts:
       ].sort());
 
       // The artifact a template produces is a document in its own right, so it
-      // opens with an `# ` heading rather than a section header (#1138).
+      // opens with a title and a blank line, not a section header (#1138).
+      const headings: Record<string, string> = {
+        'design.md': '# Design',
+        'proposal.md': '# Proposal',
+        [path.join('specs', 'spec.md')]: '# Spec Delta',
+        'tasks.md': '# Tasks',
+      };
       for (const template of templates) {
         const content = fs.readFileSync(path.join(templatesDir, template), 'utf-8');
-        expect(content.replace(/\r\n?/g, '\n').split('\n')[0]).toMatch(/^# \S/);
+        const [firstLine, secondLine] = content.replace(/\r\n?/g, '\n').split('\n');
+        expect(firstLine).toBe(headings[template]);
+        expect(secondLine).toBe('');
       }
     });
 

--- a/test/commands/schema.test.ts
+++ b/test/commands/schema.test.ts
@@ -524,7 +524,7 @@ artifacts:
       // opens with an `# ` heading rather than a section header (#1138).
       for (const template of templates) {
         const content = fs.readFileSync(path.join(templatesDir, template), 'utf-8');
-        expect(content.split('\n')[0]).toMatch(/^# \S/);
+        expect(content.replace(/\r\n?/g, '\n').split('\n')[0]).toMatch(/^# \S/);
       }
     });
 

--- a/test/core/archive.test.ts
+++ b/test/core/archive.test.ts
@@ -7472,4 +7472,68 @@ This change exists to document greeting behavior thoroughly for the team, which 
       await expect(fs.access(changeDir)).resolves.not.toThrow();
     });
   });
+  // Every packaged template opens with an `# ` heading so the artifacts an
+  // agent writes are complete markdown documents (#1138). The delta spec is the
+  // one artifact archive reads back, so its title must stay inert: it belongs to
+  // the delta, not to the main spec archive builds from it.
+  describe('templates opening with a title (#1138)', () => {
+    it('keeps the delta spec title out of the main spec it creates', async () => {
+      const changeName = 'add-widget';
+      const changeDir = path.join(tempDir, 'openspec', 'changes', changeName);
+      await fs.mkdir(path.join(changeDir, 'specs', 'widget'), { recursive: true });
+      await fs.writeFile(
+        path.join(changeDir, 'proposal.md'),
+        [
+          '# Proposal',
+          '',
+          '## Why',
+          'Widgets are the one thing this product cannot assemble today.',
+          '',
+          '## What Changes',
+          '- Add the widget capability.',
+          '',
+        ].join('\n')
+      );
+      await fs.writeFile(
+        path.join(changeDir, 'tasks.md'),
+        ['# Tasks', '', '## 1. Build', '', '- [x] 1.1 Build it', ''].join('\n')
+      );
+      await fs.writeFile(
+        path.join(changeDir, 'specs', 'widget', 'spec.md'),
+        [
+          '# Spec Delta',
+          '',
+          '## Purpose',
+          'Lets users assemble widgets from parts in a repeatable way.',
+          '',
+          '## ADDED Requirements',
+          '',
+          '### Requirement: User can build a widget',
+          'The system SHALL let a user build a widget.',
+          '',
+          '#### Scenario: Successful build',
+          '- **WHEN** a user requests a widget',
+          '- **THEN** the system builds it',
+          '',
+        ].join('\n')
+      );
+
+      await archiveCommand.execute(changeName, { yes: true });
+
+      const mainSpec = await fs.readFile(
+        path.join(tempDir, 'openspec', 'specs', 'widget', 'spec.md'),
+        'utf-8'
+      );
+
+      // The main spec keeps its own generated title, and only that one.
+      expect(mainSpec.split('\n').filter((line) => line.startsWith('# '))).toEqual([
+        '# widget Specification',
+      ]);
+      // The delta's title did not displace the Purpose archive carries over.
+      expect(mainSpec).toContain(
+        '## Purpose\nLets users assemble widgets from parts in a repeatable way.'
+      );
+      expect(mainSpec).toContain('### Requirement: User can build a widget');
+    });
+  });
 });

--- a/test/core/archive.test.ts
+++ b/test/core/archive.test.ts
@@ -7529,6 +7529,8 @@ This change exists to document greeting behavior thoroughly for the team, which 
       expect(mainSpec.split('\n').filter((line) => line.startsWith('# '))).toEqual([
         '# widget Specification',
       ]);
+      // The delta's title is gone entirely, not demoted to a lower level.
+      expect(mainSpec).not.toMatch(/^#+\s+Spec Delta\s*$/m);
       // The delta's title did not displace the Purpose archive carries over.
       expect(mainSpec).toContain(
         '## Purpose\nLets users assemble widgets from parts in a repeatable way.'

--- a/test/core/artifact-graph/instruction-loader.test.ts
+++ b/test/core/artifact-graph/instruction-loader.test.ts
@@ -23,22 +23,24 @@ describe('instruction-loader', () => {
       expect(template).toContain('exact existing path under openspec/specs/');
     });
 
-    it.each(['proposal.md', 'design.md', 'spec.md', 'tasks.md'])(
-      'opens %s with a top-level heading',
-      (templateName) => {
-        // Artifacts inherit the template's opening line, so every packaged
-        // template starts the document with an `# ` heading instead of a
-        // section header. Without it every generated proposal.md, design.md,
-        // spec.md and tasks.md trips markdownlint MD041 (#1138).
-        const template = loadTemplate('spec-driven', templateName);
+    it.each([
+      ['proposal.md', '# Proposal'],
+      ['design.md', '# Design'],
+      ['spec.md', '# Spec Delta'],
+      ['tasks.md', '# Tasks'],
+    ])('opens %s with %s', (templateName, heading) => {
+      // Artifacts inherit the template's opening line, so every packaged
+      // template starts the document with an `# ` heading instead of a section
+      // header. Without it every generated proposal.md, design.md, spec.md and
+      // tasks.md trips markdownlint MD041 (#1138).
+      const template = loadTemplate('spec-driven', templateName);
 
-        // The repository can be checked out with CRLF endings, so compare on
-        // normalized text rather than on the bytes on disk.
-        const [firstLine, secondLine] = template.replace(/\r\n?/g, '\n').split('\n');
-        expect(firstLine).toMatch(/^# \S/);
-        expect(secondLine).toBe('');
-      }
-    );
+      // The repository can be checked out with CRLF endings, so compare on
+      // normalized text rather than on the bytes on disk.
+      const [firstLine, secondLine] = template.replace(/\r\n?/g, '\n').split('\n');
+      expect(firstLine).toBe(heading);
+      expect(secondLine).toBe('');
+    });
 
     it('should throw TemplateLoadError for non-existent template', () => {
       expect(() => loadTemplate('spec-driven', 'nonexistent.md')).toThrow(

--- a/test/core/artifact-graph/instruction-loader.test.ts
+++ b/test/core/artifact-graph/instruction-loader.test.ts
@@ -23,6 +23,21 @@ describe('instruction-loader', () => {
       expect(template).toContain('exact existing path under openspec/specs/');
     });
 
+    it.each(['proposal.md', 'design.md', 'spec.md', 'tasks.md'])(
+      'opens %s with a top-level heading',
+      (templateName) => {
+        // Artifacts inherit the template's opening line, so every packaged
+        // template starts the document with an `# ` heading instead of a
+        // section header. Without it every generated proposal.md, design.md,
+        // spec.md and tasks.md trips markdownlint MD041 (#1138).
+        const template = loadTemplate('spec-driven', templateName);
+
+        const [firstLine, secondLine] = template.split('\n');
+        expect(firstLine).toMatch(/^# \S/);
+        expect(secondLine).toBe('');
+      }
+    );
+
     it('should throw TemplateLoadError for non-existent template', () => {
       expect(() => loadTemplate('spec-driven', 'nonexistent.md')).toThrow(
         TemplateLoadError

--- a/test/core/artifact-graph/instruction-loader.test.ts
+++ b/test/core/artifact-graph/instruction-loader.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
+import { parseSchema } from '../../../src/core/artifact-graph/schema.js';
 import {
   loadTemplate,
   loadChangeContext,
@@ -9,6 +10,28 @@ import {
   formatChangeStatus,
   TemplateLoadError,
 } from '../../../src/core/artifact-graph/instruction-loader.js';
+
+const PACKAGED_SCHEMAS_DIR = path.join(__dirname, '..', '..', '..', 'schemas');
+
+/** Every artifact of every packaged schema, with the template it generates from. */
+function packagedArtifacts(): Array<[schema: string, artifactId: string, template: string]> {
+  return fs
+    .readdirSync(PACKAGED_SCHEMAS_DIR, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .flatMap((entry) => {
+      const schemaPath = path.join(PACKAGED_SCHEMAS_DIR, entry.name, 'schema.yaml');
+      const schema = parseSchema(fs.readFileSync(schemaPath, 'utf-8'));
+      return schema.artifacts.map(
+        (artifact): [string, string, string] => [entry.name, artifact.id, artifact.template]
+      );
+    });
+}
+
+/** First line and the line under it, on normalized endings (the repo may be checked out CRLF). */
+function openingLines(template: string): [string, string] {
+  const [firstLine = '', secondLine = ''] = template.replace(/\r\n?/g, '\n').split('\n');
+  return [firstLine, secondLine];
+}
 
 describe('instruction-loader', () => {
   describe('loadTemplate', () => {
@@ -23,23 +46,45 @@ describe('instruction-loader', () => {
       expect(template).toContain('exact existing path under openspec/specs/');
     });
 
-    it.each([
-      ['proposal.md', '# Proposal'],
-      ['design.md', '# Design'],
-      ['spec.md', '# Spec Delta'],
-      ['tasks.md', '# Tasks'],
-    ])('opens %s with %s', (templateName, heading) => {
-      // Artifacts inherit the template's opening line, so every packaged
-      // template starts the document with an `# ` heading instead of a section
-      // header. Without it every generated proposal.md, design.md, spec.md and
-      // tasks.md trips markdownlint MD041 (#1138).
-      const template = loadTemplate('spec-driven', templateName);
+    // Artifacts inherit the template's opening line, so every packaged template
+    // starts the document with an `# ` title instead of a section header.
+    // Without it every generated proposal.md, design.md, spec.md and tasks.md
+    // trips markdownlint MD041 (#1138).
+    it.each(packagedArtifacts())(
+      'opens the %s schema\'s %s template with a title',
+      (schemaName, _artifactId, templateName) => {
+        const [firstLine, secondLine] = openingLines(loadTemplate(schemaName, templateName));
 
-      // The repository can be checked out with CRLF endings, so compare on
-      // normalized text rather than on the bytes on disk.
-      const [firstLine, secondLine] = template.replace(/\r\n?/g, '\n').split('\n');
-      expect(firstLine).toBe(heading);
-      expect(secondLine).toBe('');
+        expect(firstLine).toMatch(/^# \S/);
+        expect(secondLine).toBe('');
+      }
+    );
+
+    describe('spec-driven titles', () => {
+      const TITLES: Record<string, string> = {
+        proposal: '# Proposal',
+        specs: '# Spec Delta',
+        design: '# Design',
+        tasks: '# Tasks',
+      };
+
+      const artifacts = packagedArtifacts().filter(([schemaName]) => schemaName === 'spec-driven');
+
+      // Pins the wording, not just the shape: a template retitled by accident
+      // would pass the guard above.
+      it.each(artifacts)('titles %s\'s %s artifact', (schemaName, artifactId, templateName) => {
+        const [firstLine] = openingLines(loadTemplate(schemaName, templateName));
+
+        expect(firstLine).toBe(TITLES[artifactId]);
+      });
+
+      // And the table covers the whole schema, so a new artifact cannot be
+      // added without deciding what its document is called.
+      it('names every artifact the schema declares', () => {
+        expect(artifacts.map(([, artifactId]) => artifactId).sort()).toEqual(
+          Object.keys(TITLES).sort()
+        );
+      });
     });
 
     it('should throw TemplateLoadError for non-existent template', () => {

--- a/test/core/artifact-graph/instruction-loader.test.ts
+++ b/test/core/artifact-graph/instruction-loader.test.ts
@@ -32,7 +32,9 @@ describe('instruction-loader', () => {
         // spec.md and tasks.md trips markdownlint MD041 (#1138).
         const template = loadTemplate('spec-driven', templateName);
 
-        const [firstLine, secondLine] = template.split('\n');
+        // The repository can be checked out with CRLF endings, so compare on
+        // normalized text rather than on the bytes on disk.
+        const [firstLine, secondLine] = template.replace(/\r\n?/g, '\n').split('\n');
         expect(firstLine).toMatch(/^# \S/);
         expect(secondLine).toBe('');
       }

--- a/test/core/parsers/markdown-parser.test.ts
+++ b/test/core/parsers/markdown-parser.test.ts
@@ -512,4 +512,48 @@ The system SHALL do something real.
       );
     });
   });
+  // Every packaged template now opens the artifact with an `# ` title (#1138).
+  // A title changes the section tree - `## Purpose` becomes a child of the
+  // title rather than a root - so pin that the parsers read the document the
+  // same either way. Main specs have carried a title all along; this says the
+  // change artifacts can too.
+  describe('an artifact title is inert (#1138)', () => {
+    const SPEC_BODY = `## Purpose
+Lets users assemble widgets from parts in a repeatable way.
+
+## Requirements
+
+### Requirement: User can build a widget
+The system SHALL let a user build a widget.
+
+#### Scenario: Successful build
+- **WHEN** a user requests a widget
+- **THEN** the system builds it
+`;
+
+    const PROPOSAL_BODY = `## Why
+Widgets are the one thing this product cannot assemble today.
+
+## What Changes
+- Add the widget capability.
+`;
+
+    it('parses a spec the same with and without one', () => {
+      const untitled = new MarkdownParser(SPEC_BODY).parseSpec('widget');
+      const titled = new MarkdownParser(`# widget Specification\n\n${SPEC_BODY}`).parseSpec(
+        'widget'
+      );
+
+      expect(titled).toEqual(untitled);
+    });
+
+    it('parses a proposal the same with and without one', () => {
+      const untitled = new MarkdownParser(PROPOSAL_BODY).parseChange('add-widget');
+      const titled = new MarkdownParser(`# Proposal\n\n${PROPOSAL_BODY}`).parseChange(
+        'add-widget'
+      );
+
+      expect(titled).toEqual(untitled);
+    });
+  });
 });

--- a/test/core/templates/skill-templates-parity.test.ts
+++ b/test/core/templates/skill-templates-parity.test.ts
@@ -1,4 +1,6 @@
 import { createHash } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -36,6 +38,26 @@ import {
   getSkillTemplates,
 } from '../../../src/core/shared/skill-generation.js';
 import { STORE_SELECTION_GUIDANCE } from '../../../src/core/templates/workflows/store-selection.js';
+import { parseSchema } from '../../../src/core/artifact-graph/schema.js';
+
+/**
+ * The title `spec-driven` gives each artifact, read from the packaged templates
+ * so guidance and template cannot drift apart.
+ */
+function specDrivenTitles(): Record<string, string> {
+  const schemaDir = path.join(__dirname, '..', '..', '..', 'schemas', 'spec-driven');
+  const schema = parseSchema(fs.readFileSync(path.join(schemaDir, 'schema.yaml'), 'utf-8'));
+
+  return Object.fromEntries(
+    schema.artifacts.map((artifact) => [
+      artifact.id,
+      fs
+        .readFileSync(path.join(schemaDir, 'templates', artifact.template), 'utf-8')
+        .replace(/\r\n?/g, '\n')
+        .split('\n')[0],
+    ])
+  );
+}
 
 const EXPECTED_FUNCTION_HASHES: Record<string, string> = {
   getExploreSkillTemplate: '6315fcc5c2eb848963bc8bca4c23e657412a99608e610daee59fb4e58cd21fd4',
@@ -43,8 +65,8 @@ const EXPECTED_FUNCTION_HASHES: Record<string, string> = {
   getContinueChangeSkillTemplate: '012136f6411a99c8fa228e2f9444cb64b0a89e0f56fdeac2fe03b2f5bee0c5d7',
   getApplyChangeSkillTemplate: 'd1e7d5ceb85193c0964057dbb88e9651526754bd33f84020e2440ff0621d5dbb',
   getFfChangeSkillTemplate: 'efa6a70c111b18b61a7720250b9622afa9a212fb64edf609cf80e2182a9bdf8c',
-  getSyncSpecsSkillTemplate: 'b099e2ff31859c9b10d928066e662524f9aad9ecf2be12fceacb732d718c4146',
-  getOnboardSkillTemplate: '3a836faae463d88c289a1c129cb7ee556a563b7e53e1a52a4711ff152a3b51f7',
+  getSyncSpecsSkillTemplate: 'b4964c2e02ad80c37ddb8f83d51860d644b47863f2b642320ce4d5dfe53c2916',
+  getOnboardSkillTemplate: '2162113374514ea32716565c4f9bb01966614b593238bd8321326ddded9ee93a',
   getOpsxExploreCommandTemplate: 'b4706a5b8fd280f7929eea610ecc9d41676b2d2dd6653d259cbbc2bfe01813d9',
   getOpsxNewCommandTemplate: 'f2d30e569798a4c92ba932859d6ba4e0ad10e18feccbade1cfee0957597b3463',
   getOpsxContinueCommandTemplate: 'e50e50266efa1b8e64ff9b6274ee8254f0a240d6adc1b862d126e2f1c9d3a559',
@@ -52,10 +74,10 @@ const EXPECTED_FUNCTION_HASHES: Record<string, string> = {
   getOpsxFfCommandTemplate: '21132fc9c6d3b3ab2d2295d6bbd72d1e0052eb35ea1be0258c8b1ab3e200c4db',
   getArchiveChangeSkillTemplate: '56bfada1a5f35a127791b70de9d428a75b5aedd1584d6c9803a1ecb1fd1b4a23',
   getBulkArchiveChangeSkillTemplate: '93875998cade5322d95b43299fba794bc1da754e917dd63a770406386a6d295d',
-  getOpsxSyncCommandTemplate: '0d2427efb79986e8fff3f96bd075a739c80d45eb29159fae717e950030da8202',
+  getOpsxSyncCommandTemplate: '017f70ef8b88a8341cfe8848cb79b3bd40d48a41fbf2cb6fef6037f8a6af1d63',
   getVerifyChangeSkillTemplate: '223b7ffd99299a7d430e13092b9a0a3421b39f0d3217232f46c39d79b5f619ff',
   getOpsxArchiveCommandTemplate: '9f973c819b11620985b03322945f0e0a92a02a2ef455b94e74482f5e6292ac5d',
-  getOpsxOnboardCommandTemplate: 'ee99aa99252c602720fbb8c63fb3ac438a5bd4e952fd961ddf1ae956cbfc2c8f',
+  getOpsxOnboardCommandTemplate: 'b062a2aac0dd47e6faf164089a15d362b09bdaf20a2f5d9c37d07d2779541c5d',
   getOpsxBulkArchiveCommandTemplate: '9fa8cdebe2f5667ebfc37bdc023396762c59d5b038c771dac2d8fd2c19e2627b',
   getOpsxVerifyCommandTemplate: '1efcf7eff0671f48e9d9420f50865c563dd3079ee60f8c380bb7a90dd0102696',
   getOpsxProposeSkillTemplate: '9c0fbf0137151bd03ec30c45180f83daec96e8976ceaf517c63147f84b803446',
@@ -71,11 +93,11 @@ const EXPECTED_GENERATED_SKILL_CONTENT_HASHES: Record<string, string> = {
   'openspec-continue-change': 'bb6194a16c54891cdb253678e8f70ce53b2af86735243980f366ce551d37e42e',
   'openspec-apply-change': '81ea96d9fa6ec8536cd23c1fe561ed28e1cc1cad0a8ceb700588e08974cc0e49',
   'openspec-ff-change': '31355250514bce51b16ff37ee2b833bc9d475cd0dbd4b1f68fe2041694575623',
-  'openspec-sync-specs': 'd933d8856584d6c1253de91e652e7aee9e85c77ad4d3531f6476f79d84e6e5e8',
+  'openspec-sync-specs': '6b0d6fcab97801ec67ebefec1c5f095e1fe793bc80cf81de3fadd7ac9be4153e',
   'openspec-archive-change': '7c65053d674ba4e1e20e2bf73ba7e5a7f94baef2eaa9b33cee48d4cadea51b7a',
   'openspec-bulk-archive-change': '2039b9ecf6e64339dffe0e16272507a386d9fe326f419ff758315aa736fdd96c',
   'openspec-verify-change': 'af9be013dcbe8c6d8f6d9ab10c893fbd03f4c62933c384d82f63894dd0ceb84f',
-  'openspec-onboard': 'f6f59476acaf5e4d65dbb180da4cef62432612f3cecf207d471a951295e2003a',
+  'openspec-onboard': '655ad20ebd94d92d245f0f5680a9f6505ae2bd0045a5785b4430dacf53e697f1',
   'openspec-propose': 'e358b45102a88082cf20f5c4441cba02533724ad6eef8ed15ba174e3496cb6ed',
   'openspec-update-change': '586547406aca94422dfeb3ffedce6c01049429b743f57ce829baa79ebc714d51',
 };
@@ -997,5 +1019,38 @@ describe('apply skill/command shared instruction core', () => {
     const core = getApplyInstructions();
     expect(getApplyChangeSkillTemplate().instructions).toBe(core);
     expect(getOpsxApplyCommandTemplate().content).toBe(core);
+  });
+});
+
+describe('workflow guidance matches the packaged templates (#1138)', () => {
+  // Onboard drafts each artifact in the conversation and then saves what it
+  // drafted, so a preview missing the template's title writes an untitled file
+  // no matter what the template says.
+  it('shows every artifact title in the onboarding walkthrough', () => {
+    const titles = specDrivenTitles();
+    const surfaces: Array<[string, string]> = [
+      ['onboard skill', getOnboardSkillTemplate().instructions],
+      ['opsx onboard command', getOpsxOnboardCommandTemplate().content],
+    ];
+
+    for (const [surface, text] of surfaces) {
+      for (const artifactId of ['proposal', 'specs', 'design', 'tasks']) {
+        expect(text, `${surface} / ${artifactId}`).toContain(`\n${titles[artifactId]}\n`);
+      }
+    }
+  });
+
+  // The sync workflow prints a delta reference right beside the main-spec one.
+  // The two are only telling them apart if the delta carries its own title.
+  it('titles the delta spec in the sync format reference', () => {
+    const titles = specDrivenTitles();
+
+    for (const [surface, text] of [
+      ['sync skill', getSyncSpecsSkillTemplate().instructions],
+      ['opsx sync command', getOpsxSyncCommandTemplate().content],
+    ] as Array<[string, string]>) {
+      expect(text, surface).toContain(`\n${titles.specs}\n\n## Purpose\n`);
+      expect(text, surface).toContain('\n# <capability> Specification\n');
+    }
   });
 });


### PR DESCRIPTION
## Status

LGTM. All CI checks green on Linux, macOS and Windows. Locally the full suite is green apart from tests that already fail on `origin/main` in this sandbox (`workset`, `version-check`, `config-profile`, `artifact-workflow` — all spawn real binaries or hit path restrictions). Not merged.

Closes #1138

## What was wrong

Every artifact OpenSpec generates began on a section header:

```markdown
## Why

<!-- Explain the motivation for this change. What problem does this solve? -->
```

Two consequences, one cosmetic and one not:

- Editors running markdownlint (the [VS Code extension](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint) is the common case) flag **MD041 / first-line-heading** on *every* `proposal.md`, `design.md`, `spec.md` and `tasks.md` in every OpenSpec project. The reporter of #1138 sees it on all of them.
- The files are documents without a title. OpenSpec already knows this: archive writes main specs as `# <capability> Specification`, and `docs/getting-started.md` and `docs/concepts.md` have been showing titled delta specs all along. Change artifacts were the exception.

## How it was fixed

Each packaged template opens with a title and a blank line:

| File | Heading |
| --- | --- |
| `proposal.md` | `# Proposal` |
| `design.md` | `# Design` |
| `specs/<capability-path>/spec.md` | `# Spec Delta` |
| `tasks.md` | `# Tasks` |

`# Spec Delta` rather than `# Specifications`: a delta is not a spec, and the file sitting next to a `# <capability> Specification` main spec should say which one it is.

Templates alone would not have finished the job, so this also covers every other place the artifact shape is stated:

- **`openspec schema init`** scaffolds custom-schema templates the same way, so a forked schema starts lint-clean too.
- **The onboarding walkthrough** drafts each artifact in the conversation and then saves what it drafted (`Draft the ... content` → `Save to the resolvedOutputPath`). Its four previews would have written untitled files whatever the template said. They now show the titles.
- **The sync workflow's "Delta Spec Format Reference"** sat directly beneath a main-spec reference that does carry a title, teaching that deltas do not. Fixed on both the skill and command surfaces.
- **The schema's own `specs` and `tasks` examples**.
- **The canonical docs page** at `docs-lab/reference/schemas/spec-driven/index.md`: all four template blocks now match the shipped templates byte for byte, and the quoted `specs`/`tasks` instructions match `schema.yaml` again. `docs-lab/customize/schemas.md` gains one line telling fork authors to keep the `#` title on the first line. The legacy `docs/` tree is left untouched — the site builds from `docs-lab/` and its README keeps `docs/` as source material only.

### Why this is safe

The title is inert to everything downstream:

- The delta parsers anchor on `##`/`###` (`spec-structure.ts`, `requirement-blocks.ts`, `extractPurposeSection`); a `# ` line matches none of them.
- `MarkdownParser` does re-shape the tree — with a title, `## Purpose` becomes a child of the title rather than a root section — but `findSection` recurses, which is exactly why titled main specs have always parsed. Pinned by new tests that parse a spec and a proposal with and without a title and require identical output.
- Archive **builds** a new main spec from the delta's sections (`buildSpecSkeleton`) rather than copying the delta file, so the delta's title cannot leak in.
- Existing fixtures in `archive.test.ts` already opened delta specs with `# Docs Delta` and proposals with `# Proposal` — the codebase has been round-tripping titled artifacts all along.

## Proof it works

Guards, each verified to fail before the fix and pass after:

1. **Every packaged artifact, not a hardcoded list** — the guard enumerates every artifact of every packaged schema from `schema.yaml` and resolves its template, so a new schema or artifact is covered automatically. A second table pins the exact wording per artifact, and a third test requires that table to name every artifact the schema declares.
   Pre-fix: `expected '## Why' to match /^# \S/`, and likewise `## Context`, `## Purpose`, `## 1. ...`.
2. **The scaffolder** — `openspec schema init` writes four templates, each with the title that artifact is supposed to get, and a blank line under it.
   Pre-fix: `expected '## Context' to match /^# \S/`.
3. **Guidance cannot drift from templates** — a guard reads the titles out of the packaged templates and requires the onboard and sync surfaces to show those same titles. Verified by deleting one title from each surface: `onboard skill / design: expected ... to contain '\n# Design\n'` and `sync skill: expected ... to contain '\n# Spec Delta\n\n## Purpose\n'`.
4. **The title is inert** — `parseSpec` and `parseChange` return deep-equal results with and without a title.
5. **Round trip** — a change whose artifacts all carry titles archives; the main spec it creates contains exactly one `# ` line (`# widget Specification`), carries the delta's `## Purpose` intact, and retains no heading at any level named `Spec Delta`.

Measured rather than assumed: markdownlint over a real `openspec init` + template-shaped change now reports **zero MD041**. End to end against the built CLI, `openspec instructions <artifact> --json` returns templates opening `# Proposal` / `# Spec Delta` / `# Design` / `# Tasks`, and `validate --strict` → `view` → `archive --yes` succeeds on artifacts written from them.

The guards compare on normalized line endings — the Windows runner checks out CRLF, which caught the first version of them.

Suite: 4435 tests. The failures are the same environmental ones a clean `origin/main` clone produces in this sandbox and none of them touch templates. All three CI platforms are green.

## Notes / nits

- **Out of scope, measured not assumed:** generated `SKILL.md` and `/opsx-*` command files also start on prose. Linting them reports 12 MD041 against ~500 other violations in the same files (line length, emphasis-as-heading, fences), so a title would not make them lint-clean; they are agent instruction payloads rather than documents users lint, and retitling them churns all 12 skill mirrors and their parity hashes. Worth a separate look if anyone actually lints `.claude/`.
- **Also out of scope:** the remaining lint findings on artifacts are `MD013` (line length — a per-user preference), `MD033` (the `<placeholder>` syntax the templates use deliberately) and `MD022`/`MD032` from `#### Scenario:` sitting directly above its `- **WHEN**` list. That last one is the canonical OpenSpec scenario format used by every existing spec and by archive's own output — changing it is a spec-format decision, not a lint fix. MD041 was uniquely fixable because nothing downstream depends on the first line.
- Parity hashes were regenerated for the two workflows touched (`onboard`, `sync-specs`, skill and command variants). No other hash moved.
- Supersedes #1163 (@Pluviobyte), which has been conflicting since June. Same idea for the templates; this adds the scaffolder, the workflow guidance, the doc corrections and the regression guards. Written independently rather than rebased — @Pluviobyte got there first on the templates, and that PR can be closed in favour of this one if maintainers agree.
- The `default:` branch of `createDefaultTemplate` is unreachable today (`schema init` only accepts the four known artifact ids); it was updated anyway so the invariant holds if that set grows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Generated proposal, specification, design, and task artifacts now include clear top-level titles.
  - Custom templates and onboarding workflows now follow the same titled-document format.

- **Bug Fixes**
  - Artifact titles are handled correctly during parsing and archiving without affecting content or appearing in finalized specifications.

- **Documentation**
  - Updated schema references and customization guidance to document required template titles and formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->