### PR TITLE
fix(status): name the command that resumes a change

### DIFF
--- a/.changeset/status-names-next-step.md
+++ b/.changeset/status-names-next-step.md
@@ -1,0 +1,9 @@
+---
+"@fission-ai/openspec": patch
+---
+
+`openspec status` now names the command that moves the change forward.
+
+The text output reported state and stopped there, so picking a change back up — after a lost session, or on a change you did not start — meant already knowing which command came next. The JSON surface had carried that command all along in `nextSteps`; the text surface never printed it.
+
+Status now ends with a `Next:` line: the next ready artifact's `openspec instructions` command while planning is unfinished, and `openspec instructions apply` once every planning artifact exists. It carries `--store <id>` when the resolved root is a store, and it is built from the same source as the JSON `nextSteps` sentence, so the two surfaces cannot name different commands.

--- a/docs-lab/reference/cli.md
+++ b/docs-lab/reference/cli.md
@@ -1065,7 +1065,23 @@ Progress: 2/4 artifacts complete
 [x] specs
 [ ] design
 [-] tasks (blocked by: design)
+
+Next: openspec instructions design --change "add-rate-limit" --json
 ```
+
+The `Next:` line names the one command that moves the change forward, so `openspec status` is enough to pick a change back up in a fresh session. It names the next ready artifact while planning is unfinished, and `openspec instructions apply` once every planning artifact exists:
+
+```
+[x] proposal
+[x] specs
+[x] design
+[x] tasks
+
+All planning artifacts complete!
+Next: openspec instructions apply --change "add-rate-limit" --json
+```
+
+It carries `--store <id>` whenever the resolved root is a store, and names the same command as the JSON `nextSteps` sentence.
 
 `--json` adds per-artifact dependencies, resolved file paths, and a suggested next step. Trimmed:
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -775,7 +775,23 @@ Progress: 2/4 artifacts complete
 [x] specs
 [ ] design
 [-] tasks (blocked by: design)
+
+Next: openspec instructions design --change "add-dark-mode" --json
 ```
+
+The `Next:` line names the one command that moves the change forward, so `openspec status` is enough to pick a change back up in a fresh session. It names the next ready artifact while planning is unfinished, and `openspec instructions apply` once every planning artifact exists:
+
+```
+[x] proposal
+[x] specs
+[x] design
+[x] tasks
+
+All planning artifacts complete!
+Next: openspec instructions apply --change "add-dark-mode" --json
+```
+
+It carries `--store <id>` whenever the resolved root is a store, and it names the same command as the JSON `nextSteps` sentence.
 
 A change that declares `skip_specs: true` shows its specs stage as `[~] specs (skipped: change declares skip_specs)` and excludes it from the progress count.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -775,23 +775,7 @@ Progress: 2/4 artifacts complete
 [x] specs
 [ ] design
 [-] tasks (blocked by: design)
-
-Next: openspec instructions design --change "add-dark-mode" --json
 ```
-
-The `Next:` line names the one command that moves the change forward, so `openspec status` is enough to pick a change back up in a fresh session. It names the next ready artifact while planning is unfinished, and `openspec instructions apply` once every planning artifact exists:
-
-```
-[x] proposal
-[x] specs
-[x] design
-[x] tasks
-
-All planning artifacts complete!
-Next: openspec instructions apply --change "add-dark-mode" --json
-```
-
-It carries `--store <id>` whenever the resolved root is a store, and it names the same command as the JSON `nextSteps` sentence.
 
 A change that declares `skip_specs: true` shows its specs stage as `[~] specs (skipped: change declares skip_specs)` and excludes it from the progress count.
 

--- a/openspec/changes/add-status-next-step/.openspec.yaml
+++ b/openspec/changes/add-status-next-step/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-04

--- a/openspec/changes/add-status-next-step/proposal.md
+++ b/openspec/changes/add-status-next-step/proposal.md
@@ -1,0 +1,44 @@
+# Name the command that resumes a change
+
+## Why
+
+`openspec status` reported where a change stood and stopped there. The command
+that moves it forward was already computed — `buildNextSteps` derives it and
+`--json` publishes it as `nextSteps` — but the text surface never rendered it.
+
+So the surface a person actually reads ended on a checklist. `openspec new
+change` hands off with `Next: openspec status --change <name>`, and that next
+command then had no verb of its own. Picking a change back up after a lost
+session, or opening one somebody else started, meant already knowing which
+command came next (#906).
+
+The completion case was the worst of it. Once every planning artifact existed,
+status printed a lone green "All planning artifacts complete!" — which reads as
+*you are done* even while `tasks.md` sits half-checked. That is what #906
+reports: every artifact showed `done` rather than `ready`, so the conclusion was
+that nothing was left to run.
+
+## What Changes
+
+- `openspec status` ends with a `Next:` line naming one command: the next ready
+  artifact's `openspec instructions` call while planning is unfinished, and
+  `openspec instructions apply` once every planning artifact exists.
+- The line carries `--store <id>` whenever the resolved root is a store. A
+  command without the flag would resolve against the pointer repo instead of the
+  store the status was read from.
+- `--all` gives every change in the sweep its own line, and gives none to an
+  entry that failed to load — a failed entry has no artifact statuses to reason
+  about.
+- The line is built from the same resolution as the JSON `nextSteps` sentence,
+  so the two surfaces cannot name different commands. `nextSteps` itself is
+  unchanged, character for character.
+
+No new command, no new flag, no new JSON field. This renders a value the agent
+contract already publishes.
+
+## Impact
+
+- Affected specs: `cli-artifact-workflow` (MODIFIED: Next Artifact Discovery)
+- Affected code: `src/commands/workflow/status.ts`,
+  `src/core/change-status-policy.ts`
+- Affected docs: `docs/cli.md` (the status text output example)

--- a/openspec/changes/add-status-next-step/specs/cli-artifact-workflow/spec.md
+++ b/openspec/changes/add-status-next-step/specs/cli-artifact-workflow/spec.md
@@ -1,0 +1,37 @@
+## MODIFIED Requirements
+
+### Requirement: Next Artifact Discovery
+
+The workflow SHALL use `openspec status` output to determine what can be created next, rather than a separate next-command surface.
+
+#### Scenario: Discover next artifacts from status output
+
+- **WHEN** a user needs to know which artifact to create next
+- **THEN** `openspec status --change <id>` identifies ready artifacts with `[ ]`
+- **AND** the first `[ ]` entry is the schema's recommended next artifact
+- **AND** no dedicated "next command" is required to continue the workflow
+
+#### Scenario: Status names the command that moves the change forward
+
+- **WHEN** a user runs `openspec status --change <id>` in text mode and a next step resolves
+- **THEN** the output ends with a `Next:` line naming exactly one command to run
+- **AND** that command is `openspec instructions <artifact> --change "<id>" --json` for the first ready artifact while any planning artifact is still ready
+- **AND** it is `openspec instructions apply --change "<id>" --json` once every planning artifact exists, printed after the completion line rather than in place of it, because that line alone reads as "you are done" while implementation tasks remain
+- **AND** the named artifact is never one the change skipped, which satisfies its dependents but must not be created
+- **AND** the artifact id comes from the resolved schema, so a project whose schema declares neither of the default artifact names still gets a usable command
+
+#### Scenario: The named command carries the store selection
+
+- **WHEN** the resolved root is a store
+- **THEN** the `Next:` command includes `--store <id>`, so it resolves against the same root the status was read from rather than the pointer repo
+
+#### Scenario: Both surfaces name the same command
+
+- **WHEN** a next step resolves
+- **THEN** the command printed on the `Next:` line and the command inside the JSON `nextSteps` sentence are derived from one resolution, so the two surfaces cannot name different commands
+- **AND** the `Next:` line never appears in `--json` output, which stays parseable
+
+#### Scenario: No next step resolves
+
+- **WHEN** no artifact is ready and planning is not complete, or a change in an `--all` sweep failed to load
+- **THEN** no `Next:` line is printed for it, rather than a guessed or shared command

--- a/openspec/changes/add-status-next-step/tasks.md
+++ b/openspec/changes/add-status-next-step/tasks.md
@@ -1,0 +1,17 @@
+# Tasks
+
+## 1. Resolve the next step once
+- [x] 1.1 Extract `resolveNextStep` returning the command and the sentence, leaving `buildNextSteps` returning exactly that sentence so the JSON contract is unchanged
+- [x] 1.2 Pin the published sentences verbatim in a unit test, so splitting command from sentence cannot reword the contract
+
+## 2. Render it on the text surface
+- [x] 2.1 Print a `Next:` line from the resolved command, after the completion line rather than in place of it
+- [x] 2.2 Thread the store selection into the renderer so the command carries `--store`
+- [x] 2.3 Give every change in an `--all` sweep its own line, and a failed entry none
+
+## 3. Cover the behavior
+- [x] 3.1 Assert the ready, planning-complete, skipped, and custom-schema cases end to end
+- [x] 3.2 Assert the printed command appears verbatim inside the JSON sentence, and that the line never leaks into `--json`
+
+## 4. Record it
+- [x] 4.1 Update the `cli-artifact-workflow` spec delta and the `docs/cli.md` status output example

--- a/src/commands/workflow/status.ts
+++ b/src/commands/workflow/status.ts
@@ -83,13 +83,13 @@ export async function statusCommand(options: StatusOptions): Promise<void> {
     const rootOutput = toRootOutput(root);
     const newChangeHint = withStoreFlag(root, 'openspec new change <name>');
 
-    // Single definition of "load one change's status" so the batch and
-    // single-change payloads can never drift apart.
     // One store-flag decision serves the JSON `nextSteps` sentence and the text
     // `Next:` line, so a store-selected root can never carry `--store` in one
     // and drop it from the other.
     const storeOptions = isStoreSelectedRoot(root) ? { storeId: root.storeId } : {};
 
+    // Single definition of "load one change's status" so the batch and
+    // single-change payloads can never drift apart.
     const loadStatus = (changeName: string): ChangeStatus =>
       formatChangeStatus(
         loadChangeContext(projectRoot, changeName, options.schema, {

--- a/src/commands/workflow/status.ts
+++ b/src/commands/workflow/status.ts
@@ -19,6 +19,7 @@ import {
   formatChangeStatus,
   type ChangeStatus,
 } from '../../core/artifact-graph/index.js';
+import { resolveNextStep } from '../../core/change-status-policy.js';
 import { asStatus } from '../shared-output.js';
 import type { StoreDiagnostic } from '../../core/store/errors.js';
 import {
@@ -84,13 +85,18 @@ export async function statusCommand(options: StatusOptions): Promise<void> {
 
     // Single definition of "load one change's status" so the batch and
     // single-change payloads can never drift apart.
+    // One store-flag decision serves the JSON `nextSteps` sentence and the text
+    // `Next:` line, so a store-selected root can never carry `--store` in one
+    // and drop it from the other.
+    const storeOptions = isStoreSelectedRoot(root) ? { storeId: root.storeId } : {};
+
     const loadStatus = (changeName: string): ChangeStatus =>
       formatChangeStatus(
         loadChangeContext(projectRoot, changeName, options.schema, {
           changeDir: getChangeDir(planningHome, changeName),
           planningHome,
         }),
-        isStoreSelectedRoot(root) ? { storeId: root.storeId } : {}
+        storeOptions
       );
 
     // Handle no-changes case gracefully — status is informational,
@@ -150,7 +156,7 @@ export async function statusCommand(options: StatusOptions): Promise<void> {
             console.log();
           }
           if ('artifacts' in entry) {
-            printStatusText(entry);
+            printStatusText(entry, storeOptions);
           } else {
             console.log(chalk.red(`✗ ${entry.changeName}: ${entry.status[0]?.message}`));
           }
@@ -195,14 +201,19 @@ export async function statusCommand(options: StatusOptions): Promise<void> {
       return;
     }
 
-    printStatusText(status);
+    printStatusText(status, storeOptions);
   } catch (error) {
     spinner?.stop();
     throw error;
   }
 }
 
-export function printStatusText(status: ChangeStatus): void {
+export interface PrintStatusTextOptions {
+  /** Selected store id, so the printed command carries `--store`. */
+  storeId?: string;
+}
+
+export function printStatusText(status: ChangeStatus, options: PrintStatusTextOptions = {}): void {
   const doneCount = status.artifacts.filter((a) => a.status === 'done').length;
   const skippedCount = status.artifacts.filter((a) => a.status === 'skipped').length;
   const total = status.artifacts.length - skippedCount;
@@ -232,8 +243,26 @@ export function printStatusText(status: ChangeStatus): void {
     console.log(line);
   }
 
-  if (status.isPlanningComplete) {
+  // Derived from the same inputs as the JSON `nextSteps` sentence, so the two
+  // surfaces always name the same command. Without this line the text surface
+  // reports state and no verb, which leaves someone resuming a change - after a
+  // lost session, or on a change they did not start - with nowhere to go.
+  const nextStep = resolveNextStep({
+    changeName: status.changeName,
+    artifactStatuses: status.artifacts,
+    allArtifactsComplete: status.isPlanningComplete,
+    ...(options.storeId ? { storeId: options.storeId } : {}),
+  });
+
+  if (status.isPlanningComplete || nextStep) {
     console.log();
+  }
+
+  if (status.isPlanningComplete) {
     console.log(chalk.green('All planning artifacts complete!'));
+  }
+
+  if (nextStep) {
+    console.log(`Next: ${nextStep.command}`);
   }
 }

--- a/src/core/change-status-policy.ts
+++ b/src/core/change-status-policy.ts
@@ -62,20 +62,41 @@ export function buildActionContext(input: ActionContextInput): ActionContext {
   };
 }
 
-export function buildNextSteps(input: ChangeNextStepsInput): string[] {
+/**
+ * The one next action for a change, in both the forms the CLI needs.
+ *
+ * `sentence` is what the JSON `nextSteps` contract publishes; `command` is the
+ * bare command the text surface prints. Both are built here so the two
+ * surfaces can never name a different next step.
+ */
+export interface ChangeNextStep {
+  /** Ready-to-run command, including any `--store` flag. */
+  command: string;
+  /** Sentence form carried by the JSON `nextSteps` array. */
+  sentence: string;
+}
+
+export function resolveNextStep(input: ChangeNextStepsInput): ChangeNextStep | undefined {
   const readyArtifact = input.artifactStatuses.find((artifact) => artifact.status === 'ready');
-  const steps: string[] = [];
   const storeFlag = input.storeId ? ` --store ${input.storeId}` : '';
 
   if (readyArtifact) {
-    steps.push(
-      `Run openspec instructions ${readyArtifact.id} --change "${input.changeName}"${storeFlag} --json before writing that artifact.`
-    );
-  } else if (input.allArtifactsComplete) {
-    steps.push(
-      `All planning artifacts are complete. Run openspec instructions apply --change "${input.changeName}"${storeFlag} --json to inspect implementation progress.`
-    );
+    const command = `openspec instructions ${readyArtifact.id} --change "${input.changeName}"${storeFlag} --json`;
+    return { command, sentence: `Run ${command} before writing that artifact.` };
   }
 
-  return steps;
+  if (input.allArtifactsComplete) {
+    const command = `openspec instructions apply --change "${input.changeName}"${storeFlag} --json`;
+    return {
+      command,
+      sentence: `All planning artifacts are complete. Run ${command} to inspect implementation progress.`,
+    };
+  }
+
+  return undefined;
+}
+
+export function buildNextSteps(input: ChangeNextStepsInput): string[] {
+  const step = resolveNextStep(input);
+  return step ? [step.sentence] : [];
 }

--- a/test/commands/artifact-workflow.test.ts
+++ b/test/commands/artifact-workflow.test.ts
@@ -140,6 +140,57 @@ describe('artifact-workflow CLI commands', () => {
       expect(json.nextSteps[0]).toContain('openspec instructions specs');
     });
 
+    // #906: the text surface reported state and no verb, so someone resuming a
+    // change - after a lost session, or on a change they did not start - had to
+    // already know which command comes next. The command is now printed.
+    describe('next step', () => {
+      it('names the command for the next ready artifact', async () => {
+        await createTestChange('resume-planning');
+
+        const result = await runCLI(['status', '--change', 'resume-planning'], { cwd: tempDir });
+
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain(
+          'Next: openspec instructions specs --change "resume-planning" --json'
+        );
+      });
+
+      it('names the apply command once planning is complete', async () => {
+        await createTestChange('resume-apply', ['proposal', 'design', 'specs', 'tasks']);
+
+        const result = await runCLI(['status', '--change', 'resume-apply'], { cwd: tempDir });
+
+        expect(result.exitCode).toBe(0);
+        // The completion line alone reads as "you are done" even while tasks
+        // remain, so it must be followed by the command that resumes the work.
+        expect(result.stdout).toContain('All planning artifacts complete!');
+        expect(result.stdout).toContain(
+          'Next: openspec instructions apply --change "resume-apply" --json'
+        );
+      });
+
+      it('prints the same command the JSON nextSteps sentence names', async () => {
+        for (const artifacts of [[], ['proposal', 'design', 'specs', 'tasks']] as const) {
+          const changeName = `parity-${artifacts.length}`;
+          await createTestChange(changeName, [...artifacts]);
+
+          const text = await runCLI(['status', '--change', changeName], { cwd: tempDir });
+          const json = await runCLI(['status', '--change', changeName, '--json'], { cwd: tempDir });
+
+          const printed = text.stdout
+            .split('\n')
+            .find((line) => line.startsWith('Next: '))
+            ?.slice('Next: '.length)
+            .trim();
+
+          expect(printed).toBeDefined();
+          // One source of truth: the printed command must appear verbatim
+          // inside the published JSON sentence.
+          expect(JSON.parse(json.stdout).nextSteps[0]).toContain(printed);
+        }
+      });
+    });
+
     it('shows planning completion when all artifacts exist', async () => {
       await createTestChange('complete-change', ['proposal', 'design', 'specs', 'tasks']);
 

--- a/test/commands/artifact-workflow.test.ts
+++ b/test/commands/artifact-workflow.test.ts
@@ -169,6 +169,89 @@ describe('artifact-workflow CLI commands', () => {
         );
       });
 
+      it('names artifacts from a custom schema, not spec-driven ones', async () => {
+        // The line is built from the resolved artifact id, so a project whose
+        // schema has no proposal/specs/design/tasks must still get a usable
+        // command rather than a hard-coded default-schema one.
+        const schemaDir = path.join(tempDir, 'openspec', 'schemas', 'lean');
+        await fs.mkdir(path.join(schemaDir, 'templates'), { recursive: true });
+        await fs.writeFile(path.join(schemaDir, 'templates', 'brief.md'), '# Brief\n');
+        await fs.writeFile(path.join(schemaDir, 'templates', 'plan.md'), '# Plan\n');
+        await fs.writeFile(
+          path.join(schemaDir, 'schema.yaml'),
+          [
+            'name: lean',
+            'version: 1',
+            'artifacts:',
+            '  - id: brief',
+            '    generates: brief.md',
+            '    description: One-page brief',
+            '    template: brief.md',
+            '    requires: []',
+            '  - id: plan',
+            '    generates: plan.md',
+            '    description: Execution plan',
+            '    template: plan.md',
+            '    requires: [brief]',
+            'apply:',
+            '  requires: [plan]',
+            '',
+          ].join('\n')
+        );
+
+        const changeDir = path.join(changesDir, 'lean-change');
+        await fs.mkdir(changeDir, { recursive: true });
+        await fs.writeFile(path.join(changeDir, '.openspec.yaml'), 'schema: lean\n');
+        await fs.writeFile(path.join(changeDir, 'brief.md'), '# Brief\n\nThe brief.\n');
+
+        const ready = await runCLI(['status', '--change', 'lean-change'], { cwd: tempDir });
+        expect(ready.exitCode).toBe(0);
+        expect(ready.stdout).toContain(
+          'Next: openspec instructions plan --change "lean-change" --json'
+        );
+
+        await fs.writeFile(path.join(changeDir, 'plan.md'), '# Plan\n\nThe plan.\n');
+
+        const complete = await runCLI(['status', '--change', 'lean-change'], { cwd: tempDir });
+        expect(complete.exitCode).toBe(0);
+        expect(complete.stdout).toContain(
+          'Next: openspec instructions apply --change "lean-change" --json'
+        );
+      });
+
+      it('never points at a skipped artifact', async () => {
+        const changeDir = await createTestChange('skip-next-step', ['proposal']);
+        await fs.writeFile(
+          path.join(changeDir, '.openspec.yaml'),
+          'schema: spec-driven\nskip_specs: true\n'
+        );
+
+        const result = await runCLI(['status', '--change', 'skip-next-step'], { cwd: tempDir });
+
+        expect(result.exitCode).toBe(0);
+        // A skipped artifact satisfies its dependents but must never be
+        // created, so naming it would send the author to write a file the
+        // change forbids.
+        expect(result.stdout).toContain('[~] specs');
+        expect(result.stdout).toContain(
+          'Next: openspec instructions design --change "skip-next-step" --json'
+        );
+      });
+
+      it('stays out of the JSON payload', async () => {
+        await createTestChange('json-clean');
+
+        const result = await runCLI(['status', '--change', 'json-clean', '--json'], {
+          cwd: tempDir,
+        });
+
+        expect(result.exitCode).toBe(0);
+        // The text line must not leak into --json: it would break the parse
+        // for every agent reading this command.
+        expect(result.stdout).not.toContain('Next: ');
+        expect(() => JSON.parse(result.stdout)).not.toThrow();
+      });
+
       it('prints the same command the JSON nextSteps sentence names', async () => {
         for (const artifacts of [[], ['proposal', 'design', 'specs', 'tasks']] as const) {
           const changeName = `parity-${artifacts.length}`;

--- a/test/commands/artifact-workflow.test.ts
+++ b/test/commands/artifact-workflow.test.ts
@@ -144,13 +144,22 @@ describe('artifact-workflow CLI commands', () => {
     // change - after a lost session, or on a change they did not start - had to
     // already know which command comes next. The command is now printed.
     describe('next step', () => {
+      /**
+       * The line closes the output, so a `toContain` would still pass if some
+       * later line pushed it into the middle of the report.
+       */
+      function lastLine(result: { stdout: string }): string {
+        const lines = result.stdout.split('\n').filter((line) => line.trim() !== '');
+        return lines[lines.length - 1] ?? '';
+      }
+
       it('names the command for the next ready artifact', async () => {
         await createTestChange('resume-planning');
 
         const result = await runCLI(['status', '--change', 'resume-planning'], { cwd: tempDir });
 
         expect(result.exitCode).toBe(0);
-        expect(result.stdout).toContain(
+        expect(lastLine(result)).toBe(
           'Next: openspec instructions specs --change "resume-planning" --json'
         );
       });
@@ -164,7 +173,7 @@ describe('artifact-workflow CLI commands', () => {
         // The completion line alone reads as "you are done" even while tasks
         // remain, so it must be followed by the command that resumes the work.
         expect(result.stdout).toContain('All planning artifacts complete!');
-        expect(result.stdout).toContain(
+        expect(lastLine(result)).toBe(
           'Next: openspec instructions apply --change "resume-apply" --json'
         );
       });
@@ -206,7 +215,7 @@ describe('artifact-workflow CLI commands', () => {
 
         const ready = await runCLI(['status', '--change', 'lean-change'], { cwd: tempDir });
         expect(ready.exitCode).toBe(0);
-        expect(ready.stdout).toContain(
+        expect(lastLine(ready)).toBe(
           'Next: openspec instructions plan --change "lean-change" --json'
         );
 
@@ -214,7 +223,7 @@ describe('artifact-workflow CLI commands', () => {
 
         const complete = await runCLI(['status', '--change', 'lean-change'], { cwd: tempDir });
         expect(complete.exitCode).toBe(0);
-        expect(complete.stdout).toContain(
+        expect(lastLine(complete)).toBe(
           'Next: openspec instructions apply --change "lean-change" --json'
         );
       });
@@ -233,7 +242,7 @@ describe('artifact-workflow CLI commands', () => {
         // created, so naming it would send the author to write a file the
         // change forbids.
         expect(result.stdout).toContain('[~] specs');
-        expect(result.stdout).toContain(
+        expect(lastLine(result)).toBe(
           'Next: openspec instructions design --change "skip-next-step" --json'
         );
       });

--- a/test/commands/artifact-workflow.test.ts
+++ b/test/commands/artifact-workflow.test.ts
@@ -149,7 +149,9 @@ describe('artifact-workflow CLI commands', () => {
        * later line pushed it into the middle of the report.
        */
       function lastLine(result: { stdout: string }): string {
-        const lines = result.stdout.split('\n').filter((line) => line.trim() !== '');
+        // Split on \r?\n so a CRLF stream does not leave the carriage return
+        // attached to the line being compared.
+        const lines = result.stdout.split(/\r?\n/).filter((line) => line.trim() !== '');
         return lines[lines.length - 1] ?? '';
       }
 
@@ -269,15 +271,12 @@ describe('artifact-workflow CLI commands', () => {
           const text = await runCLI(['status', '--change', changeName], { cwd: tempDir });
           const json = await runCLI(['status', '--change', changeName, '--json'], { cwd: tempDir });
 
-          const printed = text.stdout
-            .split('\n')
-            .find((line) => line.startsWith('Next: '))
-            ?.slice('Next: '.length)
-            .trim();
+          const closing = lastLine(text);
+          expect(closing.startsWith('Next: ')).toBe(true);
 
-          expect(printed).toBeDefined();
           // One source of truth: the printed command must appear verbatim
           // inside the published JSON sentence.
+          const printed = closing.slice('Next: '.length);
           expect(JSON.parse(json.stdout).nextSteps[0]).toContain(printed);
         }
       });

--- a/test/commands/declared-store-fallback.test.ts
+++ b/test/commands/declared-store-fallback.test.ts
@@ -71,8 +71,13 @@ describe('declared store fallback (3.2)', () => {
     expect(statusHuman.exitCode).toBe(0);
     expect(statusHuman.stderr).toContain('Using OpenSpec root: team-context');
 
-    // Hint continuity: follow-ups carry --store (JSON nextSteps is the
-    // surface that prints them).
+    // Hint continuity: follow-ups carry --store on BOTH surfaces. A text
+    // `Next:` line that dropped the flag would resolve against the pointer
+    // repo instead of the store.
+    expect(statusHuman.stdout).toContain(
+      'Next: openspec instructions proposal --change "billing-rework" --store team-context --json'
+    );
+
     const statusJson = await runCLI(['status', '--change', 'billing-rework', '--json'], {
       cwd: pointerRepo,
       env,

--- a/test/commands/status-all.test.ts
+++ b/test/commands/status-all.test.ts
@@ -203,6 +203,37 @@ describe('status --all', () => {
     expect(result.stdout).toContain('2/4 artifacts complete');
   });
 
+  it('gives every change in the sweep its own next-step line', async () => {
+    await createTestChange('first-change');
+    await createTestChange('second-change', ['design']);
+
+    const result = await runCLI(['status', '--all'], { cwd: tempDir });
+
+    expect(result.exitCode).toBe(0);
+    // The point of the batch view is one screen saying what each change needs
+    // next - a single shared line, or a line for only one change, would not.
+    expect(result.stdout).toContain(
+      'Next: openspec instructions specs --change "first-change" --json'
+    );
+    expect(result.stdout).toContain(
+      'Next: openspec instructions specs --change "second-change" --json'
+    );
+  });
+
+  it('prints no next-step line for a change that failed to load', async () => {
+    await createTestChange('good-change', ['design']);
+    const brokenDir = await createTestChange('broken-change');
+    await fs.writeFile(path.join(brokenDir, '.openspec.yaml'), 'schema: does-not-exist\n');
+
+    const result = await runCLI(['status', '--all'], { cwd: tempDir });
+
+    // A failed entry has no artifact statuses to reason about, so it must not
+    // be given a next step alongside its diagnostic.
+    expect(getOutput(result)).toContain('✗ broken-change');
+    expect(result.stdout).toContain('Next: openspec instructions specs --change "good-change"');
+    expect(result.stdout).not.toContain('--change "broken-change"');
+  });
+
   it('exits 1 in text mode when a change fails to load, still printing the others', async () => {
     await createTestChange('good-change', ['design']);
     const brokenDir = await createTestChange('broken-change');

--- a/test/core/change-status-policy.test.ts
+++ b/test/core/change-status-policy.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildNextSteps,
+  resolveNextStep,
+  type ChangeNextStepsInput,
+  type ChangeStatusPolicyArtifact,
+} from '../../src/core/change-status-policy.js';
+
+/**
+ * `resolveNextStep` is the single source for the one command that moves a
+ * change forward. Two surfaces render it: the JSON `nextSteps` sentence
+ * (a published agent contract) and the text `Next:` line. These tests pin the
+ * sentences verbatim so the split into command + sentence cannot quietly
+ * reword the contract, and assert the command is always a substring of the
+ * sentence so the two surfaces can never name different commands.
+ */
+describe('change status policy - next step', () => {
+  const artifacts = (
+    ...pairs: Array<[string, ChangeStatusPolicyArtifact['status']]>
+  ): ChangeStatusPolicyArtifact[] => pairs.map(([id, status]) => ({ id, status }));
+
+  const input = (overrides: Partial<ChangeNextStepsInput> = {}): ChangeNextStepsInput => ({
+    changeName: 'add-dark-mode',
+    artifactStatuses: artifacts(['proposal', 'done'], ['specs', 'ready'], ['tasks', 'blocked']),
+    allArtifactsComplete: false,
+    ...overrides,
+  });
+
+  describe('an artifact is ready', () => {
+    it('names that artifact instructions command', () => {
+      expect(resolveNextStep(input())).toEqual({
+        command: 'openspec instructions specs --change "add-dark-mode" --json',
+        sentence:
+          'Run openspec instructions specs --change "add-dark-mode" --json before writing that artifact.',
+      });
+    });
+
+    it('picks the FIRST ready artifact, not the last', () => {
+      // The array arrives in dependency order with the schema's declaration
+      // order breaking ties, so first-ready is the artifact to write next.
+      const step = resolveNextStep(
+        input({
+          artifactStatuses: artifacts(
+            ['proposal', 'done'],
+            ['specs', 'ready'],
+            ['design', 'ready']
+          ),
+        })
+      );
+
+      expect(step?.command).toContain('openspec instructions specs ');
+      expect(step?.command).not.toContain('design');
+    });
+
+    it('never names a skipped artifact', () => {
+      // skip_specs artifacts satisfy dependencies but must not be created,
+      // so pointing at one would send the author to write a forbidden file.
+      const step = resolveNextStep(
+        input({
+          artifactStatuses: artifacts(
+            ['proposal', 'done'],
+            ['specs', 'skipped'],
+            ['design', 'ready']
+          ),
+        })
+      );
+
+      expect(step?.command).toContain('openspec instructions design ');
+      expect(step?.command).not.toContain('specs');
+    });
+
+    it('wins over allArtifactsComplete when both could apply', () => {
+      const step = resolveNextStep(input({ allArtifactsComplete: true }));
+
+      expect(step?.command).toContain('openspec instructions specs ');
+    });
+  });
+
+  describe('planning is complete', () => {
+    it('names the apply instructions command', () => {
+      const step = resolveNextStep(
+        input({
+          artifactStatuses: artifacts(['proposal', 'done'], ['specs', 'done']),
+          allArtifactsComplete: true,
+        })
+      );
+
+      expect(step).toEqual({
+        command: 'openspec instructions apply --change "add-dark-mode" --json',
+        sentence:
+          'All planning artifacts are complete. Run openspec instructions apply --change "add-dark-mode" --json to inspect implementation progress.',
+      });
+    });
+  });
+
+  describe('store selection', () => {
+    it('carries --store in both the command and the sentence', () => {
+      for (const allArtifactsComplete of [false, true]) {
+        const step = resolveNextStep(
+          input({
+            artifactStatuses: allArtifactsComplete
+              ? artifacts(['proposal', 'done'])
+              : artifacts(['proposal', 'ready']),
+            allArtifactsComplete,
+            storeId: 'team-context',
+          })
+        );
+
+        // A command that drops the flag resolves against the pointer repo
+        // instead of the store the status was read from.
+        expect(step?.command).toContain('--store team-context --json');
+        expect(step?.sentence).toContain('--store team-context --json');
+      }
+    });
+
+    it('omits the flag entirely for a repo-local root', () => {
+      expect(resolveNextStep(input())?.command).not.toContain('--store');
+    });
+  });
+
+  describe('no next step', () => {
+    it('resolves to undefined when nothing is ready and planning is unfinished', () => {
+      const step = resolveNextStep(
+        input({
+          artifactStatuses: artifacts(['proposal', 'done'], ['specs', 'blocked']),
+          allArtifactsComplete: false,
+        })
+      );
+
+      expect(step).toBeUndefined();
+    });
+
+    it('leaves nextSteps empty rather than inventing a step', () => {
+      expect(
+        buildNextSteps(
+          input({
+            artifactStatuses: artifacts(['specs', 'blocked']),
+            allArtifactsComplete: false,
+          })
+        )
+      ).toEqual([]);
+    });
+  });
+
+  describe('buildNextSteps stays the published contract', () => {
+    it('is exactly the resolved sentence, one entry', () => {
+      for (const candidate of [
+        input(),
+        input({ artifactStatuses: artifacts(['proposal', 'done']), allArtifactsComplete: true }),
+        input({ storeId: 'team-context' }),
+      ]) {
+        const step = resolveNextStep(candidate);
+        const steps = buildNextSteps(candidate);
+
+        expect(steps).toEqual([step!.sentence]);
+        // The rendered `Next:` line must be quotable from the JSON sentence.
+        expect(steps[0]).toContain(step!.command);
+      }
+    });
+  });
+});


### PR DESCRIPTION
**Status:** Ready for review.

Closes #906

## What was wrong

`openspec status` told you where a change stood and never told you what to do about it:

```
Progress: 2/4 artifacts complete

[x] proposal
[x] specs
[ ] design
[-] tasks (blocked by: design)
```

That's a dead end for anyone picking a change back up — after running out of context mid-change, or on a change someone else started. It's also the command `openspec new change` explicitly hands you off to (`Next: openspec status --change <name>`), so the chain broke on the very next step.

The command that moves the change forward already existed. `buildNextSteps` computes it and `--json` publishes it as `nextSteps`. Only the text surface dropped it.

Worse in the completion case: once every planning artifact exists, status printed a lone green **"All planning artifacts complete!"** and nothing else. That reads as *you are done* even when `tasks.md` is 1/2 checked off — which is exactly what #906 reports, an agent seeing every artifact `done` rather than `ready` and concluding there was nothing left to run.

## How it was fixed

- Extracted `resolveNextStep()` in `src/core/change-status-policy.ts`, returning `{ command, sentence }`. `buildNextSteps` returns `[sentence]` — the JSON contract is byte-identical — and the text renderer prints `command`. One source of truth, no sentence parsing.
- `printStatusText` prints a `Next: <command>` line, matching the idiom `openspec new change` already uses.
- Threaded the store selection into the renderer, so the printed command carries `--store <id>` exactly like the JSON sentence does. A `Next:` line without the flag would resolve against the pointer repo instead of the store.

```
[x] proposal
[x] specs
[x] design
[x] tasks

All planning artifacts complete!
Next: openspec instructions apply --change "add-dark-mode" --json
```

Scope is deliberately just the render. No new command, no new flag, no JSON field added, no schema or workflow-template change — it surfaces a value the agent contract already publishes.

## Proof it works

**The JSON contract is provably unchanged.** I ran `main`'s `buildNextSteps` against the three shapes and diffed its output against the literals now pinned in `test/core/change-status-policy.test.ts` — byte-identical, including the `--store` variant. The command/sentence split cannot have reworded anything an agent parses.

**Nine new end-to-end guards; eight fail on `main`.** Verified by `git checkout main -- src/commands/workflow/status.ts src/core/change-status-policy.ts`, rebuilding, and re-running:

```
× next step > names the command for the next ready artifact
× next step > names the apply command once planning is complete
× next step > names artifacts from a custom schema, not spec-driven ones
× next step > never points at a skipped artifact
× next step > prints the same command the JSON nextSteps sentence names
✓ next step > stays out of the JSON payload          <- negative guard, correctly passes on main
× status --all > gives every change in the sweep its own next-step line
× status --all > prints no next-step line for a change that failed to load
× declared store fallback > --store carried on the text surface
```

Coverage map:

| Case | Where |
|---|---|
| ready / complete / store / skipped / no-step, plus verbatim contract pins | `test/core/change-status-policy.test.ts` (new, 10 unit tests) |
| ready, complete, skipped, **custom schema**, JSON-clean, text↔JSON parity | `artifact-workflow.test.ts > status command > next step` |
| one line per change, none for a failed entry | `status-all.test.ts` |
| `--store` on the text surface | `declared-store-fallback.test.ts` |

Two of those deserve calling out:

- **Parity guard** — scrapes the printed `Next:` line and asserts it appears verbatim inside `nextSteps[0]`, in both the ready and planning-complete states. The two surfaces cannot drift.
- **Custom schema** — a `lean` schema with `brief` → `plan` and no default artifact names. The line names `plan`, then `apply`. Nothing is hard-coded to `spec-driven`.

`openspec validate add-status-next-step` passes, and `validate --all` shows no new failures (the 6 failing changes fail on `main` too).

Locally: 4417/4423 before hardening, and every touched file green after. The 6 failures are environmental — `artifact-workflow > creates skills for Cursor tool` and `config-profile > confirmed project apply` are **pre-existing on `main`** (confirmed by reverting every branch file and re-running); the other four are the 10s-`testTimeout` parallel-load flake and each passes in isolation. CI is green on linux, macOS, and Windows.

## Review round

All three CodeRabbit threads are closed:

1. **MD040 language tag on the new docs fence** — withdrawn by CodeRabbit after I pointed out that every adjacent CLI-output fence in `docs/cli.md` is untagged and the repo ships no markdownlint config or docs lint script.
2. **"Assert `Next:` is the final line"** — valid, and taken. The spec delta says the output *ends with* the line, so `toContain` was the weaker claim. Added a `lastLine()` helper compared with `toBe`, applied to all five positional cases.
3. **CRLF safety in that helper** — taken. Splits on `/\r?\n/` now. Windows CI was green either way, so this was latent rather than active. Went one step further: the parity test had its own `split('\n')` scan whose trailing `\r` was only absorbed by an incidental `.trim()`; it now routes through the same helper, so the file has one CRLF-safe reader rather than two with different guarantees.

## Notes / nits

- Includes the OpenSpec change this repo expects of user-facing work: `openspec/changes/add-status-next-step/`, whose delta modifies **Next Artifact Discovery** in `cli-artifact-workflow` — the requirement that already says status is how you learn what comes next. It now also says status names the command. No `design.md`: the schema says to write one only for cross-cutting changes, new dependencies, data-model/security/perf/migration complexity, or ambiguity needing decisions before coding, and none apply to a render change. (This is the ambiguity #1727 raises about contributor process; happy to adjust if maintainers want a different bar.)
- This addresses the half of #906 the CLI owns: the resume path is now visible from the command users are already pointed at. The other half of that report — the skill not being loaded in a fresh session — is agent-host behavior and out of scope here.
- Considered and rejected: adding a `nextCommand` field to `ChangeStatus`. It would have let the renderer read the command directly, but it expands the published agent contract in `docs/agent-contract.md` and turns a render fix into a design decision. Threading an optional renderer argument keeps the contract untouched.
- Considered and rejected: implementation task counts (`1/2 tasks`) in the text status. The single most useful fact for a resume, but it means reading `tasks.md` inside `status` and would drift from the JSON payload. `openspec instructions apply` — the command this line now names — already reports it. Worth its own issue if wanted.
- Left `openspec view` and `openspec list` alone: both are multi-change dashboards that already end with a pointer, and neither is per-change state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `openspec status` now displays a `Next:` line with the exact command needed to advance a change.
  - Next-step commands include the appropriate store option when applicable.
  - Text output stays aligned with JSON `nextSteps`, including the transition to applying completed plans.
  - `--all` status output shows a separate next-step command for each change.

- **Documentation**
  - Added examples and guidance for incomplete and fully planned changes.

- **Tests**
  - Added coverage for next-step commands, custom workflows, skipped artifacts, and store-specific output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
