### PR TITLE
fix(tasks): separate completion from archive readiness

### DIFF
--- a/schemas/spec-driven/schema.yaml
+++ b/schemas/spec-driven/schema.yaml
@@ -188,6 +188,9 @@ artifacts:
       - Each task MUST be a checkbox: `- [ ] X.Y Task description`
       - Tasks should be small enough to complete in one session
       - Order tasks by dependency (what must be done first?)
+      - Track implementation and verification work that can be completed before
+        archive. Present archive and work that depends on the change already
+        being archived as subsequent workflow steps, not task checkboxes.
       - Each task MUST state how to verify completion (a test, command,
         observable behavior, or delivered artifact). Put the verification in
         that task's checkbox description. Use a separate verification task only

--- a/schemas/spec-driven/schema.yaml
+++ b/schemas/spec-driven/schema.yaml
@@ -180,17 +180,19 @@ artifacts:
       would change what gets built, resolve them with the user first - do not
       bake an unstated assumption into the task list.
 
-      **IMPORTANT: Follow the template below exactly.** The apply phase parses
+      **IMPORTANT: Follow the template below for tracked tasks.** The apply phase parses
       checkbox format to track progress. Tasks not using `- [ ]` won't be tracked.
 
       Guidelines:
-      - Group related tasks under ## numbered headings
-      - Each task MUST be a checkbox: `- [ ] X.Y Task description`
+      - Group related tracked tasks under ## numbered headings
+      - Each tracked task MUST be a checkbox: `- [ ] X.Y Task description`
       - Tasks should be small enough to complete in one session
       - Order tasks by dependency (what must be done first?)
       - Track implementation and verification work that can be completed before
-        archive. Present archive and work that depends on the change already
-        being archived as subsequent workflow steps, not task checkboxes.
+        archive. If the requested workflow includes archive or work that requires
+        this change to be archived, preserve those steps as plain bullets in an
+        optional `## Workflow follow-up` section at the end of tasks.md. These
+        bullets are reference information outside tracked task progress.
       - Each task MUST state how to verify completion (a test, command,
         observable behavior, or delivered artifact). Put the verification in
         that task's checkbox description. Use a separate verification task only
@@ -208,6 +210,14 @@ artifacts:
 
       - [ ] 2.1 Implement data export function and verify the export test passes
       - [ ] 2.2 Add CSV formatting utilities and verify unit tests cover quoting and delimiters
+      ```
+
+      When applicable, append workflow follow-up as plain bullets, for example:
+      ```
+      ## Workflow follow-up
+
+      - Archive the change after the project's review requirements are satisfied.
+      - Verify the archived result.
       ```
 
       Reference specs for what needs to be built, design for how to build it.

--- a/skills/openspec-apply-change/SKILL.md
+++ b/skills/openspec-apply-change/SKILL.md
@@ -51,7 +51,7 @@ Implement tasks from an OpenSpec change.
 
    **Handle states:**
    - If `state: "blocked"` (missing artifacts): show message, suggest using `/openspec-continue-change` (if it is not installed, run `openspec status --change "<name>" --json` to see the next artifact and `openspec instructions <artifact-id> --change "<name>" --json` for how to create it)
-   - If `state: "all_done"`: congratulate, suggest archive
+   - If `state: "all_done"`: report that all tracked tasks are complete and suggest review or verification as appropriate before archiving
    - Otherwise: proceed to implementation
 
    Treat `context` as a required prompt-level input. Read and consider it, and
@@ -108,7 +108,7 @@ Implement tasks from an OpenSpec change.
    Display:
    - Tasks completed this session
    - Overall progress: "N/M tasks complete"
-   - If all done: suggest archive
+   - If all done: report that tracked tasks are complete and suggest review or verification as appropriate before archiving
    - If paused: explain why and wait for guidance
 
 **Output During Implementation**
@@ -139,7 +139,8 @@ Working on task 4/7: <task description>
 - [x] Task 2
 ...
 
-All tasks complete! You can archive this change with `/openspec-archive-change`.
+All tracked tasks are complete. Review or verify the change as appropriate
+before archiving with `/openspec-archive-change`.
 ```
 
 **Output On Pause (Issue Encountered)**

--- a/src/commands/workflow/instructions.ts
+++ b/src/commands/workflow/instructions.ts
@@ -451,7 +451,7 @@ export async function generateApplyInstructions(
     instruction = `The ${tracksFilename} file exists but contains no tasks to work on.\nAdd tasks to ${tracksFilename} or regenerate it with openspec-continue-change.`;
   } else if (tracksFile && remaining === 0 && total > 0) {
     state = 'all_done';
-    instruction = 'All tasks are complete! This change is ready to be archived.\nConsider running tests and reviewing the changes before archiving.';
+    instruction = 'All tracked tasks are complete.\nReview or verify the change as appropriate before archiving.';
   } else if (!tracksFile) {
     // No tracking file configured in schema - ready to apply
     state = 'ready';

--- a/src/core/templates/workflows/apply-change.ts
+++ b/src/core/templates/workflows/apply-change.ts
@@ -59,7 +59,7 @@ ${STORE_SELECTION_GUIDANCE}
 
    **Handle states:**
    - If \`state: "blocked"\` (missing artifacts): show message, suggest using \`/opsx:continue\` (if it is not installed, run \`openspec status --change "<name>" --json\` to see the next artifact and \`openspec instructions <artifact-id> --change "<name>" --json\` for how to create it)
-   - If \`state: "all_done"\`: congratulate, suggest archive
+   - If \`state: "all_done"\`: report that all tracked tasks are complete and suggest review or verification as appropriate before archiving
    - Otherwise: proceed to implementation
 
    Treat \`context\` as a required prompt-level input. Read and consider it, and
@@ -116,7 +116,7 @@ ${STORE_SELECTION_GUIDANCE}
    Display:
    - Tasks completed this session
    - Overall progress: "N/M tasks complete"
-   - If all done: suggest archive
+   - If all done: report that tracked tasks are complete and suggest review or verification as appropriate before archiving
    - If paused: explain why and wait for guidance
 
 **Output During Implementation**
@@ -147,7 +147,8 @@ Working on task 4/7: <task description>
 - [x] Task 2
 ...
 
-All tasks complete! You can archive this change with \`/opsx:archive\`.
+All tracked tasks are complete. Review or verify the change as appropriate
+before archiving with \`/opsx:archive\`.
 \`\`\`
 
 **Output On Pause (Issue Encountered)**

--- a/test/commands/artifact-workflow.test.ts
+++ b/test/commands/artifact-workflow.test.ts
@@ -941,9 +941,23 @@ operations:
       });
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain('complete ✓');
-      expect(result.stdout).toContain('ready to be archived');
+      expect(result.stdout).toContain('All tracked tasks are complete');
+      expect(result.stdout).toContain('as appropriate before archiving');
+      expect(result.stdout).not.toContain('ready to be archived');
       expect(result.stdout).toContain('### Project Context (required instruction input)');
       expect(result.stdout).toContain('### Operation Guidance (advisory)');
+
+      const jsonResult = await runCLI(
+        ['instructions', 'apply', '--change', 'done-apply', '--json'],
+        { cwd: tempDir }
+      );
+      expect(jsonResult.exitCode).toBe(0);
+      expect(jsonResult.stderr).toBe('');
+
+      const json = JSON.parse(jsonResult.stdout);
+      expect(json.state).toBe('all_done');
+      expect(json.progress).toEqual({ total: 2, complete: 2, remaining: 0 });
+      expect(json.instruction).toContain('All tracked tasks are complete');
     });
 
     it('uses spec-driven schema apply configuration', async () => {

--- a/test/core/templates/propose.test.ts
+++ b/test/core/templates/propose.test.ts
@@ -17,6 +17,7 @@ import {
   getInvocationForAdapter,
 } from '../../../src/core/command-generation/invocation.js';
 import { getCommandContents } from '../../../src/core/shared/skill-generation.js';
+import { parseTaskLines } from '../../../src/utils/task-progress.js';
 
 const proposeSkillBody = getOpsxProposeSkillTemplate().instructions;
 const proposeCommandBody = getOpsxProposeCommandTemplate().content;
@@ -69,7 +70,18 @@ describe('default task guidance', () => {
       /Track implementation and verification work that can be completed before\s+archive/
     );
     expect(tasks!.instruction).toMatch(
-      /Present archive and work that depends on the change already\s+being archived as subsequent workflow steps, not task checkboxes/
+      /preserve those steps as plain bullets in an\s+optional `## Workflow follow-up` section at the end of tasks.md/
+    );
+
+    const examples = [...tasks!.instruction.matchAll(/```\s*([\s\S]*?)```/g)];
+    expect(examples).toHaveLength(2);
+    const implementation = examples[0][1];
+    const followUp = examples[1][1];
+    expect(followUp).toContain('## Workflow follow-up');
+    expect(followUp).toContain('- Verify the archived result.');
+    expect(parseTaskLines(followUp)).toEqual([]);
+    expect(parseTaskLines(`${implementation}\n${followUp}`)).toEqual(
+      parseTaskLines(implementation)
     );
   });
 

--- a/test/core/templates/propose.test.ts
+++ b/test/core/templates/propose.test.ts
@@ -62,6 +62,17 @@ describe('propose preamble', () => {
 });
 
 describe('default task guidance', () => {
+  it('keeps tracked tasks within the pre-archive workflow (#1790)', () => {
+    const tasks = defaultSchema.artifacts.find(artifact => artifact.id === 'tasks');
+    expect(tasks).toBeDefined();
+    expect(tasks!.instruction).toMatch(
+      /Track implementation and verification work that can be completed before\s+archive/
+    );
+    expect(tasks!.instruction).toMatch(
+      /Present archive and work that depends on the change already\s+being archived as subsequent workflow steps, not task checkboxes/
+    );
+  });
+
   it('requires a concrete verification method in each task (#345)', () => {
     const tasks = defaultSchema.artifacts.find(artifact => artifact.id === 'tasks');
     expect(tasks).toBeDefined();

--- a/test/core/templates/skill-templates-parity.test.ts
+++ b/test/core/templates/skill-templates-parity.test.ts
@@ -41,14 +41,14 @@ const EXPECTED_FUNCTION_HASHES: Record<string, string> = {
   getExploreSkillTemplate: '6315fcc5c2eb848963bc8bca4c23e657412a99608e610daee59fb4e58cd21fd4',
   getNewChangeSkillTemplate: 'eabd1e895c5881dcb17dcbaa3fb26098dd59e8eacb318e400820b4dc811ef781',
   getContinueChangeSkillTemplate: '012136f6411a99c8fa228e2f9444cb64b0a89e0f56fdeac2fe03b2f5bee0c5d7',
-  getApplyChangeSkillTemplate: 'd1e7d5ceb85193c0964057dbb88e9651526754bd33f84020e2440ff0621d5dbb',
+  getApplyChangeSkillTemplate: '40680f3b83441359d265a31bbc2da102a7b3b3b4bdf4885985500c2275524569',
   getFfChangeSkillTemplate: 'efa6a70c111b18b61a7720250b9622afa9a212fb64edf609cf80e2182a9bdf8c',
   getSyncSpecsSkillTemplate: 'b099e2ff31859c9b10d928066e662524f9aad9ecf2be12fceacb732d718c4146',
   getOnboardSkillTemplate: '3a836faae463d88c289a1c129cb7ee556a563b7e53e1a52a4711ff152a3b51f7',
   getOpsxExploreCommandTemplate: 'b4706a5b8fd280f7929eea610ecc9d41676b2d2dd6653d259cbbc2bfe01813d9',
   getOpsxNewCommandTemplate: 'f2d30e569798a4c92ba932859d6ba4e0ad10e18feccbade1cfee0957597b3463',
   getOpsxContinueCommandTemplate: 'e50e50266efa1b8e64ff9b6274ee8254f0a240d6adc1b862d126e2f1c9d3a559',
-  getOpsxApplyCommandTemplate: 'e3579ac78f2e2c75fa3d3a7ac7dc3e49c395e96f7323398f0f041d94f8de9bb0',
+  getOpsxApplyCommandTemplate: 'ae8ef3da8280c86b89a2b5b8995f9f83545ae2ab288b79674b2a1eada0d77b19',
   getOpsxFfCommandTemplate: '21132fc9c6d3b3ab2d2295d6bbd72d1e0052eb35ea1be0258c8b1ab3e200c4db',
   getArchiveChangeSkillTemplate: '56bfada1a5f35a127791b70de9d428a75b5aedd1584d6c9803a1ecb1fd1b4a23',
   getBulkArchiveChangeSkillTemplate: '93875998cade5322d95b43299fba794bc1da754e917dd63a770406386a6d295d',
@@ -69,7 +69,7 @@ const EXPECTED_GENERATED_SKILL_CONTENT_HASHES: Record<string, string> = {
   'openspec-explore': 'dd84af68d3c93b40659dcdd8d383423b25b443cacdc4b514cd70614ae10c5cac',
   'openspec-new-change': 'ec4529beef978e34634a6f7286fab55d68fad8fb374dceb45691d52caab33fbb',
   'openspec-continue-change': 'bb6194a16c54891cdb253678e8f70ce53b2af86735243980f366ce551d37e42e',
-  'openspec-apply-change': '81ea96d9fa6ec8536cd23c1fe561ed28e1cc1cad0a8ceb700588e08974cc0e49',
+  'openspec-apply-change': '33c65e24ef7c499b3ee2bfd9a081f0aef29259afa636510e659c2f99d8dc5dd9',
   'openspec-ff-change': '31355250514bce51b16ff37ee2b833bc9d475cd0dbd4b1f68fe2041694575623',
   'openspec-sync-specs': 'd933d8856584d6c1253de91e652e7aee9e85c77ad4d3531f6476f79d84e6e5e8',
   'openspec-archive-change': '7c65053d674ba4e1e20e2bf73ba7e5a7f94baef2eaa9b33cee48d4cadea51b7a',
@@ -997,5 +997,12 @@ describe('apply skill/command shared instruction core', () => {
     const core = getApplyInstructions();
     expect(getApplyChangeSkillTemplate().instructions).toBe(core);
     expect(getOpsxApplyCommandTemplate().content).toBe(core);
+  });
+
+  it('keeps task completion distinct from archive readiness (#1790)', () => {
+    const core = getApplyInstructions();
+    expect(core).toContain('All tracked tasks are complete');
+    expect(core).toMatch(/Review or verify the change as appropriate\s+before archiving/);
+    expect(core).not.toContain('All tasks complete! You can archive');
   });
 });

--- a/test/utils/command-references.test.ts
+++ b/test/utils/command-references.test.ts
@@ -344,7 +344,7 @@ describe('apply skill template generates valid per-target invocations', () => {
   it('authors invocation references as transformable /opsx:* tokens', () => {
     expect(skill).toContain('/opsx:apply add-auth');
     expect(skill).toContain('suggest using `/opsx:continue`');
-    expect(skill).toContain('archive this change with `/opsx:archive`');
+    expect(skill).toContain('before archiving with `/opsx:archive`');
     // No bare, non-transformable skill-name prose remains.
     expect(skill).not.toContain('suggest using openspec-continue-change');
   });


### PR DESCRIPTION
## Summary

`openspec instructions apply` currently calls a change ready to archive when every tracked checkbox is checked. Task lists can also include archive-dependent work that cannot be completed beforehand, producing warnings in stock OpenSpec and a circular dependency under stricter project policies.

This PR reports tracked completion more precisely and helps avoid generating circular task lists. Follow-up work stays visible as ordinary bullets in the existing task document.

Closes #1790

## Key changes

- Replaces the archive-readiness claim with: "All tracked tasks are complete. Review or verify the change as appropriate before archiving."
- Guides the default spec-driven task authoring flow toward work completable before archive, including hosted review or verification when appropriate.
- Preserves requested archive and archive-dependent steps in an optional `## Workflow follow-up` section at the end of `tasks.md`, with a plain-bullet example. These bullets are reference information outside tracked task progress.
- Updates the shared apply instructions and committed generated skill, with regression coverage for output, unchanged JSON state/progress, per-tool command rewriting, and generated-template parity.

## Testing performed

- Build, lint, and TypeScript checks.
- Revised guidance: 201 focused CLI, task parsing, task-guidance, command-reference, and template-parity tests passed across six files.
- The follow-up example is checked with the existing task parser to confirm it adds no tracked tasks.
- Original implementation: full local suite passed (4,343 tests; 79 skipped). Under npm 12, that run used a process-local `npm_config_allow_git=all` for the Git-dependency installation fixture; no persistent npm configuration was changed.
- `git diff --check`.

## Risks and follow-ups

The behavioral improvement depends on agents following the guidance; this does not enforce archive readiness or guarantee generated plans. Stock OpenSpec still permits archiving incomplete tasks after confirmation. Projects remain responsible for their archive policy and review-evidence requirements.

The `all_done` state, progress fields, task syntax and parsing, validation, and archive behavior remain unchanged. There are no dependency, migration, configuration-format, or schema-format changes. No changeset is included, following the normal release cadence unless a maintainer requests dedicated tracking.

## AI assistance disclosure

Original research, implementation, and verification used OpenAI Codex with `gpt-5.6-sol` at `xhigh` reasoning effort. Subsequent review and revisions used OpenAI Codex with GPT-6 Astra.
