### PR TITLE
fix(parser): accept all CommonMark list markers in deltas

### DIFF
--- a/.changeset/delta-accepts-every-list-marker.md
+++ b/.changeset/delta-accepts-every-list-marker.md
@@ -1,0 +1,5 @@
+---
+'@fission-ai/openspec': patch
+---
+
+Read a removal or rename written with `*` or `+` as the operation it is. CommonMark opens a bullet list with `-`, `*` or `+`, but the bullet form of `## REMOVED Requirements` and the `FROM:`/`TO:` lines of `## RENAMED Requirements` both hardcoded `-`, so either other marker matched nothing at all. The operation then silently never happened: `openspec validate` reported the change valid, `openspec archive` exited 0 with "Specs updated successfully", and the requirement that was supposed to be deleted or renamed stayed exactly as it was. The change archived as complete, leaving the spec quietly disagreeing with the delta that was meant to update it. Both forms now accept `[-*+]`, the `FROM:`/`TO:` bullet stays optional, and the plain `### Requirement:` header form is unchanged. Fixes #1799.

--- a/src/core/parsers/requirement-blocks.ts
+++ b/src/core/parsers/requirement-blocks.ts
@@ -298,8 +298,11 @@ function parseRemovedNames(sectionBody: SectionBody): string[] {
       names.push(normalizeRequirementName(m[1]));
       continue;
     }
-    // Also support bullet list of headers
-    const bullet = line.match(/^\s*-\s*`?###\s*Requirement:\s*(.+?)`?\s*$/);
+    // Also support bullet list of headers. Every CommonMark bullet marker
+    // counts: `*` and `+` open a list exactly as `-` does, so accepting only
+    // `-` turned a removal written with either of them into a silent no-op -
+    // archive reported success while the requirement stayed in the spec.
+    const bullet = line.match(/^\s*[-*+]\s*`?###\s*Requirement:\s*(.+?)`?\s*$/);
     if (bullet) {
       names.push(normalizeRequirementName(bullet[1]));
     }
@@ -315,8 +318,11 @@ function parseRenamedPairs(sectionBody: SectionBody): Array<{ from: string; to: 
   for (let i = 0; i < lines.length; i++) {
     if (fenceMask[i]) continue;
     const line = lines[i];
-    const fromMatch = line.match(/^\s*-?\s*FROM:\s*`?###\s*Requirement:\s*(.+?)`?\s*$/);
-    const toMatch = line.match(/^\s*-?\s*TO:\s*`?###\s*Requirement:\s*(.+?)`?\s*$/);
+    // The bullet stays optional, and any CommonMark marker is accepted: a rename
+    // written with `*` or `+` used to match nothing at all, so the rename never
+    // happened while archive still reported success.
+    const fromMatch = line.match(/^\s*[-*+]?\s*FROM:\s*`?###\s*Requirement:\s*(.+?)`?\s*$/);
+    const toMatch = line.match(/^\s*[-*+]?\s*TO:\s*`?###\s*Requirement:\s*(.+?)`?\s*$/);
     if (fromMatch) {
       current.from = normalizeRequirementName(fromMatch[1]);
     } else if (toMatch) {

--- a/src/core/parsers/requirement-blocks.ts
+++ b/src/core/parsers/requirement-blocks.ts
@@ -286,6 +286,13 @@ function parseRequirementBlocksFromSection(
   return blocks;
 }
 
+/**
+ * Requirement names listed in `## REMOVED Requirements`, in document order.
+ *
+ * Two spellings are accepted: a plain `### Requirement:` header, and a bullet
+ * carrying one. Every CommonMark bullet marker counts for the second form -
+ * see the pattern below for why that matters.
+ */
 function parseRemovedNames(sectionBody: SectionBody): string[] {
   const { lines, fenceMask } = sectionBody;
   if (lines.length === 0) return [];
@@ -310,6 +317,13 @@ function parseRemovedNames(sectionBody: SectionBody): string[] {
   return names;
 }
 
+/**
+ * `FROM:`/`TO:` rename pairs from `## RENAMED Requirements`, in document order.
+ *
+ * The bullet is optional, and every CommonMark bullet marker is accepted: a
+ * rename written with `*` or `+` used to match nothing at all, so the rename
+ * silently never happened while archive still reported success.
+ */
 function parseRenamedPairs(sectionBody: SectionBody): Array<{ from: string; to: string }> {
   const { lines, fenceMask } = sectionBody;
   if (lines.length === 0) return [];

--- a/test/core/parsers/delta-list-markers.test.ts
+++ b/test/core/parsers/delta-list-markers.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+import { parseDeltaSpec } from '../../../src/core/parsers/requirement-blocks.js';
+import { buildUpdatedSpec, findSpecUpdates } from '../../../src/core/specs-apply.js';
+
+/**
+ * CommonMark bullet lists may open with `-`, `*` or `+`. The REMOVED bullet form
+ * and the RENAMED FROM:/TO: form used to match only `-`, so a removal or rename
+ * written with either of the other two markers matched nothing: the operation
+ * silently never happened while `validate` passed and `archive` exited 0
+ * reporting success. The project already accepts more than one marker elsewhere
+ * (`TASK_LINE_PATTERN` in utils/task-progress.ts allows `-` and `*`).
+ */
+const MARKERS = ['-', '*', '+'] as const;
+
+describe('parseDeltaSpec (REMOVED list markers)', () => {
+  for (const marker of MARKERS) {
+    it(`accepts the "${marker}" marker`, () => {
+      const plan = parseDeltaSpec(
+        ['## REMOVED Requirements', '', `${marker} \`### Requirement: Late Fees\``].join('\n')
+      );
+      expect(plan.removed).toEqual(['Late Fees']);
+    });
+
+    it(`accepts the "${marker}" marker without backticks`, () => {
+      const plan = parseDeltaSpec(
+        ['## REMOVED Requirements', '', `${marker} ### Requirement: Late Fees`].join('\n')
+      );
+      expect(plan.removed).toEqual(['Late Fees']);
+    });
+
+    it(`accepts the "${marker}" marker when the entry is indented`, () => {
+      const plan = parseDeltaSpec(
+        ['## REMOVED Requirements', '', `   ${marker} \`### Requirement: Late Fees\``].join('\n')
+      );
+      expect(plan.removed).toEqual(['Late Fees']);
+    });
+  }
+
+  it('still reads the plain header form', () => {
+    const plan = parseDeltaSpec(
+      ['## REMOVED Requirements', '', '### Requirement: Late Fees', '**Reason**: gone'].join('\n')
+    );
+    expect(plan.removed).toEqual(['Late Fees']);
+  });
+
+  it('still ignores bullets inside a code fence', () => {
+    const plan = parseDeltaSpec(
+      [
+        '## REMOVED Requirements',
+        '',
+        '```markdown',
+        '* `### Requirement: Example`',
+        '```',
+        '',
+        '- `### Requirement: Real One`',
+      ].join('\n')
+    );
+    expect(plan.removed).toEqual(['Real One']);
+  });
+
+  it('does not treat an emphasised line as a bullet', () => {
+    const plan = parseDeltaSpec(
+      ['## REMOVED Requirements', '', '**Reason**: `### Requirement: Not A Bullet`'].join('\n')
+    );
+    expect(plan.removed).toEqual([]);
+  });
+});
+
+describe('parseDeltaSpec (RENAMED list markers)', () => {
+  for (const marker of MARKERS) {
+    it(`accepts the "${marker}" marker`, () => {
+      const plan = parseDeltaSpec(
+        [
+          '## RENAMED Requirements',
+          '',
+          `${marker} FROM: \`### Requirement: Late Fees\``,
+          `${marker} TO: \`### Requirement: Overdue Penalties\``,
+        ].join('\n')
+      );
+      expect(plan.renamed).toEqual([{ from: 'Late Fees', to: 'Overdue Penalties' }]);
+    });
+  }
+
+  it('accepts a mix of markers across the two lines', () => {
+    const plan = parseDeltaSpec(
+      [
+        '## RENAMED Requirements',
+        '',
+        '* FROM: `### Requirement: Late Fees`',
+        '+ TO: `### Requirement: Overdue Penalties`',
+      ].join('\n')
+    );
+    expect(plan.renamed).toEqual([{ from: 'Late Fees', to: 'Overdue Penalties' }]);
+  });
+
+  it('still accepts FROM/TO with no bullet at all', () => {
+    const plan = parseDeltaSpec(
+      [
+        '## RENAMED Requirements',
+        '',
+        'FROM: `### Requirement: Late Fees`',
+        'TO: `### Requirement: Overdue Penalties`',
+      ].join('\n')
+    );
+    expect(plan.renamed).toEqual([{ from: 'Late Fees', to: 'Overdue Penalties' }]);
+  });
+
+  it('still ignores FROM/TO inside a code fence', () => {
+    const plan = parseDeltaSpec(
+      [
+        '## RENAMED Requirements',
+        '',
+        '```markdown',
+        '* FROM: `### Requirement: Example`',
+        '* TO: `### Requirement: Other`',
+        '```',
+      ].join('\n')
+    );
+    expect(plan.renamed).toEqual([]);
+  });
+});
+
+describe('buildUpdatedSpec (delta list markers)', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'openspec-markers-'));
+  });
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const MAIN_SPEC = [
+    '# billing Specification',
+    '',
+    '## Purpose',
+    'Defines how billing behaves for customers and operators.',
+    '',
+    '## Requirements',
+    '### Requirement: Invoice Generation',
+    'The system SHALL generate an invoice for every completed billing period.',
+    '',
+    '#### Scenario: Period closes',
+    '- **WHEN** a billing period closes',
+    '- **THEN** an invoice is generated',
+    '',
+    '### Requirement: Late Fees',
+    'The system SHALL apply a late fee to invoices overdue by 30 days.',
+    '',
+    '#### Scenario: Thirty days overdue',
+    '- **WHEN** an invoice is 30 days overdue',
+    '- **THEN** a late fee is applied',
+    '',
+  ].join('\n');
+
+  async function build(deltaBody: string) {
+    const specsRoot = path.join(tempDir, 'openspec', 'specs');
+    const specsDir = path.join(specsRoot, 'billing');
+    const changeDir = path.join(tempDir, 'openspec', 'changes', 'c');
+    await fs.mkdir(specsDir, { recursive: true });
+    await fs.mkdir(path.join(changeDir, 'specs', 'billing'), { recursive: true });
+    await fs.writeFile(path.join(specsDir, 'spec.md'), MAIN_SPEC);
+    await fs.writeFile(path.join(changeDir, 'specs', 'billing', 'spec.md'), deltaBody);
+    const [update] = await findSpecUpdates(changeDir, specsRoot);
+    return buildUpdatedSpec(update, 'c', { silent: true });
+  }
+
+  for (const marker of MARKERS) {
+    it(`removes a requirement listed with "${marker}"`, async () => {
+      const built = await build(
+        ['## REMOVED Requirements', '', `${marker} \`### Requirement: Late Fees\``].join('\n')
+      );
+      expect(built.counts.removed).toBe(1);
+      expect(built.rebuilt).not.toContain('### Requirement: Late Fees');
+      expect(built.rebuilt).toContain('### Requirement: Invoice Generation');
+    });
+
+    it(`renames a requirement listed with "${marker}"`, async () => {
+      const built = await build(
+        [
+          '## RENAMED Requirements',
+          '',
+          `${marker} FROM: \`### Requirement: Late Fees\``,
+          `${marker} TO: \`### Requirement: Overdue Penalties\``,
+        ].join('\n')
+      );
+      expect(built.counts.renamed).toBe(1);
+      expect(built.rebuilt).toContain('### Requirement: Overdue Penalties');
+      expect(built.rebuilt).not.toContain('### Requirement: Late Fees');
+    });
+  }
+});

--- a/test/core/parsers/delta-list-markers.test.ts
+++ b/test/core/parsers/delta-list-markers.test.ts
@@ -156,6 +156,10 @@ describe('buildUpdatedSpec (delta list markers)', () => {
     '',
   ].join('\n');
 
+  /**
+   * Write a main spec and a delta into a temp project, then run the merge and
+   * return its result without touching any real project.
+   */
   async function build(deltaBody: string) {
     const specsRoot = path.join(tempDir, 'openspec', 'specs');
     const specsDir = path.join(specsRoot, 'billing');


### PR DESCRIPTION
Closes #1799.

## Why

CommonMark bullet lists may open with `-`, `*` or `+`. The REMOVED bullet form
and the RENAMED `FROM:`/`TO:` form both hardcoded `-`:

```ts
parseRemovedNames : /^\s*-\s*`?###\s*Requirement:\s*(.+?)`?\s*$/
parseRenamedPairs : /^\s*-?\s*FROM:\s*`?###\s*Requirement:\s*(.+?)`?\s*$/
```

A removal or rename written with `*` or `+` therefore matched nothing at all.
The operation silently never happened: `openspec validate` reported the change
valid and `openspec archive` exited 0 with "Specs updated successfully", while
the requirement it was supposed to delete or rename stayed exactly as it was.
The change then archived as complete, so the spec quietly disagreed with the
delta that was supposed to have updated it.

The project already accepts more than one marker elsewhere — `TASK_LINE_PATTERN`
in `src/utils/task-progress.ts` is `/^\s*[-*]\s*\[([\sxX])\]\s*(.*)/`.

## What Changes

- `parseRemovedNames` bullet form accepts `[-*+]`.
- `parseRenamedPairs` `FROM:`/`TO:` forms accept an optional `[-*+]` bullet,
  keeping the existing "no bullet at all" spelling working.

Nothing else changes: the plain `### Requirement:` header form, fenced content,
and the `-` spelling all behave exactly as before.

## Testing

`test/core/parsers/delta-list-markers.test.ts` — 24 tests, written first and
watched fail (13 failed / 11 passed before, 24 passed after). The 11 that passed
before are the `-` controls, which is what makes the other 13 meaningful.

Edge cases covered:

- all three markers for REMOVED and RENAMED, with and without backticks
- indented entries
- a mix of markers across the `FROM:` and `TO:` lines of one rename
- `FROM:`/`TO:` with no bullet at all (unchanged)
- the plain header form of REMOVED (unchanged)
- bullets inside a code fence are still ignored
- an emphasised line such as `**Reason**: ...` is not mistaken for a bullet
- `buildUpdatedSpec` actually removes / renames for every marker

Full suite green on this branch.

## Changeset

Not added. Per `.changeset/README.md` the default path is the normal release
cadence; happy to run `pnpm changeset` if a maintainer wants dedicated release
notes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removal and rename entries now work with all CommonMark bullet markers: `-`, `*`, and `+`.
  * Archive operations no longer report success when supported removal or rename entries are silently ignored.
  * Requirement changes using varied list formatting are now applied consistently.

* **Tests**
  * Added coverage for mixed bullet markers, indentation, formatting variations, code fences, and rebuilt specifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->