### PR TITLE
fix(validate): report requirements outside delta sections

### DIFF
--- a/src/core/parsers/requirement-blocks.ts
+++ b/src/core/parsers/requirement-blocks.ts
@@ -126,6 +126,24 @@ export interface SkippedHeader {
   line: number; // 1-based line number in the delta file
 }
 
+/**
+ * A canonical `### Requirement:` block that sits outside every delta section -
+ * under `## Notes`, under a misspelled `## Add Requirements`, or above the
+ * first `## ` header entirely.
+ *
+ * The delta reader only ever looks inside the four delta sections, so a block
+ * written anywhere else was dropped with no error, no warning and no note -
+ * even though it is well formed and reads exactly like one that would apply.
+ * That was the inconsistency worth closing: the ADJACENT mistake, a
+ * non-canonical `###` header INSIDE a delta section, has been reported as INFO
+ * since #498 (`skippedHeaders`), while the costlier one said nothing at all.
+ */
+export interface OrphanedRequirement {
+  name: string; // requirement name as written
+  section: string | null; // the `## ` section it sits under, or null above the first one
+  line: number; // 1-based line number in the delta file
+}
+
 export interface DeltaPlan {
   added: RequirementBlock[];
   modified: RequirementBlock[];
@@ -135,6 +153,8 @@ export interface DeltaPlan {
   // reader of the removal needs. Empty for the bullet-list form, which has none.
   removedBlocks: RequirementBlock[];
   renamed: Array<{ from: string; to: string }>;
+  /** Canonical requirement blocks written outside every delta section. */
+  orphanedRequirements: OrphanedRequirement[];
   skippedHeaders: SkippedHeader[]; // non-canonical ### headers the reader skipped
   sectionPresence: {
     added: boolean;
@@ -194,6 +214,7 @@ export function parseDeltaSpec(content: string): DeltaPlan {
     removed: removedNames,
     removedBlocks,
     renamed: renamedPairs,
+    orphanedRequirements: findOrphanedRequirements(lines, fenceMask),
     skippedHeaders,
     sectionPresence: {
       added: addedLookup.found,
@@ -202,6 +223,44 @@ export function parseDeltaSpec(content: string): DeltaPlan {
       renamed: renamedLookup.found,
     },
   };
+}
+
+/** The four section titles the delta reader acts on. */
+const DELTA_SECTION_TITLE = /^(ADDED|MODIFIED|REMOVED|RENAMED)\s+Requirements$/i;
+
+/**
+ * Every canonical `### Requirement:` header that is not inside a delta section,
+ * in document order.
+ *
+ * Walks the whole file rather than the parsed sections so a requirement written
+ * ABOVE the first `## ` header is reported too - it is dropped just as silently
+ * as one under `## Notes`. Fenced lines are skipped, so a requirement shown
+ * inside a markdown example is not mistaken for an authored one.
+ */
+function findOrphanedRequirements(
+  lines: string[],
+  fenceMask: boolean[]
+): OrphanedRequirement[] {
+  const orphans: OrphanedRequirement[] = [];
+  let section: string | null = null;
+  for (let i = 0; i < lines.length; i++) {
+    if (fenceMask[i]) continue;
+    const sectionMatch = lines[i].match(/^##\s+(.+)$/);
+    if (sectionMatch) {
+      section = sectionMatch[1].trim();
+      continue;
+    }
+    if (section !== null && DELTA_SECTION_TITLE.test(section)) continue;
+    const header = lines[i].match(REQUIREMENT_HEADER_REGEX);
+    if (header) {
+      orphans.push({
+        name: normalizeRequirementName(header[1]),
+        section,
+        line: i + 1,
+      });
+    }
+  }
+  return orphans;
 }
 
 function splitTopLevelSections(lines: string[], fenceMask: boolean[]): Record<string, SectionBody> {

--- a/src/core/specs-apply.ts
+++ b/src/core/specs-apply.ts
@@ -198,6 +198,21 @@ export async function buildUpdatedSpec(
   const plan = parseDeltaSpec(changeContent);
   const specName = update.id;
 
+  // A well-formed requirement written outside every delta section is not
+  // applied. Say so here as well as in validate: archive is the last point at
+  // which the author can still notice, and the block reads exactly like one
+  // that would have applied.
+  for (const orphan of plan.orphanedRequirements) {
+    const where = orphan.section
+      ? `under "## ${orphan.section}"`
+      : 'above the first "## " section';
+    warn(
+      `${specName} - requirement "${orphan.name}" (line ${orphan.line}) is ${where}, ` +
+        `which is not a delta section, so it was not applied. ` +
+        `Move it under ADDED/MODIFIED/REMOVED/RENAMED Requirements.`
+    );
+  }
+
   // Pre-validate duplicates within sections
   const addedNames = new Set<string>();
   for (const add of plan.added) {

--- a/src/core/validation/validator.ts
+++ b/src/core/validation/validator.ts
@@ -222,6 +222,23 @@ export class Validator {
           });
         }
 
+        // A well-formed requirement written outside every delta section. The
+        // reader only looks inside the four delta sections, so this block is
+        // ignored - reported as a WARNING rather than an ERROR because a
+        // handful of pre-format archived changes still carry this shape, and
+        // the fix is to move the block, not to reject the change outright.
+        for (const orphan of plan.orphanedRequirements) {
+          const where = orphan.section
+            ? `under "## ${orphan.section}"`
+            : 'above the first "## " section';
+          issues.push({
+            level: 'WARNING',
+            path: entryPath,
+            line: orphan.line,
+            message: `Requirement "${orphan.name}" is ${where}, which is not a delta section, so it is ignored. Move it under "## ADDED Requirements", "## MODIFIED Requirements", "## REMOVED Requirements", or "## RENAMED Requirements".`,
+          });
+        }
+
         const sectionNames: string[] = [];
         if (plan.sectionPresence.added) sectionNames.push('## ADDED Requirements');
         if (plan.sectionPresence.modified) sectionNames.push('## MODIFIED Requirements');

--- a/test/core/parsers/orphaned-requirements.test.ts
+++ b/test/core/parsers/orphaned-requirements.test.ts
@@ -162,6 +162,10 @@ describe('buildUpdatedSpec (requirements outside delta sections)', () => {
     '',
   ].join('\n');
 
+  /**
+   * Write a main spec and a delta into a temp project, then run the merge and
+   * return its result without touching any real project.
+   */
   async function build(deltaBody: string) {
     const specsRoot = path.join(tempDir, 'openspec', 'specs');
     const specsDir = path.join(specsRoot, 'billing');
@@ -225,6 +229,10 @@ describe('validate <change> (requirements outside delta sections)', () => {
     await fs.rm(tempDir, { recursive: true, force: true });
   });
 
+  /**
+   * Validate a change whose only content is the given delta spec, in a temp
+   * project, and return the report.
+   */
   async function validateDelta(deltaBody: string) {
     const changeDir = path.join(tempDir, 'openspec', 'changes', 'c');
     await fs.mkdir(path.join(changeDir, 'specs', 'billing'), { recursive: true });

--- a/test/core/parsers/orphaned-requirements.test.ts
+++ b/test/core/parsers/orphaned-requirements.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+import { parseDeltaSpec } from '../../../src/core/parsers/requirement-blocks.js';
+import { buildUpdatedSpec, findSpecUpdates } from '../../../src/core/specs-apply.js';
+import { Validator } from '../../../src/core/validation/validator.js';
+
+/**
+ * A canonical `### Requirement:` block written outside every delta section is
+ * ignored by the reader. It used to be ignored in complete silence, which is
+ * inconsistent with the adjacent mistake: a non-canonical `###` header INSIDE a
+ * delta section has been reported as INFO since #498. The well-formed block in
+ * the wrong place - the costlier error, because it reads exactly like one that
+ * would apply - said nothing at all.
+ */
+describe('parseDeltaSpec (requirements outside delta sections)', () => {
+  it('reports a requirement under an unrecognised section', () => {
+    const plan = parseDeltaSpec(
+      [
+        '## ADDED Requirements',
+        '### Requirement: Applied',
+        'a',
+        '',
+        '## Notes',
+        '### Requirement: Ignored',
+        'b',
+      ].join('\n')
+    );
+
+    expect(plan.added.map((b) => b.name)).toEqual(['Applied']);
+    expect(plan.orphanedRequirements).toEqual([
+      { name: 'Ignored', section: 'Notes', line: 6 },
+    ]);
+  });
+
+  it('reports a requirement written above the first section', () => {
+    const plan = parseDeltaSpec(
+      ['### Requirement: Stray', 'a', '', '## ADDED Requirements', '### Requirement: Applied', 'b'].join(
+        '\n'
+      )
+    );
+
+    expect(plan.added.map((b) => b.name)).toEqual(['Applied']);
+    expect(plan.orphanedRequirements).toEqual([
+      { name: 'Stray', section: null, line: 1 },
+    ]);
+  });
+
+  it('reports a requirement under a misspelled delta header', () => {
+    const plan = parseDeltaSpec(
+      ['## Add Requirements', '### Requirement: Typo Section', 'a'].join('\n')
+    );
+
+    expect(plan.added).toEqual([]);
+    expect(plan.orphanedRequirements).toEqual([
+      { name: 'Typo Section', section: 'Add Requirements', line: 2 },
+    ]);
+  });
+
+  it('reports several orphans in document order', () => {
+    const plan = parseDeltaSpec(
+      [
+        '## Notes',
+        '### Requirement: One',
+        '## ADDED Requirements',
+        '### Requirement: Applied',
+        '## Context',
+        '### Requirement: Two',
+      ].join('\n')
+    );
+
+    expect(plan.orphanedRequirements.map((o) => [o.name, o.line])).toEqual([
+      ['One', 2],
+      ['Two', 6],
+    ]);
+  });
+
+  it('reports nothing when every requirement sits in a delta section', () => {
+    const plan = parseDeltaSpec(
+      [
+        '## ADDED Requirements',
+        '### Requirement: A',
+        'a',
+        '## MODIFIED Requirements',
+        '### Requirement: B',
+        'b',
+        '## REMOVED Requirements',
+        '### Requirement: C',
+        '## RENAMED Requirements',
+        '- FROM: `### Requirement: D`',
+        '- TO: `### Requirement: E`',
+      ].join('\n')
+    );
+
+    expect(plan.orphanedRequirements).toEqual([]);
+  });
+
+  it('accepts every casing of the delta headers without reporting', () => {
+    const plan = parseDeltaSpec(
+      ['## added requirements', '### Requirement: A', '## Modified Requirements', '### Requirement: B'].join(
+        '\n'
+      )
+    );
+    expect(plan.orphanedRequirements).toEqual([]);
+  });
+
+  it('does not report a requirement shown inside a code fence', () => {
+    const plan = parseDeltaSpec(
+      [
+        '## Notes',
+        'An example of the format:',
+        '',
+        '```markdown',
+        '### Requirement: Just An Example',
+        '```',
+      ].join('\n')
+    );
+
+    expect(plan.orphanedRequirements).toEqual([]);
+  });
+
+  it('does not report a delta section that legitimately has a Purpose above it', () => {
+    const plan = parseDeltaSpec(
+      [
+        '## Purpose',
+        'Describes a brand new capability.',
+        '',
+        '## ADDED Requirements',
+        '### Requirement: A',
+        'a',
+      ].join('\n')
+    );
+
+    expect(plan.orphanedRequirements).toEqual([]);
+  });
+});
+
+describe('buildUpdatedSpec (requirements outside delta sections)', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'openspec-orphan-req-'));
+  });
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const MAIN_SPEC = [
+    '# billing Specification',
+    '',
+    '## Purpose',
+    'Defines how billing behaves for customers and operators.',
+    '',
+    '## Requirements',
+    '### Requirement: Invoice Generation',
+    'The system SHALL generate an invoice for every completed billing period.',
+    '',
+    '#### Scenario: Period closes',
+    '- **WHEN** a billing period closes',
+    '- **THEN** an invoice is generated',
+    '',
+  ].join('\n');
+
+  async function build(deltaBody: string) {
+    const specsRoot = path.join(tempDir, 'openspec', 'specs');
+    const specsDir = path.join(specsRoot, 'billing');
+    const changeDir = path.join(tempDir, 'openspec', 'changes', 'c');
+    await fs.mkdir(specsDir, { recursive: true });
+    await fs.mkdir(path.join(changeDir, 'specs', 'billing'), { recursive: true });
+    await fs.writeFile(path.join(specsDir, 'spec.md'), MAIN_SPEC);
+    await fs.writeFile(path.join(changeDir, 'specs', 'billing', 'spec.md'), deltaBody);
+    const [update] = await findSpecUpdates(changeDir, specsRoot);
+    return buildUpdatedSpec(update, 'c', { silent: true });
+  }
+
+  it('warns rather than silently dropping the requirement', async () => {
+    const built = await build(
+      [
+        '## ADDED Requirements',
+        '### Requirement: Dunning Notices',
+        'The system SHALL send a dunning notice when an invoice is 7 days overdue.',
+        '',
+        '#### Scenario: Invoice overdue',
+        '- **WHEN** a',
+        '- **THEN** b',
+        '',
+        '## Notes',
+        '### Requirement: Credit Notes',
+        'The system SHALL issue a credit note when an invoice is voided.',
+      ].join('\n')
+    );
+
+    expect(built.warnings.some((w) => w.includes('Credit Notes'))).toBe(true);
+    expect(built.warnings.some((w) => w.includes('## Notes'))).toBe(true);
+    // Behaviour is unchanged: the orphan is still not applied, only reported.
+    expect(built.rebuilt).not.toContain('### Requirement: Credit Notes');
+    expect(built.rebuilt).toContain('### Requirement: Dunning Notices');
+  });
+
+  it('emits no such warning for a well-formed delta', async () => {
+    const built = await build(
+      [
+        '## ADDED Requirements',
+        '### Requirement: Dunning Notices',
+        'The system SHALL send a dunning notice.',
+        '',
+        '#### Scenario: Invoice overdue',
+        '- **WHEN** a',
+        '- **THEN** b',
+      ].join('\n')
+    );
+
+    expect(built.warnings.filter((w) => w.includes('not a delta section'))).toEqual([]);
+  });
+});
+
+describe('validate <change> (requirements outside delta sections)', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'openspec-orphan-validate-'));
+  });
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function validateDelta(deltaBody: string) {
+    const changeDir = path.join(tempDir, 'openspec', 'changes', 'c');
+    await fs.mkdir(path.join(changeDir, 'specs', 'billing'), { recursive: true });
+    await fs.writeFile(path.join(changeDir, 'specs', 'billing', 'spec.md'), deltaBody);
+    return new Validator().validateChangeDeltaSpecs(changeDir);
+  }
+
+  it('reports the orphan as a warning without failing the change', async () => {
+    const report = await validateDelta(
+      [
+        '## ADDED Requirements',
+        '### Requirement: Applied',
+        'The system SHALL do a thing.',
+        '',
+        '#### Scenario: S',
+        '- **WHEN** a',
+        '- **THEN** b',
+        '',
+        '## Notes',
+        '### Requirement: Ignored',
+        'The system SHALL do another thing.',
+      ].join('\n')
+    );
+
+    const warnings = report.issues.filter((issue) => issue.level === 'WARNING');
+    expect(warnings.some((issue) => /Requirement "Ignored" is under "## Notes"/.test(issue.message))).toBe(
+      true
+    );
+    // A warning must not change the verdict.
+    expect(report.issues.filter((i) => i.level === 'ERROR')).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #1803.

## Why

The delta reader only looks inside the four delta sections. A canonical
`### Requirement:` block written anywhere else — under `## Notes`, under a
misspelled `## Add Requirements`, or above the first `## ` header — is dropped
with no error, no warning and no note.

That is inconsistent with the treatment of the *adjacent* mistake. A
non-canonical `###` header **inside** a delta section has been recorded in
`skippedHeaders` and surfaced as INFO by `validate <change>` since #498. The
well-formed requirement in the wrong place — arguably the costlier error,
because the block reads exactly like one that would apply — said nothing at all.
`validate` reports the change valid and `archive` exits 0.

## What Changes

- `parseDeltaSpec` returns `DeltaPlan.orphanedRequirements`: every canonical
  `### Requirement:` header outside the delta sections, with the section it sits
  under (`null` above the first `## `) and its 1-based line number.
- `validate <change>` reports each one as a **WARNING** naming the section and
  the line, and listing the four headers it could move under.
- `buildUpdatedSpec` emits the same thing through its existing `warn()` channel,
  so `archive` says it too — the last point at which the author can still notice.

**Behaviour is otherwise unchanged: the orphan is still not applied.** This PR
only ends the silence.

WARNING rather than ERROR is deliberate. Scanning every delta `spec.md` in this
repository with its own parser found 8 blocks of this shape, all in archived
pre-format changes from 2025-08-19 (`add-skip-specs-archive-option`,
`structured-spec-format`). An ERROR would retroactively fail those; the fix for a
real occurrence is to move the block, not to reject the change.

## Testing

`test/core/parsers/orphaned-requirements.test.ts` — 13 tests. Run against
`main`: 12 failed / 1 passed (the passing one is the well-formed-delta control).
All 13 pass on this branch.

Edge cases covered:

- an orphan under `## Notes`, under a misspelled `## Add Requirements`, and above
  the first `## ` section
- several orphans reported in document order with correct line numbers
- nothing reported when every requirement sits in a delta section
- every casing of the four delta headers accepted without reporting
- a requirement shown inside a code fence is not reported
- a delta that legitimately opens with `## Purpose` (new capability) is not
  reported
- a header the reader does not match exactly, such as `## ADDED  Requirements`
  (two spaces), is reported, because the scanner uses the reader's own section
  rule
- requirements under a repeated `## ADDED Requirements`, with a non-delta
  section between the copies, are not reported
- `buildUpdatedSpec` warns, and still does not apply the orphan
- a well-formed delta produces no such warning
- `validate` reports it as a WARNING and the verdict stays valid (no ERROR)

Full suite green on this branch.

## Changeset

`.changeset/delta-reports-orphaned-requirements.md` (patch).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Detects requirement blocks outside recognized delta sections.
- Identifies misplaced requirements by name, section, and line number.
- Recognizes delta headers regardless of capitalization.

## Bug Fixes
- Validation and change application warn about misplaced requirements while leaving them unapplied.
- Ignores requirement examples inside code fences.
- Reports unpaired renames, naming collisions, unread delta files, and empty scenario headers.
- Improves retirement-content auditing and preserves blank lines inside code blocks.
- Adds safeguards for linked capabilities resolving outside the project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
