### PR TITLE
fix(parser): refuse malformed RENAMED pairs

### DIFF
--- a/src/core/parsers/requirement-blocks.ts
+++ b/src/core/parsers/requirement-blocks.ts
@@ -126,6 +126,26 @@ export interface SkippedHeader {
   line: number; // 1-based line number in the delta file
 }
 
+/**
+ * A `FROM:` or `TO:` line in `## RENAMED Requirements` that never formed a pair,
+ * recorded at the moment the reader steps over it.
+ *
+ * The pair reader used to carry one mutable `{ from, to }` and drop whatever did
+ * not fit: a second `FROM:` overwrote an unpaired first, a `TO:` with no pending
+ * `FROM:` vanished, and a trailing `FROM:` was forgotten at the end of the
+ * section. Nothing counted any of it, so a rename the author asked for could
+ * silently not happen - or, when the lines interleaved, a DIFFERENT requirement
+ * could be renamed under a name meant for another one.
+ *
+ * Recording them is what lets `validate` report the problem and `buildUpdatedSpec`
+ * refuse, rather than guess a pairing and rewrite the spec from it.
+ */
+export interface UnpairedRename {
+  side: 'FROM' | 'TO';
+  name: string; // requirement name as written
+  line: number; // 1-based line number in the delta file
+}
+
 export interface DeltaPlan {
   added: RequirementBlock[];
   modified: RequirementBlock[];
@@ -135,6 +155,8 @@ export interface DeltaPlan {
   // reader of the removal needs. Empty for the bullet-list form, which has none.
   removedBlocks: RequirementBlock[];
   renamed: Array<{ from: string; to: string }>;
+  /** FROM:/TO: lines in RENAMED that never formed a pair. */
+  unpairedRenames: UnpairedRename[];
   skippedHeaders: SkippedHeader[]; // non-canonical ### headers the reader skipped
   sectionPresence: {
     added: boolean;
@@ -186,7 +208,8 @@ export function parseDeltaSpec(content: string): DeltaPlan {
   });
   const removedNames = parseRemovedNames(removedLookup.body);
   const removedBlocks = parseRequirementBlocksFromSection(removedLookup.body);
-  const renamedPairs = parseRenamedPairs(renamedLookup.body);
+  const unpairedRenames: UnpairedRename[] = [];
+  const renamedPairs = parseRenamedPairs(renamedLookup.body, unpairedRenames);
   skippedHeaders.sort((a, b) => a.line - b.line);
   return {
     added,
@@ -194,6 +217,7 @@ export function parseDeltaSpec(content: string): DeltaPlan {
     removed: removedNames,
     removedBlocks,
     renamed: renamedPairs,
+    unpairedRenames,
     skippedHeaders,
     sectionPresence: {
       added: addedLookup.found,
@@ -307,26 +331,53 @@ function parseRemovedNames(sectionBody: SectionBody): string[] {
   return names;
 }
 
-function parseRenamedPairs(sectionBody: SectionBody): Array<{ from: string; to: string }> {
-  const { lines, fenceMask } = sectionBody;
+/**
+ * Read `FROM:`/`TO:` entries into rename pairs, recording every line that never
+ * formed one.
+ *
+ * A pair is a `FROM:` followed by a `TO:` with no second `FROM:` in between -
+ * the shape the documented format uses. Anything else is reported through
+ * `unpaired` rather than absorbed:
+ *
+ *   - a `FROM:` displaced by another `FROM:` before its `TO:` arrived
+ *   - a `TO:` with no pending `FROM:`
+ *   - a `FROM:` still pending when the section ends
+ *
+ * Silently dropping these is what let a requested rename not happen, and what
+ * let interleaved lines (`FROM a`, `FROM b`, `TO x`, `TO y`) pair b with x -
+ * renaming a requirement the author never named, under a name meant for a
+ * different one. Callers refuse the delta instead of guessing.
+ */
+function parseRenamedPairs(
+  sectionBody: SectionBody,
+  unpaired?: UnpairedRename[]
+): Array<{ from: string; to: string }> {
+  const { lines, fenceMask, bodyStartLine } = sectionBody;
   if (lines.length === 0) return [];
   const pairs: Array<{ from: string; to: string }> = [];
-  let current: { from?: string; to?: string } = {};
+  let pending: { name: string; line: number } | undefined;
+  const drop = (side: 'FROM' | 'TO', name: string, line: number) => {
+    unpaired?.push({ side, name, line });
+  };
   for (let i = 0; i < lines.length; i++) {
     if (fenceMask[i]) continue;
     const line = lines[i];
     const fromMatch = line.match(/^\s*-?\s*FROM:\s*`?###\s*Requirement:\s*(.+?)`?\s*$/);
     const toMatch = line.match(/^\s*-?\s*TO:\s*`?###\s*Requirement:\s*(.+?)`?\s*$/);
     if (fromMatch) {
-      current.from = normalizeRequirementName(fromMatch[1]);
+      if (pending) drop('FROM', pending.name, pending.line);
+      pending = { name: normalizeRequirementName(fromMatch[1]), line: bodyStartLine + i };
     } else if (toMatch) {
-      current.to = normalizeRequirementName(toMatch[1]);
-      if (current.from && current.to) {
-        pairs.push({ from: current.from, to: current.to });
-        current = {};
+      const to = normalizeRequirementName(toMatch[1]);
+      if (!pending) {
+        drop('TO', to, bodyStartLine + i);
+        continue;
       }
+      pairs.push({ from: pending.name, to });
+      pending = undefined;
     }
   }
+  if (pending) drop('FROM', pending.name, pending.line);
   return pairs;
 }
 

--- a/src/core/specs-apply.ts
+++ b/src/core/specs-apply.ts
@@ -198,6 +198,20 @@ export async function buildUpdatedSpec(
   const plan = parseDeltaSpec(changeContent);
   const specName = update.id;
 
+  // A FROM:/TO: line that never formed a pair means the RENAMED section does not
+  // say what the author meant. Refuse rather than apply the pairing the reader
+  // happened to form: with interleaved lines that pairing renames a requirement
+  // the delta never named, under a name written for a different one.
+  if (plan.unpairedRenames.length > 0) {
+    const first = plan.unpairedRenames[0];
+    const missing = first.side === 'FROM' ? 'TO' : 'FROM';
+    throw new Error(
+      `${specName} validation failed - RENAMED entry on line ${first.line} has no matching ${missing}: ` +
+        `for header "### Requirement: ${first.name}". ` +
+        `Write each rename as a FROM: line followed immediately by its TO: line.`
+    );
+  }
+
   // Pre-validate duplicates within sections
   const addedNames = new Set<string>();
   for (const add of plan.added) {

--- a/src/core/validation/validator.ts
+++ b/src/core/validation/validator.ts
@@ -222,6 +222,19 @@ export class Validator {
           });
         }
 
+        // A FROM:/TO: line that never formed a pair. Reported here so the author
+        // learns at authoring time, rather than having archive either skip the
+        // rename or apply it to a requirement they never named.
+        for (const unpaired of plan.unpairedRenames) {
+          const missing = unpaired.side === 'FROM' ? 'TO' : 'FROM';
+          issues.push({
+            level: 'ERROR',
+            path: entryPath,
+            line: unpaired.line,
+            message: `RENAMED ${unpaired.side}: "${unpaired.name}" has no matching ${missing}: line. Write each rename as a FROM: line followed immediately by its TO: line.`,
+          });
+        }
+
         const sectionNames: string[] = [];
         if (plan.sectionPresence.added) sectionNames.push('## ADDED Requirements');
         if (plan.sectionPresence.modified) sectionNames.push('## MODIFIED Requirements');

--- a/test/core/parsers/renamed-pair-integrity.test.ts
+++ b/test/core/parsers/renamed-pair-integrity.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+import { parseDeltaSpec } from '../../../src/core/parsers/requirement-blocks.js';
+import { buildUpdatedSpec, findSpecUpdates } from '../../../src/core/specs-apply.js';
+import { Validator } from '../../../src/core/validation/validator.js';
+
+/**
+ * The RENAMED reader used to carry one mutable `{ from, to }` and drop whatever
+ * did not fit, with nothing recording the loss: a requested rename could
+ * silently not happen, and interleaved FROM/TO lines could rename a requirement
+ * the delta never named, under a name written for a different one. Every
+ * unpaired line is now reported, and the merge refuses rather than guessing.
+ */
+describe('parseDeltaSpec (RENAMED pairing)', () => {
+  const renamed = (...lines: string[]) =>
+    parseDeltaSpec(['## RENAMED Requirements', '', ...lines].join('\n'));
+
+  it('pairs FROM/TO written in the documented order', () => {
+    const plan = renamed(
+      '- FROM: `### Requirement: Late Fees`',
+      '- TO: `### Requirement: Overdue Penalties`'
+    );
+    expect(plan.renamed).toEqual([{ from: 'Late Fees', to: 'Overdue Penalties' }]);
+    expect(plan.unpairedRenames).toEqual([]);
+  });
+
+  it('pairs several consecutive renames', () => {
+    const plan = renamed(
+      '- FROM: `### Requirement: A`',
+      '- TO: `### Requirement: B`',
+      '- FROM: `### Requirement: C`',
+      '- TO: `### Requirement: D`'
+    );
+    expect(plan.renamed).toEqual([
+      { from: 'A', to: 'B' },
+      { from: 'C', to: 'D' },
+    ]);
+    expect(plan.unpairedRenames).toEqual([]);
+  });
+
+  it('reports a TO written before its FROM instead of dropping the rename', () => {
+    const plan = renamed(
+      '- TO: `### Requirement: Overdue Penalties`',
+      '- FROM: `### Requirement: Late Fees`'
+    );
+    expect(plan.renamed).toEqual([]);
+    expect(plan.unpairedRenames).toEqual([
+      { side: 'TO', name: 'Overdue Penalties', line: 3 },
+      { side: 'FROM', name: 'Late Fees', line: 4 },
+    ]);
+  });
+
+  it('reports the FROM that a second FROM displaced', () => {
+    const plan = renamed(
+      '- FROM: `### Requirement: Invoice Generation`',
+      '- FROM: `### Requirement: Late Fees`',
+      '- TO: `### Requirement: Overdue Penalties`'
+    );
+    expect(plan.renamed).toEqual([{ from: 'Late Fees', to: 'Overdue Penalties' }]);
+    expect(plan.unpairedRenames).toEqual([
+      { side: 'FROM', name: 'Invoice Generation', line: 3 },
+    ]);
+  });
+
+  it('reports a trailing FROM that never receives a TO', () => {
+    const plan = renamed(
+      '- FROM: `### Requirement: Late Fees`',
+      '- TO: `### Requirement: Overdue Penalties`',
+      '- FROM: `### Requirement: Invoice Generation`'
+    );
+    expect(plan.renamed).toEqual([{ from: 'Late Fees', to: 'Overdue Penalties' }]);
+    expect(plan.unpairedRenames).toEqual([
+      { side: 'FROM', name: 'Invoice Generation', line: 5 },
+    ]);
+  });
+
+  it('reports both stragglers when FROM/TO lines interleave', () => {
+    const plan = renamed(
+      '- FROM: `### Requirement: Late Fees`',
+      '- FROM: `### Requirement: Invoice Generation`',
+      '- TO: `### Requirement: Overdue Penalties`',
+      '- TO: `### Requirement: Invoice Creation`'
+    );
+    expect(plan.unpairedRenames).toEqual([
+      { side: 'FROM', name: 'Late Fees', line: 3 },
+      { side: 'TO', name: 'Invoice Creation', line: 6 },
+    ]);
+  });
+
+  it('ignores FROM/TO lines inside a code fence', () => {
+    const plan = renamed(
+      '```markdown',
+      '- FROM: `### Requirement: Example`',
+      '- TO: `### Requirement: Other`',
+      '```'
+    );
+    expect(plan.renamed).toEqual([]);
+    expect(plan.unpairedRenames).toEqual([]);
+  });
+
+  it('reports nothing for a RENAMED section with no FROM/TO lines', () => {
+    const plan = renamed('Nothing to rename yet.');
+    expect(plan.renamed).toEqual([]);
+    expect(plan.unpairedRenames).toEqual([]);
+  });
+
+  it('reports nothing when there is no RENAMED section at all', () => {
+    const plan = parseDeltaSpec(
+      ['## ADDED Requirements', '### Requirement: A', 'a'].join('\n')
+    );
+    expect(plan.unpairedRenames).toEqual([]);
+  });
+});
+
+describe('buildUpdatedSpec (RENAMED pairing)', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'openspec-renamed-'));
+  });
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const MAIN_SPEC = [
+    '# billing Specification',
+    '',
+    '## Purpose',
+    'Defines how billing behaves for customers and operators.',
+    '',
+    '## Requirements',
+    '### Requirement: Invoice Generation',
+    'The system SHALL generate an invoice for every completed billing period.',
+    '',
+    '#### Scenario: Period closes',
+    '- **WHEN** a billing period closes',
+    '- **THEN** an invoice is generated',
+    '',
+    '### Requirement: Late Fees',
+    'The system SHALL apply a late fee to invoices overdue by 30 days.',
+    '',
+    '#### Scenario: Thirty days overdue',
+    '- **WHEN** an invoice is 30 days overdue',
+    '- **THEN** a late fee is applied',
+    '',
+  ].join('\n');
+
+  async function build(deltaBody: string) {
+    const specsRoot = path.join(tempDir, 'openspec', 'specs');
+    const specsDir = path.join(specsRoot, 'billing');
+    const changeDir = path.join(tempDir, 'openspec', 'changes', 'c');
+    await fs.mkdir(specsDir, { recursive: true });
+    await fs.mkdir(path.join(changeDir, 'specs', 'billing'), { recursive: true });
+    await fs.writeFile(path.join(specsDir, 'spec.md'), MAIN_SPEC);
+    await fs.writeFile(path.join(changeDir, 'specs', 'billing', 'spec.md'), deltaBody);
+    const [update] = await findSpecUpdates(changeDir, specsRoot);
+    return buildUpdatedSpec(update, 'c', { silent: true });
+  }
+
+  it('still applies a well-formed rename', async () => {
+    const built = await build(
+      [
+        '## RENAMED Requirements',
+        '',
+        '- FROM: `### Requirement: Late Fees`',
+        '- TO: `### Requirement: Overdue Penalties`',
+      ].join('\n')
+    );
+    expect(built.counts.renamed).toBe(1);
+    expect(built.rebuilt).toContain('### Requirement: Overdue Penalties');
+    expect(built.rebuilt).toContain('### Requirement: Invoice Generation');
+    expect(built.rebuilt).not.toContain('### Requirement: Late Fees');
+  });
+
+  it('refuses interleaved FROM/TO lines instead of renaming the wrong requirement', async () => {
+    await expect(
+      build(
+        [
+          '## RENAMED Requirements',
+          '',
+          '- FROM: `### Requirement: Late Fees`',
+          '- FROM: `### Requirement: Invoice Generation`',
+          '- TO: `### Requirement: Overdue Penalties`',
+          '- TO: `### Requirement: Invoice Creation`',
+        ].join('\n')
+      )
+    ).rejects.toThrow(/RENAMED entry on line 3 has no matching TO:/);
+  });
+
+  it('refuses a rename whose TO is written before its FROM', async () => {
+    await expect(
+      build(
+        [
+          '## RENAMED Requirements',
+          '',
+          '- TO: `### Requirement: Overdue Penalties`',
+          '- FROM: `### Requirement: Late Fees`',
+        ].join('\n')
+      )
+    ).rejects.toThrow(/RENAMED entry on line 3 has no matching FROM:/);
+  });
+
+  it('refuses a trailing FROM with no TO', async () => {
+    await expect(
+      build(
+        [
+          '## RENAMED Requirements',
+          '',
+          '- FROM: `### Requirement: Late Fees`',
+          '- TO: `### Requirement: Overdue Penalties`',
+          '- FROM: `### Requirement: Invoice Generation`',
+        ].join('\n')
+      )
+    ).rejects.toThrow(/RENAMED entry on line 5 has no matching TO:/);
+  });
+});
+
+describe('validate <change> (RENAMED pairing)', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'openspec-renamed-validate-'));
+  });
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function validateDelta(deltaBody: string) {
+    const changeDir = path.join(tempDir, 'openspec', 'changes', 'c');
+    await fs.mkdir(path.join(changeDir, 'specs', 'billing'), { recursive: true });
+    await fs.writeFile(path.join(changeDir, 'specs', 'billing', 'spec.md'), deltaBody);
+    return new Validator().validateChangeDeltaSpecs(changeDir);
+  }
+
+  it('reports an unpaired FROM as an error', async () => {
+    const report = await validateDelta(
+      [
+        '## RENAMED Requirements',
+        '',
+        '- FROM: `### Requirement: Late Fees`',
+        '- FROM: `### Requirement: Invoice Generation`',
+        '- TO: `### Requirement: Overdue Penalties`',
+      ].join('\n')
+    );
+
+    const errors = report.issues.filter((issue) => issue.level === 'ERROR');
+    expect(errors.some((issue) => /RENAMED FROM: "Late Fees" has no matching TO:/.test(issue.message))).toBe(
+      true
+    );
+    expect(report.valid).toBe(false);
+  });
+
+  it('leaves a well-formed rename valid', async () => {
+    const report = await validateDelta(
+      [
+        '## RENAMED Requirements',
+        '',
+        '- FROM: `### Requirement: Late Fees`',
+        '- TO: `### Requirement: Overdue Penalties`',
+      ].join('\n')
+    );
+
+    expect(
+      report.issues.filter((issue) => issue.level === 'ERROR' && /RENAMED/.test(issue.message))
+    ).toEqual([]);
+  });
+});

--- a/test/core/parsers/renamed-pair-integrity.test.ts
+++ b/test/core/parsers/renamed-pair-integrity.test.ts
@@ -14,6 +14,7 @@ import { Validator } from '../../../src/core/validation/validator.js';
  * unpaired line is now reported, and the merge refuses rather than guessing.
  */
 describe('parseDeltaSpec (RENAMED pairing)', () => {
+  /** Parse a delta whose only section is `## RENAMED Requirements`. */
   const renamed = (...lines: string[]) =>
     parseDeltaSpec(['## RENAMED Requirements', '', ...lines].join('\n'));
 
@@ -147,6 +148,10 @@ describe('buildUpdatedSpec (RENAMED pairing)', () => {
     '',
   ].join('\n');
 
+  /**
+   * Write a main spec and a delta into a temp project, then run the merge and
+   * return its result without touching any real project.
+   */
   async function build(deltaBody: string) {
     const specsRoot = path.join(tempDir, 'openspec', 'specs');
     const specsDir = path.join(specsRoot, 'billing');
@@ -227,6 +232,10 @@ describe('validate <change> (RENAMED pairing)', () => {
     await fs.rm(tempDir, { recursive: true, force: true });
   });
 
+  /**
+   * Validate a change whose only content is the given delta spec, in a temp
+   * project, and return the report.
+   */
   async function validateDelta(deltaBody: string) {
     const changeDir = path.join(tempDir, 'openspec', 'changes', 'c');
     await fs.mkdir(path.join(changeDir, 'specs', 'billing'), { recursive: true });


### PR DESCRIPTION
Closes #1805.

## Why

`parseRenamedPairs` walked `## RENAMED Requirements` carrying a single mutable
`{ from, to }` and dropped whatever did not fit:

- a second `FROM:` overwrote an unpaired first one
- a `TO:` with no pending `FROM:` was discarded
- a trailing `FROM:` was forgotten when the section ended

Nothing recorded any of it, and `validateChangeDeltaSpecs` only ever iterates
`plan.renamed` — the pairs that *did* form — so the validator structurally could
not see the dropped lines. Two outcomes, both silent:

- **A requested rename never happens.** `TO:` written before its `FROM:` yields
  no pair at all; `validate` reports the change valid and `archive` exits 0
  having renamed nothing.
- **The wrong requirement is renamed.** With FROM/FROM/TO/TO — a natural way to
  write a batch rename, listing the old names then the new ones — the *second*
  `FROM` pairs with the *first* `TO`. Archive renames a requirement the delta
  never named, under a name the author wrote for a different one, and reports
  `→ 1` as though exactly one intended rename occurred.

Verified against a project built entirely by `openspec init` + `openspec new
change`: the body under the renamed header was the *other* requirement's body.

## What Changes

- A rename pair is a `FROM:` followed by a `TO:` with no second `FROM:` between
  them — the shape the documented format uses.
- Every `FROM:`/`TO:` line that never formed a pair is recorded in a new
  `DeltaPlan.unpairedRenames` entry (`side`, `name`, 1-based `line`), sorted by
  line.
- When `## RENAMED Requirements` is written more than once, pairs are still read
  per copy: a `FROM:` left at the end of one copy is reported as unpaired, never
  paired with a `TO:` in the next.
- `validate <change>` reports each one as an **ERROR** with its line number, so
  the author learns at authoring time.
- `buildUpdatedSpec` throws on any unpaired entry, so `archive` refuses rather
  than applying a pairing it guessed. This is deliberate: with interleaved lines
  the guessed pairing rewrites the wrong requirement, and a spec rewrite is not
  something to do on a guess.

Well-formed renames are unaffected, including several consecutive pairs and the
no-bullet form.

## Testing

`test/core/parsers/renamed-pair-integrity.test.ts` — 17 tests. Run against
`main`: 15 failed / 2 passed (the passing two are well-formed-rename controls).
All 17 pass on this branch.

Edge cases covered:

- the documented order, and several consecutive pairs (controls)
- `TO:` before `FROM:`; a `FROM:` displaced by another `FROM:`; a trailing
  `FROM:`; fully interleaved FROM/FROM/TO/TO
- exact line numbers on every reported entry
- FROM/TO inside a code fence are ignored, and report nothing
- a RENAMED section with no FROM/TO lines, and a delta with no RENAMED section,
  both report nothing
- `buildUpdatedSpec` still applies a well-formed rename, and throws with the
  offending line number for each malformed shape
- `validate` reports the ERROR, and leaves a well-formed rename clean

Full suite green on this branch.

## Changeset

`.changeset/renamed-refuses-unpaired-entries.md` (patch). Worth noting for
release notes: this turns a previously silent mis-apply into a hard error, so a
change carrying a malformed RENAMED section that used to archive will now be
rejected until the pairing is fixed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Detects incomplete, reversed, or incorrectly ordered requirement rename entries instead of silently ignoring or misapplying them.
  - Reports clear, line-numbered validation errors identifying the missing `FROM:` or `TO:` entry and required consecutive format.
  - Prevents malformed rename sections from being applied when rebuilding specifications.
  - Correctly handles repeated rename sections, case variations, and `*` or `+` list markers.
  - Preserves valid consecutive rename pairs and formatting within fenced code blocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
