### PR TITLE
fix(validate): report what a MODIFIED block adds, not only what it drops

### DIFF
--- a/src/core/parsers/requirement-blocks.ts
+++ b/src/core/parsers/requirement-blocks.ts
@@ -335,37 +335,96 @@ interface ScenarioBlock {
   raw: string;
 }
 
+/** Both directions of the scenario-name comparison, plus the two totals. */
+export interface ScenarioNameDiff {
+  /** Names the current block has that the incoming block does not cover. */
+  missing: string[];
+  /** Names the incoming block introduces that the current block does not have. */
+  added: string[];
+  /** Level-4 headers in the current block. */
+  currentCount: number;
+  /** Level-4 headers in the incoming block. */
+  incomingCount: number;
+}
+
+/**
+ * Compare the scenario names of a current requirement block and an incoming
+ * (MODIFIED) one, in both directions.
+ *
+ * `missing` is the loss the guard exists to catch: a MODIFIED requirement
+ * replaces the whole block, so every name there would be dropped from the main
+ * spec. `added` and the two counts are reported alongside it, because they are
+ * the first thing a reader checks once it fires (#1697) - a block that omits
+ * two names and introduces two is shaped like a rename, one that omits two and
+ * introduces none is shaped like a truncation. Neither is proof, and intent is
+ * not recoverable from structure, so this decides nothing and only says what
+ * the two blocks contain.
+ */
+export function diffScenarioNames(
+  current: RequirementBlock,
+  incoming: RequirementBlock
+): ScenarioNameDiff {
+  const currentNames = parseScenarioBlocks(current.raw).map((scenario) => scenario.name);
+  const incomingNames = parseScenarioBlocks(incoming.raw).map((scenario) => scenario.name);
+
+  // Multiplicity-aware: a name present N times on one side and M times on the
+  // other leaves max(0, N - M) instances unmatched. Set membership would treat
+  // N>M as fully covered and let archive silently drop duplicates (residual
+  // #1246 / duplicate-scenario-name blind spot).
+  const unmatched = (names: readonly string[], against: readonly string[]): string[] => {
+    const remaining = new Map<string, number>();
+    for (const name of against) remaining.set(name, (remaining.get(name) ?? 0) + 1);
+
+    const out: string[] = [];
+    for (const name of names) {
+      const left = remaining.get(name) ?? 0;
+      if (left > 0) remaining.set(name, left - 1);
+      else out.push(name);
+    }
+    return out;
+  };
+
+  return {
+    missing: unmatched(currentNames, incomingNames),
+    added: unmatched(incomingNames, currentNames),
+    currentCount: currentNames.length,
+    incomingCount: incomingNames.length,
+  };
+}
+
 /**
  * Scenario names the current requirement block has and the incoming
  * (MODIFIED) block does not. A MODIFIED requirement replaces the whole block,
  * so every name reported here would be dropped from the main spec.
  *
- * Shared by archive (which refuses to apply the block) and validate (which
- * reports the same loss at authoring time, #1477), so the two cannot disagree
- * about what counts as a dropped scenario.
+ * The `missing` half of diffScenarioNames, which archive (refusing to apply
+ * the block) and validate (reporting the same loss at authoring time, #1477)
+ * both go through, so the two cannot disagree about what counts as a dropped
+ * scenario.
  */
 export function findMissingCurrentScenarios(current: RequirementBlock, incoming: RequirementBlock): string[] {
-  // Multiplicity-aware: a name present N times in current and M times in
-  // incoming means max(0, N - M) instances are missing. Set membership would
-  // treat N>M as fully covered and let archive silently drop duplicates
-  // (residual #1246 / duplicate-scenario-name blind spot).
-  const remainingIncoming = new Map<string, number>();
-  for (const scenario of parseScenarioBlocks(incoming.raw)) {
-    const name = scenario.name;
-    remainingIncoming.set(name, (remainingIncoming.get(name) ?? 0) + 1);
-  }
+  return diffScenarioNames(current, incoming).missing;
+}
 
-  const missing: string[] = [];
-  for (const scenario of parseScenarioBlocks(current.raw)) {
-    const name = scenario.name;
-    const remaining = remainingIncoming.get(name) ?? 0;
-    if (remaining > 0) {
-      remainingIncoming.set(name, remaining - 1);
-    } else {
-      missing.push(name);
-    }
+/** At most this many added names are listed before the rest are counted. */
+const MAX_LISTED_ADDED_SCENARIOS = 3;
+
+/**
+ * The one sentence archive and validate both append when the guard fires, so
+ * the counts a reader sees cannot differ between the two commands.
+ */
+export function describeScenarioBalance(diff: ScenarioNameDiff): string {
+  const scale = `The modified block has ${diff.incomingCount} scenario(s) to the current spec's ${diff.currentCount}`;
+  if (diff.added.length === 0) {
+    return `${scale}, and adds none.`;
   }
-  return missing;
+  const listed = diff.added
+    .slice(0, MAX_LISTED_ADDED_SCENARIOS)
+    .map((name) => `"${name}"`)
+    .join(', ');
+  const rest = diff.added.length - MAX_LISTED_ADDED_SCENARIOS;
+  const names = rest > 0 ? `${listed} and ${rest} more` : listed;
+  return `${scale}, and adds ${diff.added.length} the spec does not have: ${names}.`;
 }
 
 /**

--- a/src/core/specs-apply.ts
+++ b/src/core/specs-apply.ts
@@ -11,7 +11,8 @@ import path from 'path';
 import chalk from 'chalk';
 import {
   extractRequirementsSection,
-  findMissingCurrentScenarios,
+  diffScenarioNames,
+  describeScenarioBalance,
   foldRequirementName,
   parseDeltaSpec,
   normalizeRequirementName,
@@ -475,10 +476,10 @@ export async function buildUpdatedSpec(
         `${specName} MODIFIED failed for header "### Requirement: ${mod.name}" - header mismatch in content`
       );
     }
-    const missingScenarios = findMissingCurrentScenarios(currentBlock, mod);
-    if (missingScenarios.length > 0) {
+    const scenarioDiff = diffScenarioNames(currentBlock, mod);
+    if (scenarioDiff.missing.length > 0) {
       throw new Error(
-        `${specName} MODIFIED failed for header "### Requirement: ${mod.name}" - current spec contains scenario(s) not present in the modified block: ${missingScenarios.map(name => `"${name}"`).join(', ')}. Refresh the change spec before archiving to avoid dropping scenarios.`
+        `${specName} MODIFIED failed for header "### Requirement: ${mod.name}" - current spec contains scenario(s) not present in the modified block: ${scenarioDiff.missing.map(name => `"${name}"`).join(', ')}. ${describeScenarioBalance(scenarioDiff)} Refresh the change spec before archiving to avoid dropping scenarios.`
       );
     }
     // Identical content means the modification was already synced to the

--- a/src/core/validation/validator.ts
+++ b/src/core/validation/validator.ts
@@ -16,7 +16,8 @@ import {
   foldRequirementName,
   normalizeRequirementName,
   extractRequirementsSection,
-  findMissingCurrentScenarios,
+  diffScenarioNames,
+  describeScenarioBalance,
   type RequirementBlock,
 } from '../parsers/requirement-blocks.js';
 import {
@@ -625,15 +626,16 @@ export class Validator {
       if (renamedAway.has(key)) continue;
       const current = currentBlockFor(key);
       if (!current) continue;
-      const missing = findMissingCurrentScenarios(current, block);
-      if (missing.length === 0) continue;
+      const diff = diffScenarioNames(current, block);
+      if (diff.missing.length === 0) continue;
       issues.push({
         level: 'ERROR',
         path: entryPath,
         message:
           `MODIFIED "${block.name}" omits scenario(s) the current spec still has: ` +
-          `${missing.map(name => `"${name}"`).join(', ')}. ` +
-          'Copy them into the MODIFIED block (a MODIFIED requirement replaces the whole block, so archive refuses to drop them).',
+          `${diff.missing.map(name => `"${name}"`).join(', ')}. ` +
+          `${describeScenarioBalance(diff)} ` +
+          'Copy the omitted scenarios into the MODIFIED block (a MODIFIED requirement replaces the whole block, so archive refuses to drop them).',
       });
     }
     return issues;

--- a/test/core/parsers/requirement-blocks.test.ts
+++ b/test/core/parsers/requirement-blocks.test.ts
@@ -3,6 +3,8 @@ import {
   extractRequirementsSection,
   parseDeltaSpec,
   findMissingCurrentScenarios,
+  diffScenarioNames,
+  describeScenarioBalance,
   type RequirementBlock,
 } from '../../../src/core/parsers/requirement-blocks.js';
 
@@ -242,5 +244,95 @@ describe('findMissingCurrentScenarios: level-4 header parity', () => {
     const current = req('#### Scenario: Edge case', '- **WHEN** a', '- **THEN** b');
     const incoming = req('#### Scenario: Edge case ####', '- **WHEN** a', '- **THEN** b');
     expect(findMissingCurrentScenarios(current, incoming)).toEqual([]);
+  });
+});
+
+describe('diffScenarioNames: what the block adds, alongside what it drops', () => {
+  const block = (raw: string): RequirementBlock => ({ headerLine: raw.split('\n')[0], name: '', raw });
+  const req = (...names: string[]) =>
+    block(
+      [
+        '### Requirement: Widget state',
+        'The system SHALL report it.',
+        '',
+        ...names.flatMap((name) => [`#### Scenario: ${name}`, '- **WHEN** a', '- **THEN** b', '']),
+      ].join('\n')
+    );
+
+  it('reports both directions and both totals', () => {
+    const diff = diffScenarioNames(req('Kept', 'Dropped'), req('Kept', 'Fresh'));
+    expect(diff).toEqual({
+      missing: ['Dropped'],
+      added: ['Fresh'],
+      currentCount: 2,
+      incomingCount: 2,
+    });
+  });
+
+  it('counts added names by multiplicity, mirroring missing', () => {
+    // A name twice in the incoming block and once in the current leaves one
+    // instance unmatched, the same rule the loss half already applies.
+    const diff = diffScenarioNames(req('Edge case'), req('Edge case', 'Edge case'));
+    expect(diff.missing).toEqual([]);
+    expect(diff.added).toEqual(['Edge case']);
+  });
+
+  it('agrees with findMissingCurrentScenarios, which is its missing half', () => {
+    const current = req('Kept', 'Dropped');
+    const incoming = req('Kept');
+    expect(findMissingCurrentScenarios(current, incoming)).toEqual(
+      diffScenarioNames(current, incoming).missing
+    );
+  });
+
+  it('ignores a fenced #### on either side, like the loss half', () => {
+    const current = block(
+      ['### Requirement: Widget state', '', '#### Scenario: Real', '- **WHEN** a'].join('\n')
+    );
+    const incoming = block(
+      [
+        '### Requirement: Widget state',
+        '',
+        '#### Scenario: Real',
+        '- **WHEN** a',
+        '',
+        '```markdown',
+        '#### Scenario: Only an example',
+        '```',
+      ].join('\n')
+    );
+    expect(diffScenarioNames(current, incoming).added).toEqual([]);
+  });
+});
+
+describe('describeScenarioBalance: the sentence archive and validate share', () => {
+  const diff = (over: Partial<ReturnType<typeof diffScenarioNames>>) => ({
+    missing: [],
+    added: [],
+    currentCount: 0,
+    incomingCount: 0,
+    ...over,
+  });
+
+  it('names what a block adds, which is what separates a rename from a loss', () => {
+    expect(
+      describeScenarioBalance(diff({ added: ['Fresh'], currentCount: 2, incomingCount: 2 }))
+    ).toBe(
+      'The modified block has 2 scenario(s) to the current spec\'s 2, and adds 1 the spec does not have: "Fresh".'
+    );
+  });
+
+  it('says so when a block adds nothing, which reads as a truncation', () => {
+    expect(describeScenarioBalance(diff({ currentCount: 5, incomingCount: 2 }))).toBe(
+      "The modified block has 2 scenario(s) to the current spec's 5, and adds none."
+    );
+  });
+
+  it('caps the listing so a wholesale rewrite cannot flood the message', () => {
+    const message = describeScenarioBalance(
+      diff({ added: ['A', 'B', 'C', 'D', 'E'], currentCount: 1, incomingCount: 5 })
+    );
+    expect(message).toContain('adds 5 the spec does not have: "A", "B", "C" and 2 more.');
+    expect(message).not.toContain('"D"');
   });
 });

--- a/test/core/validation.scenario-loss.test.ts
+++ b/test/core/validation.scenario-loss.test.ts
@@ -446,4 +446,34 @@ describe('validate: MODIFIED blocks that would drop a main-spec scenario (#1477)
     expect(lossIssue(report)).toBeUndefined();
     expect(report.issues.map((i) => i.message).join('\n')).toContain('MODIFIED references old name from RENAMED');
   });
+  it('reports what the block adds, so a rename reads differently from a truncation (#1697)', async () => {
+    await writeMainSpec('widgets', mainSpec(TWO_SCENARIO_REQUIREMENT));
+    const widened = `## MODIFIED Requirements\n\n### Requirement: Widget state\nThe system SHALL report the widget state.\n\n#### Scenario: Existing scenario\n- **WHEN** queried\n- **THEN** the state is reported\n\n#### Scenario: Second scenario, widened\n- **WHEN** idle\n- **THEN** idle is reported\n`;
+    const changeDir = await writeChange('widen-scenario', 'widgets', widened);
+
+    const issue = lossIssue(await validate(changeDir));
+
+    // The guard still fires: a widened title is a dropped name, and nothing
+    // here decides whether that was deliberate.
+    expect(issue?.message).toContain('"Second scenario"');
+    expect(issue?.message).toContain(
+      "The modified block has 2 scenario(s) to the current spec's 2, and adds 1 the spec does not have: \"Second scenario, widened\"."
+    );
+    // Parity: archive refuses the same change and prints the same sentence.
+    expect(await archiveError(changeDir)).toContain(
+      'and adds 1 the spec does not have: "Second scenario, widened".'
+    );
+  });
+
+  it('says the block adds none when scenarios are only dropped (#1697)', async () => {
+    await writeMainSpec('widgets', mainSpec(TWO_SCENARIO_REQUIREMENT));
+    const changeDir = await writeChange('drop-scenario', 'widgets', DELTA_KEEPING_ONE);
+
+    const issue = lossIssue(await validate(changeDir));
+
+    expect(issue?.message).toContain(
+      "The modified block has 1 scenario(s) to the current spec's 2, and adds none."
+    );
+    expect(await archiveError(changeDir)).toContain('and adds none.');
+  });
 });


### PR DESCRIPTION
## Status

Ready for human review at `db54a3b4`; all required checks pass. Not merged.

## What was wrong

When a `MODIFIED` block omitted an existing scenario, validation and archive named the omission but not the new scenarios. Readers had to compare files to see the difference between a likely rename and a truncation.

## How it was fixed

Both commands now report the counts and up to three added names from one shared comparison. The rejection rule and exit codes are unchanged.

## Proof

The #1697 one-to-two scenario case is covered through validation and archive. Four focused test files pass (301 tests); TypeScript, lint, and diff checks pass. The latest head passes hosted Linux, macOS, Windows, and security checks.

## Note

Refs #1697's reporting request. Allowing a declared scenario rename remains a separate design decision in that issue.
