### PR TITLE
ci: report the correct pnpmDeps hash when flake.nix is stale

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,10 @@ jobs:
             echo "✅ flake.nix pnpmDeps hash is up to date"
             exit 0
           fi
-          HASH=$(sed -nE 's/.*hash = "(sha256-[^"]+)".*/\1/p' flake.nix | head -1)
+          # Scoped to the pnpmDeps block: a bare first-match would report some other
+          # FOD's hash if one is ever added above it.
+          HASH=$(sed -n '/pnpmDeps = /,/};/p' flake.nix \
+            | sed -nE 's/.*hash = "(sha256-[^"]+)".*/\1/p' | head -1)
           git diff flake.nix
           echo "::error file=flake.nix::Stale pnpmDeps hash. Set pnpmDeps.hash to $HASH and push."
           exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,6 +181,28 @@ jobs:
       - name: Setup Nix cache
         uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
 
+      # Run the update script before `nix build`, not after. The script recomputes
+      # the pnpmDeps hash from pnpm-lock.yaml and rewrites flake.nix in place, so a
+      # stale hash is reported here as the exact value to paste. Built first, the
+      # same staleness surfaces as pnpm's ERR_PNPM_NO_OFFLINE_TARBALL — which names
+      # a missing tarball, not the hash — and the script never runs to say otherwise.
+      # Every root lockfile change needs this value, and Dependabot cannot produce it.
+      - name: Verify pnpmDeps hash matches the lockfile
+        run: |
+          bash scripts/update-flake.sh
+          if git diff --quiet flake.nix; then
+            echo "✅ flake.nix pnpmDeps hash is up to date"
+            exit 0
+          fi
+          HASH=$(sed -nE 's/.*hash = "(sha256-[^"]+)".*/\1/p' flake.nix | head -1)
+          git diff flake.nix
+          echo "::error file=flake.nix::Stale pnpmDeps hash. Set pnpmDeps.hash to $HASH and push."
+          exit 1
+
+      - name: Restore flake.nix
+        if: always()
+        run: git checkout -- flake.nix || true
+
       - name: Build with Nix
         run: nix build
 
@@ -205,25 +227,6 @@ jobs:
             exit 1
           fi
           echo "✅ Binary execution successful"
-
-      - name: Validate update script
-        run: |
-          echo "Testing update-flake.sh script..."
-          bash scripts/update-flake.sh
-          echo "✅ Update script executed successfully"
-
-      - name: Check flake.nix modifications
-        run: |
-          if git diff --quiet flake.nix; then
-            echo "ℹ️  flake.nix unchanged (hash already up-to-date)"
-          else
-            echo "✅ flake.nix was updated by script"
-            git diff flake.nix
-          fi
-
-      - name: Restore flake.nix
-        if: always()
-        run: git checkout -- flake.nix || true
 
   validate-changesets:
     name: Validate Release Tracking

--- a/scripts/update-flake.sh
+++ b/scripts/update-flake.sh
@@ -10,6 +10,14 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 FLAKE_FILE="$PROJECT_ROOT/flake.nix"
 PACKAGE_JSON="$PROJECT_ROOT/package.json"
 
+# Every hash read and every hash rewrite below is confined to this sed address
+# range. flake.nix holds one fixed-output derivation today, so an unscoped
+# `hash = "sha256-..."` happens to hit the right line; the moment a second FOD
+# is added, an unscoped script would stamp the placeholder over both, extract
+# whichever mismatch Nix reported first, and write pnpmDeps' hash into the
+# other derivation. Scoping is what keeps that from being a silent corruption.
+PNPM_DEPS_BLOCK='/pnpmDeps = /,/};/'
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -49,15 +57,21 @@ fi
 echo -e "${BLUE}🔧 Current pnpm-lock.yaml:${NC} $(stat -c%y "$PROJECT_ROOT/pnpm-lock.yaml" 2>/dev/null || stat -f%Sm "$PROJECT_ROOT/pnpm-lock.yaml")"
 echo ""
 
-# Get current hash from flake.nix
-CURRENT_HASH=$(sed -nE 's/.*hash = "(sha256-[^"]+)".*/\1/p' "$FLAKE_FILE" | head -1)
+# Get current pnpmDeps hash from flake.nix
+CURRENT_HASH=$(sed -nE "$PNPM_DEPS_BLOCK"' s/.*hash = "(sha256-[^"]+)".*/\1/p' "$FLAKE_FILE" | head -1)
+if [ -z "$CURRENT_HASH" ]; then
+  echo -e "${RED}❌ Error: no pnpmDeps hash found in flake.nix${NC}"
+  echo -e "   Looked for 'hash = \"sha256-...\"' inside the 'pnpmDeps = ... };' block."
+  echo -e "   Nothing was modified."
+  exit 1
+fi
 echo -e "${BLUE}📌 Current hash:${NC} $CURRENT_HASH"
 echo ""
 
 # Set placeholder hash to trigger error
 echo -e "${YELLOW}⏳ Setting placeholder hash to calculate correct value...${NC}"
 PLACEHOLDER="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
-sed "${SED_INPLACE[@]}" "s|hash = \"sha256-[^\"]*\"|hash = \"$PLACEHOLDER\"|" "$FLAKE_FILE"
+sed "${SED_INPLACE[@]}" "$PNPM_DEPS_BLOCK s|hash = \"sha256-[^\"]*\"|hash = \"$PLACEHOLDER\"|" "$FLAKE_FILE"
 
 # Try to build and capture the correct hash
 echo -e "${BLUE}🔨 Building to determine correct hash (expected to fail)...${NC}"
@@ -77,7 +91,7 @@ if [ -z "$CORRECT_HASH" ]; then
   echo "$BUILD_OUTPUT"
   echo ""
   echo -e "${YELLOW}Restoring original hash...${NC}"
-  sed "${SED_INPLACE[@]}" "s|hash = \"$PLACEHOLDER\"|hash = \"$CURRENT_HASH\"|" "$FLAKE_FILE"
+  sed "${SED_INPLACE[@]}" "$PNPM_DEPS_BLOCK s|hash = \"$PLACEHOLDER\"|hash = \"$CURRENT_HASH\"|" "$FLAKE_FILE"
   exit 1
 fi
 
@@ -87,14 +101,14 @@ echo ""
 # Check if hash changed
 if [ "$CURRENT_HASH" = "$CORRECT_HASH" ]; then
   echo -e "${GREEN}✓ Hash is already up-to-date!${NC}"
-  sed "${SED_INPLACE[@]}" "s|hash = \"$PLACEHOLDER\"|hash = \"$CORRECT_HASH\"|" "$FLAKE_FILE"
+  sed "${SED_INPLACE[@]}" "$PNPM_DEPS_BLOCK s|hash = \"$PLACEHOLDER\"|hash = \"$CORRECT_HASH\"|" "$FLAKE_FILE"
   echo ""
   echo -e "${BLUE}ℹ️  No changes needed. Your flake is in sync with pnpm-lock.yaml${NC}"
   exit 0
 fi
 
 echo -e "${YELLOW}🔄 Updating hash in flake.nix...${NC}"
-sed "${SED_INPLACE[@]}" "s|hash = \"$PLACEHOLDER\"|hash = \"$CORRECT_HASH\"|" "$FLAKE_FILE"
+sed "${SED_INPLACE[@]}" "$PNPM_DEPS_BLOCK s|hash = \"$PLACEHOLDER\"|hash = \"$CORRECT_HASH\"|" "$FLAKE_FILE"
 
 # Verify the build works
 echo -e "${BLUE}🔍 Verifying build with new hash...${NC}"

--- a/test/update-flake-script.test.ts
+++ b/test/update-flake-script.test.ts
@@ -69,15 +69,18 @@ describe('update-flake.sh confines every hash rewrite to the pnpmDeps block', ()
 
     // Mirrors the script: read the current hash, stamp the placeholder, write
     // the calculated hash back.
-    const read = execFileSync(
-      'bash',
-      [
-        '-c',
-        `${BLOCK}\nsed -nE "$PNPM_DEPS_BLOCK"' s/.*hash = "(sha256-[^"]+)".*/\\1/p' "$1" | head -1`,
-        '_',
-        flake,
-      ],
-      { encoding: 'utf8' }
+    // `bash` runs inside the fixture directory and addresses the file by name:
+    // `sed -i` writes its temp file in the working directory and renames it
+    // into place, which fails with "Invalid cross-device link" on Windows when
+    // the repo (D:) and os.tmpdir() (C:) are different volumes.
+    const inFixture = (command: string): string =>
+      execFileSync('bash', ['-c', `${BLOCK}\n${command}`, '_', 'flake.nix'], {
+        cwd: dir,
+        encoding: 'utf8',
+      });
+
+    const read = inFixture(
+      `sed -nE "$PNPM_DEPS_BLOCK"' s/.*hash = "(sha256-[^"]+)".*/\\1/p' "$1" | head -1`
     ).trim();
 
     // The whole point: an unscoped read returns the first derivation's hash.
@@ -85,20 +88,14 @@ describe('update-flake.sh confines every hash rewrite to the pnpmDeps block', ()
     expect(read).not.toBe(other);
 
     const placeholder = 'sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=';
-    execFileSync('bash', [
-      '-c',
-      `${BLOCK}\nsed -i.bak "$PNPM_DEPS_BLOCK s|hash = \\"sha256-[^\\"]*\\"|hash = \\"${placeholder}\\"|" "$1"`,
-      '_',
-      flake,
-    ]);
+    inFixture(
+      `sed -i.bak "$PNPM_DEPS_BLOCK s|hash = \\"sha256-[^\\"]*\\"|hash = \\"${placeholder}\\"|" "$1"`
+    );
     expect(fs.readFileSync(flake, 'utf8').split(placeholder).length - 1).toBe(1);
 
-    execFileSync('bash', [
-      '-c',
-      `${BLOCK}\nsed -i.bak "$PNPM_DEPS_BLOCK s|hash = \\"${placeholder}\\"|hash = \\"${fresh}\\"|" "$1"`,
-      '_',
-      flake,
-    ]);
+    inFixture(
+      `sed -i.bak "$PNPM_DEPS_BLOCK s|hash = \\"${placeholder}\\"|hash = \\"${fresh}\\"|" "$1"`
+    );
 
     const updated = fs.readFileSync(flake, 'utf8');
     expect(updated).toContain(`hash = "${fresh}"`);

--- a/test/update-flake-script.test.ts
+++ b/test/update-flake-script.test.ts
@@ -1,0 +1,117 @@
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+const projectRoot = process.cwd();
+const scriptPath = path.join(projectRoot, 'scripts', 'update-flake.sh');
+const script = fs.readFileSync(scriptPath, 'utf8');
+
+/**
+ * `scripts/update-flake.sh` rewrites the pnpmDeps hash in flake.nix in place.
+ *
+ * flake.nix holds exactly one fixed-output derivation today, so an unscoped
+ * `hash = "sha256-..."` happens to land on the right line and the bug is
+ * invisible. Add a second FOD and an unscoped script stamps the placeholder
+ * over both, reads back whichever mismatch Nix reported first, and writes
+ * pnpmDeps' hash into the other derivation. That is a silent corruption of a
+ * supply-chain pin, so the scoping is pinned here rather than left to review.
+ */
+describe('update-flake.sh confines every hash rewrite to the pnpmDeps block', () => {
+  const BLOCK = "PNPM_DEPS_BLOCK='/pnpmDeps = /,/};/'";
+
+  it('declares the block address once, so the scoping cannot drift per call site', () => {
+    expect(script).toContain(BLOCK);
+  });
+
+  it('scopes every line that reads or rewrites a hash', () => {
+    const unscoped = script
+      .split('\n')
+      .map((line, index) => [index + 1, line.trim()] as const)
+      .filter(([, line]) => !line.startsWith('#'))
+      // Every line that extracts a hash or edits one in place.
+      .filter(([, line]) => /CURRENT_HASH=\$\(sed|sed "\$\{SED_INPLACE\[@\]\}"/.test(line))
+      .filter(([, line]) => !line.includes('PNPM_DEPS_BLOCK'));
+
+    expect(unscoped).toEqual([]);
+  });
+
+  // The static checks above say the range is spelled everywhere; this one says
+  // the range actually selects the right derivation. Runs the script's own
+  // three sed operations against a flake with three FODs, pnpmDeps in the
+  // middle, so a first-match bug and a global-replace bug both show up.
+  it('touches only the pnpmDeps hash in a flake with several derivations', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'openspec-flake-scope-'));
+    const flake = path.join(dir, 'flake.nix');
+    const other = 'sha256-OTHEROTHEROTHEROTHEROTHEROTHEROTHEROTHEROT0=';
+    const pnpm = 'sha256-PNPMPNPMPNPMPNPMPNPMPNPMPNPMPNPMPNPMPNPMPN0=';
+    const another = 'sha256-ANOTHERANOTHERANOTHERANOTHERANOTHERANOTHE0=';
+    const fresh = 'sha256-NEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNEWNE0=';
+
+    fs.writeFileSync(
+      flake,
+      [
+        '{',
+        '  other = pkgs.fetchFromGitHub {',
+        `    hash = "${other}";`,
+        '  };',
+        '  pnpmDeps = pkgs.fetchPnpmDeps {',
+        `    hash = "${pnpm}";`,
+        '  };',
+        '  another = pkgs.fetchurl {',
+        `    hash = "${another}";`,
+        '  };',
+        '}',
+        '',
+      ].join('\n')
+    );
+
+    // Mirrors the script: read the current hash, stamp the placeholder, write
+    // the calculated hash back.
+    const read = execFileSync(
+      'bash',
+      [
+        '-c',
+        `${BLOCK}\nsed -nE "$PNPM_DEPS_BLOCK"' s/.*hash = "(sha256-[^"]+)".*/\\1/p' "$1" | head -1`,
+        '_',
+        flake,
+      ],
+      { encoding: 'utf8' }
+    ).trim();
+
+    // The whole point: an unscoped read returns the first derivation's hash.
+    expect(read).toBe(pnpm);
+    expect(read).not.toBe(other);
+
+    const placeholder = 'sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=';
+    execFileSync('bash', [
+      '-c',
+      `${BLOCK}\nsed -i.bak "$PNPM_DEPS_BLOCK s|hash = \\"sha256-[^\\"]*\\"|hash = \\"${placeholder}\\"|" "$1"`,
+      '_',
+      flake,
+    ]);
+    expect(fs.readFileSync(flake, 'utf8').split(placeholder).length - 1).toBe(1);
+
+    execFileSync('bash', [
+      '-c',
+      `${BLOCK}\nsed -i.bak "$PNPM_DEPS_BLOCK s|hash = \\"${placeholder}\\"|hash = \\"${fresh}\\"|" "$1"`,
+      '_',
+      flake,
+    ]);
+
+    const updated = fs.readFileSync(flake, 'utf8');
+    expect(updated).toContain(`hash = "${fresh}"`);
+    // The neighbours are untouched, which is what a global replace would break.
+    expect(updated).toContain(`hash = "${other}"`);
+    expect(updated).toContain(`hash = "${another}"`);
+    expect(updated).not.toContain(placeholder);
+
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('refuses to touch the file when no pnpmDeps hash is found', () => {
+    expect(script).toContain('no pnpmDeps hash found in flake.nix');
+    expect(script).toContain('Nothing was modified.');
+  });
+});


### PR DESCRIPTION
**Status:** ready for review.

**What was wrong:** every root lockfile change invalidates the `pnpmDeps` FOD hash pinned in `flake.nix`, and Dependabot cannot regenerate it — so `Nix Flake Validation` fails on every npm bump PR (#1810, #1811, and #1427 before them). The job already had everything needed to report the right value: it runs `scripts/update-flake.sh`, which computes the hash from `pnpm-lock.yaml`. But that step ran *after* `nix build`, so on a stale hash the build failed first and the script never ran. What the log showed instead was pnpm's:

```
ERR_PNPM_NO_OFFLINE_TARBALL  A package is missing from the store but cannot
download it in offline mode. The missing package may be downloaded from
https://registry.npmjs.org/zod/-/zod-4.5.4.tgz
```

That names a tarball, not a hash. Worse, the standard recovery — set `hash = ""`, push, read the `got:` line — costs a **second** full CI run, because a stale hash produces no mismatch at all (the fetch succeeds against the old store and fails later, offline). Landing #1814 took exactly that two-round dance.

**How it was fixed:** run `scripts/update-flake.sh` first, then compare. If it rewrote `flake.nix`, the hash was stale: the job prints the diff and fails with a GitHub error annotation naming the value to paste. `flake.nix` is then restored and `nix build` runs against the committed file, so everything downstream is unchanged. The two now-redundant trailing steps (`Validate update script`, `Check flake.nix modifications`) are removed — the script runs earlier, and its result is asserted rather than just echoed.

**Replication / proof:** pushed a deliberately stale hash to this branch and let CI run ([job log](https://github.com/Fission-AI/OpenSpec/actions/runs/34136074439/job/101787275151)):

```
✓ Calculated hash: sha256-SNPeEUa+amkZYRO5tHeUwDBT4betXYPKnfZiEyhN7fE=
-              hash = "sha256-0000000000000000000000000000000000000000000=";
+              hash = "sha256-SNPeEUa+amkZYRO5tHeUwDBT4betXYPKnfZiEyhN7fE=";
Error: Stale pnpmDeps hash. Set pnpmDeps.hash to sha256-SNPeEUa+... and push.
```

34 seconds, one run, correct value — against a whole extra CI cycle before. That commit is removed from the branch; CI here is green on the real hash, which exercises the pass path.

**Notes / nits:** this deliberately does **not** make the check advisory on PRs, which is what I first suggested when handing over #1814. It would be the wrong trade: a merged stale hash breaks `nix build` for flake users on `main` until someone notices, and lockfile changes land roughly weekly, so `main`'s flake would be broken more often than not. It also contradicts `openspec/specs/ci-nix-validation/spec.md`, which requires the job for merge. Making the gate cheap to satisfy beats moving the breakage downstream. If unattended Dependabot merges are still the goal, the honest version is auto-repair on `main` (a bot PR that pushes the hash after merge) — a bigger change, and a maintainer call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency hash updates to modify only the intended package dependency metadata, preventing unrelated build hashes from being changed.
  * Added safeguards when expected dependency metadata is missing, leaving configuration unchanged and reporting an error.

* **Chores**
  * Improved automated build validation by detecting and reporting stale dependency metadata before builds run.
  * Ensured validation restores configuration files after checks, regardless of the outcome.
  * Streamlined workflow checks by removing separate post-build update-script validation and modification checks.

* **Tests**
  * Added coverage for targeted hash updates, missing metadata handling, and protection of unrelated build configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->