### PR TITLE
docs(explore): stop claiming explore never writes files

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ openspec init
 
 Now talk to your AI:
 
-- **Not sure what to build yet?** Start with `/opsx:explore`, a no-stakes thinking partner that reads your code, weighs options, and shapes a plan before anything is written. ([Explore guide](docs/explore.md))
+- **Not sure what to build yet?** Start with `/opsx:explore`, a no-stakes thinking partner that reads your code, weighs options, and shapes a plan before any code gets written. ([Explore guide](docs/explore.md))
 - **Already know what you want?** Go straight to `/opsx:propose <what-you-want-to-build>`.
 
 Both are in the default profile. If you want the expanded workflow (`/opsx:new`, `/opsx:continue`, `/opsx:ff`, `/opsx:verify`, `/opsx:bulk-archive`, `/opsx:onboard`), select it with `openspec config profile` and apply with `openspec update`.

--- a/docs-lab/start/quickstart.md
+++ b/docs-lab/start/quickstart.md
@@ -27,7 +27,7 @@ Think the idea through with your agent before you ask for a plan. In your AI cha
 /openspec-explore how rate limiting should work in this app
 ```
 
-Explore is a thinking mode. The agent investigates your codebase, asks the questions that matter, sketches options, and challenges assumptions. It writes no code and no files. The output is a sharper idea.
+Explore is a thinking mode. The agent investigates your codebase, asks the questions that matter, sketches options, and challenges assumptions. It never writes code. It writes nothing else unless you ask it to capture what you decided, or say yes when it offers. The output is a sharper idea.
 
 Stay here as long as the problem needs. When the shape feels right, hand it off:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ If you read nothing else, read these two pages:
 
 That second one matters more than it looks. OpenSpec has two halves: a command line tool you run in your terminal, and slash commands you give to your AI assistant. Knowing which is which saves you the most common moment of confusion.
 
-> **The best habit to build first: when you're not sure what to build, start with `/opsx:explore`.** It's a no-stakes thinking partner that reads your code, weighs options, and sharpens a fuzzy idea into a concrete plan before any artifact or code exists. The [Explore First](explore.md) guide makes the case.
+> **The best habit to build first: when you're not sure what to build, start with `/opsx:explore`.** It's a no-stakes thinking partner that reads your code, weighs options, and sharpens a fuzzy idea into a concrete plan before any code gets written. The [Explore First](explore.md) guide makes the case.
 
 ## Pick your path
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -78,7 +78,7 @@ AI:  Created openspec/changes/add-dark-mode/
 
 ### `/opsx:explore`
 
-> **Start here when you're unsure.** Explore is a no-stakes thinking partner: it reads your codebase, compares options, and sharpens a fuzzy idea into a concrete plan before any change exists. It ships in the default profile. For the full case and more examples, see the [Explore First](explore.md) guide.
+> **Start here when you're unsure.** Explore is a no-stakes thinking partner: it reads your codebase, compares options, and sharpens a fuzzy idea into a concrete plan before any code gets written. It ships in the default profile. For the full case and more examples, see the [Explore First](explore.md) guide.
 
 Think through ideas, investigate problems, and clarify requirements before committing to a change.
 
@@ -97,6 +97,7 @@ Think through ideas, investigate problems, and clarify requirements before commi
 - Investigates the codebase to answer questions
 - Compares options and approaches
 - Creates visual diagrams to clarify thinking
+- Captures the exploration when you ask, or when you say yes to its offer: scaffolds a change with `openspec new change` and writes the planning artifacts you name, or updates an existing change's artifacts
 - Can transition to `/opsx:propose` (default) or `/opsx:new` (expanded workflow) when insights crystallize
 
 **Example:**
@@ -119,14 +120,20 @@ AI:  Let me investigate your current auth setup...
 
      Your API already has CORS configured. Which direction interests you?
 
-You: Let's go with JWT. Can we start a change for that?
+You: Let's go with JWT.
 
-AI:  Ready when you are. Run /opsx:propose add-jwt-auth to begin.
+AI:  That's a decision worth keeping. Want me to start a change for it?
+
+You: Yes.
+
+AI:  Started openspec/changes/add-jwt-auth/ - change metadata only, no
+     artifacts yet. Say the word and I'll write the proposal, specs,
+     and tasks from what we just worked out.
 ```
 
 **Tips:**
 - Use when requirements are unclear or you need to investigate
-- No artifacts are created during exploration
+- It never writes code, and writes nothing else unless you ask, or say yes when it offers
 - Good for comparing multiple approaches before deciding
 - Can read files and search the codebase
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -68,7 +68,7 @@ Tip: for a fix, a good scenario is the regression test in prose. "GIVEN a logged
 
 **When to use it:** you have a problem but not yet a plan. You're not sure what to build, or which approach is right.
 
-Start with `/opsx:explore`. It's a thinking partner with no structure and no artifacts created. It reads your codebase and helps you decide.
+Start with `/opsx:explore`. It's a thinking partner with no structure. It never writes code, and writes nothing else unless you ask it to capture what you decided, or say yes when it offers. It reads your codebase and helps you decide.
 
 ```text
 You: /opsx:explore

--- a/docs/explore.md
+++ b/docs/explore.md
@@ -1,6 +1,6 @@
 # Explore First
 
-**`/opsx:explore` is your thinking partner. Reach for it whenever you have a problem but not yet a plan.** It investigates your codebase, weighs options with you, and clarifies what you actually want, all before a single artifact or line of code is created. When the picture is clear, it hands off to `/opsx:propose`.
+**`/opsx:explore` is your thinking partner. Reach for it whenever you have a problem but not yet a plan.** It investigates your codebase, weighs options with you, and clarifies what you actually want, all before a line of code is written. When the picture is clear, it hands off to `/opsx:propose`.
 
 If you take one habit from these docs, take this one: **when you're not sure, explore before you propose.**
 
@@ -27,14 +27,16 @@ Explore is a **conversation**, not a generator.
 - Compare options and name the tradeoffs of each.
 - Draw diagrams to make a design legible.
 - Help you narrow a vague idea into a concrete, buildable scope.
+- Capture the exploration when you ask, or when you accept its offer: it scaffolds the change with `openspec new change` and writes the planning artifacts you named, or updates an existing change's artifacts.
 - Transition to `/opsx:propose` when you're ready.
 
 **It does not:**
-- Create a change folder.
-- Write any artifacts (no proposal, specs, design, or tasks).
-- Write or modify code.
+- Write or modify code. Explore never writes code, on any path, capture included.
+- Design or edit your schemas or templates. Shaping those is a change, not thinking.
+- Start a change or write an artifact on its own. It writes nothing unless you ask, or say yes when it offers, and then only what you agreed to.
+- Push you toward capturing. It offers when the thinking crystallizes; you decide.
 
-That's the point. Exploring costs you nothing and commits you to nothing. You can explore three dead ends, learn something from each, and only then propose the path that survived.
+That's the point. Exploring costs you nothing and commits you to nothing until you say so. You can explore three dead ends, learn something from each, and only then propose the path that survived.
 
 ## It's already installed
 
@@ -95,6 +97,10 @@ explore  ──►  propose  ──►  apply  ──►  archive
 
 You can say it in plain language ("let's turn this into a change") or run `/opsx:propose <name>` directly. Either way, the exploration you just did becomes the foundation of the proposal, not throwaway chat.
 
+You can also ask explore to capture the change itself, without leaving the conversation: "start a change for this" scaffolds the folder, and "write the proposal too" writes exactly the artifacts you named. Scaffolding also lays down the change's own metadata, and fills in anything your project is missing at the top level (`openspec/specs/`, `openspec/changes/archive/`, a `config.yaml`).
+
+That's the same destination as handing off, with one difference: propose writes the whole set your schema requires to reach implementation, while capture writes only what you named.
+
 If you use the expanded command set, explore can hand off to `/opsx:new` instead, for step-by-step artifact creation. See [Workflows](workflows.md).
 
 ## Tips for a good exploration
@@ -107,7 +113,7 @@ If you use the expanded command set, explore can hand off to `/opsx:new` instead
 
 ## The honest tradeoffs
 
-**What you gain:** explore catches wrong turns at the cheapest possible moment, before any artifact exists. It's especially powerful in unfamiliar code, where the AI's ability to read and summarize the system saves you an afternoon of spelunking.
+**What you gain:** explore catches wrong turns at the cheapest possible moment, before you've committed to anything. It's especially powerful in unfamiliar code, where the AI's ability to read and summarize the system saves you an afternoon of spelunking.
 
 **What it costs:** a little patience. Explore is a conversation, so it's slower than firing off `/opsx:propose` and hoping. For work you genuinely understand already, that extra step is pure overhead, and you should skip it.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -50,7 +50,7 @@ Both are files OpenSpec writes so your assistant can run the workflow. Skills (`
 
 ### Where should I start if I'm not sure what to build?
 
-With `/opsx:explore`. It's a no-stakes thinking partner that reads your codebase, lays out options, and turns a fuzzy problem into a concrete plan, all before any change or code exists. It's in the default profile, so it's always available. When the plan is clear, it hands off to `/opsx:propose`. This is the single best habit to form, because it stops an eager AI from confidently building the wrong thing. See [Explore First](explore.md).
+With `/opsx:explore`. It's a no-stakes thinking partner that reads your codebase, lays out options, and turns a fuzzy problem into a concrete plan, all before any code gets written. It's in the default profile, so it's always available. When the plan is clear, it hands off to `/opsx:propose`. This is the single best habit to form, because it stops an eager AI from confidently building the wrong thing. See [Explore First](explore.md).
 
 ### What's the simplest possible flow?
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,7 +26,7 @@ Two terminal steps to set up, then you live in chat. The rest of this guide unpa
 
 **Don't want to do the terminal part yourself?** Paste the [setup prompt](installation.md#install-with-your-ai-assistant) into your assistant and it handles both lines, then reports what it created.
 
-> **Not sure what to build yet? Start with `/opsx:explore`.** It's a no-stakes thinking partner that reads your codebase, weighs options, and sharpens a fuzzy idea into a concrete plan, all before any artifact or code exists. When the picture is clear, it hands off to `/opsx:propose`. This is the single best habit for working with an AI that will otherwise confidently build the wrong thing. See the [Explore guide](explore.md).
+> **Not sure what to build yet? Start with `/opsx:explore`.** It's a no-stakes thinking partner that reads your codebase, weighs options, and sharpens a fuzzy idea into a concrete plan, all before any code gets written. When the picture is clear, it hands off to `/opsx:propose`. This is the single best habit for working with an AI that will otherwise confidently build the wrong thing. See the [Explore guide](explore.md).
 
 ## How It Works
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -46,7 +46,7 @@ Terms are grouped by topic, then alphabetized within each group.
 
 **Slash command.** A command you type into your AI assistant's chat, like `/opsx:propose`. Slash commands drive the workflow. They are not terminal commands. See [How Commands Work](how-commands-work.md).
 
-**Explore (`/opsx:explore`).** The thinking-partner command. It reads your codebase, compares options, and clarifies a fuzzy idea into a concrete plan, creating no artifacts and writing no code. The recommended starting point whenever you have a problem but not yet a plan. See [Explore First](explore.md).
+**Explore (`/opsx:explore`).** The thinking-partner command. It reads your codebase, compares options, and clarifies a fuzzy idea into a concrete plan. It never writes code, and writes nothing else unless you ask it to capture the exploration as a change, or say yes when it offers. The recommended starting point whenever you have a problem but not yet a plan. See [Explore First](explore.md).
 
 **CLI.** The `openspec` program you run in your terminal. It sets up projects, lists and validates changes, opens the dashboard, and archives. The terminal half of OpenSpec. See [CLI](cli.md).
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -56,7 +56,7 @@ In the default setup, your day looks like this. Optionally think it through firs
 /opsx:archive                   →  specs updated, change archived
 ```
 
-**When in doubt, start by exploring.** `/opsx:explore` is a no-stakes thinking partner: it reads your code, lays out options, and turns a fuzzy idea into a concrete plan before any artifact exists. It's the best antidote to an AI that will otherwise build *something* from a vague prompt. Already know exactly what you want? Skip straight to `/opsx:propose`. Either way, explore ships in the default profile, so it's always there. See the [Explore guide](explore.md).
+**When in doubt, start by exploring.** `/opsx:explore` is a no-stakes thinking partner: it reads your code, lays out options, and turns a fuzzy idea into a concrete plan before any code gets written. It's the best antidote to an AI that will otherwise build *something* from a vague prompt. Already know exactly what you want? Skip straight to `/opsx:propose`. Either way, explore ships in the default profile, so it's always there. See the [Explore guide](explore.md).
 
 Those are slash commands, typed in your AI assistant's chat. Setup (`openspec init`) happens in your terminal. If that split is new to you, read [How Commands Work](how-commands-work.md) first; it's the most common point of confusion.
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -140,7 +140,7 @@ You: Yes.
 You: /opsx:propose rebuild-search-index-on-write
 ```
 
-Explore creates no artifacts and writes no code. It's a free, no-stakes conversation that turns a vague worry into a precise change, so the proposal that follows is sharp. Already know exactly what you want? Skip it and go straight to `/opsx:propose`. Full guide: [Explore First](explore.md).
+Explore never writes code, and writes nothing else unless you ask, or say yes when it offers. It's a free, no-stakes conversation that turns a vague worry into a precise change, so the proposal that follows is sharp. Already know exactly what you want? Skip it and go straight to `/opsx:propose`. Full guide: [Explore First](explore.md).
 
 ### Expanded/Full Workflow (custom selection)
 
@@ -493,7 +493,7 @@ AI:  Let me investigate your current setup and options...
      Your current stack suggests #1 or #2. What's your scale?
 ```
 
-Exploration clarifies thinking before you create artifacts.
+Exploration clarifies thinking before any code gets written.
 
 ### Verify Before Archiving
 

--- a/test/explore-docs-claims.test.ts
+++ b/test/explore-docs-claims.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Sixteen lines across both documentation trees used to state that `explore`
+// creates no artifacts and writes no files, full stop (#1833). That has been
+// false since explore shipped (#467): the capture branch of
+// `src/core/templates/workflows/explore.ts` writes the planning artifacts the
+// user asked for, and can edit an existing change's artifacts. #1503 later
+// made it scaffold with `openspec new change` first. What stays true is narrower: explore never writes code,
+// and it writes nothing you did not ask for or agree to.
+//
+// This sweep keeps the absolute wording retired, the same way
+// test/vocabulary-sweep.test.ts keeps the pre-rename store vocabulary retired.
+// It is deliberately a flat list of phrasings over a named page list rather
+// than a grammar for the claim. An earlier draft tried the grammar - section
+// splitting, fence tracking, a conditional-marker exemption - and it was
+// imprecise in both directions on realistic prose while returning the same
+// verdict here. Phrasings that are only wrong in the absolute ("writes
+// nothing", "creates nothing") are left to review, because "writes nothing
+// unless you ask" is the wording this very test recommends.
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+// The pages that pitch explore to a user. Both trees ship: `docs/` is what
+// README links today, `docs-lab/` is what the documentation site publishes
+// (`website/content/docs` is generated from it and is not committed).
+const PAGES = [
+  'README.md',
+  'docs/README.md',
+  'docs/commands.md',
+  'docs/examples.md',
+  'docs/explore.md',
+  'docs/faq.md',
+  'docs/getting-started.md',
+  'docs/glossary.md',
+  'docs/overview.md',
+  'docs/workflows.md',
+  'docs-lab/start/quickstart.md',
+];
+
+/**
+ * Every phrasing that actually carried the claim, as a pattern. This list is
+ * grounded, not speculative: it is what the sixteen offending lines said. When
+ * a new phrasing appears, add it then. A guard does not have to be exhaustive
+ * to be worth having, and a literal list is the one thing every maintainer can
+ * extend correctly without reading a grammar.
+ */
+const FORBIDDEN: readonly RegExp[] = [
+  // The capability form.
+  /\bno artifacts\b/i,
+  /\bno files\b/i,
+  /\bwrite any artifacts\b/i,
+  // Bullet-anchored: "It does not: - Create a change folder." The same words
+  // in a sentence ("it does not create a change folder on its own") are the
+  // correct wording, so only the unconditional bullet form is forbidden.
+  /^\s*[-*]\s+creates? a change folder\b/i,
+  // The timing form: true of the default path, false as a description of what
+  // explore can do. This is the shape that survived the first pass on #1833.
+  /\bbefore any artifact\b/i,
+  /\bbefore any change\b/i,
+  /\bbefore a single artifact\b/i,
+  /\bbefore anything is written\b/i,
+  /\bbefore you create artifacts\b/i,
+];
+
+/** Lines that contain a forbidden phrase without making the claim. */
+const ALLOW = [
+  // docs/commands.md and docs/troubleshooting.md quote this CLI message.
+  /"No artifacts ready"/,
+];
+
+const TEST_FILE = 'test/explore-docs-claims.test.ts';
+
+function findOffenders(page: string, content: string): string[] {
+  const offenders: string[] = [];
+  content.split(/\r?\n/).forEach((line, index) => {
+    if (ALLOW.some((allowed) => allowed.test(line))) return;
+    const match = FORBIDDEN.map((f) => f.exec(line)).find(Boolean);
+    if (match) {
+      offenders.push(`${page}:${index + 1}: "${match[0]}" in: ${line.trim()}`);
+    }
+  });
+  return offenders;
+}
+
+describe('explore documentation', () => {
+  it('never claims explore writes nothing at all (#1833)', () => {
+    const offenders = PAGES.flatMap((page) => {
+      const file = path.join(REPO_ROOT, ...page.split('/'));
+      if (!fs.existsSync(file)) return [];
+      return findOffenders(page, fs.readFileSync(file, 'utf-8'));
+    });
+
+    expect(
+      offenders,
+      'These pages assert that explore writes nothing. It captures on ' +
+        'request: `openspec new change` plus the planning artifacts you ' +
+        'name. Keep "never writes code" and "nothing unless you ask, or say ' +
+        'yes when it offers"; drop the absolute denial. If a line below is ' +
+        `not a claim about explore, add it to ALLOW in ${TEST_FILE}.` +
+        `\n\n${offenders.join('\n')}`
+    ).toEqual([]);
+  });
+
+  it('still documents the capture path on the explore guide (#1833)', () => {
+    // A forbidden-phrase list cannot tell "the correction was deleted" from
+    // "this page never mentioned capture". Pin the concept on the one page
+    // whose whole job is explaining what explore does. Concept, not phrasing:
+    // how the page words it is review's call, not this test's.
+    const guide = fs.readFileSync(path.join(REPO_ROOT, 'docs', 'explore.md'), 'utf-8');
+    expect(
+      guide,
+      'docs/explore.md should still describe capture - the change explore ' +
+        'writes when you ask it to. See #1833.'
+    ).toMatch(/captur\w*/i);
+  });
+});


### PR DESCRIPTION
## Status

LGTM. Documentation-only, plus one sweep test. No source file changes.

## What was wrong

Sixteen lines across both documentation trees told users that `/opsx:explore` creates no artifacts and writes no files, full stop.

That has been false since explore shipped ([#467](https://github.com/Fission-AI/OpenSpec/pull/467), Jan 2026): its capture branch writes the planning artifacts the user asked for, and can edit an existing change's artifacts. [#1503](https://github.com/Fission-AI/OpenSpec/pull/1503) later made it scaffold with `openspec new change` first, closing #668 and #720. (#1833 cites #668 / #720 as the origin; they are the issues #1503 fixed, not when capture landed.) `docs-lab/reference/skills.md:64` already described this correctly. The other pages did not.

The claim appeared in two shapes:

| Shape | Example | Where |
|---|---|---|
| Capability denial | "Explore creates no artifacts and writes no code." | the 6 lines named in #1833 |
| Timing claim | "…into a concrete plan before any artifact exists." | 10 more lines |

The timing form reads as ordinary pitch copy rather than a capability claim, which is why it survived the first pass. Both leave a reader believing explore cannot write.

Two further defects found while fixing this:

- `docs/explore.md` said capture is "the same result as handing off" to propose. It isn't. Propose writes the set your schema requires for implementation, minus conditional artifacts like `design.md` and anything `skip_specs` excludes (`propose.ts:122-126`); capture writes only what you named.
- The `/opsx:explore` example answered "can we start a change for that?" with "Run `/opsx:propose add-jwt-auth` to begin" — which the template forbids: "Capture the artifact(s) the user requested **without asking them to invoke another workflow command**" (`explore.ts:155`).

## How it was fixed

Every site carries one guarantee, worded the same way:

> It never writes code, and writes nothing else unless you ask, or say yes when it offers.

Four of the rewritten sites originally described only the user-initiated trigger, which left the offer path — `explore.ts:143-146`, the path a reader actually hits — looking like it didn't exist. A reader who internalizes "unless *you* ask" and then says yes to an offer reproduces the exact confusion this PR exists to fix.

`docs/explore.md` and `docs/commands.md` gain a positive description of capture where the denial used to sit: what it writes, what scaffolding creates *beyond* what you named (`.openspec.yaml`, and `openspec/specs/`, `changes/archive/`, or a `config.yaml` if the project lacks them — `change-utils.ts:186-200`), and how it differs from handing off. The example now shows the offer path, whose confirmation choreography is identical before and after #1832.

The wording is deliberately true both before and after [#1832](https://github.com/Fission-AI/OpenSpec/pull/1832): it never claims a *separate* confirmation prompt, which is what that PR removes.

## Replication / proof

`test/explore-docs-claims.test.ts` sweeps the eleven pages that pitch explore for the phrasings that carried the claim. On `main` it fails with all sixteen:

```
README.md:144: "before anything is written"          docs/explore.md:110: "before any artifact"
docs/README.md:14: "before any artifact"             docs/faq.md:53: "before any change"
docs/commands.md:81: "before any change"             docs/getting-started.md:29: "before any artifact"
docs/commands.md:129: "No artifacts"                 docs/glossary.md:49: "no artifacts"
docs/examples.md:71: "no artifacts"                  docs/overview.md:59: "before any artifact"
docs/explore.md:3: "before a single artifact"        docs/workflows.md:143: "no artifacts"
docs/explore.md:33: "- Create a change folder"       docs/workflows.md:496: "before you create artifacts"
docs/explore.md:34: "Write any artifacts"            docs-lab/start/quickstart.md:30: "no files"
```

Clean on this branch, and probed against 19 hand-written cases — 10 correct conditional phrasings that must pass, 9 absolute ones that must fail — with no false results in either direction. CI is green on linux, macOS, and Windows.

It is a flat list, not a grammar for the claim, and that was a measured decision. An earlier draft built the grammar: section splitting, code-fence tracking, and a conditional-marker exemption so "creates no artifacts unless you ask" would pass. Against realistic prose it was imprecise in **both** directions — it flagged correct sentences like "it does not create a change folder on its own", and the exemption laundered absolute claims joined by a semicolon — while returning the same verdict on the real input. The list has no exemption logic to get wrong and any maintainer can extend it. Phrasings that are only wrong in the absolute ("writes nothing", "creates nothing") are left to review, since the conditional form of each is the wording the failure message recommends.

## Notes / nits

- **This edits `docs/`, which the charter freezes.** `docs-lab/README.md` ("Old docs"): *"Until it's removed it stays untouched: fixes land in docs-lab, never in `docs/`."* I'm proposing an exception, not overlooking the rule: `README.md:158-170` still routes every reader into `docs/explore.md`, `getting-started.md`, `faq.md`, `overview.md` and `commands.md`, so the false claim is live there; and `docs-lab/guides/explore.md` is a headings-only skeleton held back from the site, so docs-lab has nowhere to put the long-form correction. #1833 asks for both trees for this reason. Happy to cut the `docs/` half if you'd rather it wait for the rewrite.
- No changeset: documentation-only, matching #1767 and #1739 (both docs-only, neither carries one).
- `docs-lab/reference/glossary.md:18` ("Writes no code") and `src/core/templates/workflows/onboard.ts:542` ("no code changes") are accurate and untouched.
- `src/core/templates/workflows/explore.ts` and `skills/openspec-explore/SKILL.md` were already correct — no template, skill, or parity-hash changes, so nothing to regenerate.
- Swept for survivors across `src/`, `skills/`, `schemas/`, `openspec/specs/`, `website/`, and CLI help text. All clean; no committed spec asserts the claim as a requirement.
- CodeRabbit asked the docs to describe a separate confirmation step before any capture write. Not adopted, [with reasoning on the thread](https://github.com/Fission-AI/OpenSpec/pull/1838#discussion_r3981726414): that flow is what `main` says today but is exactly what #1832 removes. Its other findings are fixed.

Closes #1833

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that Explore never writes code and only captures planning content when explicitly requested or approved.
  * Documented on-demand change scaffolding and selective planning artifact capture.
  * Updated Explore descriptions and examples across the guides, FAQ, glossary, and workflows.

* **Tests**
  * Added documentation checks for accurate Explore capabilities and capture guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->