### PR TITLE
fix(update-change): draft the requested edit in step 4, write in step 5

### DIFF
--- a/.changeset/update-change-step-4-drafts.md
+++ b/.changeset/update-change-step-4-drafts.md
@@ -1,0 +1,5 @@
+---
+'@fission-ai/openspec': patch
+---
+
+Fix the update-change workflow contradicting its own confirmation gate. Step 4 said to apply the requested edit while step 5 said to write only after the user confirms, and "apply" reads as a write verb in that document - step 5 is itself titled "Confirm and apply". Step 4 now drafts the edit and step 5 remains the only write path, so `/opsx:update "the design now uses X"` always shows the revision before writing it. Both delivery surfaces carry the same wording and it is now pinned by tests.

--- a/skills/openspec-update-change/SKILL.md
+++ b/skills/openspec-update-change/SKILL.md
@@ -56,7 +56,7 @@ Revise a change's existing planning artifacts and keep them coherent. Never edit
 
 4. **Read and reconcile**
    - Read the artifact(s) the request touches and the change's other existing artifacts.
-   - Apply the requested edit. Then check every other existing artifact against it - in ANY direction: an edit to a later artifact may require revising an earlier one, not only the other way around. Build order is a useful reading order, not a constraint on which artifacts may be revised.
+   - Draft the requested edit. Then check every other existing artifact against it - in ANY direction: an edit to a later artifact may require revising an earlier one, not only the other way around. Build order is a useful reading order, not a constraint on which artifacts may be revised.
    - Note everything that is now inconsistent, missing, or contradictory.
    - Revise only files that already exist (`existingOutputPaths`). Do NOT create artifacts that don't exist yet, and do NOT invent new files under a glob artifact - note them and point the user to `/openspec-continue-change` to create them.
    - If the change is already coherent, say so and make no edits.

--- a/src/core/templates/workflows/update-change.ts
+++ b/src/core/templates/workflows/update-change.ts
@@ -58,7 +58,7 @@ ${STORE_SELECTION_GUIDANCE}
 
 4. **Read and reconcile**
    - Read the artifact(s) the request touches and the change's other existing artifacts.
-   - Apply the requested edit. Then check every other existing artifact against it - in ANY direction: an edit to a later artifact may require revising an earlier one, not only the other way around. Build order is a useful reading order, not a constraint on which artifacts may be revised.
+   - Draft the requested edit. Then check every other existing artifact against it - in ANY direction: an edit to a later artifact may require revising an earlier one, not only the other way around. Build order is a useful reading order, not a constraint on which artifacts may be revised.
    - Note everything that is now inconsistent, missing, or contradictory.
    - Revise only files that already exist (\`existingOutputPaths\`). Do NOT create artifacts that don't exist yet, and do NOT invent new files under a glob artifact - note them and point the user to \`/opsx:continue\` to create them.
    - If the change is already coherent, say so and make no edits.
@@ -149,7 +149,7 @@ ${STORE_SELECTION_GUIDANCE}
 
 4. **Read and reconcile**
    - Read the artifact(s) the request touches and the change's other existing artifacts.
-   - Apply the requested edit. Then check every other existing artifact against it - in ANY direction: an edit to a later artifact may require revising an earlier one, not only the other way around. Build order is a useful reading order, not a constraint on which artifacts may be revised.
+   - Draft the requested edit. Then check every other existing artifact against it - in ANY direction: an edit to a later artifact may require revising an earlier one, not only the other way around. Build order is a useful reading order, not a constraint on which artifacts may be revised.
    - Note everything that is now inconsistent, missing, or contradictory.
    - Revise only files that already exist (\`existingOutputPaths\`). Do NOT create artifacts that don't exist yet, and do NOT invent new files under a glob artifact - note them and point the user to \`/opsx:continue\` to create them.
    - If the change is already coherent, say so and make no edits.

--- a/test/core/templates/skill-templates-parity.test.ts
+++ b/test/core/templates/skill-templates-parity.test.ts
@@ -61,8 +61,8 @@ const EXPECTED_FUNCTION_HASHES: Record<string, string> = {
   getOpsxProposeSkillTemplate: 'b7215583fefddae0127076465de9b3de9c230f2f1ea9ae6e4fb2a46fe510e8d6',
   getOpsxProposeCommandTemplate: 'f016c66c2b6115b459751154c76a6270e444d6aee31973bb7cb8c0e6d505fb98',
   getFeedbackSkillTemplate: 'dabeb5e825b9349abc8156c3e7b8608f27987912a6d9bf47ef29addde6138133',
-  getUpdateChangeSkillTemplate: '7dc8abc6f64c58bf34d7581ed4ab095a3b7a53cb372349bee2d840db58622819',
-  getOpsxUpdateCommandTemplate: 'e2388521b22f92f74561df9a0c2f98e1fa4d265af93b5ba26f42fb47a6c5bfed',
+  getUpdateChangeSkillTemplate: 'af3c7dca6aeab8b3dfe54789f8d1570be564053d50749022091e1def59ffb9c3',
+  getOpsxUpdateCommandTemplate: '7808077fca5bc5985d463c3b3ef9235d4f1088c09417ab6258e5daad37701c89',
 };
 
 const EXPECTED_GENERATED_SKILL_CONTENT_HASHES: Record<string, string> = {
@@ -77,7 +77,7 @@ const EXPECTED_GENERATED_SKILL_CONTENT_HASHES: Record<string, string> = {
   'openspec-verify-change': 'af9be013dcbe8c6d8f6d9ab10c893fbd03f4c62933c384d82f63894dd0ceb84f',
   'openspec-onboard': 'f6f59476acaf5e4d65dbb180da4cef62432612f3cecf207d471a951295e2003a',
   'openspec-propose': '679d0f868bed23cfb34a8ecc6b4ba4ff7b88dd7dbaef91563423e98f194f988f',
-  'openspec-update-change': '586547406aca94422dfeb3ffedce6c01049429b743f57ce829baa79ebc714d51',
+  'openspec-update-change': 'bd16c9ea9a8ade956f97a5a6390402c87c642a6d459bb186f991cc1d57554179',
 };
 
 // Intentionally excludes getFeedbackSkillTemplate: this list only models templates

--- a/test/core/templates/update-change.test.ts
+++ b/test/core/templates/update-change.test.ts
@@ -118,4 +118,34 @@ describe('update-change templates', () => {
       expect(newRecommendation, label).toBeGreaterThan(newAvailabilityCheck);
     }
   });
+
+  // Regression for #1836: step 4 said "Apply the requested edit" while step 5
+  // said "Write only after the user confirms". "Apply" reads as a write verb in
+  // this document - step 5 is itself titled "Confirm and apply" - so the same
+  // request either wrote immediately or showed the revision first, depending on
+  // which passage the agent weighed. Step 5 is the only write path; step 4
+  // drafts.
+  it('keeps step 4 non-writing so step 5 owns the only write (#1836)', () => {
+    for (const [label, body] of bodies) {
+      const start = body.indexOf('4. **Read and reconcile**');
+      const end = body.indexOf('5. **Confirm and apply, one artifact at a time**');
+
+      expect(start, label).toBeGreaterThanOrEqual(0);
+      expect(end, label).toBeGreaterThan(start);
+
+      const step = body.slice(start, end);
+      expect(step, label).toContain('Draft the requested edit.');
+      expect(step, label).not.toContain('Apply the requested edit');
+    }
+  });
+
+  it('orders the draft before the confirmed write (#1836)', () => {
+    for (const [label, body] of bodies) {
+      const draft = body.indexOf('Draft the requested edit.');
+      const confirmedWrite = body.indexOf('Write only after the user confirms.');
+
+      expect(draft, label).toBeGreaterThanOrEqual(0);
+      expect(confirmedWrite, label).toBeGreaterThan(draft);
+    }
+  });
 });


### PR DESCRIPTION
Fixes #1836.

## What was wrong

`update-change` stated its write gate twice and then contradicted it a step earlier, with nothing saying which governs.

Step 5, **"Confirm and apply, one artifact at a time"**:

> - Show each proposed revision and why. **Write only after the user confirms.**

Guardrails:

> - Confirm every edit with the user before writing.

Step 4, **"Read and reconcile"**:

> - **Apply the requested edit.** Then check every other existing artifact against it…

"Apply" reads as a write verb in this document — step 5 is itself titled "Confirm and **apply**", and step 4's closing bullet ("If the change is already coherent, say so and **make no edits**") only parses if step 4 is the editing stage. So `/opsx:update "the design now uses X"` either wrote immediately or stopped and showed the revision first, depending on which passage the agent weighed. Step 5 is the workflow's only write path, so its confirmation guarantee was unenforceable whenever step 4 governed.

Same shape as #1828: a guarantee stated in one part of the body, contradicted by an instruction earlier in the same body.

## The fix

`Apply` → `Draft` in step 4, on both delivery surfaces (`update-change.ts:61` skill, `:152` command) and the committed skill. Step 5 keeps the write. One word; the fix @clay-good named in the issue.

I looked at also rewording step 4's `Revise only files that already exist` for the same reason and left it alone: it constrains *which* files may ever be revised rather than telling the agent to revise now, and it is the scope rule step 5 applies. Widening the diff there would change guidance the issue did not report.

## Verification

- New regression tests on each surface: step 4 contains `Draft the requested edit.` and not `Apply the requested edit`, and the draft precedes `Write only after the user confirms.`
- Negative check: reverting `Draft` → `Apply` in `src/` fails both new tests (2 failed | 7 passed) and passes again with the fix. The contract was unpinned before this PR.
- `pnpm lint` clean. Full suite: 4563 passed, `test/core/completion-tip.test.ts` 2 failed — pre-existing, reproduced on clean `upstream/main` with my changes stashed. Unrelated to this change.
- Parity hashes regenerated via `pnpm regen:parity-hashes`; `skills/` regenerated via `pnpm generate:skills`.

## One correction to the issue

> Also: `test/core/templates/` has **no** `update-change.test.ts`, so nothing pins this contract on either delivery surface.

`test/core/templates/update-change.test.ts` does exist on `main` (121 lines). The second half of the claim holds though — it asserts `Write only after the user confirms` but never that step 4 is non-writing, so the contradiction passed its checks. The new cases are appended to that file rather than to a new one.

Guidance-only; no CLI behavior changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the change-update workflow so requested edits are drafted and reviewed before writing.
  - Ensured the confirmation step remains the only point where changes are applied.

- **Tests**
  - Added regression coverage to verify draft-before-write behavior and instruction ordering.
  - Updated template consistency checks for the revised workflow guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->