### PR TITLE
feat(validate): let a MODIFIED block declare a renamed scenario

### DIFF
--- a/openspec/changes/add-scenario-rename-declaration/.openspec.yaml
+++ b/openspec/changes/add-scenario-rename-declaration/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-10

--- a/openspec/changes/add-scenario-rename-declaration/design.md
+++ b/openspec/changes/add-scenario-rename-declaration/design.md
@@ -1,0 +1,119 @@
+# Design
+
+## The decision this change makes
+
+#1697 asked two questions before anyone wrote code, and both are answered here.
+
+**Q1: is an explicit scenario-level operator the direction?** Yes, and this
+change proposes the spelling. The alternatives are recorded below.
+
+**Q2: should it also cover `REMOVED Scenario`?** Not here. See "Deliberately out
+of scope".
+
+## Why the declaration is a bullet inside the block, not a `####` header
+
+The follow-up comment on #1697 suggested `#### RENAMED Scenario` with `FROM:`/
+`TO:` bullets beneath it. **That spelling cannot work**, and the reason is worth
+stating because it is the kind of thing that looks fine until the guard's
+arithmetic is wrong:
+
+`parseScenarioBlocks` counts EVERY non-fenced level-4 header as a scenario, on
+purpose — the spec path's `countScenarios` does, so the delta path must, or a
+`#### Edge case` dropped by a `MODIFIED` block slips past the loss check
+(#1521, and `SCENARIO_HEADER`'s own comment warns against breaking that
+parity). A `#### RENAMED Scenario` heading would therefore enter the comparison
+as a scenario in its own right: the block gets credited with a scenario nobody
+wrote, and `findMissingCurrentScenarios` starts answering a question about the
+wrong set. A bullet cannot collide with it.
+
+So the declaration is `#1697`'s own "Suggested fix" option 1, unchanged:
+
+```markdown
+- RENAMED SCENARIO FROM: `#### Scenario: Old title`
+- RENAMED SCENARIO TO: `#### Scenario: New title`
+```
+
+## Why inside the requirement block, rather than a top-level section
+
+A `## RENAMED Scenarios` section parallel to `## RENAMED Requirements` was the
+other option #1793 offered. Two things decide against it:
+
+1. **A scenario title is only unique within its requirement.** A top-level
+   section must name the requirement for context, making every declaration a
+   three-line form. Inside the block, the context IS the block.
+2. **It would put the declaration on the wrong side of the parity seam.**
+   `findMissingCurrentScenarios(current, incoming)` is the ONE function archive
+   and validate share, exactly so the two cannot disagree about what counts as
+   a dropped scenario (#1477). A declaration carried in the block is readable
+   from `incoming.raw`, so both commands get it from the function they already
+   both call, with no new argument and no plumbing at either call site. A
+   top-level section would have to be threaded from `DeltaPlan` through both
+   paths, and any caller that missed the new argument would silently lose the
+   declaration — reopening precisely the validate/archive divergence #1477
+   closed.
+
+## Why a declaration is a claim, not a suppression
+
+The stated successor must be a scenario in the same block. Without that check
+the declaration would be a blanket `ignore this title`, and #1697's replay data
+is unambiguous that the guard is catching real losses (4 caught by hand at
+archive time, 2 shipped and repaired later). Requiring the successor means a
+declaration can only ever say "this old title is now that new one", and the new
+one has to be there to say it.
+
+Consequences, all deliberate:
+
+- **No credit without a successor.** A declaration naming an absent successor
+  grants nothing, so the omission is still reported as a loss. The author gets
+  both findings: the loss, and the reason the declaration did not answer it.
+- **One instance per declaration.** Credit is multiplicity-aware like every
+  other name in the comparison, so two instances of a title and one declaration
+  still leaves one unaccounted for — a duplicate cannot hide a real loss behind
+  a single declaration (#1246 / #1391).
+- **Read from the incoming block only.** A declaration is never read out of the
+  current spec. One that survived into canon would otherwise become a standing
+  exemption for that title, which is the loophole the guard exists to refuse.
+  (It cannot survive into canon anyway — see the strip below — but the parser
+  does not rely on that.)
+- **Merges are allowed.** Several declarations MAY name one successor: two
+  scenarios superseded by a single narrower one. That is the shape both
+  reporters described (#1793's house marker is literally spelled "Merged
+  into"), so it is permitted rather than special-cased.
+- **Unpaired halves are reported.** A `FROM:` with no `TO:`, or a `TO:` with no
+  `FROM:`, is an error. #1806 found the requirement-level parser silently
+  dropping unpaired halves, so a requested rename never happened while archive
+  reported success; the same shape is refused here from the start rather than
+  discovered later.
+
+## Why the declaration does not land in the main spec
+
+A main spec is what deltas merge INTO, and it never carries delta operation
+markers — the sync guidance states this. The declaration is change-scoped
+bookkeeping: leaving it behind would accrete one line per rename in the spec
+forever and hand the next author a marker to copy forward into their own
+`MODIFIED` block.
+
+It is stripped before the "already in sync" comparison as well as before the
+write, so re-archiving a change whose only edit was a declared rename is a
+no-op rather than a whitespace rewrite.
+
+## Deliberately out of scope
+
+- **`REMOVED Scenario`** (#1697 Q2). A deliberate deletion is the other half of
+  the "declare the omission" problem — 7 of the 26 hand-classified findings —
+  but it is a strictly larger semantic: a rename requires a successor and
+  authorizes no loss, while a removal authorizes loss and needs its own
+  justification and probably its own reason text. Folding it in here would ship
+  the loss-authorizing operator on the rename's evidence.
+- **Scenario ids.** One corpus prefixes headings with `[cap-NNN]` and renumbers
+  them in bulk (14 in one pass), which reads as a drop for the same reason. Each
+  renumber is expressible as a declaration, but a first-class scenario identity
+  would be a much larger format change (`ScenarioSchema` is `{ rawText }` and
+  has no name field at all) and is not proposed here.
+- **The stale-base class** (#1112 and #1697's 4 findings). Still blocked, and
+  correctly: the remedy is reconciling against the current base.
+- **Reporting the counts and added names when the guard fires** — #1809, open
+  and independent. It prints facts and draws no conclusion; this change adds the
+  declaration that lets an author state one. Neither needs the other. The two
+  touch `findMissingCurrentScenarios`; this change leaves its signature and
+  return type alone to keep the overlap textual rather than semantic.

--- a/openspec/changes/add-scenario-rename-declaration/proposal.md
+++ b/openspec/changes/add-scenario-rename-declaration/proposal.md
@@ -1,0 +1,125 @@
+## Why
+
+A `MODIFIED` requirement replaces its whole block, so the loss guard refuses one
+that omits a scenario the main spec still has. That guard is right, and four
+merged PRs have hardened it (#1246/#1391 multiplicity, #1475 fences, #1521 every
+level-4 header). But it compares scenario TITLES, so a deliberate **rename** is
+indistinguishable from an accidental **drop**, and the only edit that satisfies
+it is restoring the old title — reverting the change where the rename was the
+point.
+
+Two reports, two corpora:
+
+- **#1697** — renaming a scenario heading while keeping the requirement is
+  impossible. Six workarounds tried; the ones that work either keep a heading
+  that no longer describes the scenario, or disable every other check with
+  `archive --no-validate`. Where a project names its tests after scenario
+  headings, the heading is the traceability key, not decoration.
+- **#1793** — the narrowed successor CONTRADICTS its predecessor, so "just keep
+  both scenarios" puts two conflicting statements in one requirement block. That
+  reporter runs the CLI digest-pinned and reconciles `--json` findings against a
+  written per-finding disposition list, which works and is strictly worse than
+  the check being able to read the declaration: the exception lives in their
+  wrapper, invisible to anyone reading the delta, re-derived at every upgrade.
+
+A replay over 75 archived changes in a third corpus (#1697) measured **29 of 75
+changes blocked, 99 findings, every detection correct** — and of the 26 findings
+hand-classified, **16 (62%) were intended omissions**. The guard is earning its
+keep: 4 were real losses a human caught at archive time and 2 shipped and needed
+repair by a later change. So the ask is not weaker detection. It is a way to
+STATE INTENT, because intent is not recoverable from structure — one block in
+that corpus produced 6 findings against one requirement, 2 renames and 4
+accidents, identical in scenario count, heading and id presence.
+
+There is already precedent for an author-declared exclusion in this very check:
+a `MODIFIED` whose requirement is renamed away by `## RENAMED Requirements` in
+the same delta is skipped (`renamedAway`). What is missing is the same
+affordance one level down, at the scenario.
+
+## What Changes
+
+- **A `MODIFIED` requirement block MAY declare a scenario rename**, written one
+  level down from `## RENAMED Requirements` and inside the block it applies to:
+
+  ```markdown
+  ### Requirement: Full car park refuses entry
+  The system SHALL refuse entry when no bay is free, unless the driver holds a permit.
+
+  - RENAMED SCENARIO FROM: `#### Scenario: Car arrives at a full car park`
+  - RENAMED SCENARIO TO: `#### Scenario: Car without a permit arrives at a full car park`
+
+  #### Scenario: Car without a permit arrives at a full car park
+  - **WHEN** a car arrives, no bay is free, and the driver holds no permit
+  - **THEN** entry is refused
+  ```
+
+- **A declaration accounts for the old title; it does not suppress the check.**
+  The stated successor must really be a scenario in the same block. Where it is
+  not, no credit is granted, the omission is still reported as the loss it is,
+  and the unbacked declaration is reported as well.
+- **Every declaration is paired or reported.** An unpaired `FROM:` or `TO:` is
+  an error rather than a silent no-op — the class #1806 found in the
+  requirement-level parser, where a dropped half meant a requested rename never
+  happened while archive reported success.
+- **`validate` and `archive` agree**, sharing both the comparison and the
+  sentence, so a declaration accepted at authoring time cannot be refused at
+  archive time (the parity `findMissingCurrentScenarios` exists for, #1477).
+- **The declaration does not land in the main spec.** It is delta bookkeeping,
+  and a main spec never carries delta operation markers.
+
+### What this deliberately does NOT change
+
+- **Detection is untouched.** An UNDECLARED omission is reported exactly as
+  today, at the same level, with the same message and exit code. Every existing
+  test passes unmodified.
+- **The stale-base class stays blocked.** A delta authored before a sibling
+  change added a scenario still errors, which is correct: the remedy there is to
+  reconcile against the current base, not to declare an intent the author never
+  had. #1697's replay separates that class (4 of 26) precisely because its
+  remedy differs.
+- **No `REMOVED Scenario` operator.** Deliberately dropping a scenario is the
+  other half of "declare the omission" (#1697's open question 2), and it is a
+  strictly larger semantic: a rename REQUIRES a successor and authorizes no
+  loss, whereas a removal authorizes loss and needs its own justification. It
+  should be decided on its own evidence, not folded in here.
+- **No new flag, no config, no severity knob.** #1793 offers per-finding
+  suppression and a severity knob as fallbacks and calls them weaker; both move
+  intent out of the delta, which is the thing that matters.
+- **No inference.** Nothing looks at scenario bodies to guess whether two
+  titles are "the same" behaviour. That is what the hardening PRs closed.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `openspec-conventions`: the delta format gains a scenario-level rename
+  declaration carried inside a `MODIFIED` requirement block, and states that
+  the declaration is stripped when the block lands in the main spec.
+- `cli-validate`: the dropped-scenario check accounts for a declared rename
+  whose successor is present, and reports a declaration that is unpaired or
+  whose successor is absent.
+
+## Impact
+
+- **Affected specs:** `openspec-conventions` (1 added requirement),
+  `cli-validate` (1 modified, 1 added requirement).
+- **Affected code:**
+  - `src/core/parsers/requirement-blocks.ts` — the declaration parser, the
+    integrity check, the shared message, the strip, and the credit seeded into
+    `findMissingCurrentScenarios`. Its signature and return type are unchanged.
+  - `src/core/validation/validator.ts` — report declaration problems.
+  - `src/core/specs-apply.ts` — refuse them, and strip declarations from the
+    block that lands in the spec.
+- **Risk:** low. The declaration is opt-in and lexically new, so no existing
+  delta can accidentally contain one; a corpus that writes none behaves
+  identically. The one behaviour change for existing deltas is that a
+  `MODIFIED` block containing a line that begins `RENAMED SCENARIO FROM:` or
+  `TO:` is now read as a declaration rather than prose.
+
+## Issues addressed
+
+- [#1697](https://github.com/Fission-AI/OpenSpec/issues/1697) — cannot rename a
+  scenario; `MODIFIED` reads a rename as a dropped scenario and blocks archive.
+- [#1793](https://github.com/Fission-AI/OpenSpec/issues/1793) — the
+  scenario-currency check has no way to declare a deliberate scenario rename, so
+  a narrowing reads as an omission.

--- a/openspec/changes/add-scenario-rename-declaration/specs/cli-validate/spec.md
+++ b/openspec/changes/add-scenario-rename-declaration/specs/cli-validate/spec.md
@@ -1,0 +1,66 @@
+## MODIFIED Requirements
+
+### Requirement: Change validation SHALL report scenarios a MODIFIED block would drop
+
+The `validate` command SHALL compare every `MODIFIED` requirement in a change against the main specs and report, as an error naming the delta file, each scenario the main spec still has that the `MODIFIED` block omits and does not declare renamed. A `MODIFIED` requirement replaces the whole requirement block, so archive refuses to apply one that drops a scenario; this is the same check, run without writing anything.
+
+The comparison SHALL match archive's operation order, comparing a `MODIFIED` that names the new header of a rename against the renamed requirement's scenarios.
+
+A scenario the block declares renamed — `RENAMED SCENARIO FROM:`/`TO:`, with the scenario named by `TO:` present in the same block — SHALL be accounted for and not reported. The declaration SHALL be read from the `MODIFIED` block only, never from the main spec, and SHALL account for exactly one instance of the old title. Where the named successor is absent no old title SHALL be accounted for, so the omission is still reported.
+
+The check SHALL be silent when the main spec file or the requirement header is absent, because a `MODIFIED` written against a base that has not landed yet is a separate condition that archive gates. A main spec that exists but cannot be read SHALL be reported instead, since archive fails on it too.
+
+Validation run inside `openspec archive` SHALL NOT report these issues, because archive enforces the same check when it applies the deltas.
+
+#### Scenario: MODIFIED omits an existing scenario
+
+- **GIVEN** the main spec's requirement has scenarios "A" and "B"
+- **WHEN** a change MODIFIES that requirement with only scenario "A" and `openspec validate <change>` runs
+- **THEN** report an error naming the delta file and scenario "B"
+- **AND** exit with code 1
+
+#### Scenario: MODIFIED names the new header of a rename
+
+- **GIVEN** the main spec has requirement "A" with scenarios "S1" and "S2"
+- **WHEN** a change renames "A" to "B" and MODIFIES "B" with only scenario "S1"
+- **THEN** report an error naming scenario "S2"
+
+#### Scenario: MODIFIED header is not in the main spec
+
+- **GIVEN** a change MODIFIES a requirement header the main spec does not contain
+- **WHEN** `openspec validate <change>` runs
+- **THEN** do not report a dropped-scenario error for that requirement
+
+#### Scenario: MODIFIED declares the omitted scenario renamed
+
+- **GIVEN** the main spec's requirement has scenario "A"
+- **WHEN** a change MODIFIES that requirement with scenario "B", declaring `RENAMED SCENARIO FROM: A` and `RENAMED SCENARIO TO: B`
+- **THEN** do not report "A" as an omission
+- **AND** `openspec archive` SHALL apply the block
+
+## ADDED Requirements
+
+### Requirement: Change validation SHALL report a scenario rename declaration it cannot back up
+
+The `validate` command SHALL report, as an error naming the delta file and the requirement, each `RENAMED SCENARIO` declaration in a `MODIFIED` block that does not describe a rename the block carries out: a `FROM:` with no `TO:` after it, a `TO:` with no `FROM:` before it, or a `TO:` naming a scenario title the block does not contain. The error SHALL name the declared title and the line within the requirement block.
+
+`openspec archive` SHALL refuse the same block with the same sentence rather than guess at what the declaration meant, so a declaration accepted by `validate` cannot be refused by `archive`.
+
+#### Scenario: Declared successor is not in the block
+
+- **GIVEN** a `MODIFIED` block declaring `RENAMED SCENARIO TO:` a title the block does not contain
+- **WHEN** `openspec validate <change>` runs
+- **THEN** report an error naming that title and saying the block has no scenario with it
+- **AND** `openspec archive` SHALL refuse the block with the same sentence
+
+#### Scenario: Unpaired declaration half
+
+- **GIVEN** a `MODIFIED` block with a `RENAMED SCENARIO FROM:` line and no `RENAMED SCENARIO TO:` after it
+- **WHEN** `openspec validate <change>` runs
+- **THEN** report an error naming the declared title and the line within the requirement block
+
+#### Scenario: A declaration inside a fenced example
+
+- **GIVEN** a `MODIFIED` block whose body documents the declaration syntax inside a fenced code block
+- **WHEN** `openspec validate <change>` runs
+- **THEN** do not treat it as a declaration, and do not report it

--- a/openspec/changes/add-scenario-rename-declaration/specs/openspec-conventions/spec.md
+++ b/openspec/changes/add-scenario-rename-declaration/specs/openspec-conventions/spec.md
@@ -1,0 +1,53 @@
+## ADDED Requirements
+
+### Requirement: Scenario Rename Declaration
+
+A `MODIFIED` requirement block SHALL be able to declare that a scenario the main spec still carries was renamed rather than dropped, so that a deliberate rename is distinguishable from an accidental omission without weakening the omission check.
+
+The declaration is written inside the `MODIFIED` requirement block it applies to, one level down from `## RENAMED Requirements`:
+
+```markdown
+## MODIFIED Requirements
+
+### Requirement: Full car park refuses entry
+The system SHALL refuse entry when no bay is free, unless the driver holds a permit.
+
+- RENAMED SCENARIO FROM: `#### Scenario: Car arrives at a full car park`
+- RENAMED SCENARIO TO: `#### Scenario: Car without a permit arrives at a full car park`
+
+#### Scenario: Car without a permit arrives at a full car park
+- **WHEN** a car arrives, no bay is free, and the driver holds no permit
+- **THEN** entry is refused
+```
+
+The bullet is optional and every CommonMark bullet marker is accepted, matching `## RENAMED Requirements`. The declared name MAY be written as a full `#### Scenario: Title` header, as `Scenario: Title`, or as the bare `Title`, with or without surrounding backticks; all three name the same scenario. A declaration inside a fenced code block declares nothing.
+
+#### Scenario: Declaring a scenario rename
+
+- **WHEN** a `MODIFIED` requirement retitles a scenario the main spec still has
+- **THEN** the block MAY carry a `RENAMED SCENARIO FROM:` line followed by a `RENAMED SCENARIO TO:` line
+- **AND** the old title SHALL be accounted for rather than reported as an omission
+- **AND** the scenario named by `TO:` SHALL be present in the same block
+
+#### Scenario: A declaration whose successor is absent
+
+- **WHEN** a `MODIFIED` block declares a rename to a scenario title the block does not contain
+- **THEN** the declaration SHALL be reported as an error
+- **AND** the old title SHALL still be reported as an omission, because nothing accounted for it
+
+#### Scenario: An unpaired declaration
+
+- **WHEN** a `RENAMED SCENARIO FROM:` line has no `RENAMED SCENARIO TO:` after it, or a `TO:` line has no `FROM:` before it
+- **THEN** it SHALL be reported as an error rather than ignored
+
+#### Scenario: Several scenarios merged into one
+
+- **WHEN** two scenarios are superseded by a single narrower one
+- **THEN** the block MAY carry one declaration per old title, each naming that same successor
+- **AND** each declaration SHALL account for exactly one instance of its old title
+
+#### Scenario: Declarations do not reach the main spec
+
+- **WHEN** a `MODIFIED` block carrying declarations is applied to the main spec
+- **THEN** the declaration lines SHALL NOT appear in the main spec, which never carries delta operation markers
+- **AND** applying the same block again SHALL be recognized as already in sync

--- a/openspec/changes/add-scenario-rename-declaration/tasks.md
+++ b/openspec/changes/add-scenario-rename-declaration/tasks.md
@@ -1,0 +1,55 @@
+# Tasks
+
+## 1. Format
+
+- [x] 1.1 Add the scenario-rename declaration to `openspec-conventions`: the
+      `FROM:`/`TO:` spelling, that it lives inside the `MODIFIED` requirement
+      block, that the successor must be present, and that it is stripped from
+      the block that lands in the main spec.
+- [x] 1.2 Record in `cli-validate` that the dropped-scenario check accounts for
+      a declared rename, and that an unpaired or unbacked declaration is an
+      error. Reproduce the requirement's existing scenarios in the MODIFIED
+      block (none of them is renamed).
+
+## 2. Parser
+
+- [x] 2.1 `parseScenarioRenames(requirementRaw)` in
+      `src/core/parsers/requirement-blocks.ts`: fence-masked, bullet optional,
+      every CommonMark marker, backticks optional, names normalized through the
+      same `scenarioNameAt` every `#### ` header runs through.
+- [x] 2.2 Record every half that never paired instead of dropping it (#1806's
+      class one level up).
+- [x] 2.3 `findScenarioRenameProblems(incoming)` — unpaired halves plus a
+      declared successor the block does not contain. A function of the incoming
+      block alone, so it needs no current spec.
+- [x] 2.4 `describeScenarioRenameProblem(problem)` — one shared sentence, so
+      validate and archive cannot describe the same declaration differently.
+- [x] 2.5 Seed `findMissingCurrentScenarios` with one credit per declaration
+      whose successor is present. Signature and return type unchanged.
+- [x] 2.6 `stripScenarioRenameDeclarations(requirementRaw)` — fence-aware, and
+      it removes the blank line the declaration left behind so a block with no
+      declaration comes out byte-identical.
+
+## 3. Commands
+
+- [x] 3.1 `validate`: report each declaration problem as an ERROR naming the
+      delta file, after the `renamedAway` skip so a block already reported for
+      naming an old requirement header is not complained about twice.
+- [x] 3.2 `archive`: refuse a block whose declaration it cannot back up, before
+      the loss check, with the same sentence validate prints.
+- [x] 3.3 `archive`: write the block with its declarations stripped, and strip
+      before the "already in sync" comparison too.
+
+## 4. Tests
+
+- [x] 4.1 Parser unit tests: pairing, the three accepted name forms, every
+      bullet marker, fence masking, unpaired halves, absent successor,
+      multiplicity, merge, a declaration in the CURRENT spec ignored, and the
+      strip (including byte-identity for a block with none).
+- [x] 4.2 Parity tests through both commands on both reported reproductions:
+      accepted and applied, the declaration absent from the written spec,
+      already-in-sync on a second archive, and refused in both commands for an
+      absent successor and an unpaired `FROM:`.
+- [x] 4.3 Regression: an UNDECLARED omission still reported, and only the
+      undeclared one when a declared rename sits beside it.
+- [x] 4.4 Full suite green with no existing test modified.


### PR DESCRIPTION
Refs #1793, #1697 — this is a proposal, not a fix, so it does not close either issue itself (see "Process note").

This answers #1697's **Q1** ("is an explicit scenario-level operator the
direction?") with a concrete spelling and design rationale. Its **Q2** (should
it also cover `REMOVED Scenario`?) is deliberately left open — see "Deliberately
out of scope" in `design.md` — so that issue should stay open for it.

## Process note, read this first

Per CONTRIBUTING §2 this is a format change ("anything that changes OpenSpec's
architecture needs an OpenSpec change proposal first... Open it as a PR
containing only `openspec/changes/<name>/` and wait for it to be approved
before you write the code"), so **this PR contains only
`openspec/changes/add-scenario-rename-declaration/`** — `proposal.md`,
`design.md`, `tasks.md`, and the two delta specs.

The implementation is written and tested — `tasks.md` is checked off — but it
is deliberately **not** in this PR. It sits on a separate branch in my fork,
ready to open as its own PR the moment the format is agreed:

https://github.com/Fission-AI/OpenSpec/compare/main...brettheap:OpenSpec:fix/scenario-rename-declaration-impl

That link is a read-only diff for reviewers who want to see the shape of the
code before ruling on the format — not a request to review code in this PR.

## What

A `MODIFIED` requirement block may declare that a scenario the main spec still
carries was **renamed**, not dropped:

```markdown
## MODIFIED Requirements

### Requirement: Full car park refuses entry
The system SHALL refuse entry when no bay is free, unless the driver holds a permit.

- RENAMED SCENARIO FROM: `#### Scenario: Car arrives at a full car park`
- RENAMED SCENARIO TO: `#### Scenario: Car without a permit arrives at a full car park`

#### Scenario: Car without a permit arrives at a full car park
- **WHEN** a car arrives, no bay is free, and the driver holds no permit
- **THEN** entry is refused
```

That is #1697's own "Suggested fix" option 1, unchanged.

## Why

The loss guard compares scenario TITLES, so a deliberate rename is
indistinguishable from an accidental drop and the only edit that satisfies it is
restoring the old title — reverting the change where the rename was the point.
#1793 is the sharper form: there the narrowed successor **contradicts** its
predecessor, so "just keep both scenarios" puts two conflicting statements in one
requirement block.

The precedent for the fix is inside this very check: a `MODIFIED` whose
requirement is renamed away by `## RENAMED Requirements` in the same delta is
already skipped (`renamedAway`). This is that affordance one level down.

**Detection is not weakened, and that was the design constraint.** @johnmcarbajal's
replay over 75 archived changes (quoted in full in `proposal.md`) found the guard
catching real losses — 4 caught by hand at archive time, 2 shipped and repaired
by a later change — so this adds no inference and no suppression. An UNDECLARED
omission is reported exactly as today, at the same level, with the same message
and exit code.

## Shape

**A declaration is a claim, not a suppression.** The scenario named by `TO:` must
really be in the block. Where it is not, no credit is granted, the omission is
still reported as the loss it is, and the unbacked declaration is reported too.
So a declaration can only ever say "this old title is now that new one", and the
new one has to be there to say it.

- **Multiplicity-aware**, like every other name in the comparison: one credit per
  declaration, so two instances of a title and one declaration still leaves one
  unaccounted for. A duplicate cannot hide a loss behind a single declaration
  (#1246 / #1391).
- **Fence-aware** on both halves, inherited from the same mask (#1475), so an
  example documenting the syntax declares nothing.
- **Read from the incoming block only.** A declaration is never read out of the
  current spec; one that survived into canon would otherwise be a standing
  exemption for that title.
- **Merges are allowed** — several declarations may name one successor (two
  scenarios superseded by a single narrower one), which is the shape both
  reporters described.
- **Unpaired halves are errors**, not silent no-ops — the class #1806 found in
  `parseRenamedPairs`, where a dropped half meant a requested rename never
  happened while archive reported success.
- **`validate` and `archive` share the comparison AND the sentence**, so a
  declaration accepted at authoring time cannot be refused at archive time
  (the parity `findMissingCurrentScenarios` exists for, #1477).
- **The declaration does not land in the main spec.** A main spec is what deltas
  merge INTO and carries no delta operation markers — the sync guidance says so
  in those words. It is stripped before the "already in sync" comparison as well
  as before the write, so re-archiving a change whose only edit was a declared
  rename is a no-op rather than a whitespace rewrite.

`findMissingCurrentScenarios` keeps its signature and its return type; the
declaration enters as extra credit seeded into the tally it already builds. That
is deliberate — #1809 is open on the same function, and this keeps the overlap
textual rather than semantic.

## Why NOT `#### RENAMED Scenario`

The follow-up comment on #1697 suggested a `#### RENAMED Scenario` heading with
`FROM:`/`TO:` bullets under it. **That spelling cannot work**, and the reason is
worth stating because it looks fine right up until the guard's arithmetic is
wrong: `parseScenarioBlocks` counts EVERY non-fenced level-4 header as a
scenario, on purpose, because the spec path's `countScenarios` does and the two
must agree (#1521 — `SCENARIO_HEADER`'s own comment warns against breaking that
parity). A `#### RENAMED Scenario` heading would therefore enter the comparison
as a scenario in its own right: the block gets credited with a scenario nobody
wrote. A bullet cannot collide with it.

## Alternatives considered

| Option | Why not |
|---|---|
| Top-level `## RENAMED Scenarios` section (#1793's first ask) | A scenario title is only unique within its requirement, so every declaration needs a third line naming the requirement. Worse, it lands on the wrong side of the parity seam: it would have to be threaded from `DeltaPlan` into both commands, and a caller that missed the new argument would silently lose the declaration — reopening the validate/archive divergence #1477 closed. Inside the block, both commands read it from the one function they already share. |
| A recognized in-block prose marker (#1793's reported workaround form) | Same seam, and it works, but it reads as prose: nothing distinguishes a declaration from a sentence that happens to be phrased that way, and it has no natural place to carry the successor's title as a checkable field. The reporter explicitly said they were not asking for their own spelling. |
| Per-finding suppression in `openspec/config.yaml` (#1793's second ask) | Moves intent out of the delta and into project config, which is the thing #1793 says makes their current workaround worse than the fix. The reporter ranks it below the operator. |
| A severity knob for this one check (#1793's third ask) | The reporter calls it the weakest option and mentions it only for completeness. It turns a specific judgment into a blanket one. |
| Infer a rename from scenario bodies | #1697's replay settles it: one block produced 6 findings against one requirement, 2 renames and 4 accidents, identical in count, heading and id presence. Intent is not recoverable from structure. This is what the hardening PRs closed. |
| `REMOVED Scenario` in the same change (#1697 Q2) | A strictly larger semantic: a rename requires a successor and authorizes no loss; a removal authorizes loss and needs its own justification. Shipping it on the rename's evidence would be the wrong trade. Left open. |

## Scope and safety

- Opt-in and lexically new: no existing delta can accidentally contain a
  declaration, so a corpus that writes none behaves identically.
- The one behaviour change for an existing delta is that a line beginning
  `RENAMED SCENARIO FROM:`/`TO:` inside a `MODIFIED` block is now read as a
  declaration rather than prose.
- The **stale-base** class stays blocked, which is correct — its remedy is
  reconciling against the current base, not declaring an intent the author never
  had. #1697's replay separates that class for exactly this reason.
- No new command, flag, config key, or output format. No exit code changes for
  any input that validates today.

## Tests (already written, on the linked branch)

- `test/core/parsers/requirement-blocks.test.ts` — 18 added: pairing, the three
  accepted name forms, every CommonMark bullet marker, fence masking, unpaired
  halves, absent successor, multiplicity, merge, a declaration in the CURRENT
  spec ignored, and the strip (including byte-identity for a block with none).
- `test/core/validation.scenario-rename.test.ts` — 7 added, both reported
  reproductions driven through **both** commands: accepted and applied, the
  declaration absent from the written spec, already-in-sync on a second archive,
  and refused by both for an absent successor and for an unpaired `FROM:`.
- **No existing test assertion changed.** Three golden hashes in
  `test/core/templates/skill-templates-parity.test.ts` are updated, because that
  guard pins template payloads byte-for-byte and the guidance edit (documenting
  that the declaration must not be copied into a main spec) is a deliberate
  content change — no assertion logic touched.

I ran the full toolchain myself on the implementation branch before opening
this proposal, in two passes:

- `pnpm build`, `pnpm exec tsc --noEmit`, and `pnpm lint` are clean. All 68
  tests in the three files this change touches or adds pass, both inside the
  full run and in isolation:
  `test/core/parsers/requirement-blocks.test.ts` (35), `test/core/validation.scenario-rename.test.ts`
  (7), `test/core/templates/skill-templates-parity.test.ts` (26).
- A first full-suite pass read `Tests 4 failed | 4584 passed (4588)`, all four
  pre-existing and unrelated to this change (two `completion-tip` timing
  assertions, one `file-state` lock-contention timeout, one completion-cache
  TTL test that only fails under full-suite parallel load) — I reproduced the
  identical four on unmodified `origin/main`.
- A second full-suite pass, on a more heavily loaded machine, surfaced
  additional failures — every one a hard `testTimeout`/`hookTimeout` (never an
  assertion) scattered across files this change does not touch (`init`,
  `update`, `store`, `workset`, `doctor`, and others). Rather than wave that
  away, I re-ran the exact same file list against a pristine `origin/main`
  worktree on the same machine and got the same class of failures at a
  comparable rate (e.g. `test/core/archive.test.ts` alone: 4 failed of 241 on
  both trees, different specific tests each run — consistent with scheduler
  contention, not a regression). The one failing file this change actually
  touches, `test/core/specs-apply.security.test.ts`, passes 6/6 in isolation.
  Net: build/typecheck/lint are clean, every test this proposal is responsible
  for is green under any load, and nothing failing is new.
- The repo's own corpus is unaffected: several of this repo's own pending
  `openspec/changes/*` entries already trip the very check this proposal
  extends (a maintainer call on whether to declare those renames, not mine to
  make).

## Notes

- **No changeset**, per `.changeset/README.md`'s default of the normal release
  cadence. Say the word and I will add one on the implementation PR — this is
  user-facing enough that you may well want it release-tracked.
- `skills/openspec-sync-specs/SKILL.md` moves with
  `src/core/templates/workflows/sync-specs.ts` via `pnpm generate:skills` on the
  implementation branch, so the parity test stays green. The guidance change
  matters beyond discoverability: without it an agent following the sync
  workflow would copy the declaration lines into the main spec, which is the one
  thing that guidance says never to do.
- Not related to #843: that changes `MODIFIED` from whole-block replacement to a
  scenario-level merge, which is a different model for a different problem.
  This proposal assumes today's replacement semantics and would need
  re-reading, not reverting, if #843 lands.
- Independent of #1809 (open), which prints the counts and added names when the
  guard fires. That says which file to open; this lets an author state an
  intent. Neither needs the other, and the implementation leaves
  `findMissingCurrentScenarios`'s signature alone so the two do not conflict
  semantically.

## Provenance

Drafted with Claude Code (Anthropic); I reviewed the design and every line of
the implementation, and ran every command above myself before opening this.
