### PR TITLE
docs(community): add openspec-guard

### DIFF
--- a/docs/community.md
+++ b/docs/community.md
@@ -7,6 +7,7 @@ Listed projects are maintained independently. Inclusion does not imply official 
 ## Projects and resources
 
 - **[OpenSpec UI](https://github.com/VeryComplexAndLongName/OpenSpec-UI)**: A standalone web dashboard and VS Code extension for browsing OpenSpec changes, archives, specs, and tasks.
+- **[openspec-guard](https://github.com/guillaume-flambard/openspec-guard)**: CLI and GitHub Action that reports which OpenSpec scenarios are covered by a Vitest or Jest test, without running the tests.
 
 ## Add your project
 


### PR DESCRIPTION
## Motivation

`docs/community.md` invites projects built with or for OpenSpec to add themselves
through a pull request. openspec-guard reads `openspec/specs` and reports which
scenarios have a test in front of them, which is squarely "supporting its use".

## What it does

- Adds one entry under "Projects and resources", in the existing format.

## Proof it works

- The entry follows the file's rules: a direct link, a description of what people
  can use, no promotional claim, no referral or tracking link. MIT, no paid
  features and no account required, so there is nothing to disclose on that front.
- Rendered `docs/community.md` through GitHub's Markdown API and checked the link
  resolves and the list renders as one item per project.
- `git diff --check` passed.
- No changeset: this changes documentation only and does not affect users of the
  package.

Closes #1844.

## Disclosure

Written with Claude Opus 5 in Claude Code, reviewed and verified by me before
opening. CONTRIBUTING asks contributors to say so.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added `openspec-guard` to the community showcase’s projects and resources list.
  - Documented its ability to report which OpenSpec scenarios are covered by Vitest or Jest tests without executing those tests.
  - Included a link to the project repository for additional details and access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->