### PR TITLE
feat(github): add issue forms and a PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,67 @@
+name: Bug report
+description: Something in OpenSpec does not work the way it should.
+labels: ['bug', 'needs-triage']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting this.
+
+        Already have OpenSpec installed and an agent open? `openspec feedback "..."`
+        drafts and files this for you, with the version and platform filled in.
+
+  - type: textarea
+    id: what_happened
+    attributes:
+      label: What happened
+      description: The actual behavior. Paste the command you ran and its output if you have it.
+      placeholder: |
+        I ran `openspec archive add-login` and it exited 0 without writing the main spec.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected instead
+      placeholder: The main spec at openspec/specs/auth/spec.md should have been updated.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal steps to reproduce
+      description: The shortest path from a fresh project to the problem. This is the single most useful thing you can give us.
+      placeholder: |
+        1. `openspec init` in an empty directory
+        2. ...
+        3. ...
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: OpenSpec version
+      description: Output of `openspec --version`.
+      placeholder: '1.11.0'
+    validations:
+      required: true
+
+  - type: input
+    id: agent
+    attributes:
+      label: Coding agent and model
+      description: Which agent and model were driving OpenSpec, if any. Behavior often differs between them.
+      placeholder: Claude Code, Opus 4.6
+    validations:
+      required: false
+
+  - type: input
+    id: environment
+    attributes:
+      label: OS and Node version
+      placeholder: macOS 15.6, Node 22.11.0
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Core design change
+    url: https://github.com/Fission-AI/OpenSpec/discussions/categories/ideas
+    about: Anything that changes how OpenSpec works at its core starts as a discussion, per CONTRIBUTING step 1.
+  - name: Question or help with your setup
+    url: https://github.com/Fission-AI/OpenSpec/discussions/categories/q-a
+    about: Not sure whether it is a bug? Ask here and we will help you narrow it down.
+  - name: Discord
+    url: https://discord.gg/YctCnvvshC
+    about: Chat with the community and the maintainers.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,44 @@
+name: Feature request
+description: Something OpenSpec should do that it does not do yet.
+labels: ['enhancement', 'needs-triage']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        If this would change OpenSpec's core design, open a
+        [discussion](https://github.com/Fission-AI/OpenSpec/discussions) instead — see
+        [CONTRIBUTING.md](https://github.com/Fission-AI/OpenSpec/blob/main/CONTRIBUTING.md).
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem, in one or two sentences
+      description: What you were trying to do, and where OpenSpec got in the way. Describe the problem, not the solution.
+      placeholder: There is no way to tell which change a spec came from after it is archived.
+    validations:
+      required: true
+
+  - type: textarea
+    id: who
+    attributes:
+      label: Who this affects
+      description: Just you, everyone on a particular agent, everyone using a particular workflow, or everyone. OpenSpec serves many agents and models, so this shapes whether a change fits.
+      placeholder: Anyone archiving more than a handful of changes.
+    validations:
+      required: true
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: What you tried
+      description: Existing commands, flags, or workarounds you reached for, and why they fell short.
+    validations:
+      required: false
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What you have in mind
+      description: Optional. A sketch is fine — we will agree on the approach before anyone builds it.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+Closes #
+
+<!--
+No issue yet? Every change starts with one (CONTRIBUTING step 1).
+Run `openspec feedback "..."` from your project, or open one here:
+https://github.com/Fission-AI/OpenSpec/issues/new/choose
+
+Already discussed instead of filed? Replace the line above with a link to the discussion.
+-->
+
+## What this changes
+
+<!-- What was wrong or missing, and what the new behavior is. Plain language. -->
+
+## How you verified it
+
+<!--
+The failing-then-passing test, repro steps, or before/after output.
+CI runs exactly these:
+  pnpm build && pnpm test && pnpm exec tsc --noEmit && pnpm lint
+-->
+
+## Notes
+
+<!-- Optional: scope limits, follow-ups, anything non-blocking. -->
+
+---
+
+- [ ] Ran `pnpm changeset` if this affects users, and committed the file
+- [ ] If a coding agent wrote this, named the agent and model below, and verified the result myself


### PR DESCRIPTION
**Status:** Ready for review. Step 1 of #1834 — `.github/`-only, no code and no spec touched.

## What was missing

`CONTRIBUTING.md` asks every change to start with an issue or a discussion. That only works if filing one is the path of least resistance, and for a contributor who clones this repo it currently isn't: there is no `.github/ISSUE_TEMPLATE/` and no PR template. They get a blank box, and later a review comment asking them to go file the issue they didn't know they needed. That's the contributor we're most likely to lose.

## What it does

| File | Asks for |
|---|---|
| `ISSUE_TEMPLATE/bug_report.yml` | what happened, what was expected, a minimal repro, `openspec --version` (required); agent + model, OS/Node (optional) |
| `ISSUE_TEMPLATE/feature_request.yml` | the problem in a sentence or two, who it affects (required); what was tried, what they have in mind (optional) |
| `ISSUE_TEMPLATE/config.yml` | routes core-design topics to Discussions per CONTRIBUTING step 1, plus Q&A and Discord |
| `PULL_REQUEST_TEMPLATE.md` | `Closes #` on the first line, with the "no issue yet?" path directly under it |

Two details worth calling out:

- **The bug form points users who already have OpenSpec installed at `openspec feedback "..."`** rather than at the form. They have the version, the platform and the failing command already; the form is for people who don't.
- **`blank_issues_enabled: true`** is deliberate. The pre-filled URL that `openspec feedback` prints when `gh` is missing or unauthenticated (`generateManualSubmissionUrl()` in `src/commands/feedback.ts`) points at `/issues/new?title=…&body=…`. Turning blank issues off would break that path for every user without `gh`. Teaching that URL to prefill the form itself is step 3 of #1834 and needs a change proposal; until then, this keeps it working.

The PR template deliberately carries no bot and no CI gate. It catches the PR-first contributor at the exact moment they need it, which per #1834 should make an enforcement gate mostly unnecessary.

## Proof it works

- All three YAML files parse and satisfy GitHub's issue-form schema (every non-`markdown` block has a unique, valid `id` and an `attributes.label`; `markdown` blocks carry no `id`/`validations`; `config.yml` has a boolean `blank_issues_enabled` and complete `contact_links`). Verified by parsing with the repo's own `yaml` dependency.
- Every label the forms apply already exists in this repository: `bug`, `enhancement`, `needs-triage` (checked against `gh label list`).
- No source, spec, test, or workflow file changes, so nothing in the build or the test suite can regress. `ISSUE_TEMPLATE` and `PULL_REQUEST_TEMPLATE` appear nowhere else in the repo, and neither path is in any tool's `detectionPaths` in `src/core/config.ts`, so OpenSpec's own `.github`-based GitHub Copilot detection is unaffected.
- No changeset: this changes nothing for users of the published package.

## Notes

- Does not close #1834. Steps 2 (register the `feedback` workflow, whose template already exists at `src/core/templates/workflows/feedback.ts` but was never added to `ALL_WORKFLOWS`) and 3 (`openspec feedback --type` and form-prefilled fallback URL) add a workflow and a CLI flag, so per CONTRIBUTING step 2 they get a change proposal PR first.
- CI enforcement of "every PR links an issue" stays out of scope, per #1834.

Written by Claude Code (Opus 5); YAML schema validation and label existence checked locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added structured templates for reporting bugs and requesting features, helping contributors provide clearer reproduction details, context, and proposed solutions.
  * Added pull request guidance covering issue references, change descriptions, verification steps, and optional contributor information.

* **Chores**
  * Added issue configuration with links for design discussions, setup questions, and community support.
  * Enabled blank issue creation alongside the guided templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->