### PR TITLE
fix(parser): read change deltas with the archive reader

### DIFF
--- a/.changeset/show-deltas-match-archive.md
+++ b/.changeset/show-deltas-match-archive.md
@@ -1,0 +1,5 @@
+---
+'@fission-ai/openspec': patch
+---
+
+Make `openspec show --json --deltas-only` report the deltas archive applies. `ChangeParser`, which backs `show --json`, the `change list` delta counts and archive's proposal warnings, read delta specs with its own section lookup instead of `parseDeltaSpec`, the reader archive uses, and the two disagreed. A REMOVED written in the bullet form (`` - `### Requirement: X` ``) was invisible to it, so it fell back to the proposal's "What Changes" prose and reported an invented MODIFIED while archive deleted the requirement; a repeated section header was read only once; and a RENAMED line written with `*` or `+` was dropped. The inspection command OpenSpec's own error text recommends therefore misreported a deletion. `ChangeParser` now derives every operation from `parseDeltaSpec`, and a change that has delta spec files is described by them alone, so proposal prose is never reported as a structured delta. Requirement text and scenarios are read exactly as before, header-form deltas produce the same output, and a change with no delta spec files still falls back to the "What Changes" bullets.

--- a/src/core/parsers/change-parser.ts
+++ b/src/core/parsers/change-parser.ts
@@ -1,14 +1,21 @@
 import { MarkdownParser, Section } from './markdown-parser.js';
 import { buildCodeFenceMask } from './requirement-text.js';
+import { parseDeltaSpec, type RequirementBlock } from './requirement-blocks.js';
 import { Change, Delta, DeltaOperation, Requirement } from '../schemas/index.js';
 import path from 'path';
 import { promises as fs } from 'fs';
-import { discoverSpecFiles } from '../../utils/spec-discovery.js';
+import { discoverSpecFiles, type DiscoveredSpec } from '../../utils/spec-discovery.js';
 
 interface DeltaSection {
   operation: DeltaOperation;
   requirements: Requirement[];
   renames?: Array<{ from: string; to: string }>;
+}
+
+/** A header-only block for a REMOVED entry written in the bullet form. */
+function removedNameBlock(name: string): RequirementBlock {
+  const headerLine = `### Requirement: ${name}`;
+  return { headerLine, name, raw: headerLine };
 }
 
 export class ChangeParser extends MarkdownParser {
@@ -32,15 +39,15 @@ export class ChangeParser extends MarkdownParser {
       throw new Error('Change must have a What Changes section');
     }
 
-    // Parse deltas from the What Changes section (simple format)
-    const simpleDeltas = this.parseDeltas(whatChanges);
-    
-    // Check if there are spec files with delta format
-    const specsDir = path.join(this.changeDir, 'specs');
-    const deltaDeltas = await this.parseDeltaSpecs(specsDir);
-    
-    // Combine both types of deltas, preferring delta format if available
-    const deltas = deltaDeltas.length > 0 ? deltaDeltas : simpleDeltas;
+    // Delta spec files, when the change has any, are the only source of
+    // structured deltas, even when they hold no entry archive can apply.
+    // Falling back to the "What Changes" prose then reported operations that
+    // never happen: a bullet-form REMOVED showed up as an invented MODIFIED.
+    // The prose (simple format) is read only for a change with no delta specs.
+    const specFiles = await discoverSpecFiles(path.join(this.changeDir, 'specs'));
+    const deltas = specFiles.length > 0
+      ? await this.parseDeltaSpecs(specFiles)
+      : this.parseDeltas(whatChanges);
 
     return {
       name,
@@ -54,12 +61,10 @@ export class ChangeParser extends MarkdownParser {
     };
   }
 
-  private async parseDeltaSpecs(specsDir: string): Promise<Delta[]> {
+  // The spec files come from discoverSpecFiles, which walks specs/ recursively
+  // so nested layouts like specs/<area>/<capability>/spec.md are parsed too (#1353)
+  private async parseDeltaSpecs(specFiles: DiscoveredSpec[]): Promise<Delta[]> {
     const deltas: Delta[] = [];
-
-    // Discover delta specs recursively so nested layouts like
-    // specs/<area>/<capability>/spec.md are parsed too (#1353)
-    const specFiles = await discoverSpecFiles(specsDir);
 
     for (const { id, specFile } of specFiles) {
       try {
@@ -98,99 +103,83 @@ export class ChangeParser extends MarkdownParser {
     });
   }
 
+  /**
+   * The deltas in one spec file, read by parseDeltaSpec — the reader archive
+   * applies — so what `show` reports is what archive will do. This used to be a
+   * second reader that disagreed with it: a bullet-form REMOVED was invisible,
+   * a repeated section header was read only once, and a RENAMED line written
+   * with `*` or `+` was dropped.
+   */
   private parseSpecDeltas(specName: string, content: string): Delta[] {
     const deltas: Delta[] = [];
-    const sections = this.parseSectionsFromContent(content);
-    
+    const plan = parseDeltaSpec(content);
+
     // Parse ADDED requirements
-    const addedSection = this.findSection(sections, 'ADDED Requirements');
-    if (addedSection) {
-      const requirements = this.parseRequirements(addedSection);
-      requirements.forEach(req => {
-        deltas.push({
-          spec: specName,
-          operation: 'ADDED' as DeltaOperation,
-          description: `Add requirement: ${req.text}`,
-          // Provide both single and plural forms for compatibility
-          requirement: req,
-          requirements: [req],
-        });
+    this.toRequirements(plan.added).forEach(req => {
+      deltas.push({
+        spec: specName,
+        operation: 'ADDED' as DeltaOperation,
+        description: `Add requirement: ${req.text}`,
+        // Provide both single and plural forms for compatibility
+        requirement: req,
+        requirements: [req],
       });
-    }
-    
+    });
+
     // Parse MODIFIED requirements
-    const modifiedSection = this.findSection(sections, 'MODIFIED Requirements');
-    if (modifiedSection) {
-      const requirements = this.parseRequirements(modifiedSection);
-      requirements.forEach(req => {
-        deltas.push({
-          spec: specName,
-          operation: 'MODIFIED' as DeltaOperation,
-          description: `Modify requirement: ${req.text}`,
-          requirement: req,
-          requirements: [req],
-        });
+    this.toRequirements(plan.modified).forEach(req => {
+      deltas.push({
+        spec: specName,
+        operation: 'MODIFIED' as DeltaOperation,
+        description: `Modify requirement: ${req.text}`,
+        requirement: req,
+        requirements: [req],
       });
-    }
-    
-    // Parse REMOVED requirements
-    const removedSection = this.findSection(sections, 'REMOVED Requirements');
-    if (removedSection) {
-      const requirements = this.parseRequirements(removedSection);
-      requirements.forEach(req => {
-        deltas.push({
-          spec: specName,
-          operation: 'REMOVED' as DeltaOperation,
-          description: `Remove requirement: ${req.text}`,
-          requirement: req,
-          requirements: [req],
-        });
+    });
+
+    // Parse REMOVED requirements, in document order. A bullet-form entry
+    // carries only a name, so it reads as a header-form removal with no body.
+    const removedBlocks = [...plan.removedBlocks];
+    const removed = plan.removed.map((name) => {
+      const index = removedBlocks.findIndex((block) => block.name === name);
+      return index === -1 ? removedNameBlock(name) : removedBlocks.splice(index, 1)[0];
+    });
+    this.toRequirements(removed).forEach(req => {
+      deltas.push({
+        spec: specName,
+        operation: 'REMOVED' as DeltaOperation,
+        description: `Remove requirement: ${req.text}`,
+        requirement: req,
+        requirements: [req],
       });
-    }
-    
+    });
+
     // Parse RENAMED requirements
-    const renamedSection = this.findSection(sections, 'RENAMED Requirements');
-    if (renamedSection) {
-      const renames = this.parseRenames(renamedSection.content);
-      renames.forEach(rename => {
-        deltas.push({
-          spec: specName,
-          operation: 'RENAMED' as DeltaOperation,
-          description: `Rename requirement from "${rename.from}" to "${rename.to}"`,
-          rename,
-        });
+    plan.renamed.forEach(rename => {
+      deltas.push({
+        spec: specName,
+        operation: 'RENAMED' as DeltaOperation,
+        description: `Rename requirement from "${rename.from}" to "${rename.to}"`,
+        rename,
       });
-    }
-    
+    });
+
     return deltas;
   }
 
-  private parseRenames(content: string): Array<{ from: string; to: string }> {
-    const renames: Array<{ from: string; to: string }> = [];
-    const lines = ChangeParser.normalizeContent(content).split('\n');
-    
-    let currentRename: { from?: string; to?: string } = {};
-    
-    for (const line of lines) {
-      const fromMatch = line.match(/^\s*-?\s*FROM:\s*`?###\s*Requirement:\s*(.+?)`?\s*$/);
-      const toMatch = line.match(/^\s*-?\s*TO:\s*`?###\s*Requirement:\s*(.+?)`?\s*$/);
-      
-      if (fromMatch) {
-        currentRename.from = fromMatch[1].trim();
-      } else if (toMatch) {
-        currentRename.to = toMatch[1].trim();
-        
-        if (currentRename.from && currentRename.to) {
-          renames.push({
-            from: currentRename.from,
-            to: currentRename.to,
-          });
-          currentRename = {};
-        }
-      }
-    }
-    
-    return renames;
+  /**
+   * One Requirement per block, read by the same section parser (and the
+   * header filter above) as before, so text and scenarios are unchanged.
+   */
+  private toRequirements(blocks: RequirementBlock[]): Requirement[] {
+    return blocks.flatMap((block) => {
+      const [headerLine, ...body] = block.raw.split('\n');
+      // Canonical header: the delta reader also accepts `###Requirement:` with
+      // no space, which the section parser would not see as a header.
+      const title = headerLine.replace(/^###\s*/, '').trim();
+      const [section] = this.parseSectionsFromContent([`### ${title}`, ...body].join('\n'));
+      return this.parseRequirements({ level: 2, title: '', content: '', children: [section] });
+    });
   }
 
   private parseSectionsFromContent(content: string): Section[] {

--- a/test/core/parsers/change-parser-delta-agreement.test.ts
+++ b/test/core/parsers/change-parser-delta-agreement.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect, afterAll } from 'vitest';
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+import { ChangeParser } from '../../../src/core/parsers/change-parser.js';
+import { parseDeltaSpec } from '../../../src/core/parsers/requirement-blocks.js';
+import type { Change } from '../../../src/core/schemas/index.js';
+import { runCLI } from '../../helpers/run-cli.js';
+
+/**
+ * `openspec show --json --deltas-only` reads deltas through ChangeParser, while
+ * `archive` applies them through parseDeltaSpec. The two used to disagree:
+ *
+ * - A REMOVED written in the bullet form was invisible to ChangeParser, so it
+ *   fell back to the proposal's "What Changes" prose and reported an invented
+ *   MODIFIED, while archive deleted the requirement.
+ * - A repeated section header was read only once (the #1802 case).
+ * - A RENAMED line written with `*` or `+` was dropped (the #1800 case).
+ *
+ * The inspection command OpenSpec recommends must report what archive applies.
+ */
+
+const PROPOSAL = [
+  '# Edit billing',
+  '',
+  '## Why',
+  'We need to keep the billing contract accurate for operators and customers over time.',
+  '',
+  '## What Changes',
+  '- **billing**: updates billing requirements',
+  '',
+].join('\n');
+
+const temps: string[] = [];
+afterAll(async () => {
+  await Promise.all(temps.map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+async function tempDir(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  temps.push(dir);
+  return dir;
+}
+
+/** Parse a change whose single delta spec, specs/billing/spec.md, is `delta`. */
+async function parseChange(delta: string): Promise<Change> {
+  const dir = await tempDir('openspec-change-deltas-');
+  await fs.mkdir(path.join(dir, 'specs', 'billing'), { recursive: true });
+  await fs.writeFile(path.join(dir, 'specs', 'billing', 'spec.md'), delta);
+  return new ChangeParser(PROPOSAL, dir).parseChangeWithDeltas('edit');
+}
+
+const operations = (change: Change) => change.deltas.map((delta) => delta.operation);
+
+describe('ChangeParser reads deltas the way archive applies them', () => {
+  it('control: reads a header-form REMOVED as REMOVED', async () => {
+    const change = await parseChange(
+      ['## REMOVED Requirements', '', '### Requirement: Late Fees', '**Reason**: gone'].join('\n')
+    );
+    expect(operations(change)).toEqual(['REMOVED']);
+  });
+
+  for (const marker of ['-', '*', '+']) {
+    it(`reads a bullet-form REMOVED written with "${marker}"`, async () => {
+      const change = await parseChange(
+        ['## REMOVED Requirements', '', `${marker} \`### Requirement: Late Fees\``].join('\n')
+      );
+      expect(operations(change)).toEqual(['REMOVED']);
+      expect(change.deltas[0].spec).toBe('billing');
+      expect(change.deltas[0].description).toContain('Late Fees');
+    });
+  }
+
+  it('reports a bullet-form REMOVED exactly as the same removal written as a header', async () => {
+    const bullet = await parseChange(['## REMOVED Requirements', '', '- `### Requirement: Late Fees`'].join('\n'));
+    const header = await parseChange(['## REMOVED Requirements', '', '### Requirement: Late Fees'].join('\n'));
+    expect(bullet.deltas).toEqual(header.deltas);
+  });
+
+  it('never invents a MODIFIED from the proposal prose for a bullet-form REMOVED', async () => {
+    const change = await parseChange(['## REMOVED Requirements', '- `### Requirement: Late Fees`'].join('\n'));
+    expect(operations(change)).not.toContain('MODIFIED');
+    expect(change.deltas.map((delta) => delta.description)).not.toContain('updates billing requirements');
+  });
+
+  it('reads bullet and header REMOVED entries together, in document order', async () => {
+    const change = await parseChange(
+      [
+        '## REMOVED Requirements',
+        '',
+        '- `### Requirement: Invoice Generation`',
+        '',
+        '### Requirement: Late Fees',
+      ].join('\n')
+    );
+    expect(operations(change)).toEqual(['REMOVED', 'REMOVED']);
+    expect(change.deltas[0].description).toContain('Invoice Generation');
+    expect(change.deltas[1].description).toContain('Late Fees');
+  });
+
+  it('reads every copy of a repeated section header', async () => {
+    const change = await parseChange(
+      [
+        '## ADDED Requirements',
+        '### Requirement: Credit Notes',
+        'The system SHALL issue a credit note when an invoice is voided.',
+        '',
+        '#### Scenario: Invoice voided',
+        '- **WHEN** an invoice is voided',
+        '- **THEN** a credit note is issued',
+        '',
+        '## REMOVED Requirements',
+        '- `### Requirement: Late Fees`',
+        '',
+        '## ADDED Requirements',
+        '### Requirement: Refunds',
+        'The system SHALL refund a cancelled invoice.',
+        '',
+        '#### Scenario: Invoice cancelled',
+        '- **WHEN** an invoice is cancelled',
+        '- **THEN** a refund is issued',
+        '',
+        '## REMOVED Requirements',
+        '- `### Requirement: Invoice Generation`',
+      ].join('\n')
+    );
+    expect(operations(change)).toEqual(['ADDED', 'ADDED', 'REMOVED', 'REMOVED']);
+    expect(change.deltas[0].requirement?.text).toBe('The system SHALL issue a credit note when an invoice is voided.');
+    expect(change.deltas[1].requirement?.text).toBe('The system SHALL refund a cancelled invoice.');
+    expect(change.deltas[1].requirement?.scenarios).toHaveLength(1);
+  });
+
+  for (const marker of ['*', '+']) {
+    it(`reads a RENAMED pair written with "${marker}"`, async () => {
+      const change = await parseChange(
+        [
+          '## RENAMED Requirements',
+          `${marker} FROM: \`### Requirement: Late Fees\``,
+          `${marker} TO: \`### Requirement: Overdue Penalties\``,
+        ].join('\n')
+      );
+      expect(operations(change)).toEqual(['RENAMED']);
+      expect(change.deltas[0].rename).toEqual({ from: 'Late Fees', to: 'Overdue Penalties' });
+    });
+  }
+
+  it('reports the same entries, in the same numbers, as parseDeltaSpec', async () => {
+    const delta = [
+      '## ADDED Requirements',
+      '### Requirement: Credit Notes',
+      'The system SHALL issue a credit note when an invoice is voided.',
+      '',
+      '#### Scenario: Invoice voided',
+      '- **WHEN** an invoice is voided',
+      '- **THEN** a credit note is issued',
+      '',
+      '## MODIFIED Requirements',
+      '### Requirement: Invoice Generation',
+      'The system SHALL generate an invoice within one day of a completed billing period.',
+      '',
+      '#### Scenario: Period closes',
+      '- **WHEN** a billing period closes',
+      '- **THEN** an invoice is generated within one day',
+      '',
+      '## REMOVED Requirements',
+      '+ `### Requirement: Late Fees`',
+      '### Requirement: Paper Invoices',
+      '**Reason**: replaced by email',
+      '',
+      '## RENAMED Requirements',
+      '- FROM: `### Requirement: Refunds`',
+      '- TO: `### Requirement: Refund Processing`',
+      '',
+      '## ADDED Requirements',
+      '### Requirement: Dunning',
+      'The system SHALL send a reminder for every overdue invoice.',
+      '',
+      '#### Scenario: Invoice overdue',
+      '- **WHEN** an invoice becomes overdue',
+      '- **THEN** a reminder is sent',
+    ].join('\n');
+    const plan = parseDeltaSpec(delta);
+    const change = await parseChange(delta);
+    const count = (operation: string) => operations(change).filter((op) => op === operation).length;
+
+    expect(count('ADDED')).toBe(plan.added.length);
+    expect(count('MODIFIED')).toBe(plan.modified.length);
+    expect(count('REMOVED')).toBe(plan.removed.length);
+    expect(count('RENAMED')).toBe(plan.renamed.length);
+    expect(change.deltas).toHaveLength(6);
+  });
+
+  it('never reports proposal prose as a delta when the change has delta spec files', async () => {
+    // A delta file whose sections hold no parseable entry: archive applies
+    // nothing, so there is nothing to report.
+    const change = await parseChange(['## ADDED Requirements', '', '- add credit notes'].join('\n'));
+    expect(change.deltas).toEqual([]);
+  });
+
+  it('control: still reads the proposal prose when the change has no delta spec files', async () => {
+    const dir = await tempDir('openspec-change-no-deltas-');
+    const change = await new ChangeParser(PROPOSAL, dir).parseChangeWithDeltas('edit');
+    expect(change.deltas).toEqual([
+      { spec: 'billing', operation: 'MODIFIED', description: 'updates billing requirements' },
+    ]);
+  });
+});
+
+const SEED = [
+  '## ADDED Requirements',
+  '### Requirement: Invoice Generation',
+  'The system SHALL generate an invoice for every completed billing period.',
+  '',
+  '#### Scenario: Period closes',
+  '- **WHEN** a billing period closes',
+  '- **THEN** an invoice is generated',
+  '',
+  '### Requirement: Late Fees',
+  'The system SHALL apply a late fee to invoices overdue by 30 days.',
+  '',
+  '#### Scenario: Thirty days overdue',
+  '- **WHEN** an invoice is 30 days overdue',
+  '- **THEN** a late fee is applied',
+  '',
+].join('\n');
+
+/**
+ * A real project whose main billing spec was written by OpenSpec itself, by
+ * archiving a seed change, plus an open `edit` change carrying `delta`.
+ */
+async function projectWithDelta(delta: string) {
+  const base = await tempDir('openspec-show-deltas-e2e-');
+  const home = path.join(base, 'home');
+  const project = path.join(base, 'project');
+  await fs.mkdir(home, { recursive: true });
+  await fs.mkdir(project, { recursive: true });
+  const env = {
+    HOME: home,
+    USERPROFILE: home,
+    XDG_CONFIG_HOME: path.join(home, '.config'),
+    XDG_DATA_HOME: path.join(home, '.local', 'share'),
+    OPENSPEC_NO_ANIMATION: '1',
+  };
+  const cli = (args: string[]) => runCLI(args, { cwd: project, env, timeoutMs: 60_000 });
+  const writeChange = async (name: string, spec: string) => {
+    expect((await cli(['new', 'change', name])).exitCode).toBe(0);
+    const dir = path.join(project, 'openspec', 'changes', name);
+    await fs.mkdir(path.join(dir, 'specs', 'billing'), { recursive: true });
+    await fs.writeFile(path.join(dir, 'proposal.md'), PROPOSAL);
+    await fs.writeFile(path.join(dir, 'tasks.md'), '## 1. Work\n- [x] 1.1 Done\n');
+    await fs.writeFile(path.join(dir, 'specs', 'billing', 'spec.md'), spec);
+  };
+
+  expect((await cli(['init', '--tools', 'claude'])).exitCode).toBe(0);
+  await writeChange('seed', SEED);
+  expect((await cli(['archive', 'seed', '--yes'])).exitCode).toBe(0);
+  await writeChange('edit', delta);
+
+  const mainSpec = path.join(project, 'openspec', 'specs', 'billing', 'spec.md');
+  return {
+    cli,
+    shownOperations: async () => {
+      const result = await cli(['show', 'edit', '--json', '--deltas-only']);
+      expect(result.exitCode).toBe(0);
+      return (JSON.parse(result.stdout).deltas as Array<{ operation: string }>).map((d) => d.operation);
+    },
+    mainRequirements: async () =>
+      (await fs.readFile(mainSpec, 'utf-8'))
+        .split('\n')
+        .filter((line) => line.startsWith('### Requirement:'))
+        .map((line) => line.replace('### Requirement:', '').trim()),
+  };
+}
+
+describe('show --json --deltas-only reports what archive applies (e2e)', () => {
+  it('control: a header-form REMOVED is shown as REMOVED and archived as a removal', async () => {
+    const project = await projectWithDelta(
+      ['## REMOVED Requirements', '### Requirement: Late Fees', '**Reason**: no longer charged', ''].join('\n')
+    );
+    expect(await project.shownOperations()).toEqual(['REMOVED']);
+    expect((await project.cli(['archive', 'edit', '--yes'])).exitCode).toBe(0);
+    expect(await project.mainRequirements()).toEqual(['Invoice Generation']);
+  }, 120_000);
+
+  it('a bullet-form REMOVED is shown as the removal archive performs', async () => {
+    const project = await projectWithDelta(['## REMOVED Requirements', '- `### Requirement: Late Fees`', ''].join('\n'));
+    const shown = await project.shownOperations();
+
+    expect((await project.cli(['archive', 'edit', '--yes'])).exitCode).toBe(0);
+    expect(await project.mainRequirements()).toEqual(['Invoice Generation']);
+    expect(shown).toEqual(['REMOVED']);
+  }, 120_000);
+});


### PR DESCRIPTION
Closes #1855.

## Why

`openspec show <change> --json --deltas-only` is the command OpenSpec's own
error text recommends for inspecting parsed deltas
(`src/core/validation/constants.ts:61`). It reads deltas through
`ChangeParser`, which had its own section lookup instead of `parseDeltaSpec`,
the reader `archive` applies. The two disagreed, and `show` misreported what
archive would do:

- **A bullet-form REMOVED was invisible.** `change-parser.ts:137` read REMOVED
  only from `### Requirement:` header children. With no structured delta left,
  `:36`/`:43` fell back to the proposal's "What Changes" prose and reported it
  as an operation. So for `` - `### Requirement: Late Fees` `` the command
  showed an invented `MODIFIED "updates billing requirements"`, while archive
  deleted `Late Fees`.
- **A repeated section header was read once.** `findSection` (`:106`, `:122`,
  `:137`, `:152`) returns the first match, while `parseDeltaSpec` applies
  every copy (#1802).
- **A RENAMED line written with `*` or `+` was dropped.** `parseRenames`
  (`:175-176`) accepted only `-`, while `parseDeltaSpec` accepts every
  CommonMark marker (#1800).

The parser's own comment (`:87`) states the goal these broke: "keep the two
readers in agreement".

## What Changes

- `ChangeParser.parseSpecDeltas` now derives every operation from
  `parseDeltaSpec`: ADDED and MODIFIED blocks, REMOVED names in document order
  (header and bullet forms), and RENAMED pairs. The divergent `parseRenames`
  is removed.
- Each block is still turned into a `Requirement` by the same section parser
  and `### Requirement:` header filter as before (`toRequirements`), so
  requirement text and scenarios are unchanged, and the JSON shape is
  unchanged.
- A bullet-form REMOVED carries only a name, so it is read as a header-form
  removal with no body. The two spellings of the same removal produce
  identical deltas.
- A change whose delta spec files carry a delta section is described by them
  alone. When those sections hold no parseable entry, the result is no deltas,
  which is what archive applies, rather than proposal prose.

Unchanged:

- A change with **no** delta spec files, or a legacy change whose spec files
  carry no delta section at all (a full future-state spec under `specs/`),
  still falls back to the "What Changes" bullets (the simple, legacy format).
  That path is what `change list` delta counts and archive's proposal warnings
  use for such changes, and it never contradicts archive, because there is no
  delta section for archive to apply. Kept deliberately.
- Header-form deltas produce the same output as before.
- `validate` and `archive` are untouched; they already used `parseDeltaSpec`.

`change.ts` `enrichDeltasWithDiffs` matches MODIFIED deltas to
`collectSpecDiffs` results by source order. Both now come from
`plan.modified`, so a repeated `## MODIFIED Requirements` section no longer
misaligns the attached diffs.

## Testing

`test/core/parsers/change-parser-delta-agreement.test.ts`: 16 tests. The first
15 were written first and watched fail on `9d4e597` (12 failed / 3 passed
before, 15 passed after); the 3 that passed before are the controls. The 16th,
the legacy fallback, was added in the second pass and fails on `bdcd442`.

Edge cases covered:

- header-form REMOVED (control)
- bullet-form REMOVED with each marker `-`, `*`, `+`
- bullet and header forms produce identical deltas
- no invented MODIFIED from proposal prose
- mixed bullet and header REMOVED entries, in document order
- repeated `## ADDED` and `## REMOVED` sections, both copies read
- RENAMED with `*` and `+` bullets
- a composite delta: per-operation counts equal `parseDeltaSpec`'s
- delta files with no parseable entry yield no deltas, not prose
- no delta files: the prose fallback still applies (control)
- legacy spec files with no delta section: the prose fallback still applies
  (added in the second pass; fails on `bdcd442`, where such a change reported
  no deltas and archive printed an extra "No deltas found" warning)
- end to end, in a project built with `openspec init` + `openspec new change`
  and a main spec written by archiving a seed change: `show --json
  --deltas-only` reports `REMOVED` for a bullet-form removal, and archive then
  removes exactly that requirement (plus the header-form control)

Verification, in a clean Linux sandbox on Node 20.19.0 (the CI version):

- `pnpm run build`: ok
- `pnpm exec tsc --noEmit`: ok
- `pnpm lint`: ok
- `pnpm test`: 4562 passed, 16 failed (4578 tests, 159 files). Every failure
  was a timeout in a loaded sandbox, not an assertion:
  - 15 were `Test timed out in 10000ms` in the store and workset CLI suites
    (`store*.test.ts`, `workset.test.ts`, `declared-store-fallback.test.ts`);
  - 1 was `spawnSync npm ETIMEDOUT` in `package-install-scripts.test.ts`.

  None of those files touches the changed code. Rerun in isolation, the 7
  affected files passed 167/168, and clean `main` gave the identical 167/168
  on the same files in the same sandbox. The one left on both,
  `package-install-scripts > refuses to pack when TypeScript compilation fails`,
  is an `npm pack` + `tsc` run that times out at 10s there. With
  `--testTimeout=120000`, `package-install-scripts.test.ts` passes 8/8 on this
  branch and on `main`.

## Changeset

`.changeset/show-deltas-match-archive.md` (patch).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected change summaries and JSON output to accurately reflect added, modified, removed, and renamed requirements from delta specification files.
  * Fixed recognition of bullet-form removals, repeated section headers, and alternate rename markers.
  * Prevented proposal prose from overriding structured delta information when delta files are present.
  * Preserved prose-based delta detection when no delta specification files exist.

* **Tests**
  * Added coverage confirming that displayed changes match archive operations across supported delta formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
