### PR TITLE
fix(validate): reject a scenario header with no body

### DIFF
--- a/.changeset/validate-rejects-empty-scenarios.md
+++ b/.changeset/validate-rejects-empty-scenarios.md
@@ -1,0 +1,5 @@
+---
+'@fission-ai/openspec': patch
+---
+
+Stop `validate` accepting a requirement whose only scenario is a bare header. The delta scenario counter counted every `####` header, while the spec path that archive uses to validate the rebuilt spec keeps a scenario only when its body has content, so `validate` called such a change valid and `archive` then refused it with a generic "Requirement must have at least one scenario" that did not name the requirement. Both paths now share one rule, `hasScenarioBody`, and read a scenario's body up to the same boundary, so `validate` rejects exactly what archive rejects, naming the requirement and saying that a header with no body under it does not count. A scenario whose body is only a fenced block or a deeper header still counts, a requirement with one real scenario is still accepted even when another is empty, and main-spec validation is unchanged.

--- a/src/core/parsers/markdown-parser.ts
+++ b/src/core/parsers/markdown-parser.ts
@@ -1,5 +1,5 @@
 import { Spec, Change, Requirement, Scenario, Delta, DeltaOperation } from '../schemas/index.js';
-import { buildCodeFenceMask, extractRequirementText } from './requirement-text.js';
+import { buildCodeFenceMask, extractRequirementText, hasScenarioBody } from './requirement-text.js';
 
 export interface Section {
   level: number;
@@ -172,8 +172,9 @@ export class MarkdownParser {
     const scenarios: Scenario[] = [];
     
     for (const scenarioSection of requirementSection.children) {
-      // Store the raw text content of the scenario section
-      if (scenarioSection.content.trim()) {
+      // Store the raw text content of the scenario section. A header with no
+      // body is not a scenario; the delta counter applies the same rule.
+      if (hasScenarioBody(scenarioSection.content)) {
         scenarios.push({
           rawText: scenarioSection.content
         });

--- a/src/core/parsers/requirement-text.ts
+++ b/src/core/parsers/requirement-text.ts
@@ -26,8 +26,23 @@ const HEADER_LINE = /^#{1,6}\s/;
  * as a scenario, so the delta counter must too (parity). The delta/loss path
  * reuses this exact constant via `scenarioHeaderAt` in requirement-blocks.ts;
  * keep both paths on it rather than reintroducing a separate `Scenario:` regex.
+ * A header alone is not yet a scenario on either path: see hasScenarioBody.
  */
 export const SCENARIO_HEADER = /^####\s+/;
+
+/** A header at scenario level or above (`#` to `####`): where a scenario body ends. */
+const SCENARIO_BODY_END = /^#{1,4}\s/;
+
+/**
+ * Whether a scenario's body has content. The spec path
+ * (`MarkdownParser.parseScenarios`) drops a scenario whose body is empty, so
+ * the delta counter must too (parity): otherwise `validate` accepts a
+ * requirement whose only scenario is a bare header, and archive rejects it when
+ * it validates the rebuilt spec.
+ */
+export function hasScenarioBody(body: string): boolean {
+  return body.trim().length > 0;
+}
 
 /**
  * The one predicate for normative-keyword detection. Matches `SHALL` or `MUST`
@@ -88,15 +103,31 @@ export function extractRequirementText(headerTitle: string, bodyLines: string[])
 
 /**
  * Count the real scenarios in a requirement block: `#### ` headers on non-fenced
- * lines. A `#### Scenario:` that lives inside a fenced example is not a real
- * scenario and is not counted.
+ * lines whose body has content. A `#### Scenario:` that lives inside a fenced
+ * example is not a real scenario and is not counted.
  */
 export function countScenarios(bodyLines: string[]): number {
+  return readScenarioBodies(bodyLines).filter(hasScenarioBody).length;
+}
+
+/** Count the `#### ` headers in a requirement block that have no body under them. */
+export function countEmptyScenarios(bodyLines: string[]): number {
+  return readScenarioBodies(bodyLines).filter((body) => !hasScenarioBody(body)).length;
+}
+
+/**
+ * The body of each scenario in a requirement block. A body runs to the next
+ * non-fenced header of level 4 or above, the boundary the spec path uses, so a
+ * fenced block or a deeper `#####` header is part of it.
+ */
+function readScenarioBodies(bodyLines: string[]): string[] {
   const mask = buildCodeFenceMask(bodyLines);
-  let count = 0;
+  const bodies: string[] = [];
   for (let i = 0; i < bodyLines.length; i++) {
-    if (mask[i]) continue;
-    if (SCENARIO_HEADER.test(bodyLines[i])) count++;
+    if (mask[i] || !SCENARIO_HEADER.test(bodyLines[i])) continue;
+    let end = i + 1;
+    while (end < bodyLines.length && (mask[end] || !SCENARIO_BODY_END.test(bodyLines[end]))) end++;
+    bodies.push(bodyLines.slice(i + 1, end).join('\n'));
   }
-  return count;
+  return bodies;
 }

--- a/src/core/validation/validator.ts
+++ b/src/core/validation/validator.ts
@@ -23,6 +23,7 @@ import {
   extractRequirementBody as extractRequirementBodyShared,
   containsShallOrMust as containsShallOrMustShared,
   countScenarios as countScenariosShared,
+  countEmptyScenarios,
 } from '../parsers/requirement-text.js';
 import { findMainSpecStructureIssues } from '../parsers/spec-structure.js';
 import { FileSystemUtils } from '../../utils/file-system.js';
@@ -271,7 +272,7 @@ export class Validator {
           }
           const scenarioCount = this.countScenarios(block.raw);
           if (scenarioCount < 1) {
-            issues.push({ level: 'ERROR', path: entryPath, message: `ADDED "${block.name}" must include at least one scenario` });
+            issues.push({ level: 'ERROR', path: entryPath, message: `ADDED "${block.name}" must include at least one scenario${this.emptyScenarioHint(block.raw)}` });
           }
         }
 
@@ -306,7 +307,7 @@ export class Validator {
           }
           const scenarioCount = this.countScenarios(block.raw);
           if (scenarioCount < 1) {
-            issues.push({ level: 'ERROR', path: entryPath, message: `MODIFIED "${block.name}" must include at least one scenario` });
+            issues.push({ level: 'ERROR', path: entryPath, message: `MODIFIED "${block.name}" must include at least one scenario${this.emptyScenarioHint(block.raw)}` });
           }
         }
 
@@ -927,6 +928,16 @@ export class Validator {
     // Fence-aware count via the shared reader: a `#### Scenario:` inside a fenced
     // example is not a real scenario. Drop the header line (index 0).
     return countScenariosShared(blockRaw.split('\n').slice(1));
+  }
+
+  /**
+   * Why a requirement with a visible scenario header still has no scenario:
+   * the header has no body, and the spec path archive validates against does
+   * not count it. Empty when the block has no bare scenario header.
+   */
+  private emptyScenarioHint(blockRaw: string): string {
+    if (countEmptyScenarios(blockRaw.split('\n').slice(1)) === 0) return '';
+    return ' (a scenario header with no body under it does not count; add its steps, e.g. "- **WHEN** ..." and "- **THEN** ...")';
   }
 
   private formatSectionList(sections: string[]): string {

--- a/test/core/validation.scenario-body-parity.test.ts
+++ b/test/core/validation.scenario-body-parity.test.ts
@@ -1,0 +1,205 @@
+import { describe, it, expect, afterAll } from 'vitest';
+import { promises as fs } from 'fs';
+import os from 'os';
+import path from 'path';
+import { countScenarios } from '../../src/core/parsers/requirement-text.js';
+import { MarkdownParser } from '../../src/core/parsers/markdown-parser.js';
+import { Validator } from '../../src/core/validation/validator.js';
+import { runCLI } from '../helpers/run-cli.js';
+
+/**
+ * A scenario header with nothing under it used to pass `validate` and then fail
+ * `archive`. The delta counter (countScenarios) counted every `####` header,
+ * while the spec path (MarkdownParser.parseScenarios) keeps a scenario only
+ * when its body has content. Archive validates the rebuilt spec on the spec
+ * path, so it refused a change `validate` had just called valid.
+ *
+ * The point of these tests is parity: for every scenario shape, both counters
+ * return the same number, and `validate` accepts exactly what `archive` applies.
+ */
+
+const REQUIREMENT_TEXT = 'The system SHALL issue a credit note when an invoice is voided.';
+
+const CASES: Array<{ name: string; scenarios: string[]; expected: number }> = [
+  {
+    name: 'a scenario with steps',
+    scenarios: ['#### Scenario: Invoice voided', '- **WHEN** an invoice is voided', '- **THEN** a credit note is issued'],
+    expected: 1,
+  },
+  { name: 'a scenario header with no body', scenarios: ['#### Scenario: Invoice voided'], expected: 0 },
+  {
+    name: 'a scenario whose body is only blank and whitespace lines',
+    scenarios: ['#### Scenario: Invoice voided', '', '   ', '\t'],
+    expected: 0,
+  },
+  {
+    name: 'two scenarios, one of them empty',
+    scenarios: [
+      '#### Scenario: Not written yet',
+      '',
+      '#### Scenario: Invoice voided',
+      '- **WHEN** an invoice is voided',
+      '- **THEN** a credit note is issued',
+    ],
+    expected: 1,
+  },
+  {
+    name: 'a scenario whose body is only a fenced block',
+    scenarios: ['#### Scenario: Invoice voided', '```text', 'WHEN voided THEN a credit note is issued', '```'],
+    expected: 1,
+  },
+  { name: 'a closed scenario header with no body', scenarios: ['#### Scenario: Invoice voided ####'], expected: 0 },
+  {
+    name: 'a closed scenario header with steps',
+    scenarios: ['#### Scenario: Invoice voided ####', '- **WHEN** an invoice is voided', '- **THEN** a credit note is issued'],
+    expected: 1,
+  },
+  {
+    name: 'a scenario whose body is only a deeper header',
+    scenarios: ['#### Scenario: Invoice voided', '##### Notes'],
+    expected: 1,
+  },
+  {
+    name: 'a scenario header inside a fenced example',
+    scenarios: ['```markdown', '#### Scenario: Example', '- **WHEN** x', '```'],
+    expected: 0,
+  },
+];
+
+/** The requirement block's lines after its `### Requirement:` header. */
+const deltaBodyLines = (scenarios: string[]) => [REQUIREMENT_TEXT, '', ...scenarios];
+
+/** How many scenarios the spec path keeps for the same requirement. */
+function specPathScenarioCount(scenarios: string[]): number {
+  const spec = [
+    '# billing Specification',
+    '',
+    '## Purpose',
+    'Define how billing documents are issued for these tests.',
+    '',
+    '## Requirements',
+    '',
+    '### Requirement: Credit Notes',
+    ...deltaBodyLines(scenarios),
+    '',
+  ].join('\n');
+  return new MarkdownParser(spec).parseSpec('billing').requirements[0].scenarios.length;
+}
+
+describe('scenario counting: delta path and spec path agree', () => {
+  for (const { name, scenarios, expected } of CASES) {
+    it(`counts ${name} the same on both paths`, () => {
+      expect(specPathScenarioCount(scenarios)).toBe(expected);
+      expect(countScenarios(deltaBodyLines(scenarios))).toBe(expected);
+    });
+  }
+});
+
+const temps: string[] = [];
+afterAll(async () => {
+  await Promise.all(temps.map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+
+async function tempDir(prefix: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  temps.push(dir);
+  return dir;
+}
+
+const deltaSpec = (section: 'ADDED' | 'MODIFIED', scenarios: string[]) =>
+  [`## ${section} Requirements`, '### Requirement: Credit Notes', ...deltaBodyLines(scenarios), ''].join('\n');
+
+describe('validate rejects a requirement whose only scenario is empty', () => {
+  async function validateDelta(delta: string) {
+    const changeDir = await tempDir('openspec-scenario-body-');
+    await fs.mkdir(path.join(changeDir, 'specs', 'billing'), { recursive: true });
+    await fs.writeFile(path.join(changeDir, 'specs', 'billing', 'spec.md'), delta);
+    return new Validator().validateChangeDeltaSpecs(changeDir);
+  }
+
+  const scenarioErrors = (report: { issues: Array<{ level: string; message: string }> }) =>
+    report.issues.filter((issue) => issue.level === 'ERROR' && issue.message.includes('scenario'));
+
+  it('control: accepts a scenario with steps', async () => {
+    const report = await validateDelta(deltaSpec('ADDED', CASES[0].scenarios));
+    expect(report.valid).toBe(true);
+  });
+
+  for (const section of ['ADDED', 'MODIFIED'] as const) {
+    it(`rejects a ${section} requirement whose only scenario has no body, naming it`, async () => {
+      const report = await validateDelta(deltaSpec(section, ['#### Scenario: Invoice voided']));
+      expect(report.valid).toBe(false);
+      const errors = scenarioErrors(report);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toContain(`${section} "Credit Notes"`);
+      // Say why a header the author can see does not count.
+      expect(errors[0].message).toMatch(/no body|nothing under/i);
+    });
+  }
+
+  it('rejects a scenario whose body is only whitespace', async () => {
+    const report = await validateDelta(deltaSpec('ADDED', ['#### Scenario: Invoice voided', '   ', '\t']));
+    expect(report.valid).toBe(false);
+  });
+
+  it('accepts two scenarios when only one is empty, as archive does', async () => {
+    const report = await validateDelta(deltaSpec('ADDED', CASES[3].scenarios));
+    expect(scenarioErrors(report)).toEqual([]);
+  });
+});
+
+/**
+ * A real project, created with `openspec init` and `openspec new change`, whose
+ * change `edit` adds a Credit Notes requirement with the given scenarios.
+ */
+async function projectWithScenarios(scenarios: string[]) {
+  const base = await tempDir('openspec-scenario-body-e2e-');
+  const home = path.join(base, 'home');
+  const project = path.join(base, 'project');
+  await fs.mkdir(home, { recursive: true });
+  await fs.mkdir(project, { recursive: true });
+  const env = {
+    HOME: home,
+    USERPROFILE: home,
+    XDG_CONFIG_HOME: path.join(home, '.config'),
+    XDG_DATA_HOME: path.join(home, '.local', 'share'),
+    OPENSPEC_NO_ANIMATION: '1',
+  };
+  const cli = (args: string[]) => runCLI(args, { cwd: project, env, timeoutMs: 60_000 });
+
+  expect((await cli(['init', '--tools', 'claude'])).exitCode).toBe(0);
+  expect((await cli(['new', 'change', 'edit'])).exitCode).toBe(0);
+  const dir = path.join(project, 'openspec', 'changes', 'edit');
+  await fs.mkdir(path.join(dir, 'specs', 'billing'), { recursive: true });
+  await fs.writeFile(
+    path.join(dir, 'proposal.md'),
+    '# Credit notes\n\n## Why\nVoided invoices need a matching credit note so the ledger always balances.\n\n## What Changes\n- **billing**: adds credit notes\n'
+  );
+  await fs.writeFile(path.join(dir, 'tasks.md'), '## 1. Work\n- [x] 1.1 Done\n');
+  await fs.writeFile(path.join(dir, 'specs', 'billing', 'spec.md'), deltaSpec('ADDED', scenarios));
+
+  return {
+    verdicts: async () => {
+      const validated = JSON.parse((await cli(['validate', 'edit', '--json'])).stdout);
+      const archived = await cli(['archive', 'edit', '--yes']);
+      return { valid: validated.items[0].valid as boolean, archived: archived.exitCode === 0 };
+    },
+  };
+}
+
+describe('validate and archive give the same verdict (e2e)', () => {
+  it('control: a scenario with steps is valid and archives', async () => {
+    const project = await projectWithScenarios(CASES[0].scenarios);
+    expect(await project.verdicts()).toEqual({ valid: true, archived: true });
+  }, 120_000);
+
+  it('a scenario header with no body is rejected by both', async () => {
+    const project = await projectWithScenarios(['#### Scenario: Invoice voided']);
+    expect(await project.verdicts()).toEqual({ valid: false, archived: false });
+  }, 120_000);
+
+  it('two scenarios where one is empty are accepted by both', async () => {
+    const project = await projectWithScenarios(CASES[3].scenarios);
+    expect(await project.verdicts()).toEqual({ valid: true, archived: true });
+  }, 120_000);
+});


### PR DESCRIPTION
Closes #1857.

## Why

A requirement whose only scenario is a header with nothing under it passed
`validate` and was then refused by `archive`:

```
openspec validate edit --json   # "valid": true
openspec archive edit --yes     # ✗ Requirement must have at least one scenario
                                #   Aborted. No files were changed.
```

The two scenario counters the code says must agree did not:

- The delta path, `countScenarios` (`src/core/parsers/requirement-text.ts:94`),
  counted every non-fenced `####` header. `validate` uses it for ADDED and
  MODIFIED (`src/core/validation/validator.ts:272`, `:307`).
- The spec path, `MarkdownParser.parseScenarios`
  (`src/core/parsers/markdown-parser.ts:176`), keeps a scenario only when its
  body has content. Archive validates the rebuilt spec on this path.

So the failure was deferred from authoring time to archive time, and the
archive error did not name the requirement. The parity is already stated as a
requirement at `requirement-text.ts:26`.

## What Changes

- New shared predicate `hasScenarioBody` in `requirement-text.ts`. The spec
  path now calls it instead of its inline `content.trim()`, and the delta
  counter applies it too, so the rule lives in one place.
- `countScenarios` reads each scenario's body up to the next non-fenced header
  of level 4 or above, the same boundary the spec path's section reader uses,
  and counts only scenarios whose body has content.
- `validate`'s "must include at least one scenario" error for ADDED and
  MODIFIED gains a hint when the block does have a bare scenario header:
  "(a scenario header with no body under it does not count; add its steps,
  e.g. ...)". The message already names the requirement; the hint explains why
  a header the author can see does not count. It is appended only in that case,
  so every existing message is unchanged.

Unchanged:

- Main-spec parsing and `validate <spec>` (same predicate, same behavior).
- A scenario whose body is only a fenced block, or only a deeper `#####`
  header, still counts on both paths.
- A requirement with one real scenario still passes when another scenario is
  empty; archive accepts that too.
- The MODIFIED scenario-loss check (`parseScenarioBlocks` in
  `requirement-blocks.ts`) is name-based and still sees every `####` header,
  including empty ones. That is the conservative direction: it can refuse to
  drop an empty scenario, never silently drop a real one.

## Testing

`test/core/validation.scenario-body-parity.test.ts`: 17 tests, written first
and watched fail on `9d4e597` (8 failed / 9 passed before, 17 passed after).

- **Parity table.** For 9 scenario shapes, both counters return the expected
  number: `countScenarios` on the delta block, and
  `MarkdownParser.parseSpec(...).requirements[0].scenarios.length` on the same
  requirement written as a main spec. The shapes are:
  - with steps;
  - header only;
  - blank and whitespace-only body;
  - two scenarios with one empty;
  - fenced-only body;
  - closed header (`#### Scenario: X ####`) with and without steps;
  - a deeper header as the body;
  - a `####` inside a fence.
- **Validator.** An ADDED or MODIFIED requirement whose only scenario is empty
  is rejected with one error naming it and explaining the rule. A
  whitespace-only body is rejected. One empty scenario next to a real one is
  accepted. The control with steps passes.
- **End to end,** in a project built with `openspec init` + `openspec new
  change`: `validate` and `archive` give the same verdict. An empty scenario is
  rejected by both, a scenario with steps is accepted by both, and two
  scenarios with one empty are accepted by both.

Verification, in a clean Linux sandbox on Node 20.19.0 (the CI version):

- `pnpm run build`: ok
- `pnpm exec tsc --noEmit`: ok
- `pnpm lint`: ok
- `pnpm test`: 4562 passed, 18 failed (4580 tests, 159 files). Every failure
  was a timeout in a loaded sandbox, not an assertion:
  - 17 were `Test timed out in 10000ms` in the store and workset CLI suites
    (`store*.test.ts`, `workset.test.ts`);
  - 1 was `spawnSync npm ETIMEDOUT` in `package-install-scripts.test.ts`.

  None of those files touches the changed code. Rerun in isolation, the 6
  affected files passed 162/163. The one left,
  `package-install-scripts > refuses to pack when TypeScript compilation fails`,
  is an `npm pack` + `tsc` run that also times out at 10s on clean `main` in the
  same sandbox. With `--testTimeout=120000`, `package-install-scripts.test.ts`
  passes 8/8 on this branch and on `main`.

## Changeset

`.changeset/validate-rejects-empty-scenarios.md` (patch). Worth noting for
release notes: a change whose only scenario is a bare header now fails
`validate`. Archive already refused it, so nothing that archived before stops
archiving.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed validation so requirements containing only empty scenario headers are rejected consistently.
  - Validation and archiving now apply the same rules when evaluating scenario content.
  - Error messages identify the affected requirement and explain that the scenario needs content.
  - Scenarios containing steps, fenced blocks, deeper headers, or at least one valid scenario continue to be accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->