### PR TITLE
fix(parser): drop closing hashes from requirement names

### DIFF
--- a/.changeset/requirement-names-drop-closing-hashes.md
+++ b/.changeset/requirement-names-drop-closing-hashes.md
@@ -1,0 +1,5 @@
+---
+'@fission-ai/openspec': patch
+---
+
+Read a requirement heading written with a CommonMark closing sequence, such as `### Requirement: Late Fees ###`, as the requirement it renders as. The trailing `#` run stayed in the name, so a REMOVED written that way looked for "Late Fees ###", missed the requirement, and archive exited 0 with a false "treating it as already removed" warning while the requirement stayed in the spec; a closed MODIFIED or RENAMED heading failed as "not found", and a closed and an open heading of one requirement were not reported as duplicates. Requirement names now drop the closing run wherever they are read, exactly as scenario names already did: only a run preceded by a space or tab counts, so a name such as `C#` keeps its `#`. Headings without a closing run are unaffected.

--- a/src/core/parsers/requirement-blocks.ts
+++ b/src/core/parsers/requirement-blocks.ts
@@ -15,7 +15,11 @@ export interface RequirementsSectionParts {
 }
 
 export function normalizeRequirementName(name: string): string {
-  return name.trim();
+  // An ATX heading may end in a closing run of `#`s: `### Requirement: Foo ###`
+  // renders as `Foo`, so the run is not part of the name. As for scenario names,
+  // only a run preceded by a space or tab closes the heading, so `C#` keeps its
+  // `#`, and `[ \t]` rather than `\s` keeps an NBSP-separated run in the name.
+  return name.replace(/[ \t]+#+[ \t]*$/, '').trim();
 }
 
 /**

--- a/src/core/parsers/spec-structure.ts
+++ b/src/core/parsers/spec-structure.ts
@@ -1,4 +1,5 @@
 import { buildCodeFenceMask } from './code-fence.js';
+import { normalizeRequirementName } from './requirement-blocks.js';
 
 const REQUIREMENTS_SECTION_HEADER = /^##\s+Requirements\s*$/i;
 const TOP_LEVEL_SECTION_HEADER = /^##\s+/;
@@ -73,7 +74,9 @@ export function findMainSpecStructureIssues(content: string): MainSpecStructureI
       continue;
     }
 
-    const requirementName = requirementMatch[1].trim();
+    // The same name every other reader uses, so a closed heading
+    // (`### Requirement: Foo ###`) duplicates `### Requirement: Foo`.
+    const requirementName = normalizeRequirementName(requirementMatch[1]);
     const previousLine = requirementLines.get(requirementName);
     if (previousLine !== undefined) {
       issues.push({

--- a/test/cli-e2e/archive-closed-requirement-heading.test.ts
+++ b/test/cli-e2e/archive-closed-requirement-heading.test.ts
@@ -1,0 +1,111 @@
+import { afterAll, describe, expect, it } from 'vitest';
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+import { runCLI } from '../helpers/run-cli.js';
+
+/**
+ * End to end: a REMOVED heading written with a CommonMark closing run
+ * (`### Requirement: Late Fees ###`) must remove the requirement, instead of
+ * archiving as a no-op behind a false "treating it as already removed" warning.
+ */
+const tempRoots: string[] = [];
+afterAll(async () => {
+  await Promise.all(tempRoots.map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+const TIMEOUT = 120_000;
+
+const PROPOSAL = [
+  '# Edit billing',
+  '',
+  '## Why',
+  'We need to keep the billing contract accurate for operators and customers over time.',
+  '',
+  '## What Changes',
+  '- **billing**: updates billing requirements',
+  '',
+].join('\n');
+
+const SEED = [
+  '## ADDED Requirements',
+  '### Requirement: Invoice Generation',
+  'The system SHALL generate an invoice for every completed billing period.',
+  '',
+  '#### Scenario: Period closes',
+  '- **WHEN** a billing period closes',
+  '- **THEN** an invoice is generated',
+  '',
+  '### Requirement: Late Fees',
+  'The system SHALL apply a late fee to invoices overdue by 30 days.',
+  '',
+  '#### Scenario: Thirty days overdue',
+  '- **WHEN** an invoice is 30 days overdue',
+  '- **THEN** a late fee is applied',
+  '',
+].join('\n');
+
+/**
+ * A project whose main billing spec was written by archiving a seed change,
+ * plus an open `edit` change waiting for a delta.
+ */
+async function seededProject() {
+  const base = await fs.mkdtemp(path.join(os.tmpdir(), 'openspec-closed-heading-e2e-'));
+  tempRoots.push(base);
+  const home = path.join(base, 'home');
+  const project = path.join(base, 'project');
+  await fs.mkdir(home, { recursive: true });
+  await fs.mkdir(project, { recursive: true });
+  const env = {
+    HOME: home,
+    USERPROFILE: home,
+    XDG_CONFIG_HOME: path.join(home, '.config'),
+    XDG_DATA_HOME: path.join(home, '.local', 'share'),
+    OPENSPEC_NO_ANIMATION: '1',
+  };
+  const cli = (args: string[]) => runCLI(args, { cwd: project, env, timeoutMs: 60_000 });
+
+  expect((await cli(['init', '--tools', 'claude'])).exitCode).toBe(0);
+  expect((await cli(['new', 'change', 'seed'])).exitCode).toBe(0);
+  const seedDir = path.join(project, 'openspec', 'changes', 'seed');
+  await fs.mkdir(path.join(seedDir, 'specs', 'billing'), { recursive: true });
+  await fs.writeFile(path.join(seedDir, 'proposal.md'), PROPOSAL);
+  await fs.writeFile(path.join(seedDir, 'tasks.md'), '## 1. Work\n- [x] 1.1 Done\n');
+  await fs.writeFile(path.join(seedDir, 'specs', 'billing', 'spec.md'), SEED);
+  expect((await cli(['archive', 'seed', '--yes'])).exitCode).toBe(0);
+
+  expect((await cli(['new', 'change', 'edit'])).exitCode).toBe(0);
+  const editDir = path.join(project, 'openspec', 'changes', 'edit');
+  await fs.mkdir(path.join(editDir, 'specs', 'billing'), { recursive: true });
+  await fs.writeFile(path.join(editDir, 'proposal.md'), PROPOSAL);
+  await fs.writeFile(path.join(editDir, 'tasks.md'), '## 1. Work\n- [x] 1.1 Done\n');
+
+  const mainSpec = path.join(project, 'openspec', 'specs', 'billing', 'spec.md');
+  return {
+    cli,
+    writeDelta: (body: string) => fs.writeFile(path.join(editDir, 'specs', 'billing', 'spec.md'), body),
+    headers: async () =>
+      (await fs.readFile(mainSpec, 'utf-8'))
+        .split('\n')
+        .filter((line) => line.startsWith('### Requirement:'))
+        .map((line) => line.slice('### Requirement:'.length).trim()),
+  };
+}
+
+describe('archive with a closed REMOVED heading', () => {
+  it('removes the requirement for a plain REMOVED heading (control)', async () => {
+    const p = await seededProject();
+    await p.writeDelta('## REMOVED Requirements\n### Requirement: Late Fees\n**Reason**: no longer charged\n');
+    const result = await p.cli(['archive', 'edit', '--yes']);
+    expect(result.exitCode).toBe(0);
+    expect(await p.headers()).toEqual(['Invoice Generation']);
+  }, TIMEOUT);
+
+  it('removes the requirement for a REMOVED heading with a closing # run', async () => {
+    const p = await seededProject();
+    await p.writeDelta('## REMOVED Requirements\n### Requirement: Late Fees ###\n**Reason**: no longer charged\n');
+    const result = await p.cli(['archive', 'edit', '--yes']);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout + result.stderr).not.toContain('treating it as already removed');
+    expect(await p.headers()).toEqual(['Invoice Generation']);
+  }, TIMEOUT);
+});

--- a/test/core/parsers/closed-requirement-heading.test.ts
+++ b/test/core/parsers/closed-requirement-heading.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+import {
+  extractRequirementsSection,
+  normalizeRequirementName,
+  parseDeltaSpec,
+} from '../../../src/core/parsers/requirement-blocks.js';
+import { findMainSpecStructureIssues } from '../../../src/core/parsers/spec-structure.js';
+import { buildUpdatedSpec, findSpecUpdates } from '../../../src/core/specs-apply.js';
+
+const NBSP = String.fromCharCode(0xa0);
+
+/**
+ * CommonMark lets an ATX heading end in a closing run of `#`s, so
+ * `### Requirement: Late Fees ###` renders as the same heading as
+ * `### Requirement: Late Fees`. Requirement names kept the run, so a REMOVED
+ * written that way looked for "Late Fees ###", missed the requirement, and
+ * archive skipped the removal with a false "treating it as already removed"
+ * warning. Scenario names already dropped the run; requirement names now do too.
+ */
+describe('requirement names with a CommonMark closing sequence', () => {
+  describe('normalizeRequirementName', () => {
+    it.each([
+      ['Late Fees ###', 'Late Fees'],
+      ['Late Fees #', 'Late Fees'],
+      ['Late Fees \t##  ', 'Late Fees'],
+      ['  Late Fees  ', 'Late Fees'],
+    ])('strips the closing run from %j', (input, expected) => {
+      expect(normalizeRequirementName(input)).toBe(expected);
+    });
+
+    it.each([
+      // Not a closing sequence: the run must be preceded by a space or tab.
+      ['C#', 'C#'],
+      ['Foo##', 'Foo##'],
+      // Not a closing sequence: the run must end the line.
+      ['Priority #1', 'Priority #1'],
+      // CommonMark does not treat NBSP as the separator, so the run stays.
+      [`Late Fees${NBSP}###`, `Late Fees${NBSP}###`],
+    ])('keeps %j unchanged', (input, expected) => {
+      expect(normalizeRequirementName(input)).toBe(expected);
+    });
+  });
+
+  describe('readers', () => {
+    it('names a closed main-spec heading by its rendered text', () => {
+      const parts = extractRequirementsSection(
+        ['## Requirements', '### Requirement: Late Fees ###', 'The system SHALL charge late fees.', ''].join('\n')
+      );
+      expect(parts.bodyBlocks.map((b) => b.name)).toEqual(['Late Fees']);
+    });
+
+    it('reads every delta section header form without the closing run', () => {
+      const plan = parseDeltaSpec(
+        [
+          '## ADDED Requirements',
+          '### Requirement: Credit Notes ##',
+          'The system SHALL issue credit notes.',
+          '',
+          '## MODIFIED Requirements',
+          '### Requirement: Invoice Generation ###',
+          'The system SHALL generate invoices.',
+          '',
+          '## REMOVED Requirements',
+          '### Requirement: Late Fees ###',
+          '- `### Requirement: Grace Period ###`',
+          '',
+          '## RENAMED Requirements',
+          '- FROM: `### Requirement: Refunds ###`',
+          '- TO: `### Requirement: Credit Refunds ###`',
+          '',
+        ].join('\n')
+      );
+      expect(plan.added.map((b) => b.name)).toEqual(['Credit Notes']);
+      expect(plan.modified.map((b) => b.name)).toEqual(['Invoice Generation']);
+      expect(plan.removed).toEqual(['Late Fees', 'Grace Period']);
+      expect(plan.renamed).toEqual([{ from: 'Refunds', to: 'Credit Refunds' }]);
+    });
+
+    it('reports a closed and an open heading of one requirement as duplicates', () => {
+      const issues = findMainSpecStructureIssues(
+        [
+          '## Requirements',
+          '### Requirement: Late Fees',
+          'The system SHALL charge late fees.',
+          '',
+          '### Requirement: Late Fees ###',
+          'The system SHALL charge late fees again.',
+          '',
+        ].join('\n')
+      );
+      expect(issues.map((issue) => issue.kind)).toEqual(['duplicate-requirement']);
+    });
+
+    it('does not report distinct names as duplicates (control)', () => {
+      const issues = findMainSpecStructureIssues(
+        ['## Requirements', '### Requirement: C', 'x', '', '### Requirement: C#', 'y', ''].join('\n')
+      );
+      expect(issues).toEqual([]);
+    });
+  });
+
+  describe('buildUpdatedSpec', () => {
+    let tempDir: string;
+
+    beforeEach(async () => {
+      tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'openspec-closed-heading-'));
+    });
+    afterEach(async () => {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    });
+
+    const mainSpec = (lateFeesHeader = '### Requirement: Late Fees') =>
+      [
+        '# billing Specification',
+        '',
+        '## Purpose',
+        'Defines how billing behaves for customers and operators.',
+        '',
+        '## Requirements',
+        '### Requirement: Invoice Generation',
+        'The system SHALL generate an invoice for every completed billing period.',
+        '',
+        '#### Scenario: Period closes',
+        '- **WHEN** a billing period closes',
+        '- **THEN** an invoice is generated',
+        '',
+        lateFeesHeader,
+        'The system SHALL apply a late fee to invoices overdue by 30 days.',
+        '',
+        '#### Scenario: Thirty days overdue',
+        '- **WHEN** an invoice is 30 days overdue',
+        '- **THEN** a late fee is applied',
+        '',
+      ].join('\n');
+
+    async function build(deltaBody: string, main = mainSpec()) {
+      const specsRoot = path.join(tempDir, 'openspec', 'specs');
+      const specsDir = path.join(specsRoot, 'billing');
+      const changeDir = path.join(tempDir, 'openspec', 'changes', 'c');
+      await fs.mkdir(specsDir, { recursive: true });
+      await fs.mkdir(path.join(changeDir, 'specs', 'billing'), { recursive: true });
+      await fs.writeFile(path.join(specsDir, 'spec.md'), main);
+      await fs.writeFile(path.join(changeDir, 'specs', 'billing', 'spec.md'), deltaBody);
+      const [update] = await findSpecUpdates(changeDir, specsRoot);
+      return buildUpdatedSpec(update, 'c', { silent: true });
+    }
+
+    const headers = (spec: string) => spec.split('\n').filter((line) => line.startsWith('### Requirement:'));
+
+    const modifiedLateFees = (header: string) =>
+      [
+        '## MODIFIED Requirements',
+        header,
+        'The system SHALL apply a late fee to invoices overdue by 45 days.',
+        '',
+        '#### Scenario: Thirty days overdue',
+        '- **WHEN** an invoice is 45 days overdue',
+        '- **THEN** a late fee is applied',
+        '',
+      ].join('\n');
+
+    it('removes a requirement named by a closed REMOVED heading', async () => {
+      const result = await build(
+        ['## REMOVED Requirements', '### Requirement: Late Fees ###', '**Reason**: no longer charged', ''].join('\n')
+      );
+      expect(headers(result.rebuilt)).toEqual(['### Requirement: Invoice Generation']);
+      expect(result.counts.removed).toBe(1);
+      expect(JSON.stringify(result.warnings)).not.toMatch(/already removed/);
+    });
+
+    it('removes a requirement named by a closed REMOVED bullet', async () => {
+      const result = await build(['## REMOVED Requirements', '- `### Requirement: Late Fees ###`', ''].join('\n'));
+      expect(headers(result.rebuilt)).toEqual(['### Requirement: Invoice Generation']);
+      expect(result.counts.removed).toBe(1);
+    });
+
+    it('removes a requirement whose main-spec heading is closed, named plainly in the delta', async () => {
+      const result = await build(
+        ['## REMOVED Requirements', '### Requirement: Late Fees', '**Reason**: no longer charged', ''].join('\n'),
+        mainSpec('### Requirement: Late Fees ###')
+      );
+      expect(headers(result.rebuilt)).toEqual(['### Requirement: Invoice Generation']);
+      expect(result.counts.removed).toBe(1);
+    });
+
+    it('modifies a plain main-spec requirement from a closed MODIFIED heading', async () => {
+      const result = await build(modifiedLateFees('### Requirement: Late Fees ###'));
+      expect(result.counts.modified).toBe(1);
+      expect(result.rebuilt).toContain('overdue by 45 days');
+      expect(result.rebuilt).not.toContain('overdue by 30 days');
+    });
+
+    it('modifies a closed main-spec requirement from a plain MODIFIED heading', async () => {
+      const result = await build(
+        modifiedLateFees('### Requirement: Late Fees'),
+        mainSpec('### Requirement: Late Fees ###')
+      );
+      expect(result.counts.modified).toBe(1);
+      expect(result.rebuilt).toContain('overdue by 45 days');
+    });
+
+    it('renames from and to closed headings, writing the rendered name', async () => {
+      const result = await build(
+        [
+          '## RENAMED Requirements',
+          '- FROM: `### Requirement: Late Fees ###`',
+          '- TO: `### Requirement: Overdue Fees ##`',
+          '',
+        ].join('\n')
+      );
+      expect(headers(result.rebuilt)).toEqual([
+        '### Requirement: Invoice Generation',
+        '### Requirement: Overdue Fees',
+      ]);
+    });
+
+    it('treats a closed ADDED heading of an existing requirement as that requirement', async () => {
+      await expect(
+        build(
+          [
+            '## ADDED Requirements',
+            '### Requirement: Late Fees ###',
+            'The system SHALL apply a late fee to invoices overdue by 15 days.',
+            '',
+            '#### Scenario: Fifteen days overdue',
+            '- **WHEN** an invoice is 15 days overdue',
+            '- **THEN** a late fee is applied',
+            '',
+          ].join('\n')
+        )
+      ).rejects.toThrow('billing ADDED failed for header "### Requirement: Late Fees" - already exists');
+    });
+
+    it('keeps a trailing # that is part of the name (control)', async () => {
+      const result = await build(
+        [
+          '## ADDED Requirements',
+          '### Requirement: C#',
+          'The system SHALL support C# clients.',
+          '',
+          '#### Scenario: Client connects',
+          '- **WHEN** a C# client connects',
+          '- **THEN** it is served',
+          '',
+        ].join('\n')
+      );
+      expect(headers(result.rebuilt)).toContain('### Requirement: C#');
+      expect(result.counts.added).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
Closes #1859.

## Why

CommonMark lets an ATX heading end in a closing run of `#`s, so
`### Requirement: Late Fees ###` renders exactly like
`### Requirement: Late Fees`. Every requirement-name reader kept the run:
`REQUIREMENT_HEADER_REGEX` (`src/core/parsers/requirement-blocks.ts:33`)
captures it, and `normalizeRequirementName` only trimmed whitespace. Scenario
names already strip it (`requirement-blocks.ts:439`, `:454`).

The visible failure is REMOVED. A closed heading names `"Late Fees ###"`, which
is not in the spec, so `buildUpdatedSpec` takes the early-sync branch
(`src/core/specs-apply.ts:454`), warns that the requirement is "not in the
current spec; treating it as already removed", and archive exits 0 — while
`Late Fees` stays in the spec. The same heading under MODIFIED or as a RENAMED
source fails as "not found", and a main spec holding both
`### Requirement: Late Fees` and `### Requirement: Late Fees ###` was not
reported as a duplicate.

## What Changes

- `normalizeRequirementName` strips a closing sequence — a run of `#` preceded
  by a space or tab and followed only by spaces or tabs — then trims. This is the
  same rule `scenarioNameAt` uses, including `[ \t]` rather than `\s`, so `C#`,
  `Foo##` and `Priority #1` keep their `#`, and an NBSP-separated run is kept, as
  CommonMark keeps it.
- Because every reader already funnels names through `normalizeRequirementName`
  — main-spec blocks, ADDED/MODIFIED/REMOVED headers, the REMOVED bullet form,
  RENAMED FROM/TO, the MODIFIED header check in `buildUpdatedSpec`, the validator
  and `requirement-diff` — they all agree without further changes.
- `findMainSpecStructureIssues` (`src/core/parsers/spec-structure.ts`) keyed its
  duplicate check on a bare `trim()`; it now uses `normalizeRequirementName`, so
  a closed and an open heading of one requirement are reported as duplicates.

A RENAMED target written with a closing run is written back as the rendered name
(`### Requirement: Overdue Fees`). Headings without a closing run are unaffected.

## Testing

Written first and watched fail, then passing:

- `test/core/parsers/closed-requirement-heading.test.ts` — 20 tests:
  `normalizeRequirementName` (4 stripped forms, 4 kept forms), the readers
  (main-spec section, every delta header form, duplicate detection and its
  control), and `buildUpdatedSpec` (closed REMOVED heading and bullet, closed
  main-spec heading, closed MODIFIED either way, closed RENAMED FROM/TO, closed
  ADDED of an existing requirement, `C#` control)
- `test/cli-e2e/archive-closed-requirement-heading.test.ts` — 2 end-to-end tests
  through the built CLI: plain REMOVED (control) and closed REMOVED, asserting
  the requirement is removed and the "treating it as already removed" warning is
  gone

Before the fix: 14 failed / 8 passed (the 8 passing are controls and the kept
forms). After: 22 passed.

The round-2 report's own reproduction for this bug (2 tests through the built
CLI) failed on `main` and passes on this branch.

CI parity, run on Node 20.19.0 (the CI version) with the commands from
`.github/workflows/ci.yml`:

- `pnpm run build` — pass
- `pnpm exec tsc --noEmit` — pass
- `pnpm lint` — pass
- `changeset status --since=origin/main` — pass (patch → 1.13.1), run on
  Node 22 because `@changesets/cli` 3 needs `module.enableCompileCache`; the
  CI job that runs it uses Node 24
- `VITEST_MAX_WORKERS=4 pnpm test` — 4528 passed, 57 failed of 4585. All 57
  are timing failures on a heavily shared host (load average up to 19 on 6
  cores; part of the run also shared the machine with a second test run):
  56 × "Test timed out in 10000ms" and 1 × `spawnSync npm ETIMEDOUT`. None is
  an assertion failure.
- Those 10 files rerun on their own (`VITEST_MAX_WORKERS=2`): 298 of 299
  passed. That includes all of `show-diff.test.ts` (18) and
  `artifact-workflow.test.ts` (78), the two that read requirement names. The
  one left is the `npm pack` + `tsc` test in `package-install-scripts.test.ts`,
  which timed out at 11.2s, as it also did on `fix-requirement-name-near-miss`.
- That `npm pack` test run alone, twice each on `main`, this branch and
  `fix-requirement-name-near-miss`: 8 of 8 passed every time.
- Full suite again on a quiet host (`VITEST_MAX_WORKERS=2 pnpm test`): all
  4585 tests in 160 files passed.

## Changeset

`.changeset/requirement-names-drop-closing-hashes.md` (patch).

## Notes for reviewers

- `src/core/parsers/change-parser.ts` (the reader behind
  `show --json --deltas-only`) has its own RENAMED FROM/TO regex that does not go
  through `normalizeRequirementName`; it is left alone here because
  `fix-show-deltas-reader` reworks that reader.
- `fix-requirement-name-near-miss` edits the `foldRequirementName` doc comment in
  the same file, a few lines below the function changed here. The hunks do not
  overlap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Requirement headings with CommonMark-style closing `#` characters are now parsed correctly.
  - Changes can reliably remove, modify, or rename requirements whose headings use closing hashes.
  - Duplicate detection now recognizes equivalent closed and unclosed headings.
  - Hashes that are part of a requirement name, such as `C#`, remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->