### PR TITLE
fix(tasks): count checkboxes under every list marker

### DIFF
--- a/.changeset/tasks-count-every-list-marker.md
+++ b/.changeset/tasks-count-every-list-marker.md
@@ -1,0 +1,5 @@
+---
+'@fission-ai/openspec': patch
+---
+
+Count task checkboxes under every CommonMark list marker. The task counter shared by `list`, `status`, `view`, `instructions apply`, `validate --archived` and archive's incomplete-task check recognised only `-` and `*` bullets, so a task written as an ordered item (`1. [ ]`, `1) [ ]`) or under a `+` bullet was invisible to all of them: a change with unfinished ordered tasks reported "✓ Complete", and `openspec archive` archived it without its incomplete-task warning. Task lines under `+` and ordered markers (`.` or `)`, up to nine digits, as CommonMark allows) now count exactly like `-` and `*` ones, including nested sub-tasks, CRLF files and the existing tolerance of a missing space after the marker, and task-numbering checks now see them too. Ordered and `+` items without a checkbox are still ignored, and `-` and `*` tasks count as before.

--- a/src/utils/task-progress.ts
+++ b/src/utils/task-progress.ts
@@ -5,7 +5,10 @@ import { resolveArtifactOutputs, resolveSchema } from '../core/artifact-graph/in
 import { resolveSchemaForChange } from './change-metadata.js';
 
 /**
- * A Markdown task line: a `-`/`*` bullet carrying a `[ ]` or `[x]` checkbox.
+ * A Markdown task line: a list item carrying a `[ ]` or `[x]` checkbox, under
+ * any CommonMark list marker - `-`, `*`, `+`, or an ordered `1.` / `1)` of up
+ * to nine digits. Reading only `-` and `*` left an unchecked `1. [ ]` or
+ * `+ [ ]` task out of every count, so archive reported "✓ Complete" over it.
  *
  * Leading whitespace is allowed so nested sub-tasks count like their parents.
  * Anchoring at column 0 made `  - [ ] 1.1.1 ...` invisible to progress, to the
@@ -20,7 +23,7 @@ import { resolveSchemaForChange } from './change-metadata.js';
  * Deliberately unanchored at the end: `.` does not match `\r`, so writing the
  * description group as `(.*)$` would reject every line of a CRLF tasks.md.
  */
-const TASK_LINE_PATTERN = /^\s*[-*]\s*\[([\sxX])\]\s*(.*)/;
+const TASK_LINE_PATTERN = /^\s*(?:[-*+]|\d{1,9}[.)])\s*\[([\sxX])\]\s*(.*)/;
 
 export interface ParsedTask {
   /** Checkbox state: `[x]`/`[X]` is done, anything else is not. */

--- a/test/utils/task-progress.list-markers.test.ts
+++ b/test/utils/task-progress.list-markers.test.ts
@@ -1,0 +1,158 @@
+import { afterAll, describe, expect, it } from 'vitest';
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+import { countTasksFromContent, parseTaskLines } from '../../src/utils/task-progress.js';
+import { findTaskNumberingIssues } from '../../src/core/validation/task-numbering.js';
+import { runCLI } from '../helpers/run-cli.js';
+
+/**
+ * A GFM task is a list item, and CommonMark has five list markers: `-`, `*`,
+ * `+`, and the ordered `1.` and `1)`. Only `-` and `*` used to count, so an
+ * unchecked `1. [ ]` or `+ [ ]` task was invisible to every progress surface,
+ * and `openspec archive` reported "✓ Complete" over unfinished work.
+ */
+describe('task checkboxes under every CommonMark list marker', () => {
+  it.each([
+    ['plus', '+ [ ] 1.1 Task'],
+    ['ordered with a dot', '1. [ ] 1.1 Task'],
+    ['ordered with a paren', '1) [ ] 1.1 Task'],
+    ['multi-digit ordered', '10. [ ] 1.1 Task'],
+    ['nine-digit ordered', '123456789. [ ] 1.1 Task'],
+  ])('reads a %s task', (_label, line) => {
+    expect(parseTaskLines(`${line}\n`)).toEqual([{ done: false, description: '1.1 Task' }]);
+  });
+
+  it('reads the checkbox state under each marker, in either case', () => {
+    const tasks = parseTaskLines('+ [x] a\n+ [X] b\n1. [x] c\n2) [X] d\n3. [ ] e\n');
+
+    expect(tasks.map((task) => task.done)).toEqual([true, true, true, true, false]);
+  });
+
+  it('counts a file that mixes every marker', () => {
+    const content = [
+      '## 1. Work',
+      '- [x] 1.1 Dash',
+      '* [ ] 1.2 Star',
+      '+ [ ] 1.3 Plus',
+      '1. [x] 1.4 Ordered',
+      '2) [ ] 1.5 Ordered with a paren',
+      '',
+    ].join('\n');
+
+    expect(countTasksFromContent(content)).toEqual({ total: 5, completed: 2 });
+  });
+
+  it('counts ordered and plus sub-tasks at every indent, spaces or tabs', () => {
+    const content = [
+      '- [x] 1.1 Parent',
+      '  1. [ ] 1.1.1 Child',
+      '    + [ ] 1.1.1.1 Grandchild',
+      '\t2) [x] 1.1.2 Tab child',
+      '',
+    ].join('\n');
+
+    expect(countTasksFromContent(content)).toEqual({ total: 4, completed: 2 });
+  });
+
+  it('keeps the no-space tolerance the dash bullet already had', () => {
+    // `-[x]` has always counted; the other markers follow the same rule.
+    expect(countTasksFromContent('-[x] a\n+[ ] b\n1.[ ] c\n2)[x] d\n')).toEqual({
+      total: 4,
+      completed: 2,
+    });
+  });
+
+  it('reads ordered tasks in a CRLF file', () => {
+    expect(parseTaskLines('1. [ ] 1.1 First\r\n2) [x] 1.2 Second\r\n')).toEqual([
+      { done: false, description: '1.1 First' },
+      { done: true, description: '1.2 Second' },
+    ]);
+  });
+
+  it('still ignores ordered and plus items that carry no checkbox', () => {
+    expect(parseTaskLines('1. A numbered item\n+ A plus bullet\n2) Another item\n')).toEqual([]);
+  });
+
+  it('does not read a task id or an over-long number as an ordered marker', () => {
+    // `1.1` is a task id, not the marker `1.`; CommonMark caps an ordered
+    // marker at nine digits.
+    expect(parseTaskLines('1.1 [ ] Not a list item\n1234567890. [ ] Ten digits\n')).toEqual([]);
+  });
+
+  it('checks the numbering of ordered tasks like any other task', () => {
+    const issues = findTaskNumberingIssues([
+      { path: 'tasks.md', content: '## 1. Work\n1. [ ] 1.1 First\n2. [ ] 2.1 Wrong group\n' },
+    ]);
+
+    expect(issues).toEqual([
+      expect.objectContaining({ path: 'tasks.md', line: 3, message: expect.stringContaining('"2.1"') }),
+    ]);
+  });
+});
+
+describe('ordered and plus tasks through the CLI', () => {
+  const temps: string[] = [];
+  afterAll(async () => {
+    await Promise.all(temps.map((dir) => fs.rm(dir, { recursive: true, force: true })));
+  });
+
+  /** A real project holding one valid change whose tasks.md is `tasks`. */
+  async function projectWithTasks(tasks: string) {
+    const base = await fs.mkdtemp(path.join(os.tmpdir(), 'openspec-task-markers-'));
+    temps.push(base);
+    const home = path.join(base, 'home');
+    const project = path.join(base, 'project');
+    await fs.mkdir(home, { recursive: true });
+    await fs.mkdir(project, { recursive: true });
+    const env = {
+      HOME: home,
+      USERPROFILE: home,
+      XDG_CONFIG_HOME: path.join(home, '.config'),
+      XDG_DATA_HOME: path.join(home, '.local', 'share'),
+      OPENSPEC_NO_ANIMATION: '1',
+    };
+    const cli = (args: string[]) => runCLI(args, { cwd: project, env, timeoutMs: 60_000 });
+
+    expect((await cli(['init', '--tools', 'claude'])).exitCode).toBe(0);
+    expect((await cli(['new', 'change', 'add-thing'])).exitCode).toBe(0);
+    const changeDir = path.join(project, 'openspec', 'changes', 'add-thing');
+    await fs.mkdir(path.join(changeDir, 'specs', 'billing'), { recursive: true });
+    await fs.writeFile(
+      path.join(changeDir, 'proposal.md'),
+      '# Add thing\n\n## Why\nWe need billing documented so operators and customers share one contract for invoices.\n\n## What Changes\n- **billing**: adds a requirement\n'
+    );
+    await fs.writeFile(
+      path.join(changeDir, 'specs', 'billing', 'spec.md'),
+      '## ADDED Requirements\n### Requirement: Invoice Generation\nThe system SHALL generate an invoice for every completed billing period.\n\n#### Scenario: Period closes\n- **WHEN** a billing period closes\n- **THEN** an invoice is generated\n'
+    );
+    await fs.writeFile(path.join(changeDir, 'tasks.md'), tasks);
+    return { cli };
+  }
+
+  it.each([
+    ['dash', '- [ ] 1.2 Not done\n- [ ] 1.3 Not done\n'],
+    ['ordered', '1. [ ] 1.2 Not done\n2. [ ] 1.3 Not done\n'],
+    ['plus', '+ [ ] 1.2 Not done\n+ [ ] 1.3 Not done\n'],
+  ])(
+    'counts unchecked %s tasks in list, and archive warns about them',
+    async (_label, unchecked) => {
+      const project = await projectWithTasks(`## 1. Work\n- [x] 1.1 Done\n${unchecked}`);
+
+      const listed = await project.cli(['list', '--json']);
+      expect(listed.exitCode).toBe(0);
+      expect(JSON.parse(listed.stdout).changes[0]).toMatchObject({
+        name: 'add-thing',
+        completedTasks: 1,
+        totalTasks: 3,
+        status: 'in-progress',
+      });
+
+      const archived = await project.cli(['archive', 'add-thing', '--yes']);
+      const output = archived.stdout + archived.stderr;
+      expect(output).toMatch(/2 incomplete task\(s\) found/);
+      expect(output).not.toMatch(/Task status: ✓ Complete/);
+    },
+    120_000
+  );
+});


### PR DESCRIPTION
Closes #1861.

## Why

The task counter behind every progress surface only recognised `-` and `*`
bullets (`src/utils/task-progress.ts:23`):

```ts
const TASK_LINE_PATTERN = /^\s*[-*]\s*\[([\sxX])\]\s*(.*)/;
```

A GFM task is a list item, and CommonMark has five list markers: `-`, `*`, `+`,
and the ordered `1.` and `1)`. Numbered task lists are ordinary Markdown and
common agent output, but a task written as `1. [ ]` or `+ [ ]` was invisible to
everything that reads this counter:

- `openspec list` and `list --json` (`completedTasks`, `totalTasks`, `status`)
- `openspec status`, `openspec view`, and `openspec change`
- `openspec instructions apply`: its task list, its progress, and the `all_done`
  state
- archive's incomplete-task check (`src/core/archive.ts:1335`)
- `openspec validate --archived`
- task-numbering validation (`src/core/validation/task-numbering.ts:46`)

A change with one `- [x]` and two unchecked ordered tasks reported `1/1`,
`"status": "complete"`. `openspec archive` then printed `Task status: ✓ Complete`
and archived the change without its incomplete-task warning. The pattern's own
comment names the stakes: "a task this parser drops is a task `openspec archive`
stops warning about". Delta parsing already accepts every CommonMark marker
(#1800); this counter never caught up.

Verified against a project built entirely by `openspec init` and
`openspec new change`, on a build of `main` @ `9d4e597` and on the published
`@fission-ai/openspec@1.13.0`.

## What Changes

- `TASK_LINE_PATTERN` accepts `-`, `*`, `+`, and ordered markers
  `\d{1,9}[.)]`. CommonMark caps an ordered marker at nine digits.
- Nothing else about the pattern changes:
  - leading whitespace, so nested sub-tasks count
  - `\s` inside the box
  - the CRLF-safe unanchored end
  - counting checkboxes inside fences
  - the tolerance of a missing space after the marker. `-[x]` has always
    counted, and `+[ ]` and `1.[ ]` now follow the same rule.
- Every consumer goes through `parseTaskLines`, so this one change fixes all the
  surfaces listed above at once.
- docs-lab: the tracked-file example in `reference/schemas/schema-yaml.md` now shows `+`, `1.` and `2)` tasks and states the marker rule.

Unchanged:

- Ordered and `+` items without a checkbox are still ignored.
- A task id such as `1.1 [ ]` is not read as the marker `1.`.
- A ten-digit number is not read as an ordered marker.
- Workflow template prose that tells agents to flip `- [ ]` to `- [x]` is
  untouched.

Worth noting for review: task-numbering validation now also sees ordered and
`+` tasks. A tasks file that numbers ordered checkboxes inconsistently can now
get the same ambiguous-numbering warning a `-` task would.

## Testing

`test/utils/task-progress.list-markers.test.ts` has 16 tests. I wrote them first
and watched them fail on `main`: 13 failed and 3 passed, and the 3 that passed
are the controls. All 16 pass after the fix.

Edge cases covered:

- `+`, `1.`, `1)`, `10.`, and a nine-digit ordered marker
- checkbox state under each marker, in either case
- a file mixing every marker
- ordered and `+` sub-tasks at every indent, with spaces or tabs
- the missing-space tolerance: `-[x]`, `+[ ]`, `1.[ ]`, `2)[x]`
- ordered tasks in a CRLF file
- controls: ordered and `+` items without a checkbox are still ignored, and
  neither `1.1 [ ]` nor a ten-digit number is read as a marker
- task-numbering validation flags an ordered task under the wrong group
- end to end through the built CLI, for `-` (control), ordered and `+` tasks:
  `list --json` reports `1/3` and `in-progress`, and `archive --yes` warns about
  `2 incomplete task(s)` and never prints `✓ Complete`

The existing `test/utils/task-progress.test.ts` passes unchanged.

CI parity: I ran the CI steps in a clean Linux container under Node 20.19.0 (the
CI version), after `pnpm install --frozen-lockfile`. `pnpm run build`,
`pnpm exec tsc --noEmit` and `pnpm lint` pass. The container was shared with
other test runs (load average 12–18 on 6 CPUs). Under the repo's default
10-second `testTimeout`, the full suite's only failures were timeouts in
CLI-spawning store, workset, doctor and schema tests that this change does not
touch; none was an assertion failure. With `--testTimeout=120000
--hookTimeout=120000`, the full `pnpm test` ran 4579 tests: 4574 passed and 5
failed, all for environmental reasons:

- Four `store root selection` tests (#1689) set their own 30-second timeout
  (`test/commands/store-root-selection.test.ts:190`), which overrides the flag,
  and hit it.
- One `npm source installation` test failed when an `npm` subprocess hit its
  30-second `spawnSync` timeout (`ETIMEDOUT`).

I reran both of those files on their own, under the suite lock with
`--maxWorkers=2`. They pass on this branch (52/52), and they pass the same way on
a pristine `main` @ `9d4e597`.

CI's `validate-changesets` job runs on Node 24, and
`@changesets/cli` 3 needs Node 22 or newer because it calls
`module.enableCompileCache`. So I ran `pnpm exec changeset status` under
Node 22; it lists the patch bump for `@fission-ai/openspec`.

## Changeset

`.changeset/tasks-count-every-list-marker.md` (patch).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Task progress and completion checks now recognize checklist items using `+` bullets and ordered markers such as `1.` and `1)`.
  - Unfinished tasks in these formats now appear correctly in status, list, view, validation, and archive checks.
  - Nested tasks, CRLF files, and existing no-space checklist syntax are supported consistently.
  - Non-checkbox list items remain excluded from task counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
