### PR TITLE
fix(archive): refuse requirement names differing only in case

### DIFF
--- a/.changeset/archive-refuses-requirement-name-near-miss.md
+++ b/.changeset/archive-refuses-requirement-name-near-miss.md
@@ -1,0 +1,5 @@
+---
+'@fission-ai/openspec': patch
+---
+
+Stop archive adding a second copy of an existing requirement under a name that differs only in case or spacing. ADDED and the RENAMED target compared requirement names exactly, while REMOVED and the RENAMED source already treated a case or whitespace variant as a mistyped header, so an ADDED `late fees` beside an existing `Late Fees`, or a rename to `LATE FEES`, archived cleanly and left two contradicting requirements in the main spec, which `validate` then accepted. Both now refuse with an error naming the existing requirement, in the same form REMOVED already used. The exact-duplicate error is unchanged, a case-only rename of a requirement to its own name still works, and a variant of a requirement the same delta removes or renames away is still allowed, because ADDED is checked against the spec as it stands after the earlier operations, as the exact check already was.

--- a/src/core/parsers/requirement-blocks.ts
+++ b/src/core/parsers/requirement-blocks.ts
@@ -21,9 +21,10 @@ export function normalizeRequirementName(name: string): string {
 /**
  * Case- and whitespace-insensitive fold of a requirement name. Requirement
  * matching itself is case-sensitive (normalizeRequirementName); this fold
- * exists only for typo detection - near-miss REMOVED headers and the
- * RENAMED+REMOVED cross-section conflict - where two spellings that differ
- * only in case or interior whitespace mean a mistake, never two requirements.
+ * exists only for typo detection - near-miss REMOVED, ADDED and RENAMED
+ * headers and the RENAMED+REMOVED cross-section conflict - where two spellings
+ * that differ only in case or interior whitespace mean a mistake, never two
+ * requirements.
  */
 export function foldRequirementName(name: string): string {
   return normalizeRequirementName(name).toLowerCase().replace(/\s+/g, ' ');

--- a/src/core/specs-apply.ts
+++ b/src/core/specs-apply.ts
@@ -412,6 +412,17 @@ export async function buildUpdatedSpec(
     if (nameToBlock.has(to)) {
       throw new Error(`${specName} RENAMED failed for header "### Requirement: ${r.to}" - target already exists`);
     }
+    // A target that differs from another requirement only in case or interior
+    // whitespace would leave two copies of one requirement. The source itself
+    // is exempt, so a case-only rename of a requirement stays allowed.
+    const targetNearMiss = [...nameToBlock.keys()].find(
+      (k) => k !== from && foldRequirementName(k) === foldRequirementName(to)
+    );
+    if (targetNearMiss !== undefined) {
+      throw new Error(
+        `${specName} RENAMED failed for header "### Requirement: ${r.to}" - "### Requirement: ${nameToBlock.get(targetNearMiss)!.name}" already exists and differs only in case or spacing; choose a distinct name`
+      );
+    }
     const block = nameToBlock.get(from)!;
     const newHeader = `### Requirement: ${to}`;
     const rawLines = block.raw.split('\n');
@@ -504,6 +515,17 @@ export async function buildUpdatedSpec(
         continue;
       }
       throw new Error(`${specName} ADDED failed for header "### Requirement: ${add.name}" - already exists`);
+    }
+    // A name that differs from an existing requirement only in case or
+    // interior whitespace is that requirement written again: adding it would
+    // leave two contradicting copies in the spec. Like the exact check above,
+    // this compares against the spec as it stands after the earlier operations,
+    // so a variant of a requirement this delta removed or renamed away is fine.
+    const nearMiss = [...nameToBlock.keys()].find((k) => foldRequirementName(k) === foldRequirementName(key));
+    if (nearMiss !== undefined) {
+      throw new Error(
+        `${specName} ADDED failed for header "### Requirement: ${add.name}" - "### Requirement: ${nameToBlock.get(nearMiss)!.name}" already exists and differs only in case or spacing; use MODIFIED with that exact header to change it, or choose a distinct name`
+      );
     }
     nameToBlock.set(key, add);
     addedApplied++;

--- a/test/cli-e2e/archive-requirement-name-near-miss.test.ts
+++ b/test/cli-e2e/archive-requirement-name-near-miss.test.ts
@@ -1,0 +1,147 @@
+import { afterAll, describe, expect, it } from 'vitest';
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+import { runCLI } from '../helpers/run-cli.js';
+
+/**
+ * End to end: archive must refuse an ADDED or RENAMED name that differs only in
+ * case or spacing from an existing requirement, instead of writing a second,
+ * contradicting copy of it into the main spec.
+ */
+const tempRoots: string[] = [];
+afterAll(async () => {
+  await Promise.all(tempRoots.map((dir) => fs.rm(dir, { recursive: true, force: true })));
+});
+const TIMEOUT = 120_000;
+const exists = (p: string) => fs.access(p).then(() => true, () => false);
+
+const PROPOSAL = [
+  '# Edit billing',
+  '',
+  '## Why',
+  'We need to keep the billing contract accurate for operators and customers over time.',
+  '',
+  '## What Changes',
+  '- **billing**: updates billing requirements',
+  '',
+].join('\n');
+
+const SEED = [
+  '## ADDED Requirements',
+  '### Requirement: Invoice Generation',
+  'The system SHALL generate an invoice for every completed billing period.',
+  '',
+  '#### Scenario: Period closes',
+  '- **WHEN** a billing period closes',
+  '- **THEN** an invoice is generated',
+  '',
+  '### Requirement: Late Fees',
+  'The system SHALL apply a late fee to invoices overdue by 30 days.',
+  '',
+  '#### Scenario: Thirty days overdue',
+  '- **WHEN** an invoice is 30 days overdue',
+  '- **THEN** a late fee is applied',
+  '',
+].join('\n');
+
+const addedLateFees = (name: string) =>
+  [
+    '## ADDED Requirements',
+    `### Requirement: ${name}`,
+    'The system SHALL apply a late fee of 10 percent to invoices overdue by 15 days.',
+    '',
+    '#### Scenario: Fifteen days overdue',
+    '- **WHEN** an invoice is 15 days overdue',
+    '- **THEN** a 10 percent late fee is applied',
+    '',
+  ].join('\n');
+
+const renamed = (from: string, to: string) =>
+  ['## RENAMED Requirements', `- FROM: \`### Requirement: ${from}\``, `- TO: \`### Requirement: ${to}\``, ''].join('\n');
+
+/**
+ * A project whose main billing spec was written by archiving a seed change,
+ * plus an open `edit` change waiting for a delta.
+ */
+async function seededProject() {
+  const base = await fs.mkdtemp(path.join(os.tmpdir(), 'openspec-near-miss-e2e-'));
+  tempRoots.push(base);
+  const home = path.join(base, 'home');
+  const project = path.join(base, 'project');
+  await fs.mkdir(home, { recursive: true });
+  await fs.mkdir(project, { recursive: true });
+  const env = {
+    HOME: home,
+    USERPROFILE: home,
+    XDG_CONFIG_HOME: path.join(home, '.config'),
+    XDG_DATA_HOME: path.join(home, '.local', 'share'),
+    OPENSPEC_NO_ANIMATION: '1',
+  };
+  const cli = (args: string[]) => runCLI(args, { cwd: project, env, timeoutMs: 60_000 });
+
+  expect((await cli(['init', '--tools', 'claude'])).exitCode).toBe(0);
+  expect((await cli(['new', 'change', 'seed'])).exitCode).toBe(0);
+  const seedDir = path.join(project, 'openspec', 'changes', 'seed');
+  await fs.mkdir(path.join(seedDir, 'specs', 'billing'), { recursive: true });
+  await fs.writeFile(path.join(seedDir, 'proposal.md'), PROPOSAL);
+  await fs.writeFile(path.join(seedDir, 'tasks.md'), '## 1. Work\n- [x] 1.1 Done\n');
+  await fs.writeFile(path.join(seedDir, 'specs', 'billing', 'spec.md'), SEED);
+  expect((await cli(['archive', 'seed', '--yes'])).exitCode).toBe(0);
+
+  expect((await cli(['new', 'change', 'edit'])).exitCode).toBe(0);
+  const editDir = path.join(project, 'openspec', 'changes', 'edit');
+  await fs.mkdir(path.join(editDir, 'specs', 'billing'), { recursive: true });
+  await fs.writeFile(path.join(editDir, 'proposal.md'), PROPOSAL);
+  await fs.writeFile(path.join(editDir, 'tasks.md'), '## 1. Work\n- [x] 1.1 Done\n');
+
+  const mainSpec = path.join(project, 'openspec', 'specs', 'billing', 'spec.md');
+  return {
+    cli,
+    editDir,
+    writeDelta: (body: string) => fs.writeFile(path.join(editDir, 'specs', 'billing', 'spec.md'), body),
+    headers: async () =>
+      (await fs.readFile(mainSpec, 'utf-8'))
+        .split('\n')
+        .filter((line) => line.startsWith('### Requirement:'))
+        .map((line) => line.slice('### Requirement:'.length).trim()),
+  };
+}
+
+describe('archive refuses requirement names that differ only in case or spacing', () => {
+  it('refuses an exact duplicate ADDED name (control)', async () => {
+    const p = await seededProject();
+    await p.writeDelta(addedLateFees('Late Fees'));
+    const result = await p.cli(['archive', 'edit', '--yes']);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout + result.stderr).toMatch(/already exists/);
+  }, TIMEOUT);
+
+  it('refuses an ADDED name that differs only in case and leaves the spec and change untouched', async () => {
+    const p = await seededProject();
+    await p.writeDelta(addedLateFees('late fees'));
+    const result = await p.cli(['archive', 'edit', '--yes']);
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stdout + result.stderr).toContain(
+      '"### Requirement: Late Fees" already exists and differs only in case or spacing'
+    );
+    expect(await p.headers()).toEqual(['Invoice Generation', 'Late Fees']);
+    expect(await exists(p.editDir)).toBe(true);
+  }, TIMEOUT);
+
+  it('refuses a RENAMED target that differs only in case from another requirement', async () => {
+    const p = await seededProject();
+    await p.writeDelta(renamed('Invoice Generation', 'LATE FEES'));
+    const result = await p.cli(['archive', 'edit', '--yes']);
+    expect(result.exitCode).not.toBe(0);
+    expect(await p.headers()).toEqual(['Invoice Generation', 'Late Fees']);
+  }, TIMEOUT);
+
+  it('still archives a case-only rename of a requirement to its own name', async () => {
+    const p = await seededProject();
+    await p.writeDelta(renamed('Late Fees', 'LATE FEES'));
+    const result = await p.cli(['archive', 'edit', '--yes']);
+    expect(result.exitCode).toBe(0);
+    expect(await p.headers()).toEqual(['Invoice Generation', 'LATE FEES']);
+  }, TIMEOUT);
+});

--- a/test/core/specs-apply.requirement-name-near-miss.test.ts
+++ b/test/core/specs-apply.requirement-name-near-miss.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+import { buildUpdatedSpec, findSpecUpdates } from '../../src/core/specs-apply.js';
+
+/**
+ * Two requirement names that differ only in case or interior whitespace are
+ * one requirement written twice (foldRequirementName). REMOVED and the RENAMED
+ * source already refused such a near-miss, but ADDED and the RENAMED target
+ * compared names exactly: archive wrote `late fees` next to `Late Fees`, two
+ * contradicting copies of one requirement, and `validate` accepted the result.
+ */
+describe('buildUpdatedSpec (requirement name near-misses)', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'openspec-near-miss-'));
+  });
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  const MAIN_SPEC = [
+    '# billing Specification',
+    '',
+    '## Purpose',
+    'Defines how billing behaves for customers and operators.',
+    '',
+    '## Requirements',
+    '### Requirement: Invoice Generation',
+    'The system SHALL generate an invoice for every completed billing period.',
+    '',
+    '#### Scenario: Period closes',
+    '- **WHEN** a billing period closes',
+    '- **THEN** an invoice is generated',
+    '',
+    '### Requirement: Late Fees',
+    'The system SHALL apply a late fee to invoices overdue by 30 days.',
+    '',
+    '#### Scenario: Thirty days overdue',
+    '- **WHEN** an invoice is 30 days overdue',
+    '- **THEN** a late fee is applied',
+    '',
+  ].join('\n');
+
+  /**
+   * Write the main spec and a delta into a temp project, then run the merge
+   * without touching any real project.
+   */
+  async function build(deltaBody: string) {
+    const specsRoot = path.join(tempDir, 'openspec', 'specs');
+    const specsDir = path.join(specsRoot, 'billing');
+    const changeDir = path.join(tempDir, 'openspec', 'changes', 'c');
+    await fs.mkdir(specsDir, { recursive: true });
+    await fs.mkdir(path.join(changeDir, 'specs', 'billing'), { recursive: true });
+    await fs.writeFile(path.join(specsDir, 'spec.md'), MAIN_SPEC);
+    await fs.writeFile(path.join(changeDir, 'specs', 'billing', 'spec.md'), deltaBody);
+    const [update] = await findSpecUpdates(changeDir, specsRoot);
+    return buildUpdatedSpec(update, 'c', { silent: true });
+  }
+
+  /** One ADDED requirement, by default contradicting the seeded `Late Fees`. */
+  const added = (
+    name: string,
+    body = 'The system SHALL apply a late fee of 10 percent to invoices overdue by 15 days.'
+  ) =>
+    [
+      `### Requirement: ${name}`,
+      body,
+      '',
+      '#### Scenario: Overdue',
+      '- **WHEN** an invoice is overdue',
+      '- **THEN** a late fee is applied',
+      '',
+    ].join('\n');
+
+  const renamed = (from: string, to: string) =>
+    ['## RENAMED Requirements', `- FROM: \`### Requirement: ${from}\``, `- TO: \`### Requirement: ${to}\``, ''].join(
+      '\n'
+    );
+
+  const headers = (spec: string) =>
+    spec
+      .split('\n')
+      .filter((line) => line.startsWith('### Requirement:'))
+      .map((line) => line.slice('### Requirement:'.length).trim());
+
+  const ADDED_NEAR_MISS = (name: string, existing: string) =>
+    `billing ADDED failed for header "### Requirement: ${name}" - "### Requirement: ${existing}" already exists and differs only in case or spacing`;
+  const RENAMED_NEAR_MISS = (name: string, existing: string) =>
+    `billing RENAMED failed for header "### Requirement: ${name}" - "### Requirement: ${existing}" already exists and differs only in case or spacing`;
+
+  describe('ADDED', () => {
+    it('adds a requirement whose name is distinct (control)', async () => {
+      const result = await build(['## ADDED Requirements', added('Credit Notes')].join('\n'));
+      expect(headers(result.rebuilt)).toEqual(['Invoice Generation', 'Late Fees', 'Credit Notes']);
+      expect(result.counts.added).toBe(1);
+    });
+
+    it('still refuses an exact duplicate name with different content (control)', async () => {
+      await expect(build(['## ADDED Requirements', added('Late Fees')].join('\n'))).rejects.toThrow(
+        'billing ADDED failed for header "### Requirement: Late Fees" - already exists'
+      );
+    });
+
+    it('refuses a name that differs only in case from an existing requirement', async () => {
+      await expect(build(['## ADDED Requirements', added('late fees')].join('\n'))).rejects.toThrow(
+        ADDED_NEAR_MISS('late fees', 'Late Fees')
+      );
+    });
+
+    it('refuses a name that differs only in interior whitespace', async () => {
+      await expect(build(['## ADDED Requirements', added('Late  Fees')].join('\n'))).rejects.toThrow(
+        ADDED_NEAR_MISS('Late  Fees', 'Late Fees')
+      );
+    });
+
+    it('refuses a case variant even when its body matches the existing requirement', async () => {
+      // Identical content is the early-sync no-op only for the exact header; a
+      // case variant would still write a second header.
+      const sameBody = added('LATE FEES', 'The system SHALL apply a late fee to invoices overdue by 30 days.');
+      await expect(build(['## ADDED Requirements', sameBody].join('\n'))).rejects.toThrow(
+        ADDED_NEAR_MISS('LATE FEES', 'Late Fees')
+      );
+    });
+
+    it('refuses two ADDED requirements in one delta that differ only in case', async () => {
+      await expect(
+        build(['## ADDED Requirements', added('Credit Notes'), added('credit notes')].join('\n'))
+      ).rejects.toThrow(ADDED_NEAR_MISS('credit notes', 'Credit Notes'));
+    });
+
+    it('allows a case variant of a requirement the same delta removes', async () => {
+      // Operations apply RENAMED -> REMOVED -> MODIFIED -> ADDED, and ADDED is
+      // checked against the spec as it stands after the earlier operations, the
+      // same order the exact-name check already uses. The old spelling is gone
+      // by then, so the result holds one requirement, not two.
+      const result = await build(
+        [
+          '## REMOVED Requirements',
+          '### Requirement: Late Fees',
+          '**Reason**: replaced by the stricter policy below',
+          '',
+          '## ADDED Requirements',
+          added('late fees'),
+        ].join('\n')
+      );
+      expect(headers(result.rebuilt)).toEqual(['Invoice Generation', 'late fees']);
+      expect(result.counts).toMatchObject({ removed: 1, added: 1 });
+    });
+
+    it('allows a case variant of a requirement the same delta renames away', async () => {
+      const result = await build(
+        [renamed('Late Fees', 'Overdue Fees'), '## ADDED Requirements', added('late fees')].join('\n')
+      );
+      expect(headers(result.rebuilt)).toEqual(['Invoice Generation', 'Overdue Fees', 'late fees']);
+    });
+  });
+
+  describe('RENAMED', () => {
+    it('still refuses a target that exists exactly (control)', async () => {
+      await expect(build(renamed('Invoice Generation', 'Late Fees'))).rejects.toThrow(
+        'billing RENAMED failed for header "### Requirement: Late Fees" - target already exists'
+      );
+    });
+
+    it('refuses a target that differs only in case from another requirement', async () => {
+      await expect(build(renamed('Invoice Generation', 'LATE FEES'))).rejects.toThrow(
+        RENAMED_NEAR_MISS('LATE FEES', 'Late Fees')
+      );
+    });
+
+    it('refuses a target that differs only in interior whitespace from another requirement', async () => {
+      await expect(build(renamed('Invoice Generation', 'Late   Fees'))).rejects.toThrow(
+        RENAMED_NEAR_MISS('Late   Fees', 'Late Fees')
+      );
+    });
+
+    it('still allows a case-only rename of a requirement to its own name', async () => {
+      const result = await build(renamed('Late Fees', 'LATE FEES'));
+      expect(headers(result.rebuilt)).toEqual(['Invoice Generation', 'LATE FEES']);
+      expect(result.rebuilt).toContain('overdue by 30 days');
+      expect(result.counts.renamed).toBe(1);
+    });
+
+    it('refuses a target that collides with a requirement the same delta removes, as an exact target does', async () => {
+      // RENAMED runs before REMOVED, so the removed requirement still exists
+      // when the target is checked. That was already true for an exact target.
+      const removeLateFees = ['## REMOVED Requirements', '### Requirement: Late Fees', '**Reason**: gone', ''].join('\n');
+      await expect(build([renamed('Invoice Generation', 'Late Fees'), removeLateFees].join('\n'))).rejects.toThrow(
+        'target already exists'
+      );
+      await expect(build([renamed('Invoice Generation', 'late fees'), removeLateFees].join('\n'))).rejects.toThrow(
+        RENAMED_NEAR_MISS('late fees', 'Late Fees')
+      );
+    });
+  });
+
+  describe('MODIFIED', () => {
+    it('still refuses a header that matches an existing requirement only by case', async () => {
+      // Unchanged: MODIFIED already refused this, as "not found".
+      await expect(
+        build(
+          [
+            '## MODIFIED Requirements',
+            '### Requirement: late fees',
+            'The system SHALL apply a late fee to invoices overdue by 45 days.',
+            '',
+            '#### Scenario: Thirty days overdue',
+            '- **WHEN** an invoice is 45 days overdue',
+            '- **THEN** a late fee is applied',
+            '',
+          ].join('\n')
+        )
+      ).rejects.toThrow('billing MODIFIED failed for header "### Requirement: late fees" - not found');
+    });
+  });
+});


### PR DESCRIPTION
Closes #1863.

## Why

Requirement names are matched exactly, but two spellings that differ only in
case or interior whitespace are one requirement written twice — the comment on
`foldRequirementName` (`src/core/parsers/requirement-blocks.ts:25-26`) calls them
"a mistake, never two requirements". REMOVED (`src/core/specs-apply.ts:447`) and
the RENAMED source (`:400`) already refuse such a near-miss. The two operations
that *introduce* a name did not:

- ADDED looked the name up with an exact `nameToBlock.get(key)`;
- the RENAMED target check (`specs-apply.ts:413`) used an exact
  `nameToBlock.has(to)`.

So an ADDED `late fees` beside an existing `Late Fees`, or a rename to
`LATE FEES`, archived with exit 0 and left two contradicting requirements in the
main spec (`Late Fees` "30 days" and `late fees` "15 days"), which
`openspec validate` then accepted.

Verified against a project built entirely by `openspec init` + `openspec new
change`, with the main spec written by archiving a first change.

## What Changes

- **ADDED**: when no requirement matches exactly but one matches after folding
  case and whitespace, `buildUpdatedSpec` throws
  `billing ADDED failed for header "### Requirement: late fees" - "### Requirement: Late Fees" already exists and differs only in case or spacing; use MODIFIED with that exact header to change it, or choose a distinct name`.
- **RENAMED target**: the same check against every requirement other than the
  rename's own source, with `...; choose a distinct name`.
- The `foldRequirementName` doc comment now lists ADDED and RENAMED among its
  uses.

Unchanged, and pinned by tests:

- the exact-duplicate ADDED error and the exact `target already exists` error;
- a case-only rename of a requirement to its own name (`Late Fees` →
  `LATE FEES`) still applies — the source is exempt from the target check;
- a case variant of a requirement the same delta REMOVES or RENAMES away is still
  allowed. Operations apply RENAMED → REMOVED → MODIFIED → ADDED, and ADDED is
  checked against the spec as it stands at that point, exactly as the existing
  exact-name check is, so the result holds one requirement, not two;
- MODIFIED with a fold-only match already refused (`- not found`) and still does.

## Testing

Written first and watched fail, then passing:

- `test/core/specs-apply.requirement-name-near-miss.test.ts` — 14 tests
  (ADDED ×8, RENAMED ×5, MODIFIED ×1)
- `test/cli-e2e/archive-requirement-name-near-miss.test.ts` — 4 end-to-end
  tests through the built CLI: exact duplicate refused (control), ADDED case
  variant refused with spec and change left untouched, RENAMED case variant
  refused, case-only self-rename still archives

Before the fix: 9 failed / 9 passed (the 9 passing are controls and the
ordering cases that were already right). After: 18 passed.

Edge cases covered: case variant, interior-whitespace variant, a case variant
whose body is identical to the existing requirement (not treated as an
early-sync no-op), two ADDED entries in one delta that differ only in case, a
variant of a requirement removed or renamed away in the same delta, a RENAMED
target colliding with a requirement the same delta removes (refused, as an
exact target already was, since RENAMED runs first).

The round-2 report's own reproduction for this bug (4 tests through the built
CLI) failed on `main` and passes on this branch.

CI parity, run on Node 20.19.0 (the CI version) with the commands from
`.github/workflows/ci.yml`:

- `pnpm run build` — pass
- `pnpm exec tsc --noEmit` — pass
- `pnpm lint` — pass
- `changeset status --since=origin/main` — pass (patch → 1.13.1), run on
  Node 22 because `@changesets/cli` 3 needs `module.enableCompileCache`; the
  CI job that runs it uses Node 24
- `VITEST_MAX_WORKERS=4 pnpm test` — 4562 passed, 19 failed of 4581. All 19
  are timing failures on a heavily shared host (load average 8–19 on 6 cores):
  18 × "Test timed out in 10000ms" and 1 × `spawnSync npm ETIMEDOUT`, in
  store, workset, package-install and CLI e2e files that do not touch spec
  merging. None is an assertion failure.
- Those 8 files rerun on their own (`VITEST_MAX_WORKERS=2`): 196 of 197
  passed. The one left is the `npm pack` + `tsc` test in
  `package-install-scripts.test.ts`, which timed out at 11.6s.
- That `npm pack` test run alone, twice each on `main`, this branch and
  `fix-closed-requirement-heading`: 8 of 8 passed every time.
- Full suite again on a quieter host (`VITEST_MAX_WORKERS=2 pnpm test`): 4580
  of 4581 passed. The one failure was that same `npm pack` test timing out
  (12.1s against the 10s limit). Rerun on its own immediately afterwards, it
  passed 8 of 8 on this branch and on clean `main`. The test builds a
  throwaway fixture in a temp directory from `build.js` and the
  `package.json` scripts, neither of which this branch changes.

## Changeset

`.changeset/archive-refuses-requirement-name-near-miss.md` (patch). Worth noting
for release notes: a change that used to archive by adding a case variant of an
existing requirement is now rejected until the name is fixed.

## Notes for reviewers

- `validate` still does not compare ADDED names against the main spec — not for
  exact duplicates either — so this stays an archive-time check, consistent with
  the existing exact-duplicate behavior.
- `fix-closed-requirement-heading` also edits
  `src/core/parsers/requirement-blocks.ts` (the `normalizeRequirementName` body,
  a few lines above the comment changed here). The hunks do not overlap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Archive operations now reject added or renamed requirements whose names differ from existing requirements only by capitalization or spacing.
  - Error messages identify the conflicting requirement and preserve existing exact-duplicate behavior.
  - Case-only renames of the same requirement remain supported.
  - Changes are safely rejected without modifying the main specification or change records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->