### PR TITLE
fix(list): skip unresolvable entries when dating changes

### DIFF
--- a/.changeset/list-skips-unresolvable-entries.md
+++ b/.changeset/list-skips-unresolvable-entries.md
@@ -1,0 +1,5 @@
+---
+'@fission-ai/openspec': patch
+---
+
+Stop one unresolvable file from breaking `openspec list`. To sort changes by recency, `list` stats every file inside each change, and any entry it could not stat failed the whole command: a dangling symlink, such as the `.#tasks.md` lock Emacs keeps beside every file with unsaved edits, or a symlink loop made `list` exit 1 and `list --json` report `"changes": []`, so agents discovering work through it saw no changes at all. An entry that no longer resolves (removed mid-walk, a dangling symlink, or a loop) is now skipped when computing a change's last-modified time. Valid symlinks are dated as before, and any other error, such as a permission failure, still fails the listing.

--- a/src/core/list.ts
+++ b/src/core/list.ts
@@ -28,6 +28,17 @@ function isMissingPathError(error: unknown): boolean {
   );
 }
 
+/**
+ * An entry that cannot be dated because it no longer resolves: it was removed
+ * after `readdir` listed it, or it is a symlink whose target is missing (an
+ * Emacs `.#file` lock) or that loops back on itself.
+ */
+function isUnresolvableEntryError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null || !('code' in error)) return false;
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === 'ENOENT' || code === 'ELOOP';
+}
+
 async function readChangeDirectoryEntries(changesDir: string): Promise<Dirent[]> {
   try {
     return await fs.readdir(changesDir, { withFileTypes: true });
@@ -48,13 +59,18 @@ async function getLastModified(dirPath: string): Promise<Date> {
     const entries = await fs.readdir(dir, { withFileTypes: true });
     for (const entry of entries) {
       const fullPath = path.join(dir, entry.name);
-      if (entry.isDirectory()) {
-        await walk(fullPath);
-      } else {
-        const stat = await fs.stat(fullPath);
-        if (latest === null || stat.mtime > latest) {
-          latest = stat.mtime;
+      try {
+        if (entry.isDirectory()) {
+          await walk(fullPath);
+        } else {
+          const stat = await fs.stat(fullPath);
+          if (latest === null || stat.mtime > latest) {
+            latest = stat.mtime;
+          }
         }
+      } catch (error) {
+        // Skip the one entry rather than fail the listing of every change.
+        if (!isUnresolvableEntryError(error)) throw error;
       }
     }
   }

--- a/test/core/list.test.ts
+++ b/test/core/list.test.ts
@@ -3,6 +3,7 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import os from 'os';
 import { ListCommand } from '../../src/core/list.js';
+import { runCLI } from '../helpers/run-cli.js';
 
 describe('ListCommand', () => {
   let tempDir: string;
@@ -186,5 +187,88 @@ Regular text that should be ignored
       expect(logOutput.some(line => line.includes('partial') && line.includes('1/3 tasks'))).toBe(true);
       expect(logOutput.some(line => line.includes('no-tasks') && line.includes('No tasks'))).toBe(true);
     });
+  });
+
+  describe('entries that cannot be stat-ed', () => {
+    // Emacs drops a `.#<file>` lock symlink, pointing at a nonexistent target,
+    // next to every file with unsaved edits. One such entry used to fail the
+    // whole listing with ENOENT, so `list --json` reported zero changes.
+    async function writeChange(name: string): Promise<string> {
+      const changeDir = path.join(tempDir, 'openspec', 'changes', name);
+      await fs.mkdir(changeDir, { recursive: true });
+      await fs.writeFile(path.join(changeDir, 'tasks.md'), '- [x] Task 1\n- [ ] Task 2\n');
+      return changeDir;
+    }
+
+    async function listJson(): Promise<Array<{ name: string; completedTasks: number; totalTasks: number }>> {
+      await new ListCommand().execute(tempDir, 'changes', { json: true });
+      return JSON.parse(logOutput.join('\n')).changes;
+    }
+
+    it.skipIf(process.platform === 'win32')('lists every change while a dangling symlink sits inside one', async () => {
+      const changeDir = await writeChange('locked-change');
+      await writeChange('other-change');
+      await fs.symlink('user@host.4242:1789000000', path.join(changeDir, '.#tasks.md'));
+
+      const changes = await listJson();
+
+      expect(changes.map(change => change.name).sort()).toEqual(['locked-change', 'other-change']);
+      expect(changes.find(change => change.name === 'locked-change')).toMatchObject({
+        completedTasks: 1,
+        totalTasks: 2,
+      });
+    });
+
+    it.skipIf(process.platform === 'win32')('lists a change holding a dangling symlink in a nested directory', async () => {
+      const changeDir = await writeChange('nested-lock');
+      await fs.mkdir(path.join(changeDir, 'specs', 'billing'), { recursive: true });
+      await fs.symlink('missing-target', path.join(changeDir, 'specs', 'billing', '.#spec.md'));
+
+      expect((await listJson()).map(change => change.name)).toEqual(['nested-lock']);
+    });
+
+    it.skipIf(process.platform === 'win32')('lists a change holding a symlink loop', async () => {
+      const changeDir = await writeChange('loop-change');
+      await fs.symlink('loop-b', path.join(changeDir, 'loop-a'));
+      await fs.symlink('loop-a', path.join(changeDir, 'loop-b'));
+
+      expect((await listJson()).map(change => change.name)).toEqual(['loop-change']);
+    });
+
+    it.skipIf(process.platform === 'win32')('still lists and dates a change holding a valid symlink', async () => {
+      const changeDir = await writeChange('linked-change');
+      const target = path.join(changeDir, 'notes.md');
+      await fs.writeFile(target, 'notes\n');
+      const future = new Date('2099-01-01T00:00:00.000Z');
+      await fs.utimes(target, future, future);
+      await fs.symlink('notes.md', path.join(changeDir, 'notes-link.md'));
+
+      await new ListCommand().execute(tempDir, 'changes', { json: true });
+      const [change] = JSON.parse(logOutput.join('\n')).changes;
+
+      expect(change.lastModified).toBe(future.toISOString());
+    });
+
+    it.skipIf(process.platform === 'win32')('keeps list --json working end to end', async () => {
+      const changeDir = await writeChange('cli-change');
+      await fs.mkdir(path.join(tempDir, 'openspec', 'specs'), { recursive: true });
+      await fs.symlink('user@host.4242:1789000000', path.join(changeDir, '.#tasks.md'));
+      const home = path.join(tempDir, 'home');
+      await fs.mkdir(home, { recursive: true });
+
+      const result = await runCLI(['list', '--json'], {
+        cwd: tempDir,
+        env: {
+          HOME: home,
+          XDG_CONFIG_HOME: path.join(home, '.config'),
+          XDG_DATA_HOME: path.join(home, '.local', 'share'),
+        },
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(JSON.parse(result.stdout).changes.map((change: { name: string }) => change.name)).toEqual([
+        'cli-change',
+      ]);
+    }, 60_000);
   });
 });


### PR DESCRIPTION
Closes #1865.

## Why

`openspec list` sorts changes by recency. To do that, `getLastModified`
(`src/core/list.ts:44-71`) walks every entry of each change, dotfiles included,
and calls `fs.stat` on each non-directory (`:54`) with no error handling.
`fs.stat` follows symlinks, so any entry that no longer resolves throws, and the
whole command fails. Such entries include:

- a dangling symlink. Emacs creates one by default beside every file with
  unsaved changes: `.#tasks.md`, pointing at `user@host.PID:TIMESTAMP`.
- a symlink loop (`ELOOP`)
- a file removed between `readdir` and `stat`, such as an editor's temp file

With `openspec/changes/add-thing/.#tasks.md` dangling:

```
$ openspec list
✖ Error: ENOENT: no such file or directory, stat '.../openspec/changes/add-thing/.#tasks.md'
$ openspec list --json          # exit 1
{"changes":[],"root":null,"status":[{"severity":"error","code":"list_error","message":"ENOENT: ..."}]}
```

`list --json` is how agents discover changes, and it reports none at all while
the file is open with unsaved edits. `view`, `status` and `validate` walk the
same tree without failing; only `list` broke.

Verified on a build of `main` @ `9d4e597` and on the published
`@fission-ai/openspec@1.13.0`.

## What Changes

- If reading a subdirectory or statting an entry fails with `ENOENT` or `ELOOP`,
  that one entry is skipped when computing the change's last-modified time. A
  new `isUnresolvableEntryError` helper sits next to the existing
  `isMissingPathError`.

Unchanged:

- Valid symlinks are still followed and dated as before.
- Symlinked directories are still not walked. `Dirent` reports them as
  symlinks, not directories.
- Any other error, such as `EACCES`, still fails the listing, as before.
- A change with nothing datable still falls back to the directory's own mtime.

## Testing

`test/core/list.test.ts` gains 5 tests under "entries that cannot be stat-ed". I
wrote them first. On `main`, 4 failed: `ENOENT` twice, `ELOOP` once, and CLI exit
1. The valid-symlink control passed. All pass after the fix.

- a dangling lock symlink at a change's top level, with a second change listed
  alongside it and its task counts intact
- a dangling symlink in a nested directory
- a symlink loop
- control: a change holding a valid symlink still lists, and is dated by its
  newest file
- end to end: `openspec list --json` through the built CLI exits 0 and lists
  the change

The symlink tests use `it.skipIf(process.platform === 'win32')`, the repo's
existing convention, because creating symlinks on Windows needs elevated
rights. The fix itself is platform-independent. The existing `ListCommand`
tests pass unchanged.

CI parity: I ran the CI steps in a clean Linux container under Node 20.19.0 (the
CI version), after `pnpm install --frozen-lockfile`. `pnpm run build`,
`pnpm exec tsc --noEmit` and `pnpm lint` pass. The container was shared with
other test runs (load average 12–18 on 6 CPUs). That load made the repo's
CLI-spawning tests time out under the default 10-second `testTimeout`, so I ran
the full suite with `--testTimeout=120000 --hookTimeout=120000`. It ran 4568
tests: 4567 passed and 1 failed.

The one failure was environmental: an `npm source installation` test whose
`npm` subprocess hit its 30-second `spawnSync` timeout (`ETIMEDOUT`). I reran
that file on its own, under the suite lock with `--maxWorkers=2`. It passes on
this branch, and it passes the same way on a pristine `main` @ `9d4e597`.

CI's `validate-changesets` job runs on Node 24, and
`@changesets/cli` 3 needs Node 22 or newer because it calls
`module.enableCompileCache`. So I ran `pnpm exec changeset status` under
Node 22; it lists the patch bump for `@fission-ai/openspec`.

## Changeset

`.changeset/list-skips-unresolvable-entries.md` (patch).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `openspec list` failing when a change contains dangling or looping symlinks, or files removed during scanning.
  * Listings now skip unresolvable entries while continuing to display valid changes.
  * Valid symlinks continue to retain their correct last-modified dates.
  * Other errors, such as permission failures, still report normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->