### PR TITLE
fix(completion): restore .bashrc byte for byte on bash uninstall

### DIFF
--- a/.changeset/bash-completion-uninstall-restores-bashrc.md
+++ b/.changeset/bash-completion-uninstall-restores-bashrc.md
@@ -1,0 +1,5 @@
+---
+'@fission-ai/openspec': patch
+---
+
+Make `openspec completion uninstall bash` hand `.bashrc` back exactly as `completion install bash` found it. Install adds the OpenSpec block at the top of the file followed by a blank separator line; uninstall removed the block but kept that blank line at the top, then stripped every trailing blank line and wrote the file back without its final newline. The byte count happened to come out unchanged, but the next tool to append to `.bashrc` with `>>` (the nvm, conda and rustup installers all do) merged its first line into the user's last line and broke both. Uninstall now also drops the separator line install added when the block sits at the top of the file, and leaves the rest untouched: the final newline, trailing blank lines and CRLF line endings all survive the round trip. A block the user moved elsewhere in the file is still removed, and the zsh, fish and PowerShell installers are unchanged.

--- a/src/core/completions/installers/bash-installer.ts
+++ b/src/core/completions/installers/bash-installer.ts
@@ -203,9 +203,11 @@ export class BashInstaller {
       // Remove lines between markers (inclusive)
       lines.splice(startIndex, endIndex - startIndex + 1);
 
-      // Remove trailing empty lines
-      while (lines.length > 0 && lines[lines.length - 1].trim() === '') {
-        lines.pop();
+      // Install puts the block at the top of the file followed by one blank
+      // separator line; drop that line too so the file reads as it did before.
+      // Everything else, including the file's final newline, is left as is.
+      if (startIndex === 0 && lines.length > 0 && lines[0].trim() === '') {
+        lines.shift();
       }
 
       // Write back

--- a/test/core/completions/installers/bash-installer.round-trip.test.ts
+++ b/test/core/completions/installers/bash-installer.round-trip.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+import { BashInstaller } from '../../../../src/core/completions/installers/bash-installer.js';
+import { runCLI } from '../../../helpers/run-cli.js';
+
+/**
+ * Installing and then uninstalling bash completions must hand the user's
+ * .bashrc back byte for byte, as the zsh installer already does. Uninstall
+ * used to keep the blank separator line install had added above the user's
+ * content and drop the file's final newline, so the next `>>` append (nvm,
+ * conda, rustup) was glued onto the user's last line.
+ */
+describe('BashInstaller .bashrc round trip', () => {
+  let homeDir: string;
+  let bashrcPath: string;
+  let completionsDir: string;
+  let installer: BashInstaller;
+
+  beforeEach(async () => {
+    homeDir = await fs.mkdtemp(path.join(os.tmpdir(), 'openspec-bashrc-round-trip-'));
+    bashrcPath = path.join(homeDir, '.bashrc');
+    completionsDir = path.join(homeDir, '.local', 'share', 'bash-completion', 'completions');
+    installer = new BashInstaller(homeDir);
+  });
+
+  afterEach(async () => {
+    await fs.rm(homeDir, { recursive: true, force: true });
+  });
+
+  /** Writes `original`, adds the OpenSpec block, removes it, and returns the file. */
+  async function roundTrip(original: string): Promise<string> {
+    await fs.writeFile(bashrcPath, original);
+    expect(await installer.configureBashrc(completionsDir)).toBe(true);
+    expect(await fs.readFile(bashrcPath, 'utf-8')).toContain('# OPENSPEC:START');
+    expect(await installer.removeBashrcConfig()).toBe(true);
+    return fs.readFile(bashrcPath, 'utf-8');
+  }
+
+  it.each([
+    ['a file ending in a newline', 'export PATH="$HOME/bin:$PATH"\nalias ll="ls -la"\n'],
+    ['a file with no final newline', 'export PATH="$HOME/bin:$PATH"\nalias ll="ls -la"'],
+    ['a single line', 'alias ll="ls -la"\n'],
+    ['an empty file', ''],
+    ['a file ending in blank lines', 'alias ll="ls -la"\n\n\n'],
+    ['a file starting with blank lines', '\n\nalias ll="ls -la"\n'],
+    ['a file with CRLF line endings', 'export PATH="$HOME/bin:$PATH"\r\nalias ll="ls -la"\r\n'],
+  ])('restores %s byte for byte', async (_label, original) => {
+    expect(await roundTrip(original)).toBe(original);
+  });
+
+  it('keeps a later >> append on its own line', async () => {
+    await roundTrip('alias ll="ls -la"\n');
+    await fs.appendFile(bashrcPath, 'export NVM_DIR="$HOME/.nvm"\n');
+
+    const lines = (await fs.readFile(bashrcPath, 'utf-8')).split('\n');
+    expect(lines).toEqual(['alias ll="ls -la"', 'export NVM_DIR="$HOME/.nvm"', '']);
+  });
+
+  it('restores the file after installing twice', async () => {
+    const original = 'alias ll="ls -la"\n';
+    await fs.writeFile(bashrcPath, original);
+    expect(await installer.configureBashrc(completionsDir)).toBe(true);
+    expect(await installer.configureBashrc(completionsDir)).toBe(true);
+
+    const installed = await fs.readFile(bashrcPath, 'utf-8');
+    expect(installed.split('# OPENSPEC:START')).toHaveLength(2);
+
+    expect(await installer.removeBashrcConfig()).toBe(true);
+    expect(await fs.readFile(bashrcPath, 'utf-8')).toBe(original);
+  });
+
+  it('leaves an empty file when install created .bashrc', async () => {
+    expect(await installer.configureBashrc(completionsDir)).toBe(true);
+    expect(await installer.removeBashrcConfig()).toBe(true);
+    expect(await fs.readFile(bashrcPath, 'utf-8')).toBe('');
+  });
+
+  it('leaves an empty file when .bashrc holds only the OpenSpec block', async () => {
+    await fs.writeFile(bashrcPath, '# OPENSPEC:START\n# OpenSpec shell completions configuration\n# OPENSPEC:END\n');
+    expect(await installer.removeBashrcConfig()).toBe(true);
+    expect(await fs.readFile(bashrcPath, 'utf-8')).toBe('');
+  });
+
+  it('removes only the block when the user moved it into the middle of the file', async () => {
+    await fs.writeFile(
+      bashrcPath,
+      [
+        'export PATH="$HOME/bin:$PATH"',
+        '# OPENSPEC:START',
+        '# OpenSpec shell completions configuration',
+        '# OPENSPEC:END',
+        'alias ll="ls -la"',
+        '',
+      ].join('\n')
+    );
+
+    expect(await installer.removeBashrcConfig()).toBe(true);
+    expect(await fs.readFile(bashrcPath, 'utf-8')).toBe('export PATH="$HOME/bin:$PATH"\nalias ll="ls -la"\n');
+  });
+
+  it('restores .bashrc through install() and uninstall()', async () => {
+    const original = 'export PATH="$HOME/bin:$PATH"\nalias ll="ls -la"\n';
+    await fs.writeFile(bashrcPath, original);
+
+    expect((await installer.install('# openspec completion script\n')).success).toBe(true);
+    expect((await installer.uninstall()).success).toBe(true);
+
+    expect(await fs.readFile(bashrcPath, 'utf-8')).toBe(original);
+  });
+});
+
+describe('openspec completion install/uninstall bash (end to end)', () => {
+  let base: string;
+
+  beforeEach(async () => {
+    base = await fs.mkdtemp(path.join(os.tmpdir(), 'openspec-bashrc-cli-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(base, { recursive: true, force: true });
+  });
+
+  it('leaves .bashrc byte-identical', async () => {
+    const home = path.join(base, 'home');
+    await fs.mkdir(home, { recursive: true });
+    const env = {
+      HOME: home,
+      USERPROFILE: home,
+      XDG_CONFIG_HOME: path.join(home, '.config'),
+      XDG_DATA_HOME: path.join(home, '.local', 'share'),
+      OPENSPEC_NO_ANIMATION: '1',
+    };
+    const rc = path.join(home, '.bashrc');
+    const original = 'export PATH="$HOME/bin:$PATH"\nalias ll="ls -la"\n';
+    await fs.writeFile(rc, original);
+
+    const installed = await runCLI(['completion', 'install', 'bash'], { cwd: home, env, timeoutMs: 60_000 });
+    expect(installed.exitCode).toBe(0);
+    expect(await fs.readFile(rc, 'utf-8')).toContain('# OPENSPEC:START');
+
+    const removed = await runCLI(['completion', 'uninstall', 'bash', '--yes'], { cwd: home, env, timeoutMs: 60_000 });
+    expect(removed.exitCode).toBe(0);
+    expect(await fs.readFile(rc, 'utf-8')).toBe(original);
+  }, 120_000);
+});


### PR DESCRIPTION
Closes #1871.

## Why

`openspec completion install bash` puts an `# OPENSPEC:START` … `# OPENSPEC:END`
block at the top of `~/.bashrc`, followed by one blank separator line
(`FileSystemUtils.updateFileWithMarkers`). `openspec completion uninstall bash`
removed the block but did not hand the file back as it found it
(`src/core/completions/installers/bash-installer.ts:206-212`):

- the blank separator line stayed at the top of the file;
- every trailing blank line was popped, and the file was written back with
  `lines.join('\n')` and **no final newline**.

The byte count came out unchanged, since one newline was added at the front and
one taken off the end, so nothing looked wrong. The damage was latent: the next
tool to append to `.bashrc` with `>>` (the nvm, conda and rustup installers all
do) wrote its first line straight onto the end of the user's last line, and
broke both:

```
after a normal '>>' append, last line: alias ll="ls -la"export NVM_DIR="$HOME/.nvm"
```

The zsh installer already round-trips `.zshrc` byte for byte.

## What Changes

- Uninstall no longer strips trailing blank lines, so the file keeps its final
  newline, any trailing blank lines, and CRLF line endings.
- When the block sits at the top of the file, which is where install puts it,
  uninstall also drops the single blank separator line install added after it.
- A block the user moved elsewhere in the file is still removed, and the lines
  around it are left as they are.

The zsh, fish and PowerShell installers are unchanged. One note for a possible
follow-up: `ZshInstaller.removeZshrcConfig` strips *every* leading blank line of
`.zshrc`, even when the block is not at the top. It round-trips every file shape
install produces, so it is out of scope here.

## Testing

`test/core/completions/installers/bash-installer.round-trip.test.ts` — 14 tests,
written first and watched fail (**11 failed / 3 passed** on `main`, **14 passed**
with the fix).

Edge cases covered:

- byte-for-byte round trips for: a file ending in a newline, a file with no
  final newline, a single line, an empty file, a file ending in blank lines, a
  file starting with blank lines, and a CRLF file
- a `>>` append after uninstall stays on its own line
- installing twice, then uninstalling, restores the original
- `.bashrc` created by install, and a `.bashrc` holding only the block, are left
  empty
- a block moved into the middle of the file is removed without touching the
  surrounding lines
- the public `install()` / `uninstall()` path
- end to end: `openspec completion install bash` then
  `openspec completion uninstall bash --yes` with a temporary `HOME`

The 3 tests that already passed on `main` are the empty-file cases, where the
old code's trailing-line stripping happens to give the right answer; they guard
those shapes against regression.

The existing `bash-installer.test.ts` tests pass unchanged.

## Verification

Run in OpenSandbox on a clean clone of `9d4e597` with this change applied,
under Node 20.19.0 (the CI version), using the same commands as
`.github/workflows/ci.yml`:

- `pnpm run build`: pass
- `pnpm exec tsc --noEmit`: pass
- `pnpm lint`: pass
- the new test file: 11 failed / 3 passed on `main`, 14 passed with the fix
- the existing `bash-installer.test.ts`: passes unchanged
- full suite (`VITEST_MAX_WORKERS=4 pnpm test`): **4561 passed, 16 failed**
  (159 files, 6 failed)

Every full-suite failure is in a file this change does not touch:
`package-install-scripts`, `store-references`, `store-root-selection`, `store`,
`store-remote` and `workset`. The failures are npm registry timeouts
(`spawnSync npm ETIMEDOUT`) and multi-step CLI tests exceeding the 10 s default
timeout on a heavily shared runner. All six files fail the same way on clean
`9d4e597` when run alone in the same sandbox:

| File | clean `9d4e597`, alone | this branch, alone |
|---|---|---|
| `package-install-scripts` | 3 failed / 5 passed | 1 failed / 7 passed |
| `store-references` | 3 failed / 5 passed | 3 failed / 5 passed |
| `store-root-selection` | 3 failed / 41 passed | 3 failed / 41 passed |
| `store` | 2 failed / 41 passed | 43 passed |
| `workset` | 10 failed / 31 passed | 1 failed / 40 passed |
| `store-remote` | 1 failed / 18 passed | 19 passed |

No file fails more tests on this branch than on clean `9d4e597`, and `store` and
`store-remote` pass in full when run alone. These are environment and load
failures, not a regression.

## Changeset

`.changeset/bash-completion-uninstall-restores-bashrc.md` (patch).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Bash completion uninstall now restores `.bashrc` content exactly, preserving final newlines, blank lines, separator lines, and CRLF formatting.
  - Bash completion blocks moved within the file are removed without altering unrelated content.
  - Prevented later shell configuration entries from being merged onto incorrect lines.

- **Tests**
  - Added coverage for installation and uninstallation across varied newline, formatting, and file-content scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->