### PR TITLE
fix(init): keep user files in legacy command folders

### DIFF
--- a/.changeset/legacy-cleanup-keeps-user-files.md
+++ b/.changeset/legacy-cleanup-keeps-user-files.md
@@ -1,0 +1,5 @@
+---
+'@fission-ai/openspec': patch
+---
+
+Stop legacy cleanup deleting the user's own files. The six pre-skills tools that kept their commands in a `<tool>/commands/openspec/` folder (Claude Code, CodeBuddy, Qoder, Lingma, Crush and Gemini CLI) had that whole folder removed recursively whenever it existed, so a command the user kept there, such as a team review checklist, was deleted along with OpenSpec's files, and the summary named only the folder. Because `openspec init` cleans up automatically when there is no TTY, an agent or CI running plain `openspec init` did this without `--force` and without a prompt, and `openspec update --force` did the same. Cleanup now deletes only the files OpenSpec wrote there (`proposal`, `apply` and `archive`), removes the folder only once nothing else is left in it, and lists each thing it kept. A folder holding nothing OpenSpec wrote is no longer reported as legacy at all. A folder holding only OpenSpec's files, or nothing, is still removed exactly as before, with the same summary line.

--- a/docs/migration-guide.md
+++ b/docs/migration-guide.md
@@ -131,7 +131,7 @@ Needs your attention
 
 **What happens when you say yes:**
 
-1. Legacy slash command directories are removed
+1. Legacy slash command files are removed, and their folder too once nothing else is left in it (anything you added there is kept)
 2. OpenSpec markers are stripped from `CLAUDE.md`, `AGENTS.md`, etc. (your content stays)
 3. `openspec/AGENTS.md` is deleted
 4. New skills are installed in `.claude/skills/`

--- a/src/core/legacy-cleanup.ts
+++ b/src/core/legacy-cleanup.ts
@@ -26,19 +26,27 @@ export const LEGACY_CONFIG_FILES = [
   'QWEN.md',
 ] as const;
 
+/** The three commands the old SlashCommandRegistry wrote into each directory. */
+const LEGACY_DIRECTORY_COMMAND_FILES = ['proposal.md', 'apply.md', 'archive.md'] as const;
+
 /**
  * Legacy slash command patterns from the old SlashCommandRegistry.
  * These map toolId to the path pattern where legacy commands were created.
  * Some tools used a directory structure, others used individual files.
  */
 export const LEGACY_SLASH_COMMAND_PATHS: Record<string, LegacySlashCommandPattern> = {
-  // Directory-based: .tooldir/commands/openspec/ or .tooldir/commands/openspec/*.md
-  'claude': { type: 'directory', path: '.claude/commands/openspec' },
-  'codebuddy': { type: 'directory', path: '.codebuddy/commands/openspec' },
-  'qoder': { type: 'directory', path: '.qoder/commands/openspec' },
-  'lingma': { type: 'directory', path: '.lingma/commands/openspec' },
-  'crush': { type: 'directory', path: '.crush/commands/openspec' },
-  'gemini': { type: 'directory', path: '.gemini/commands/openspec' },
+  // Directory-based: .tooldir/commands/openspec/. Each entry names the files
+  // OpenSpec wrote there, because users keep their own commands in the same
+  // folder: only those files are deleted, and the folder only once it is empty.
+  'claude': { type: 'directory', path: '.claude/commands/openspec', managedFileNames: LEGACY_DIRECTORY_COMMAND_FILES },
+  'codebuddy': { type: 'directory', path: '.codebuddy/commands/openspec', managedFileNames: LEGACY_DIRECTORY_COMMAND_FILES },
+  'qoder': { type: 'directory', path: '.qoder/commands/openspec', managedFileNames: LEGACY_DIRECTORY_COMMAND_FILES },
+  // Lingma support arrived after the opsx rename and has always written to
+  // `.lingma/commands/opsx/`, so OpenSpec never put a file here: only an empty
+  // leftover folder is removed.
+  'lingma': { type: 'directory', path: '.lingma/commands/openspec', managedFileNames: [] },
+  'crush': { type: 'directory', path: '.crush/commands/openspec', managedFileNames: LEGACY_DIRECTORY_COMMAND_FILES },
+  'gemini': { type: 'directory', path: '.gemini/commands/openspec', managedFileNames: ['proposal.toml', 'apply.toml', 'archive.toml'] },
 
   // File-based: individual openspec-*.md files in a commands/workflows/prompts folder
   'cursor': { type: 'files', pattern: '.cursor/commands/openspec-*.md' },
@@ -110,6 +118,8 @@ export const LEGACY_GLOBAL_SLASH_COMMAND_PATHS: Record<string, LegacyGlobalPromp
 export interface LegacySlashCommandPattern {
   type: 'directory' | 'files';
   path?: string; // For directory type
+  /** For directory type: the only files in `path` that OpenSpec wrote. */
+  managedFileNames?: readonly string[];
   pattern?: string | string[]; // For files type (glob pattern or array of patterns)
 }
 
@@ -320,8 +330,20 @@ export async function detectLegacySlashCommands(
   for (const pattern of Object.values(LEGACY_SLASH_COMMAND_PATHS)) {
     if (pattern.type === 'directory' && pattern.path) {
       const dirPath = FileSystemUtils.joinPath(projectPath, pattern.path);
-      if (await FileSystemUtils.directoryExists(dirPath)) {
+      if (!(await FileSystemUtils.directoryExists(dirPath))) {
+        continue;
+      }
+      const entries = await readLegacyCommandDir(dirPath, pattern.managedFileNames ?? []);
+      if (!entries) {
+        continue;
+      }
+      if (entries.others.length === 0) {
+        // Only OpenSpec's own files, or nothing: the whole folder can go.
         directories.push(pattern.path);
+      } else {
+        // The folder also holds the user's files, so report OpenSpec's files
+        // one by one; cleanup deletes those and leaves the folder in place.
+        files.push(...entries.managed.map((name) => `${pattern.path}/${name}`));
       }
     } else if (pattern.type === 'files' && pattern.pattern) {
       const patterns = Array.isArray(pattern.pattern) ? pattern.pattern : [pattern.pattern];
@@ -333,6 +355,76 @@ export async function detectLegacySlashCommands(
   }
 
   return { directories, files };
+}
+
+/**
+ * Splits a legacy command directory's entries into the files OpenSpec wrote
+ * there and everything else, sorted. Only a regular file with a managed name
+ * counts as OpenSpec's; a folder or link carrying one of those names is the
+ * user's. Subdirectories are listed with a trailing '/'. Returns undefined when
+ * the directory cannot be read.
+ */
+async function readLegacyCommandDir(
+  dirPath: string,
+  managedFileNames: readonly string[]
+): Promise<{ managed: string[]; others: string[] } | undefined> {
+  let entries;
+  try {
+    entries = await fs.readdir(dirPath, { withFileTypes: true });
+  } catch {
+    return undefined;
+  }
+
+  const managed: string[] = [];
+  const others: string[] = [];
+  for (const entry of entries) {
+    if (entry.isFile() && managedFileNames.includes(entry.name)) {
+      managed.push(entry.name);
+    } else {
+      others.push(entry.isDirectory() ? `${entry.name}/` : entry.name);
+    }
+  }
+  return { managed: managed.sort(), others: others.sort() };
+}
+
+/**
+ * The legacy command directory, and its tool, that a repo-local path is one of
+ * OpenSpec's own files in.
+ */
+function legacyCommandDirForFile(file: string): { toolId: string; dir: string } | undefined {
+  const normalizedFile = normalizePathForMatch(file);
+  for (const [toolId, pattern] of Object.entries(LEGACY_SLASH_COMMAND_PATHS)) {
+    if (pattern.type !== 'directory' || !pattern.path) continue;
+    const dir = pattern.path;
+    if (pattern.managedFileNames?.some((name) => normalizedFile === `${dir}/${name}`)) {
+      return { toolId, dir };
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Removes a legacy command directory once OpenSpec's files are gone from it,
+ * or records what is left in it as kept. Never recursive: whatever remains was
+ * not written by OpenSpec. Returns true when the directory was removed.
+ */
+async function settleLegacyCommandDir(
+  projectPath: string,
+  dirPath: string,
+  result: CleanupResult
+): Promise<boolean> {
+  const fullPath = FileSystemUtils.joinPath(projectPath, dirPath);
+  const remaining = await readLegacyCommandDir(fullPath, []);
+  if (!remaining) {
+    return false;
+  }
+  if (remaining.others.length === 0) {
+    await fs.rmdir(fullPath);
+    result.deletedDirs.push(dirPath);
+    return true;
+  }
+  result.keptFiles!.push(...remaining.others.map((name) => `${dirPath}/${name}`));
+  return false;
 }
 
 /**
@@ -506,6 +598,8 @@ export interface CleanupResult {
   modifiedFiles: string[];
   /** Directories that were deleted */
   deletedDirs: string[];
+  /** Entries left in a legacy command directory because OpenSpec did not write them */
+  keptFiles?: string[];
   /** Whether project.md exists and needs manual migration */
   projectMdNeedsMigration: boolean;
   /** Error messages if any operations failed */
@@ -529,6 +623,7 @@ export async function cleanupLegacyArtifacts(
     deletedFileReplacementLabels: {},
     modifiedFiles: [],
     deletedDirs: [],
+    keptFiles: [],
     projectMdNeedsMigration: detection.hasProjectMd,
     errors: [],
   };
@@ -548,25 +643,51 @@ export async function cleanupLegacyArtifacts(
     }
   }
 
-  // Delete legacy slash command directories (these are 100% OpenSpec-managed)
+  // Delete legacy slash command directories: only the files OpenSpec wrote,
+  // then the directory once it is empty. Detection reports a directory only
+  // when it holds nothing else, but a file the user added since is still kept.
   for (const dirPath of detection.slashCommandDirs) {
     const fullPath = FileSystemUtils.joinPath(projectPath, dirPath);
     try {
-      await fs.rm(fullPath, { recursive: true, force: true });
-      result.deletedDirs.push(dirPath);
+      const managedFileNames = legacyManagedFileNamesForDir(dirPath);
+      const entries = await readLegacyCommandDir(fullPath, managedFileNames);
+      if (!entries) {
+        continue;
+      }
+      for (const name of entries.managed) {
+        await fs.unlink(path.join(fullPath, name));
+      }
+      if (!(await settleLegacyCommandDir(projectPath, dirPath, result))) {
+        result.deletedFiles.push(...entries.managed.map((name) => `${dirPath}/${name}`));
+      }
     } catch (error: any) {
       result.errors.push(`Failed to delete directory ${dirPath}: ${error.message}`);
     }
   }
 
   // Delete legacy slash command files (these are 100% OpenSpec-managed)
+  const partlyCleanedDirs = new Set<string>();
   for (const filePath of detection.slashCommandFiles) {
     const fullPath = FileSystemUtils.joinPath(projectPath, filePath);
     try {
       await fs.unlink(fullPath);
       result.deletedFiles.push(filePath);
+      const commandDir = legacyCommandDirForFile(filePath);
+      if (commandDir) {
+        partlyCleanedDirs.add(commandDir.dir);
+      }
     } catch (error: any) {
       result.errors.push(`Failed to delete ${filePath}: ${error.message}`);
+    }
+  }
+
+  // A legacy command directory that also held the user's files was cleaned
+  // file by file above; record what was left in it.
+  for (const dirPath of partlyCleanedDirs) {
+    try {
+      await settleLegacyCommandDir(projectPath, dirPath, result);
+    } catch (error: any) {
+      result.errors.push(`Failed to delete directory ${dirPath}: ${error.message}`);
     }
   }
 
@@ -621,7 +742,14 @@ export async function cleanupLegacyArtifacts(
 export function formatCleanupSummary(result: CleanupResult): string {
   const lines: string[] = [];
 
-  if (result.deletedFiles.length > 0 || result.deletedDirs.length > 0 || result.modifiedFiles.length > 0) {
+  const keptFiles = result.keptFiles ?? [];
+
+  if (
+    result.deletedFiles.length > 0 ||
+    result.deletedDirs.length > 0 ||
+    result.modifiedFiles.length > 0 ||
+    keptFiles.length > 0
+  ) {
     lines.push('Cleaned up legacy files:');
 
     for (const file of result.deletedFiles) {
@@ -635,6 +763,10 @@ export function formatCleanupSummary(result: CleanupResult): string {
 
     for (const dir of result.deletedDirs) {
       lines.push(`  ✓ Removed ${dir}/ (replaced by OpenSpec skills and commands)`);
+    }
+
+    for (const entry of keptFiles) {
+      lines.push(`  • Kept ${entry} (not created by OpenSpec)`);
     }
 
     for (const file of result.modifiedFiles) {
@@ -832,8 +964,24 @@ function legacyToolIdForDir(dir: string): string | undefined {
   return undefined;
 }
 
+/** The files OpenSpec wrote into a repo-local legacy slash-command directory. */
+function legacyManagedFileNamesForDir(dir: string): readonly string[] {
+  const normalizedDir = normalizePathForMatch(dir);
+  for (const pattern of Object.values(LEGACY_SLASH_COMMAND_PATHS)) {
+    if (pattern.type === 'directory' && pattern.path === normalizedDir) {
+      return pattern.managedFileNames ?? [];
+    }
+  }
+  return [];
+}
+
 /** The tool that owns a repo-local legacy slash-command file, if any. */
 function legacyToolIdForFile(file: string): string | undefined {
+  // A file from a directory-based tool, reported because the directory also
+  // holds the user's own files.
+  const commandDir = legacyCommandDirForFile(file);
+  if (commandDir) return commandDir.toolId;
+
   // Normalize to forward slashes so the glob patterns match on Windows too.
   const normalizedFile = normalizePathForMatch(file);
   for (const [toolId, pattern] of Object.entries(LEGACY_SLASH_COMMAND_PATHS)) {

--- a/test/core/legacy-cleanup.test.ts
+++ b/test/core/legacy-cleanup.test.ts
@@ -1162,6 +1162,7 @@ ${OPENSPEC_MARKERS.end}`);
       expect(LEGACY_SLASH_COMMAND_PATHS['claude']).toEqual({
         type: 'directory',
         path: '.claude/commands/openspec',
+        managedFileNames: ['proposal.md', 'apply.md', 'archive.md'],
       });
 
       expect(LEGACY_SLASH_COMMAND_PATHS['cursor']).toEqual({

--- a/test/core/legacy-cleanup.user-files.test.ts
+++ b/test/core/legacy-cleanup.user-files.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+import {
+  cleanupLegacyArtifacts,
+  detectLegacyArtifacts,
+  formatCleanupSummary,
+  formatDetectionSummary,
+  getToolsFromLegacyArtifacts,
+  omitToolLegacyArtifacts,
+  LEGACY_SLASH_COMMAND_PATHS,
+} from '../../src/core/legacy-cleanup.js';
+import { runCLI } from '../helpers/run-cli.js';
+
+/**
+ * Pre-opsx tools kept their commands in a `<tool>/commands/openspec/` folder,
+ * and users keep their own commands in that same folder. Cleanup may delete
+ * only the files OpenSpec wrote there, and the folder only once nothing else
+ * is left in it.
+ */
+
+// The files the old SlashCommandRegistry wrote, per directory-based tool.
+const LEGACY_COMMAND_DIRS = [
+  { toolId: 'claude', dir: '.claude/commands/openspec', files: ['apply.md', 'archive.md', 'proposal.md'], userFile: 'team-review.md' },
+  { toolId: 'codebuddy', dir: '.codebuddy/commands/openspec', files: ['apply.md', 'archive.md', 'proposal.md'], userFile: 'team-review.md' },
+  { toolId: 'qoder', dir: '.qoder/commands/openspec', files: ['apply.md', 'archive.md', 'proposal.md'], userFile: 'team-review.md' },
+  { toolId: 'crush', dir: '.crush/commands/openspec', files: ['apply.md', 'archive.md', 'proposal.md'], userFile: 'team-review.md' },
+  { toolId: 'gemini', dir: '.gemini/commands/openspec', files: ['apply.toml', 'archive.toml', 'proposal.toml'], userFile: 'team-review.toml' },
+];
+
+const CLAUDE_DIR = '.claude/commands/openspec';
+const CLAUDE_FILES = ['apply.md', 'archive.md', 'proposal.md'];
+
+describe('legacy command directories and the files users keep in them', () => {
+  let testDir: string;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(async () => {
+    originalEnv = { ...process.env };
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'openspec-legacy-user-files-'));
+    process.env.CODEX_HOME = path.join(testDir, 'codex-home');
+    await fs.mkdir(path.join(testDir, 'openspec'), { recursive: true });
+  });
+
+  afterEach(async () => {
+    process.env = originalEnv;
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  const inProject = (dir: string, ...names: string[]) => path.join(testDir, dir, ...names);
+  const exists = (filePath: string) => fs.access(filePath).then(() => true, () => false);
+
+  async function writeFiles(dir: string, names: readonly string[]): Promise<void> {
+    for (const name of names) {
+      const filePath = inProject(dir, name);
+      await fs.mkdir(path.dirname(filePath), { recursive: true });
+      await fs.writeFile(filePath, `content of ${name}`);
+    }
+  }
+
+  it('covers every directory-based legacy entry', () => {
+    const directoryTools = Object.entries(LEGACY_SLASH_COMMAND_PATHS)
+      .filter(([, pattern]) => pattern.type === 'directory')
+      .map(([toolId]) => toolId)
+      .sort();
+    expect(directoryTools).toEqual([...LEGACY_COMMAND_DIRS.map((entry) => entry.toolId), 'lingma'].sort());
+  });
+
+  describe.each(LEGACY_COMMAND_DIRS)('$toolId', ({ toolId, dir, files, userFile }) => {
+    it('removes the folder when it holds only OpenSpec files', async () => {
+      await writeFiles(dir, files);
+
+      const detection = await detectLegacyArtifacts(testDir);
+      expect(detection.slashCommandDirs).toContain(dir);
+      const result = await cleanupLegacyArtifacts(testDir, detection);
+
+      expect(result.deletedDirs).toContain(dir);
+      expect(await exists(inProject(dir))).toBe(false);
+    });
+
+    it('keeps a user file and removes only the OpenSpec files', async () => {
+      await writeFiles(dir, [...files, userFile]);
+
+      const detection = await detectLegacyArtifacts(testDir);
+      const result = await cleanupLegacyArtifacts(testDir, detection);
+
+      expect(await fs.readFile(inProject(dir, userFile), 'utf-8')).toBe(`content of ${userFile}`);
+      for (const name of files) {
+        expect(await exists(inProject(dir, name))).toBe(false);
+      }
+      expect(result.deletedDirs).not.toContain(dir);
+      expect(result.deletedFiles).toEqual(expect.arrayContaining(files.map((name) => `${dir}/${name}`)));
+      expect(result.keptFiles).toEqual([`${dir}/${userFile}`]);
+      expect(getToolsFromLegacyArtifacts(detection)).toContain(toolId);
+    });
+  });
+
+  it('keeps a nested folder of user commands', async () => {
+    await writeFiles(CLAUDE_DIR, [...CLAUDE_FILES, path.join('team', 'review.md')]);
+
+    const result = await cleanupLegacyArtifacts(testDir, await detectLegacyArtifacts(testDir));
+
+    expect(await fs.readFile(inProject(CLAUDE_DIR, 'team', 'review.md'), 'utf-8')).toBe(
+      `content of ${path.join('team', 'review.md')}`
+    );
+    expect(result.keptFiles).toEqual([`${CLAUDE_DIR}/team/`]);
+    expect(result.deletedDirs).not.toContain(CLAUDE_DIR);
+  });
+
+  it('treats a folder that carries a legacy file name as the user\'s', async () => {
+    await writeFiles(CLAUDE_DIR, ['proposal.md', path.join('apply.md', 'notes.md')]);
+
+    const result = await cleanupLegacyArtifacts(testDir, await detectLegacyArtifacts(testDir));
+
+    expect(await exists(inProject(CLAUDE_DIR, 'apply.md', 'notes.md'))).toBe(true);
+    expect(await exists(inProject(CLAUDE_DIR, 'proposal.md'))).toBe(false);
+    expect(result.keptFiles).toEqual([`${CLAUDE_DIR}/apply.md/`]);
+  });
+
+  it('keeps a Gemini markdown file that shares a legacy command name', async () => {
+    const dir = '.gemini/commands/openspec';
+    await writeFiles(dir, ['proposal.toml', 'proposal.md']);
+
+    const result = await cleanupLegacyArtifacts(testDir, await detectLegacyArtifacts(testDir));
+
+    expect(await exists(inProject(dir, 'proposal.md'))).toBe(true);
+    expect(await exists(inProject(dir, 'proposal.toml'))).toBe(false);
+    expect(result.keptFiles).toEqual([`${dir}/proposal.md`]);
+  });
+
+  it('neither reports nor touches a folder holding no OpenSpec files', async () => {
+    await writeFiles(CLAUDE_DIR, ['team-review.md']);
+
+    const detection = await detectLegacyArtifacts(testDir);
+    expect(detection.slashCommandDirs).not.toContain(CLAUDE_DIR);
+    expect(detection.slashCommandFiles.filter((file) => file.startsWith(CLAUDE_DIR))).toEqual([]);
+    expect(detection.hasLegacyArtifacts).toBe(false);
+
+    await cleanupLegacyArtifacts(testDir, detection);
+    expect(await exists(inProject(CLAUDE_DIR, 'team-review.md'))).toBe(true);
+  });
+
+  it('leaves files in the Lingma folder alone, because OpenSpec never wrote there', async () => {
+    const dir = '.lingma/commands/openspec';
+    await writeFiles(dir, ['proposal.md']);
+
+    const detection = await detectLegacyArtifacts(testDir);
+    expect(detection.slashCommandDirs).not.toContain(dir);
+    await cleanupLegacyArtifacts(testDir, detection);
+
+    expect(await exists(inProject(dir, 'proposal.md'))).toBe(true);
+  });
+
+  it('still removes an empty leftover legacy folder', async () => {
+    const dir = '.lingma/commands/openspec';
+    await fs.mkdir(inProject(dir), { recursive: true });
+
+    const detection = await detectLegacyArtifacts(testDir);
+    expect(detection.slashCommandDirs).toContain(dir);
+    const result = await cleanupLegacyArtifacts(testDir, detection);
+
+    expect(result.deletedDirs).toContain(dir);
+    expect(await exists(inProject(dir))).toBe(false);
+  });
+
+  it('keeps a file added between detection and cleanup', async () => {
+    await writeFiles(CLAUDE_DIR, CLAUDE_FILES);
+    const detection = await detectLegacyArtifacts(testDir);
+    expect(detection.slashCommandDirs).toContain(CLAUDE_DIR);
+
+    // e.g. while the interactive upgrade prompt was waiting
+    await writeFiles(CLAUDE_DIR, ['team-review.md']);
+    const result = await cleanupLegacyArtifacts(testDir, detection);
+
+    expect(await exists(inProject(CLAUDE_DIR, 'team-review.md'))).toBe(true);
+    expect(result.deletedDirs).not.toContain(CLAUDE_DIR);
+    expect(result.keptFiles).toEqual([`${CLAUDE_DIR}/team-review.md`]);
+  });
+
+  it('lists OpenSpec\'s files, not the folder, in the upgrade prompt when the folder holds user files', async () => {
+    await writeFiles(CLAUDE_DIR, [...CLAUDE_FILES, 'team-review.md']);
+
+    const summary = formatDetectionSummary(await detectLegacyArtifacts(testDir));
+    const lines = summary.split('\n').map((line) => line.trim());
+
+    expect(lines).toContain(`• ${CLAUDE_DIR}/proposal.md`);
+    expect(lines).not.toContain(`• ${CLAUDE_DIR}/`);
+    expect(summary).not.toContain('team-review.md');
+  });
+
+  it('names what was kept in the cleanup summary and never claims the folder was removed', async () => {
+    await writeFiles(CLAUDE_DIR, [...CLAUDE_FILES, 'team-review.md']);
+
+    const result = await cleanupLegacyArtifacts(testDir, await detectLegacyArtifacts(testDir));
+    const summary = formatCleanupSummary(result);
+
+    expect(summary).toContain(`Kept ${CLAUDE_DIR}/team-review.md (not created by OpenSpec)`);
+    expect(summary).toContain(`Removed ${CLAUDE_DIR}/proposal.md`);
+    expect(summary).not.toContain(`Removed ${CLAUDE_DIR}/ `);
+  });
+
+  it('leaves a mixed folder untouched when its tool is omitted from cleanup', async () => {
+    await writeFiles(CLAUDE_DIR, [...CLAUDE_FILES, 'team-review.md']);
+
+    const detection = omitToolLegacyArtifacts(await detectLegacyArtifacts(testDir), ['claude']);
+    expect(detection.slashCommandFiles.filter((file) => file.startsWith(CLAUDE_DIR))).toEqual([]);
+    await cleanupLegacyArtifacts(testDir, detection);
+
+    expect(await exists(inProject(CLAUDE_DIR, 'proposal.md'))).toBe(true);
+  });
+});
+
+describe('openspec init with a legacy command folder', () => {
+  const T = 120_000;
+  let base: string;
+
+  beforeEach(async () => {
+    base = await fs.mkdtemp(path.join(os.tmpdir(), 'openspec-legacy-init-'));
+  });
+
+  afterEach(async () => {
+    await fs.rm(base, { recursive: true, force: true });
+  });
+
+  async function legacyProject(withUserFile: boolean) {
+    const home = path.join(base, 'home');
+    const project = path.join(base, 'project');
+    const dir = path.join(project, '.claude', 'commands', 'openspec');
+    await fs.mkdir(home, { recursive: true });
+    await fs.mkdir(dir, { recursive: true });
+    for (const name of CLAUDE_FILES) {
+      await fs.writeFile(path.join(dir, name), `---\nname: OpenSpec: ${name}\n---\nold\n`);
+    }
+    if (withUserFile) {
+      await fs.writeFile(path.join(dir, 'team-review.md'), '---\ndescription: my team review checklist\n---\nReview carefully.\n');
+    }
+    const env = {
+      HOME: home,
+      USERPROFILE: home,
+      XDG_CONFIG_HOME: path.join(home, '.config'),
+      XDG_DATA_HOME: path.join(home, '.local', 'share'),
+      CODEX_HOME: path.join(home, '.codex'),
+      OPENSPEC_NO_ANIMATION: '1',
+    };
+    const init = (extraArgs: string[]) =>
+      runCLI(['init', '--tools', 'claude', ...extraArgs], { cwd: project, env, timeoutMs: 60_000 });
+    return { dir, init };
+  }
+
+  it('removes a folder holding only OpenSpec files', async () => {
+    const { dir, init } = await legacyProject(false);
+    expect((await init([])).exitCode).toBe(0);
+    await expect(fs.access(dir)).rejects.toThrow();
+  }, T);
+
+  // Without a TTY, init cleans up automatically even without --force, which
+  // is how agents and CI run it.
+  it.each([[[] as string[]], [['--force']]])('keeps a user file in the folder (init %j)', async (extraArgs) => {
+    const { dir, init } = await legacyProject(true);
+
+    const result = await init(extraArgs);
+
+    expect(result.exitCode).toBe(0);
+    expect(await fs.readFile(path.join(dir, 'team-review.md'), 'utf-8')).toContain('Review carefully.');
+    await expect(fs.access(path.join(dir, 'proposal.md'))).rejects.toThrow();
+    expect(result.stdout).toContain(`Kept ${CLAUDE_DIR}/team-review.md (not created by OpenSpec)`);
+  }, T);
+});

--- a/test/core/update.test.ts
+++ b/test/core/update.test.ts
@@ -2782,11 +2782,12 @@ ${OPENSPEC_MARKERS.end}
         'old'
       );
 
-      // Create legacy slash command directory
+      // Create legacy slash command directory holding a command OpenSpec wrote.
+      // Only those files are removed; any other file here is the user's.
       const legacyCommandDir = path.join(testDir, '.claude', 'commands', 'openspec');
       await fs.mkdir(legacyCommandDir, { recursive: true });
       await fs.writeFile(
-        path.join(legacyCommandDir, 'old-command.md'),
+        path.join(legacyCommandDir, 'proposal.md'),
         'old command'
       );
 


### PR DESCRIPTION
Closes #1873.

## Why

Six entries in `LEGACY_SLASH_COMMAND_PATHS` (`src/core/legacy-cleanup.ts:36-41`)
were `directory` entries: Claude Code, CodeBuddy, Qoder, Lingma, Crush and
Gemini CLI, each at `<tool>/commands/openspec/`. Detection flagged the folder
whenever it existed (`:321-323`). Cleanup then ran
`fs.rm(fullPath, { recursive: true, force: true })` (`:555`), deleting everything
in it. Users keep their own commands in that folder, and they went with
OpenSpec's three old ones:

- The upgrade prompt listed the folder under "Files to remove / No user content
  to preserve".
- The summary said `✓ Removed .claude/commands/openspec/`.

So nothing ever told the user their files had been in it.

`openspec init` runs this cleanup automatically when `--force` is set **or when
there is no TTY** (`src/core/init.ts:500-501`). So an agent or CI running plain
`openspec init --tools claude` deleted the files without a prompt.
`openspec update --force` uses the same function.

The file already names the hazard for CoStrict (`:69-71`), which #1492 made
file-scoped. The directory entries never got the same treatment.

## What Changes

- **Each directory entry now lists the files OpenSpec wrote there**, in a new
  `managedFileNames`. The names come from the slash configurators removed in
  #565: `proposal.md`, `apply.md` and `archive.md`, or `.toml` for Gemini.
  Lingma is the exception. Its support arrived after the opsx rename and has
  always written to `.lingma/commands/opsx/`, so OpenSpec never wrote a file
  into `.lingma/commands/openspec/`, and its list is empty.
- **Detection:**
  - A folder holding only those files, or nothing, is reported as a folder,
    exactly as before.
  - A folder that also holds anything else has only OpenSpec's files reported,
    one by one. The upgrade prompt then lists exactly what will be deleted.
  - A folder holding none of OpenSpec's files is not reported at all.
- **Cleanup deletes only managed files.** It then removes the folder with a
  non-recursive `rmdir`, and only if the folder is empty. Anything left is
  recorded in a new optional `CleanupResult.keptFiles` and printed as
  `• Kept .claude/commands/openspec/team-review.md (not created by OpenSpec)`.
  This also protects a file added between detection and cleanup, for example
  while the interactive prompt waits.
- **Files reported from a mixed folder map back to their tool.** So
  `getToolsFromLegacyArtifacts` and `omitToolLegacyArtifacts` treat them like any
  other legacy file. The second is what the legacy-upgrade path uses to skip a
  tool whose replacement was not written.
- **Ownership is checked by content, not just by name.** A managed file counts as OpenSpec's only when it is a regular file whose content still carries the OpenSpec markers every legacy command was generated with. Cleanup re-checks that right before each unlink, so a same-named file the user wrote (or swapped in while the prompt waited) is kept. A symlinked command folder is never followed.

The common upgrade is unchanged: a folder holding only OpenSpec's files is
removed as before, with the same prompt line and the same summary line.

## Testing

New file `test/core/legacy-cleanup.user-files.test.ts`, now 30 tests. The first
24 were written first: on clean `9d4e597` they gave 15 failed and 9 passed, every
failure a bug assertion and every control passing. The later ownership and
recheck tests each fail without the change that added them. With the fix, all 30
pass.

Edge cases covered:

- **Per tool (claude, codebuddy, qoder, crush, gemini):** a folder of only
  OpenSpec files is still removed (control). A user file in it is kept, the
  OpenSpec files are deleted, the folder stays, and the files map back to the
  tool.
- A nested folder of user commands is kept, and so is a folder named like a
  legacy file (`apply.md/`).
- A Gemini `proposal.md` is kept while `proposal.toml` is removed.
- A folder holding no OpenSpec files is neither reported nor touched.
- Lingma files are left alone. An empty leftover folder is still removed.
- A file added between detection and cleanup is kept.
- A user-authored file that only shares a legacy command name is kept, alone or
  beside OpenSpec's files, and a symlinked command folder is never followed.
- A `proposal.md` the user swaps in between detection and cleanup, or after
  cleanup has scanned the folder, is kept and reported as kept.
- The upgrade prompt lists OpenSpec's files, not the folder. The summary names
  what was kept and never claims the folder was removed.
- When `omitToolLegacyArtifacts` skips the tool, a mixed folder is untouched.
- A guard fails if a new directory entry is added without a test row.
- **End to end:** `openspec init --tools claude` keeps `team-review.md`, both
  without a TTY and with `--force`. It still removes a folder of only OpenSpec
  files.

Two existing tests encoded the old behaviour and were updated:

- **`test/core/update.test.ts`** › "should cleanup legacy slash command
  directories with --force". Its fixture was `old-command.md`, a file OpenSpec
  never wrote, and it asserted that such a file is deleted along with the folder.
  That is the behaviour this PR removes. The fixture is now `proposal.md`, and
  the assertions are unchanged.
- **`test/core/legacy-cleanup.test.ts`** › "should include expected tool
  patterns". It compares the claude entry with `toEqual`, so it now includes
  `managedFileNames`.

## Verification

Run in a Linux sandbox under Node 20.19.0, the CI version, on `9d4e597` with
this patch:

- `pnpm run build`: ok
- `pnpm exec tsc --noEmit`: ok
- `pnpm lint`: ok
- Targeted (`legacy-cleanup.user-files`, `legacy-cleanup`, `update`, `init`):
  all passed
- Full suite, `VITEST_MAX_WORKERS=4 pnpm test`: 4579 passed and 8 failed, in 5
  files. The 5 files are `store-references`, `store-root-selection`, `store`,
  `workset` and `package-install-scripts`, none of which touches legacy
  cleanup. Every failure was a 10-second test timeout on a shared, heavily
  loaded machine (load average 6 to 13).

None of these failures come from this change:

- `store-references`, `store-root-selection`, `workset` and
  `package-install-scripts` fail the same tests, the same way, on clean
  `9d4e597` under the same load.
- `store` passes 43/43 on this branch and on clean `9d4e597` when run
  side by side. Its two slow tests take 8.6 to 9.0 seconds even on
  `9d4e597`.
- Only `init.ts` and `update.ts` import `legacy-cleanup.ts`, and none of the
  store or workset commands reach either one.

## Changeset

Added `.changeset/legacy-cleanup-keeps-user-files.md` (patch).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Legacy cleanup now removes only files generated by OpenSpec, preserving user-created files with matching names.
  * Symlinked command folders and files without OpenSpec markers are protected from removal.
  * Cleanup summaries now list retained files and remove legacy folders only when empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

