### PR TITLE
fix(store): stop a store named specs or changes becoming the root

### DIFF
--- a/.changeset/store-named-specs-is-not-a-root.md
+++ b/.changeset/store-named-specs-is-not-a-root.md
@@ -1,0 +1,5 @@
+---
+'@fission-ai/openspec': patch
+---
+
+Stop a store named `specs` or `changes` from taking over root selection. Stores are placed at `~/openspec/<id>`, so a store with one of those ids is itself `~/openspec/specs` or `~/openspec/changes`, and that made `$HOME` look like a planning root. Every command run anywhere under the home directory then resolved `$HOME` as the nearest root: the global `defaultStore` was never consulted, and `new change` wrote into `~/openspec/changes`, outside any store. A `specs/` or `changes/` directory that carries store metadata no longer counts as planning content of the directory above it, so these stores resolve like any other. A real project's `openspec/specs/` and `openspec/changes/` are unaffected.

--- a/src/core/project-config.ts
+++ b/src/core/project-config.ts
@@ -3,6 +3,8 @@ import path from 'path';
 import { parse as parseYaml } from 'yaml';
 import { z } from 'zod';
 
+import { getStoreMetadataPath } from './store/foundation.js';
+
 export const OPERATION_IDS = ['apply', 'archive'] as const;
 export type OperationId = (typeof OPERATION_IDS)[number];
 
@@ -577,7 +579,10 @@ export function storePointerProblem(reason: 'unparseable' | 'non_string'): strin
 }
 
 export interface OpenSpecDirClassification {
-  /** True when openspec/specs or openspec/changes exists as a directory. */
+  /**
+   * True when openspec/specs or openspec/changes exists as a directory
+   * that is not itself a store root.
+   */
   hasPlanningShape: boolean;
   pointer: StorePointerRead;
 }
@@ -586,13 +591,22 @@ export interface OpenSpecDirClassification {
  * One classification for "real root vs config-only pointer dir", shared
  * by root resolution and the init pointer guard so they can never
  * disagree (slice 3.2).
+ *
+ * A specs/ or changes/ directory carrying store metadata is a store at
+ * the recommended `~/openspec/<id>` layout whose id is `specs` or
+ * `changes`, not planning content of the directory above it. Counting it
+ * would make $HOME the phantom root the qualifying walk exists to prevent.
  */
 export function classifyOpenSpecDir(projectRoot: string): OpenSpecDirClassification {
   const openspecDir = path.join(projectRoot, 'openspec');
   const hasPlanningShape =
-    isDirectorySync(path.join(openspecDir, 'specs')) ||
-    isDirectorySync(path.join(openspecDir, 'changes'));
+    isPlanningDirectorySync(path.join(openspecDir, 'specs')) ||
+    isPlanningDirectorySync(path.join(openspecDir, 'changes'));
   return { hasPlanningShape, pointer: readStorePointer(projectRoot) };
+}
+
+function isPlanningDirectorySync(candidatePath: string): boolean {
+  return isDirectorySync(candidatePath) && !existsSync(getStoreMetadataPath(candidatePath));
 }
 
 function isDirectorySync(candidatePath: string): boolean {

--- a/test/commands/store-phantom-root.test.ts
+++ b/test/commands/store-phantom-root.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { classifyOpenSpecDir } from '../../src/core/project-config.js';
+import { runCLI, type RunCLIResult } from '../helpers/run-cli.js';
+import { createOpenSpecRoot } from '../helpers/openspec-fixtures.js';
+
+/**
+ * The guide's store layout is `~/openspec/<id>`. With the id `specs` or
+ * `changes`, the store folder is itself `~/openspec/specs` or
+ * `~/openspec/changes`, which gave `$HOME` a planning shape. `$HOME` then
+ * became the nearest root for every command under the home tree: the global
+ * `defaultStore` was never consulted and new changes landed outside the store.
+ */
+describe('a store named specs or changes at ~/openspec/<id>', () => {
+  let tempDir: string;
+  let home: string;
+  let workDir: string;
+  let env: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    tempDir = fs.realpathSync.native(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'openspec-store-phantom-root-'))
+    );
+    home = path.join(tempDir, 'home');
+    workDir = path.join(home, 'src', 'web-app');
+    fs.mkdirSync(workDir, { recursive: true });
+    env = {
+      XDG_DATA_HOME: path.join(tempDir, 'data'),
+      XDG_CONFIG_HOME: path.join(tempDir, 'config'),
+      OPEN_SPEC_INTERACTIVE: '0',
+      OPENSPEC_TELEMETRY: '0',
+    };
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  });
+
+  function parseJson(result: RunCLIResult): any {
+    try {
+      return JSON.parse(result.stdout);
+    } catch (error) {
+      throw new Error(
+        `Could not parse JSON.\nCommand: ${result.command}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}\n${String(error)}`
+      );
+    }
+  }
+
+  /** `store setup <id> --path ~/openspec/<id>`, then `config set defaultStore <id>`. */
+  async function setupDefaultStore(id: string): Promise<string> {
+    const storeRoot = path.join(home, 'openspec', id);
+    const setup = await runCLI(
+      ['store', 'setup', id, '--path', storeRoot, '--no-init-git', '--json'],
+      { cwd: tempDir, env }
+    );
+    expect(setup.exitCode).toBe(0);
+    const config = await runCLI(['config', 'set', 'defaultStore', id], { cwd: tempDir, env });
+    expect(config.exitCode).toBe(0);
+    return storeRoot;
+  }
+
+  async function rootFrom(cwd: string): Promise<any> {
+    const result = await runCLI(['list', '--json'], { cwd, env });
+    expect(result.exitCode).toBe(0);
+    return parseJson(result).root;
+  }
+
+  it('control: a store named team-plans resolves as the global default', async () => {
+    const storeRoot = await setupDefaultStore('team-plans');
+
+    expect(await rootFrom(workDir)).toEqual({
+      path: storeRoot,
+      source: 'global_default',
+      store_id: 'team-plans',
+    });
+  }, 60_000);
+
+  it.each(['specs', 'changes'])(
+    'a store named %s still resolves as the global default',
+    async (id) => {
+      const storeRoot = await setupDefaultStore(id);
+
+      expect(await rootFrom(workDir)).toEqual({
+        path: storeRoot,
+        source: 'global_default',
+        store_id: id,
+      });
+    },
+    60_000
+  );
+
+  it.each(['specs', 'changes'])(
+    'new change lands in the store named %s, not under $HOME/openspec',
+    async (id) => {
+      const storeRoot = await setupDefaultStore(id);
+
+      const result = await runCLI(['new', 'change', 'probe-change', '--json'], { cwd: workDir, env });
+
+      expect(result.exitCode).toBe(0);
+      expect(fs.existsSync(path.join(storeRoot, 'openspec', 'changes', 'probe-change'))).toBe(true);
+      expect(fs.existsSync(path.join(home, 'openspec', 'changes', 'probe-change'))).toBe(false);
+    },
+    60_000
+  );
+
+  it('resolves the store itself as the nearest root from inside it', async () => {
+    const storeRoot = await setupDefaultStore('specs');
+
+    expect(await rootFrom(path.join(storeRoot, 'openspec', 'changes'))).toEqual({
+      path: storeRoot,
+      source: 'nearest',
+    });
+  }, 60_000);
+
+  it('keeps a real project root at $HOME as the nearest root', async () => {
+    await setupDefaultStore('team-plans');
+    createOpenSpecRoot(home);
+
+    expect(await rootFrom(workDir)).toEqual({ path: home, source: 'nearest' });
+  }, 60_000);
+
+  it('keeps $HOME a root when its changes/ is real planning, even beside a store named specs', async () => {
+    await setupDefaultStore('specs');
+    fs.mkdirSync(path.join(home, 'openspec', 'changes'), { recursive: true });
+
+    expect(await rootFrom(workDir)).toEqual({ path: home, source: 'nearest' });
+  }, 60_000);
+});
+
+describe('classifyOpenSpecDir planning shape', () => {
+  let projectRoot: string;
+
+  beforeEach(() => {
+    projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'openspec-classify-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(projectRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  });
+
+  function makeStoreFolder(relativePath: string, id: string): void {
+    const metadataDir = path.join(projectRoot, relativePath, '.openspec-store');
+    fs.mkdirSync(metadataDir, { recursive: true });
+    fs.writeFileSync(path.join(metadataDir, 'store.yaml'), `version: 1\nid: ${id}\n`);
+  }
+
+  it.each(['specs', 'changes'])('counts a plain openspec/%s directory as planning', (dir) => {
+    fs.mkdirSync(path.join(projectRoot, 'openspec', dir), { recursive: true });
+
+    expect(classifyOpenSpecDir(projectRoot).hasPlanningShape).toBe(true);
+  });
+
+  it.each(['specs', 'changes'])('does not count openspec/%s when it is a store root', (dir) => {
+    makeStoreFolder(path.join('openspec', dir), dir);
+
+    expect(classifyOpenSpecDir(projectRoot).hasPlanningShape).toBe(false);
+  });
+
+  it('counts the other directory when only one of them is a store root', () => {
+    makeStoreFolder(path.join('openspec', 'specs'), 'specs');
+    fs.mkdirSync(path.join(projectRoot, 'openspec', 'changes'), { recursive: true });
+
+    expect(classifyOpenSpecDir(projectRoot).hasPlanningShape).toBe(true);
+  });
+
+  it('still counts a specs directory whose store metadata sits deeper inside it', () => {
+    makeStoreFolder(path.join('openspec', 'specs', 'billing'), 'billing');
+
+    expect(classifyOpenSpecDir(projectRoot).hasPlanningShape).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #1881.

## Why

The stores guide places a store at `~/openspec/<id>`. With the id `specs` or
`changes`, the store's own folder *is* `~/openspec/specs` or
`~/openspec/changes`.

`classifyOpenSpecDir` treated any existing `openspec/specs` or
`openspec/changes` directory as a planning shape, so `$HOME` qualified as a real
root. From anywhere under the home directory:

- `list`, `status`, `new change` and the rest resolved `$HOME` as the `nearest`
  root, and the global `defaultStore` was never consulted
- `new change` wrote into `~/openspec/changes/`, outside every store

`src/core/root-selection.ts` states that the qualifying walk exists to prevent
exactly this: "the recommended `~/openspec/<id>` store layout would make $HOME a
phantom root that captures every command under the home tree". The walk
handled a bare `~/openspec/` but not these two ids.

## What Changes

- `classifyOpenSpecDir` no longer counts a `specs/` or `changes/` directory as
  planning shape when that directory carries store metadata
  (`.openspec-store/store.yaml`). Such a directory is a store root, not planning
  content of the directory above it.
- The change is inside the one shared classifier, so root resolution, the
  `init` pointer guard, `store setup`'s pointer check and `doctor` keep agreeing,
  as that function's comment requires.

Unchanged:

- a real project's `openspec/specs/` and `openspec/changes/`
- resolution from inside the store itself
- a `$HOME` whose `openspec/changes/` is real planning stays a root, even when
  `openspec/specs/` beside it is a store

### Why detect by metadata rather than by the registry?

A store folder is a store whether or not this machine has registered it yet, for
example a fresh clone. The metadata check also keeps `classifyOpenSpecDir`
synchronous and free of registry reads, like the rest of the root walk.

## Testing

`test/commands/store-phantom-root.test.ts`: 15 tests. 9 run through the built
CLI; 6 are unit tests of `classifyOpenSpecDir`. Written first and watched fail:

- **Before the fix (tests only, on `9d4e597`):** 7 failed, 8 passed.
  - For the `specs` and `changes` stores, `root` came back as
    `{ path: <$HOME>, source: 'nearest' }` instead of the store's
    `global_default`.
  - `new change` did not land in the store.
  - `classifyOpenSpecDir` returned `true` for a store-root folder.
  - Every control passed.
- **After the fix:** 15 passed.

### CI parity

Run in an isolated sandbox on `9d4e597` under Node 20.19.0 and pnpm 10.34.5,
with the steps from `.github/workflows/ci.yml`:

| Step | Result |
|---|---|
| `pnpm run build` | pass |
| `pnpm exec tsc --noEmit` | pass |
| `pnpm lint` | pass |
| `pnpm test` (`VITEST_MAX_WORKERS=4`) | 4565 passed, 12 failed (4577) |
| `pnpm test` on clean `9d4e597`, same sandbox | 4555 passed, 8 failed (4563) |

The full-suite failures are all timeouts — `Test timed out in 10000ms`, or
`spawnSync npm ETIMEDOUT` in the npm packing test — in CLI-heavy files this
change does not touch: `store-references`, `store-remote`,
`store-root-selection`, `workset`, `package-install-scripts` and
`store.test.ts`. Two checks say the sandbox causes them, not this change:

- clean `9d4e597` fails the same files the same way on the same machine
- every one of those files passes alone (`--maxWorkers=2`), on this branch and
  on clean `9d4e597`: `store-references` 8/8, `store-remote` 19/19,
  `store-root-selection` 44/44, `store.test.ts` 43/43, `workset` 41/41,
  `package-install-scripts` 8/8

At that run the branch added exactly its 14 new tests: 4577 = 4563 + 14. The symlinked-alias test added since brings the file to 15.

Edge cases covered:

- control: a store named `team-plans` resolves as `global_default`
- stores named `specs` and `changes` resolve as `global_default`, with the right
  path and `store_id`
- `new change` lands in the store for both ids, and nothing is written under
  `$HOME/openspec/changes/`
- from inside the store, the store itself is the `nearest` root
- a real project at `$HOME` still wins as `nearest`, ahead of `defaultStore`
- `$HOME` with a real `openspec/changes/` beside a `specs` store stays a root
- from a symlinked alias of the home tree, the `specs` store still resolves as `global_default` at its canonical path (skipped on Windows, where directory symlinks need elevation)
- unit tests:
  - a plain `openspec/specs` or `openspec/changes` counts as planning
  - a store-root `openspec/specs` or `openspec/changes` does not
  - when only one of them is a store root, the other still counts
  - store metadata deeper inside `openspec/specs` does not disqualify it

## Changeset

`.changeset/store-named-specs-is-not-a-root.md` (patch).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed project root detection for stores named `specs` or `changes`.
  - Commands run from home-directory workspaces now resolve the configured default store correctly.
  - New changes are saved inside the intended store instead of an unintended home-directory location.
  - Existing project planning directories and genuine project roots continue to resolve as expected.

- **Tests**
  - Added coverage for store resolution, change creation, and planning-directory classification in these scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
