### PR TITLE
fix(store): let setup --no-init-git run inside a git repository

### DIFF
--- a/.changeset/store-setup-no-init-git-inside-repo.md
+++ b/.changeset/store-setup-no-init-git-inside-repo.md
@@ -1,0 +1,5 @@
+---
+'@fission-ai/openspec': patch
+---
+
+Let `openspec store setup --no-init-git` create a store inside an existing Git repository. Setup refuses a path inside another repository because initializing the store there would nest one repository in another, but it ran that check even with `--no-init-git`, which creates no repository at all. Users who keep their home directory as a dotfiles repository therefore could not set up a store at the recommended `~/openspec/<id>` path with any flag. With `--no-init-git` the check is now skipped, and the store never records the enclosing repository's remote. The default setup and an explicit `--init-git` still refuse a path inside another repository.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -254,6 +254,8 @@ openspec store setup [id] [options]
 
 Non-interactive runs (`--json`, scripts, agents) must pass both the store id and `--path`. In an interactive terminal, setup prompts for the location with an editable suggestion in a visible, user-owned place (for example `~/openspec/<id>`); it never defaults to OpenSpec's managed data directory.
 
+Setup refuses a `--path` inside another Git repository, because initializing the store there would nest one repository in another. `--no-init-git` creates no repository, so it skips that check: use it to keep a store at `~/openspec/<id>` when your home directory is itself a Git repository, such as a dotfiles repo.
+
 Examples:
 
 ```bash

--- a/src/commands/store.ts
+++ b/src/commands/store.ts
@@ -294,9 +294,12 @@ async function resolveSetupInput(
 
 async function prepareSetupInput(
   input: ResolvedStoreSetupInput,
-  _options: StoreSetupOptions
+  options: StoreSetupOptions
 ) {
-  return prepareStoreSetup(input);
+  return prepareStoreSetup({
+    ...input,
+    ...(options.initGit !== undefined ? { initGit: options.initGit } : {}),
+  });
 }
 
 async function confirmSetup(

--- a/src/core/store/operations.ts
+++ b/src/core/store/operations.ts
@@ -457,7 +457,7 @@ async function resolveBackendWithObservedOrigin(
 }
 
 async function prepareSetupPlan(
-  input: Pick<SetupStoreInput, 'id' | 'path' | 'allowInsideGitRepository' | 'remote'>
+  input: Pick<SetupStoreInput, 'id' | 'path' | 'initGit' | 'allowInsideGitRepository' | 'remote'>
 ): Promise<StoreSetupPlan> {
   const id = validateStoreId(input.id ?? '');
   if (input.remote !== undefined && input.remote.length === 0) {
@@ -481,9 +481,10 @@ async function prepareSetupPlan(
   }
 
   // Stores may be Git-backed, but creating one inside an implementation
-  // repo is almost always an accidental nested-repo setup.
+  // repo is almost always an accidental nested-repo setup. --no-init-git
+  // creates no repository, so there is nothing to nest.
   await assertSetupPathIsNotNestedInGitRepo(storeRoot, {
-    allowInsideGitRepository: input.allowInsideGitRepository,
+    allowInsideGitRepository: input.allowInsideGitRepository || input.initGit === false,
   });
 
   let metadata: Awaited<ReturnType<typeof readStoreMetadataForOperation>> = null;
@@ -557,7 +558,7 @@ export function resolveSetupGitEnabled(
 }
 
 export async function prepareStoreSetup(
-  input: Pick<SetupStoreInput, 'id' | 'path' | 'allowInsideGitRepository' | 'remote'>
+  input: Pick<SetupStoreInput, 'id' | 'path' | 'initGit' | 'allowInsideGitRepository' | 'remote'>
 ): Promise<PreparedStoreSetup> {
   const plan = await prepareSetupPlan(input);
 

--- a/test/commands/store-setup-no-init-git.test.ts
+++ b/test/commands/store-setup-no-init-git.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import {
+  getGlobalDataDir,
+  getStoreMetadataPath,
+  readStoreRegistryState,
+} from '../../src/core/index.js';
+import { runCLI, type RunCLIResult } from '../helpers/run-cli.js';
+import { isolatedGitEnv } from '../helpers/store-git.js';
+
+/**
+ * The nested-repo guard exists because store setup normally runs `git init`,
+ * and a new repository inside an existing one is almost always an accident.
+ * `--no-init-git` creates no repository, so there is nothing to nest: the
+ * guard must not refuse it. The motivating layout is a `$HOME` kept as a
+ * dotfiles repository with the guide's recommended `~/openspec/<id>` store.
+ */
+describe('store setup --no-init-git inside an existing Git repository', () => {
+  let tempDir: string;
+  let home: string;
+  let storeRoot: string;
+  let globalDataDir: string;
+  let env: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    tempDir = fs.realpathSync.native(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'openspec-store-no-init-git-'))
+    );
+    home = path.join(tempDir, 'home');
+    fs.mkdirSync(home, { recursive: true });
+    storeRoot = path.join(home, 'openspec', 'team-plans');
+    env = {
+      XDG_DATA_HOME: path.join(tempDir, 'data'),
+      XDG_CONFIG_HOME: path.join(tempDir, 'config'),
+      OPEN_SPEC_INTERACTIVE: '0',
+      OPENSPEC_TELEMETRY: '0',
+      ...isolatedGitEnv(tempDir),
+    };
+    globalDataDir = getGlobalDataDir({ env });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  });
+
+  function git(args: string[]): string {
+    return execFileSync('git', args, {
+      cwd: tempDir,
+      env: { ...process.env, ...env },
+      stdio: 'pipe',
+    }).toString().trim();
+  }
+
+  function makeHomeADotfilesRepo(): void {
+    git(['init', '-q', home]);
+  }
+
+  function setup(flags: string[]): Promise<RunCLIResult> {
+    return runCLI(
+      ['store', 'setup', 'team-plans', '--path', storeRoot, ...flags, '--json'],
+      { cwd: tempDir, env }
+    );
+  }
+
+  function parseJson(result: RunCLIResult): any {
+    try {
+      return JSON.parse(result.stdout);
+    } catch (error) {
+      throw new Error(
+        `Could not parse JSON.\nCommand: ${result.command}\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}\n${String(error)}`
+      );
+    }
+  }
+
+  it('control: sets up with --no-init-git when no repository encloses the path', async () => {
+    const result = await setup(['--no-init-git']);
+
+    expect(result.exitCode).toBe(0);
+    expect(parseJson(result).registry.registered).toBe(true);
+  }, 30_000);
+
+  it('sets up and registers the store when $HOME is a Git repository', async () => {
+    makeHomeADotfilesRepo();
+
+    const result = await setup(['--no-init-git']);
+
+    expect(result.exitCode).toBe(0);
+    const payload = parseJson(result);
+    expect(payload.status).toEqual([]);
+    expect(payload.store.root).toBe(storeRoot);
+    expect(payload.registry).toEqual(expect.objectContaining({ registered: true }));
+    expect(payload.git).toEqual({
+      is_repository: false,
+      initialized: false,
+      committed: false,
+    });
+    expect(fs.existsSync(getStoreMetadataPath(storeRoot))).toBe(true);
+    expect(fs.existsSync(path.join(storeRoot, 'openspec', 'config.yaml'))).toBe(true);
+  }, 30_000);
+
+  it('creates no repository and commits nothing in the enclosing one', async () => {
+    makeHomeADotfilesRepo();
+
+    expect((await setup(['--no-init-git'])).exitCode).toBe(0);
+
+    expect(fs.existsSync(path.join(storeRoot, '.git'))).toBe(false);
+    expect(git(['-C', home, 'rev-list', '--all', '--count'])).toBe('0');
+  }, 30_000);
+
+  it("never records the enclosing repository's origin as the store remote", async () => {
+    makeHomeADotfilesRepo();
+    git(['-C', home, 'remote', 'add', 'origin', 'https://example.com/dotfiles.git']);
+
+    expect((await setup(['--no-init-git'])).exitCode).toBe(0);
+
+    await expect(readStoreRegistryState({ globalDataDir })).resolves.toEqual({
+      version: 1,
+      stores: {
+        'team-plans': {
+          backend: { type: 'git', local_path: storeRoot },
+        },
+      },
+    });
+  }, 30_000);
+
+  it('reports a rerun with --no-init-git as an already-registered no-op', async () => {
+    makeHomeADotfilesRepo();
+    expect((await setup(['--no-init-git'])).exitCode).toBe(0);
+
+    const rerun = await setup(['--no-init-git']);
+
+    expect(rerun.exitCode).toBe(0);
+    expect(parseJson(rerun).registry).toEqual(
+      expect.objectContaining({ registered: false, already_registered: true })
+    );
+  }, 30_000);
+
+  it('still refuses the default setup, which would nest a new repository', async () => {
+    makeHomeADotfilesRepo();
+
+    const result = await setup([]);
+
+    expect(result.exitCode).toBe(1);
+    expect(parseJson(result).status[0]).toEqual(
+      expect.objectContaining({ code: 'store_setup_inside_git_repo' })
+    );
+    expect(fs.existsSync(path.join(storeRoot, 'openspec'))).toBe(false);
+    expect(fs.existsSync(getStoreMetadataPath(storeRoot))).toBe(false);
+  }, 30_000);
+
+  it('still refuses an explicit --init-git', async () => {
+    makeHomeADotfilesRepo();
+
+    const result = await setup(['--init-git']);
+
+    expect(result.exitCode).toBe(1);
+    expect(parseJson(result).status[0]).toEqual(
+      expect.objectContaining({ code: 'store_setup_inside_git_repo' })
+    );
+    expect(fs.existsSync(path.join(storeRoot, 'openspec'))).toBe(false);
+  }, 30_000);
+});

--- a/test/commands/store.test.ts
+++ b/test/commands/store.test.ts
@@ -420,7 +420,7 @@ describe('store command', () => {
     const storeRoot = path.join(repoRoot, 'team-context');
 
     const result = await runCLI(
-      ['store', 'setup', 'team-context', '--path', storeRoot, '--no-init-git', '--json'],
+      ['store', 'setup', 'team-context', '--path', storeRoot, '--json'],
       { cwd: tempDir, env }
     );
 
@@ -440,7 +440,7 @@ describe('store command', () => {
     const storeRoot = path.join(repoRoot, 'team-context');
 
     const result = await runCLI(
-      ['store', 'setup', 'team-context', '--path', storeRoot, '--no-init-git', '--json'],
+      ['store', 'setup', 'team-context', '--path', storeRoot, '--json'],
       { cwd: tempDir, env }
     );
 


### PR DESCRIPTION
Closes #1883.

## Why

`openspec store setup` refuses a `--path` inside another Git repository
(`store_setup_inside_git_repo`). Its comment gives the reason: "creating one
inside an implementation repo is almost always an accidental nested-repo
setup". The check also ran with `--no-init-git`, which creates no repository, so
there is nothing to nest.

Users who keep their home directory as a dotfiles repository could not set up a
store at the recommended `~/openspec/<id>` with any flag. The core already had a
bypass, `allowInsideGitRepository`, but nothing passed it. The CLI's
`prepareSetupInput` received the command options, including `initGit`, and
ignored them (`_options`).

## What Changes

- `prepareSetupPlan` skips the nested-repo check when `initGit === false`. The
  decision lives in the core, next to the check and its comment, so the
  programmatic `setupStore` behaves the same as the CLI.
- The CLI forwards an explicit `--init-git` / `--no-init-git` into the prepare
  step.
- `docs-lab/reference/cli.md` explains the check and when `--no-init-git` skips it.

Unchanged:

- the default setup and an explicit `--init-git` still refuse a path inside
  another repository
- the store never records the enclosing repository's `origin`. The existing
  at-root check in `resolveBackendWithObservedOrigin` already ensured this; a
  test now covers it.

### Existing tests changed

Two tests in `test/commands/store.test.ts` passed `--no-init-git` while
asserting the refusal, so they encoded this bug:

- `rejects explicit setup paths inside an existing Git repo in non-interactive mode`
- `rejects setup paths inside git-like parents when git cannot resolve the repo`

They now run the default setup, which initializes Git and is exactly what the
check is for. They still assert the refusal and that nothing was created. The
check runs in prepare, before the Git identity preflight, so they still need no
Git identity.

## Testing

`test/commands/store-setup-no-init-git.test.ts`: 7 tests, run through the built
CLI. Written first and watched fail:

- **Before the fix (tests only, on `9d4e597`):** 4 failed, 3 passed. Every
  `--no-init-git` setup under a `$HOME` repository exited 1, refused by the
  nested-repo guard (`expected 1 to be +0`). The not-a-repository control and
  the two still-refused cases (default and `--init-git`) passed.
- **After the fix:** 7 passed.

`test/commands/store.test.ts`, holding the two updated cases, passes all 43
tests both before and after the fix. Before the fix those two cases still assert
the refusal, which the default setup still gives.

### CI parity

Run in an isolated sandbox on `9d4e597` under Node 20.19.0 and pnpm 10.34.5,
with the steps from `.github/workflows/ci.yml`:

| Step | Result |
|---|---|
| `pnpm run build` | pass |
| `pnpm exec tsc --noEmit` | pass |
| `pnpm lint` | pass |
| `pnpm test` (`VITEST_MAX_WORKERS=4`) | 4561 passed, 9 failed (4570) |
| `pnpm test` on clean `9d4e597`, same sandbox | 4555 passed, 8 failed (4563) |

The full-suite failures are all timeouts — `Test timed out in 10000ms`, or
`spawnSync npm ETIMEDOUT` in the npm packing test — in CLI-heavy files:
`store-references`, `store-remote`, `store-root-selection`, `workset` and
`package-install-scripts`. Two checks say the sandbox causes them, not this
change:

- clean `9d4e597` fails the same files the same way on the same machine
- every one of those files passes alone (`--maxWorkers=2`), on this branch and
  on clean `9d4e597`: `store-references` 8/8, `store-remote` 19/19,
  `store-root-selection` 44/44, `store.test.ts` 43/43, `workset` 41/41,
  `package-install-scripts` 8/8

The branch adds exactly its 7 new tests: 4570 = 4563 + 7.

Edge cases covered:

- control: `--no-init-git` outside any repository
- `$HOME` is a repository:
  - setup succeeds and registers the store
  - `git` reports `is_repository/initialized/committed: false`
  - metadata and config are written
- no `.git` is created in the store, and the enclosing repository gets no commit
- an `origin` on the enclosing repository is never recorded as the store's remote
- a rerun with `--no-init-git` is an already-registered no-op
- the default setup is still refused, and nothing is created
- an explicit `--init-git` is still refused

## Changeset

`.changeset/store-setup-no-init-git-inside-repo.md` (patch).

## Notes for review

- A rerun without `--no-init-git` of a store already registered inside a
  repository is still refused, because the check runs before the registry
  lookup that makes reruns Git-free. Passing `--no-init-git` again works. I kept
  the change to the explicit flag rather than reordering the prepare step.
- `fix-store-remove-nested` also edits `src/core/store/operations.ts`, but in
  `removeStore`. The two should merge without conflicts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `openspec store setup --no-init-git` now supports creating stores inside existing Git repositories without initializing nested repositories or recording the enclosing repository’s remote.
  - Re-running setup in this mode reports the store as already registered without making changes.

- **Documentation**
  - Clarified Git repository restrictions and when to use `--no-init-git`.

- **Bug Fixes**
  - Preserved the existing rejection behavior for default setup and explicit `--init-git` inside Git repositories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
